### PR TITLE
Fix error: a.qualityMenu is not a function

### DIFF
--- a/assets/src/blocks/easydam-player/frontend.js
+++ b/assets/src/blocks/easydam-player/frontend.js
@@ -547,6 +547,12 @@ function easyDAMPlayer() {
 			} );
 		}
 
+		try {
+			player.qualityMenu();
+		} catch ( e ) {
+			console.log( e );
+		}
+
 		player.ready( function() {
 			// player.ima.initializeAdDisplayContainer();
 			// player.ima.requestAds();


### PR DESCRIPTION
Adds a temporary solution to fix the error by wrapping the code in try catch block