### PR TITLE
Transcoding URL changes

### DIFF
--- a/admin/godam-transcoder-actions.php
+++ b/admin/godam-transcoder-actions.php
@@ -263,17 +263,12 @@ function add_transcoded_url_field( $form_fields, $post ) {
 
 	// Add the transcoded URL field.
 	$form_fields['transcoded_url'] = array(
-		'label' => __( 'Transcoded MPD URL', 'godam' ),
+		'label' => __( 'Transcoded CDN URL', 'godam' ),
 		'input' => 'html',
 		'html'  => '<input type="text" name="attachments[' . $post->ID . '][transcoded_url]" id="attachments-' . $post->ID . '-transcoded_url" value="' . esc_url( $transcoded_url ) . '" readonly>',
 		'value' => esc_url( $transcoded_url ),
-		'helps' => __( 'The URL of the transcoded .mpd file is generated automatically and cannot be edited.', 'godam' ),
+		'helps' => __( 'The URL of the transcoded file is generated automatically and cannot be edited.', 'godam' ),
 	);
-
-	// Add a note if adaptive bitrate streaming is disabled.
-	if ( ! $adaptive_bitrate_enabled ) {
-		$form_fields['transcoded_url']['helps'] = __( 'This feature is available only when adaptive bitrate streaming is enabled.', 'godam' );
-	}
 
 	return $form_fields;
 }

--- a/admin/godam-transcoder-handler.php
+++ b/admin/godam-transcoder-handler.php
@@ -1046,6 +1046,14 @@ class RT_Transcoder_Handler {
 								if ( ! empty( $uploaded_file ) ) {
 									$transcoded_files[ $key ][] = $uploaded_file;
 									update_post_meta( $attachment_id, '_wp_attached_file', $uploaded_file );
+									update_post_meta( $attachment_id, '_rt_transcoded_url', $download_url );
+
+									$wpdb->update(
+										$wpdb->posts,
+										array( 'post_mime_type' => 'video/mp4' ),
+										array( 'ID' => $attachment_id )
+									);
+									
 								}
 							} else {
 								$flag = esc_html__( 'Could not read file.', 'godam' );

--- a/godam.php
+++ b/godam.php
@@ -115,3 +115,11 @@ add_filter( 'network_admin_plugin_action_links', 'rtt_action_links', 11, 2 );
  * Autoloader for the vendor directory.
  */
 require GODAM_PATH . 'vendor/autoload.php';
+
+/**
+ * Runs when the plugin is deactivated.
+ */
+function godam_plugin_deactivate() {
+	\Transcoder\Inc\Cron::get_instance()->unschedule_video_cleanup();
+}
+register_deactivation_hook( __FILE__, 'godam_plugin_deactivate' );

--- a/inc/classes/class-cron.php
+++ b/inc/classes/class-cron.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Class for handling scheduled tasks (CRON jobs) related to video cleanup.
+ *
+ * @package Transcoder
+ */
+
+namespace Transcoder\Inc;
+
+use Transcoder\Inc\Traits\Singleton;
+
+/**
+ * Class Cron
+ */
+class Cron {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+		// Schedule the cron job on plugin activation.
+		add_action( 'wp', array( $this, 'schedule_video_cleanup' ) );
+
+		// Hook into the scheduled event.
+		add_action( 'godam_cleanup_expired_videos', array( $this, 'cleanup_expired_videos' ) );
+
+		add_filter(
+			'cron_schedules',
+			function ( $schedules ) {
+				$schedules['twelve_hours'] = array(
+					'interval' => 12 * HOUR_IN_SECONDS,
+					'display'  => __( 'Every 12 Hours' ),
+				);
+				return $schedules;
+			}
+		);
+	}
+
+	/**
+	 * Schedule the cron job for cleaning up expired videos.
+	 */
+	public function schedule_video_cleanup() {
+		if ( ! wp_next_scheduled( 'godam_cleanup_expired_videos' ) ) {
+			wp_schedule_event( time(), 'twelve_hours', 'godam_cleanup_expired_videos' );
+		}
+	}
+
+	/**
+	 * Clean up expired videos from CDN and remove MPD URLs.
+	 */
+	public function cleanup_expired_videos() {
+
+		global $wpdb;
+
+		$batch_size = 50; // Process in batches to avoid performance issues.
+
+		$usage_data  = get_site_option( 'rt-transcoding-usage', array() );
+		$license_key = get_site_option( 'rt-transcoding-api-key', '' );
+		$usage_data  = isset( $usage_data[ $license_key ] ) ? (array) $usage_data[ $license_key ] : null;
+
+		// If there is no valid license usage data, do nothing.
+		if ( empty( $usage_data ) ) {
+			return;
+		}
+
+		// Extract subscription end date.
+		$subscription_end    = isset( $usage_data['end_date'] ) ? strtotime( $usage_data['end_date'] ) : null;
+		$grace_period_days   = 30;
+		$current_time        = time();
+		$days_until_deletion = floor( ( $subscription_end + ( $grace_period_days * DAY_IN_SECONDS ) - $current_time ) / DAY_IN_SECONDS );
+
+		// Ensure the subscription is expired and the grace period has ended.
+		if ( $days_until_deletion <= 0 ) {
+
+			$batch_size = 50; // Number of media items per batch.
+
+			// Get total number of expired media.
+			$total_media = $wpdb->get_var(
+				"SELECT COUNT(*) FROM {$wpdb->posts} 
+				WHERE post_type = 'attachment' "
+			);
+
+			if ( empty( $total_media ) || $total_media < 1 ) {
+				return; // No expired media, exit early.
+			}
+
+			// Calculate total number of batches.
+			$total_batches = ceil( $total_media / $batch_size );
+
+			for ( $batch = 0; $batch < $total_batches; $batch++ ) {
+				$offset = $batch * $batch_size;
+
+				// Fetch next batch of expired media.
+				$expired_media = $wpdb->get_col(
+					$wpdb->prepare(
+						"SELECT ID FROM {$wpdb->posts} 
+					WHERE post_type = 'attachment' 
+					LIMIT %d OFFSET %d",
+						$batch_size,
+						$offset
+					)
+				);
+
+				if ( empty( $expired_media ) ) {
+					break; // No more media to process.
+				}
+
+				foreach ( $expired_media as $video_id ) {
+					$cdn_url = get_post_meta( $video_id, '_rt_transcoded_url', true );
+					if ( ! empty( $cdn_url ) ) {
+						delete_post_meta( $video_id, '_rt_transcoded_url' );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Remove the scheduled cron event on plugin deactivation.
+	 */
+	public function unschedule_video_cleanup() {
+		$timestamp = wp_next_scheduled( 'godam_cleanup_expired_videos' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'godam_cleanup_expired_videos' );
+		}
+		wp_schedule_single_event( time() + 10, 'godam_cleanup_expired_videos' );
+	}
+}

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -12,6 +12,7 @@ use Transcoder\Inc\Pages;
 use Transcoder\Inc\Blocks;
 use Transcoder\Inc\Assets;
 use Transcoder\Inc\Deactivation;
+use Transcoder\Inc\Cron;
 
 use Transcoder\Inc\Taxonomies\Media_Folders;
 
@@ -42,6 +43,7 @@ class Plugin {
 		Blocks::get_instance();
 		Pages::get_instance();
 		Media_Library_Ajax::get_instance();
+		Cron::get_instance();
 
 		$this->load_post_types();
 		$this->load_taxonomies();

--- a/pages/godam/VideoSettings.js
+++ b/pages/godam/VideoSettings.js
@@ -29,13 +29,13 @@ const VideoSettings = ( { isPremiumUser, mediaSettings, saveMediaSettings } ) =>
 
 	const videoQualityOptions = [
 		{ label: 'Auto', value: 'auto' },
-		{ label: '240p (352 x 240)', value: '240p' },
-		{ label: '360p (640 x 360)', value: '360p' },
-		{ label: '480p (842 x 480)', value: '480p' },
-		{ label: '720p (1280 x 720)', value: '720p' },
-		{ label: '1080p (1920 x 1080) (HD)', value: '1080p' },
-		{ label: '1440p (2560 x 1440) (HD)', value: '1440p' },
-		{ label: '2160p (3840 x 2160) (4K)', value: '2160p' },
+		{ label: '240p (352 x 240)', value: '240' },
+		{ label: '360p (640 x 360)', value: '360' },
+		{ label: '480p (842 x 480)', value: '480' },
+		{ label: '720p (1280 x 720)', value: '720' },
+		{ label: '1080p (1920 x 1080) (HD)', value: '1080' },
+		{ label: '1440p (2560 x 1440) (HD)', value: '1440' },
+		{ label: '2160p (3840 x 2160) (4K)', value: '2160' },
 	];
 
 	const handleSubmit = ( e ) => {


### PR DESCRIPTION
# Updates:
1. Created CRON job to delete Transcoded CDN URLs for all videos when the 30-day grace period after license expiry is exceeded. Also unscheduled the event when plugin is deactivated. 
2. Updated Transcoded CDN URL for Non-ABS videos as well.
3. Updated Post MIME Type for all videos to mp4 to fix video playback issue.
4. Adjusted Video Resolution values in Video settings.

# Screenshots
## 1. CRON Job
![image](https://github.com/user-attachments/assets/5823600e-8aa7-44b9-bfd5-80271f16a137)

## 2. Transcoded CDN URLs and updated MIME type. Uploaded `.avi` file in this example, which is transcoded into mp4 (All Non-ABS videos are transcoded to mp4):
![Screenshot 2025-02-28 at 6 46 54 PM](https://github.com/user-attachments/assets/68fcfbc0-ff5f-4424-853c-4a72b365e544)

