### PR TITLE
Analytics Redirect and Plugin Name change

### DIFF
--- a/godam.php
+++ b/godam.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: GoDAM
+ * Plugin Name: DAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and optimize digital assets with GoDAM – featuring transcoding, adaptive streaming, interactive video layers, gravity forms integration, and ad integration.
  * Version: 1.0.0

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -344,6 +344,7 @@ class Pages {
 					'nonce'            => wp_create_nonce( 'wp_rest' ),     // WordPress nonce for API requests.
 					'currentUserId'    => get_current_user_id(),            // Current user ID.
 					'currentUserRoles' => wp_get_current_user()->roles,     // Current user roles.
+					'adminUrl'         => admin_url( 'admin.php?page=godam' ),
 				)
 			);
 

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -60,11 +60,12 @@ const Analytics = ( { attachmentID } ) => {
 
 			<div id="license-overlay" className="license-overlay hidden">
 				<div className="license-message">
-					<p>{ __( 'Please activate your license to access the Analytics feature.', 'godam' ) }</p>
 					<p>
+						{ __( 'Please ', 'godam' ) }
 						<a href={ adminUrl } target="_blank" rel="noopener noreferrer">
-							{ __( 'Activate your license here.', 'godam' ) }
+							{ __( 'activate your license', 'godam' ) }
 						</a>
+						{ __( ' to access the Analytics feature.', 'godam' ) }
 					</p>
 				</div>
 			</div>

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -62,8 +62,8 @@ const Analytics = ( { attachmentID } ) => {
 				<div className="license-message">
 					<p>{ __( 'Please activate your license to access the Analytics feature.', 'godam' ) }</p>
 					<p>
-						<a href={ adminUrl } className="button button-primary">
-							{ __( 'Activate License', 'godam' ) }
+						<a href={ adminUrl } target="_blank" rel="noopener noreferrer">
+							{ __( 'Activate your license here.', 'godam' ) }
 						</a>
 					</p>
 				</div>

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -20,6 +20,8 @@ import { __ } from '@wordpress/i18n';
 const Analytics = ( { attachmentID } ) => {
 	const [ analyticsData, setAnalyticsData ] = useState( null );
 
+	const adminUrl = window.videoData?.adminUrl || '/wp-admin/admin.php?page=godam';
+
 	useEffect( () => {
 		if ( attachmentID ) {
 			const url = `/wp-json/wp/v2/media/${ attachmentID }`;
@@ -59,6 +61,11 @@ const Analytics = ( { attachmentID } ) => {
 			<div id="license-overlay" className="license-overlay hidden">
 				<div className="license-message">
 					<p>{ __( 'Please activate your license to access the Analytics feature.', 'godam' ) }</p>
+					<p>
+						<a href={ adminUrl } className="button button-primary">
+							{ __( 'Activate License', 'godam' ) }
+						</a>
+					</p>
 				</div>
 			</div>
 

--- a/pages/analytics/index.scss
+++ b/pages/analytics/index.scss
@@ -187,6 +187,15 @@
 	font-size: 16px;
 	font-weight: bold;
 }
+.license-message a {
+	color: #3b82f6;
+	text-decoration: none;
+	font-weight: 600;
+}
+
+.license-message a:hover {
+	text-decoration: underline;
+}
 
 .hidden {
 	display: none;


### PR DESCRIPTION
- Added a link that redirects to General Settings page from Analytics page, to activate license.
- Changed Plugin Name in main plugin file from GoDAM to DAM
# Screenshot
![image](https://github.com/user-attachments/assets/2a29928a-7f6e-4324-b72f-a8034605a330)

