### PR TITLE
Add support to display ads from ad server like google ads managers

### DIFF
--- a/assets/src/blocks/easydam-player/render.php
+++ b/assets/src/blocks/easydam-player/render.php
@@ -49,7 +49,16 @@ $ads_layers = array_filter(
 		return 'ad' === $layer['type'];
 	}
 );
-$ad_tag_url = rest_url( '/easydam/v1/adTagURL/' ) . $attachment_id;
+$ad_tag_url = '';
+
+$ad_server = isset( $easydam_meta_data['videoConfig']['adServer'] ) ? sanitize_text_field( $easydam_meta_data['videoConfig']['adServer'] ) : '';
+
+if ( 'ad-server' === $ad_server ) :
+	$ad_tag_url = isset( $easydam_meta_data['videoConfig']['adTagURL'] ) ? $easydam_meta_data['videoConfig']['adTagURL'] : '';
+elseif ( 'self-hosted' === $ad_server && ! empty( $ads_layers ) ) :
+	$ad_tag_url = rest_url( '/easydam/v1/adTagURL/' ) . $attachment_id;
+endif;
+
 ?>
 
 <?php if ( ! empty( $sources ) ) : ?>
@@ -58,7 +67,7 @@ $ad_tag_url = rest_url( '/easydam/v1/adTagURL/' ) . $attachment_id;
 		<video
 			class="easydam-player video-js vjs-big-play-centered"
 			data-setup="<?php echo esc_attr( $video_setup ); ?>"
-			data-ad_tag_url="<?php echo esc_url( ! empty( $ads_layers ) ? esc_url( $ad_tag_url ) : '' ); ?>"
+			data-ad_tag_url="<?php echo esc_url_raw( $ad_tag_url ); ?>"
 		>
 			<?php
 			foreach ( $sources as $source ) :

--- a/pages/style.css
+++ b/pages/style.css
@@ -364,3 +364,30 @@ input, textarea, select {
   font-weight: 500;
   margin-bottom: 0.5rem;
 }
+
+.button-tabs {
+	border-bottom: none;
+}
+.button-tabs .components-tab-panel__tabs {
+	display: flex;
+	gap: 0.5rem;
+	border: none;
+}
+
+.button-tabs .is-active {
+	background-color: #1e1e1e;
+	color: #fff !important;
+}
+
+.button-tabs .is-active::after {
+	display: none;
+}
+
+.button-tabs .components-tab-panel__tabs-item {
+	border-radius: 2px;
+	box-shadow: inset 0 0 0 1px #ddd;
+}
+
+.button-tabs .components-tab-panel__tabs-item.is-active {
+	box-shadow: inset 0 0 0 1px #1e1e1e;
+}

--- a/pages/video-editor/components/SidebarLayers.js
+++ b/pages/video-editor/components/SidebarLayers.js
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Icon, Modal } from '@wordpress/components';
+import { Button, Icon, Modal, Tooltip } from '@wordpress/components';
 import { plus, preformatted, customLink, arrowRight, video, customPostType } from '@wordpress/icons';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -47,9 +47,11 @@ const SidebarLayers = ( { currentTime, onSelectLayer } ) => {
 	const closeModal = () => setOpen( false );
 
 	const [ selectedLayer, setSelectedLayer ] = useState( null );
+	const dispatch = useDispatch();
 
 	const layers = useSelector( ( state ) => state.videoReducer.layers );
-	const dispatch = useDispatch();
+	const videoConfig = useSelector( ( state ) => state.videoReducer.videoConfig );
+	const adServer = videoConfig?.adServer ?? 'self-hosted';
 
 	// Sort the array (ascending order)
 	const sortedLayers = [ ...layers ].sort( ( a, b ) => a.displayTime - b.displayTime );
@@ -132,22 +134,32 @@ const SidebarLayers = ( { currentTime, onSelectLayer } ) => {
 					<div id="sidebar-layers" className="p-4">
 						{
 							sortedLayers?.map( ( layer ) => (
-								<button
+								<Tooltip
 									key={ layer.id }
-									className="w-full flex justify-between items-center p-2 border rounded mb-2 hover:bg-gray-50 cursor-pointer"
-									onClick={ () => {
-										setSelectedLayer( layer );
-										onSelectLayer( layer.displayTime );
-									} }
+									text={ adServer === 'ad-server' && layer.type === 'ad' ? __( 'This ad will be override by Ad server\'s ads', 'transcoder' ) : '' }
+									placement="right"
 								>
-									<div className="flex items-center gap-2">
-										<Icon icon={ layerTypes.find( ( type ) => type.type === layer.type ).icon } />
-										<p>{ layer?.type?.toUpperCase() } layer at <b>{ layer.displayTime }s</b></p>
+									<div className="border rounded mb-2">
+										<Button
+											className={ `w-full flex justify-between items-center p-2 border-1 rounded hover:bg-gray-50 cursor-pointer border-[#e5e7eb] ${ adServer === 'ad-server' && layer.type === 'ad' ? 'bg-orange-50 hover:bg-orange-50' : '' }` }
+											label={
+												adServer === 'ad-server' && layer.type === 'ad' ? __( 'This ad will be override by Ad server\'s ads', 'transcoder' ) : ''
+											}
+											onClick={ () => {
+												setSelectedLayer( layer );
+												onSelectLayer( layer.displayTime );
+											} }
+										>
+											<div className="flex items-center gap-2">
+												<Icon icon={ layerTypes.find( ( type ) => type.type === layer.type ).icon } />
+												<p>{ layer?.type?.toUpperCase() } layer at <b>{ layer.displayTime }s</b></p>
+											</div>
+											<div>
+												<Icon icon={ arrowRight } />
+											</div>
+										</Button>
 									</div>
-									<div>
-										<Icon icon={ arrowRight } />
-									</div>
-								</button>
+								</Tooltip>
 							) )
 						}
 						{

--- a/pages/video-editor/components/appearance/Appearance.js
+++ b/pages/video-editor/components/appearance/Appearance.js
@@ -13,12 +13,14 @@ import '../../video-control.css';
 import {
 	Button,
 	CheckboxControl,
-	ColorPicker,
 	CustomSelectControl,
 	Icon,
 	RangeControl,
 	ColorPalette,
+	TabPanel,
+	TextareaControl,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateVideoConfig } from '../../redux/slice/videoSlice';
 import EasyDAM from '../../../../assets/src/images/EasyDAM.png';
@@ -660,6 +662,61 @@ const Appearance = () => {
 							);
 						} }
 					/>
+				</div>
+
+				<div className="form-group">
+					<label
+						htmlFor="custom-hover-color"
+						className="text-[11px] uppercase font-bold mb-2"
+					>
+						{ __( 'Select Ad server', 'transcoder' ) }
+					</label>
+					<TabPanel
+						onSelect={ ( val ) => {
+							dispatch(
+								updateVideoConfig( {
+									adServer: val,
+								} ),
+							);
+						} }
+						initialTabName={ videoConfig.adServer ?? 'self-hosted' }
+						className="button-tabs"
+						tabs={ [
+							{
+								name: 'self-hosted',
+								title: 'Self Hosted Ads',
+								className: 'flex-1 justify-center items-center',
+								component: null,
+							},
+							{
+								name: 'ad-server',
+								title: "Ad Server\'s Ads",
+								className: 'flex-1 justify-center items-center',
+								component: <div className="mt-2">
+									<TextareaControl
+										label={ __( 'adTag URL', 'transcoder' ) }
+										help={ <>
+											<div>
+												{ __( 'A VAST ad tag URL is used by a player to retrieve video and audio ads ', 'transcoder' ) }
+												<a href="https://support.google.com/admanager/answer/177207?hl=en" target="_blank" rel="noreferrer noopener" className="text-blue-500 underline">{ __( 'Learn more.', 'transcoder' ) }</a>
+											</div>
+										</>
+										}
+										value={ videoConfig.adTagURL }
+										onChange={ ( val ) => {
+											dispatch(
+												updateVideoConfig( {
+													adTagURL: val,
+												} ),
+											);
+										} }
+									/>
+								</div>,
+							},
+						] }
+					>
+						{ ( tab ) => tab.component }
+					</TabPanel>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
- Add toggle in appearance settings to display ads between `self-hosted ads` or `ad-servers ads`.
- Add a tooltip message on the self-hosted ad layer if `ad-server's ad` was selected as priority.
- Update the easyDAM block frontend to change between the ad-server and self-hosted ads.

https://github.com/user-attachments/assets/4ae3373d-646a-4d24-a697-c900f2fa610f

