### PR TITLE
Add preview thumbnail feature

### DIFF
--- a/assets/src/blocks/godam-player/VideoJS.js
+++ b/assets/src/blocks/godam-player/VideoJS.js
@@ -5,6 +5,7 @@ import React from 'react';
 import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
 import 'videojs-contrib-quality-menu';
+import SpriteThumbnails from 'videojs-sprite-thumbnails';
 
 /**
  * WordPress dependencies
@@ -47,6 +48,31 @@ export const VideoJS = ( props ) => {
 			player.playsinline( options.playsinline );
 			player.src( options.sources );
 		}
+
+		const pluginName = 'spriteThumbnails';
+
+		if ( typeof videojs.getPlugin( pluginName ) === 'undefined' ) {
+			videojs.registerPlugin( pluginName, SpriteThumbnails );
+		}
+
+		let spriteUrl = '';
+
+		if ( 2 === options.sources.length ) {
+			const source = options.sources[ 0 ].src;
+			const urlParts = source.split( '/' );
+			urlParts[ urlParts.length - 1 ] = 'sprite.png'; // Replace the filename with 'sprite.png'
+
+			spriteUrl = urlParts.join( '/' ); // Reconstruct the URL
+		}
+
+		playerRef.current.spriteThumbnails?.( {
+			url: spriteUrl,
+			width: 320,
+			height: 180,
+			interval: 10,
+			columns: 10,
+			downlink: 0,
+		} );
 	}, [ options, videoRef ] );
 
 	// Dispose the Video.js player when the functional component unmounts

--- a/assets/src/blocks/godam-player/frontend.js
+++ b/assets/src/blocks/godam-player/frontend.js
@@ -11,6 +11,7 @@ import videojs from 'video.js';
 import 'videojs-contrib-ads';
 import 'videojs-ima';
 import 'videojs-contrib-quality-menu';
+import SpriteThumbnails from 'videojs-sprite-thumbnails';
 
 /**
  * FontAwesome dependencies
@@ -68,6 +69,30 @@ function GODAMPlayer( videoRef = null ) {
 
 		const player = videojs( video, videoSetupControls );
 
+		const pluginName = 'spriteThumbnails';
+
+		let spriteUrl = '';
+
+		if ( 2 === videoSetupControls.sources.length ) {
+			const source = videoSetupControls.sources[ 0 ].src;
+			const urlParts = source.split( '/' );
+			urlParts[ urlParts.length - 1 ] = 'sprite.png'; // Replace the filename with 'sprite.png'
+
+			spriteUrl = urlParts.join( '/' ); // Reconstruct the URL
+		}
+
+		if ( typeof videojs.getPlugin( pluginName ) === 'undefined' ) {
+			videojs.registerPlugin( pluginName, SpriteThumbnails );
+		}
+
+		player.spriteThumbnails( {
+			url: spriteUrl,
+			width: 320,
+			height: 180,
+			interval: 10,
+			columns: 10,
+			downlink: 0,
+		} );
 		let isPreview = null;
 
 		const watcher = {

--- a/assets/src/blocks/godam-player/render.php
+++ b/assets/src/blocks/godam-player/render.php
@@ -25,25 +25,25 @@ $attachment_id = ! empty( $attributes['id'] ) ? intval( $attributes['id'] ) : nu
 $video_preview = isset( $attributes['preview'] ) ? $attributes['preview'] : false;
 
 // Retrieve 'easydam_meta' for the given attachment ID, defaulting to an empty array if not found.
-$easydam_meta_data = $attachment_id ? get_post_meta( $attachment_id, 'easydam_meta', true ) : [];
-$easydam_meta_data = is_array( $easydam_meta_data ) ? $easydam_meta_data : [];
+$easydam_meta_data = $attachment_id ? get_post_meta( $attachment_id, 'easydam_meta', true ) : array();
+$easydam_meta_data = is_array( $easydam_meta_data ) ? $easydam_meta_data : array();
 
 // Extract control bar settings with a fallback to an empty array.
-$control_bar_settings = $easydam_meta_data['videoConfig']['controlBar'] ?? [];
+$control_bar_settings = $easydam_meta_data['videoConfig']['controlBar'] ?? array();
 
 $poster_image = get_post_meta( $attachment_id, '_rt_media_video_thumbnail', true );
 $poster_image = ! empty( $poster_image ) ? $poster_image : '';
 
-$sources = [];
-$transcoded_url    = $attachment_id ? get_post_meta( $attachment_id, '_rt_transcoded_url', true ) : '';
-$video_src         = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
-$video_src_type    = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
+$sources        = array();
+$transcoded_url = $attachment_id ? get_post_meta( $attachment_id, '_rt_transcoded_url', true ) : '';
+$video_src      = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
+$video_src_type = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
 
 if ( ! empty( $transcoded_url ) ) {
 	$sources = array(
 		array(
 			'src'  => $transcoded_url,
-			'type' => strtolower(end(explode('.', $transcoded_url)))=== 'mp4' ? 'video/mp4' : 'application/dash+xml',
+			'type' => strtolower( end( explode( '.', $transcoded_url ) ) ) === 'mp4' ? 'video/mp4' : 'application/dash+xml',
 		),
 		array(
 			'src'  => $video_src,
@@ -55,7 +55,7 @@ if ( ! empty( $transcoded_url ) ) {
 		array(
 			'src'  => $video_src,
 			'type' => $video_src_type === 'video/quicktime' ? 'video/mp4' : $video_src_type,
-		)
+		),
 	);
 }
 

--- a/assets/src/blocks/godam-player/render.php
+++ b/assets/src/blocks/godam-player/render.php
@@ -43,7 +43,7 @@ if ( ! empty( $transcoded_url ) ) {
 	$sources = array(
 		array(
 			'src'  => $transcoded_url,
-			'type' => 'application/dash+xml',
+			'type' => strtolower(end(explode('.', $transcoded_url)))=== 'mp4' ? 'video/mp4' : 'application/dash+xml',
 		),
 		array(
 			'src'  => $video_src,

--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -461,6 +461,7 @@
 
 	#branding-icon {
 		height: 100%;
-		object-fit: fill;
+		object-fit: contain;
+		width: unset;
 	}
 }

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -64,7 +64,7 @@ class Assets {
 			'analytics-library',
 			GODAM_URL . '/assets/src/libs/analytics.min.js',
 			array(),
-			filemtime( GODAM_URL . '/assets/src/libs/analytics.min.js' ),
+			filemtime( GODAM_PATH . '/assets/src/libs/analytics.min.js' ),
 			true
 		);
 
@@ -193,8 +193,8 @@ class Assets {
 		/**
 		 * Dependency library for date range picker.
 		 */
-		wp_enqueue_script( 'moment-js', GODAM_URL . '/assets/src/libs/moment-js.min.js', array(), filemtime( GODAM_URL . '/assets/src/libs/moment-js.min.js' ), true );
-		wp_enqueue_script( 'daterangepicker-js', GODAM_URL . '/assets/src/libs/daterangepicker.min.js', array( 'moment-js' ), filemtime( GODAM_URL . '/assets/src/libs/daterangepicker.min.js' ), true );
-		wp_enqueue_style( 'daterangepicker-css', GODAM_URL . '/assets/src/libs/daterangepicker.css', array(), filemtime( GODAM_URL . '/assets/src/libs/daterangepicker.css' ) );
+		wp_enqueue_script( 'moment-js', GODAM_URL . '/assets/src/libs/moment-js.min.js', array(), filemtime( GODAM_PATH . '/assets/src/libs/moment-js.min.js' ), true );
+		wp_enqueue_script( 'daterangepicker-js', GODAM_URL . '/assets/src/libs/daterangepicker.min.js', array( 'moment-js' ), filemtime( GODAM_PATH . '/assets/src/libs/daterangepicker.min.js' ), true );
+		wp_enqueue_style( 'daterangepicker-css', GODAM_URL . '/assets/src/libs/daterangepicker.css', array(), filemtime( GODAM_PATH . '/assets/src/libs/daterangepicker.css' ) );
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
 				"video.js": "^8.21.0",
 				"videojs-contrib-ads": "^7.5.2",
 				"videojs-contrib-quality-menu": "^1.0.3",
-				"videojs-ima": "^2.3.0"
+				"videojs-ima": "^2.3.0",
+				"videojs-sprite-thumbnails": "2.2.3"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.21.8",
@@ -26653,6 +26654,20 @@
 			"resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
 			"integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/videojs-sprite-thumbnails": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/videojs-sprite-thumbnails/-/videojs-sprite-thumbnails-2.2.3.tgz",
+			"integrity": "sha512-aKtiGZXSbDOWHOkrz+xqh42BN07jURnyGbmRALTq5g7j+KHoZJkIMGJsESeVrAbb8gd172TXxHxVdHJPfFlqkw==",
+			"license": "MIT",
+			"dependencies": {
+				"global": "^4.4.0",
+				"video.js": "^8"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6"
+			}
 		},
 		"node_modules/videojs-vtt.js": {
 			"version": "0.15.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 		"video.js": "^8.21.0",
 		"videojs-contrib-ads": "^7.5.2",
 		"videojs-contrib-quality-menu": "^1.0.3",
-		"videojs-ima": "^2.3.0"
+		"videojs-ima": "^2.3.0",
+		"videojs-sprite-thumbnails": "2.2.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.21.8",
@@ -75,7 +76,7 @@
 		"style-loader": "^4.0.0",
 		"tailwindcss": "^3.4.15",
 		"webpack-remove-empty-scripts": "^1.0.3"
-  	},
+	},
 	"scripts": {
 		"build:dev": "cross-env NODE_ENV=development npm-run-all 'build:!(dev|prod)'",
 		"build:prod": "cross-env NODE_ENV=production npm-run-all 'build:!(dev|prod)'",

--- a/plugin-build.sh
+++ b/plugin-build.sh
@@ -15,18 +15,19 @@ CHECKOUT_BRANCH="git checkout $GIT_BRANCH"
 
 # Define unwanted files and folders to remove after build
 UNWANTED_ITEMS=(
-    "node_modules"          # Remove node_modules
-    "assets/src/blocks"     # Remove source code files
-    "assets/src/css"     # Remove source code files
-    "assets/src/js"     # Remove source code files
-    "pages/analytics"       # Remove source code files
-    "pages/godam"           # Remove source code files
-    "pages/help"            # Remove source code files
-    "pages/media-library"   # Remove source code files
-    "pages/video-editor"    # Remove source code files
-    "pages/style.css"          # Remove source code files
-    "tests"
-    ".browserslistrc"       # Remove log files
+    "node_modules"                          # Remove node_modules
+    "assets/src/blocks"                     # Remove source code files
+    "assets/src/css"                        # Remove source code files
+    "assets/src/js"                         # Remove source code files
+    "assets/src/jquery-ui-1.14.1.draggable" # Remove source code files
+    "pages/analytics"                       # Remove source code files
+    "pages/godam"                           # Remove source code files
+    "pages/help"                            # Remove source code files
+    "pages/media-library"                   # Remove source code files
+    "pages/video-editor"                    # Remove source code files
+    "pages/style.css"                       # Remove source code files
+    "tests"                                 # Remove test files 
+    ".browserslistrc"                       # Remove log files
     ".eslintignore"        
     ".eslintrc"
     ".gitignore"


### PR DESCRIPTION
###  Add Support for Video Thumbnail Sprites in Hover Previews  

This PR introduces **video thumbnail sprite** support to enhance the video hover preview experience. The following key updates have been implemented:  

#### **1. Sprite Image Handling**  
- The **sprite image URL** is dynamically generated based on the video source.  
  - The filename (whether `.mpd` or `.mp4`) is replaced with `sprite.png`.  
- Added logic to **fetch and display sprite thumbnails** at predefined intervals of 10 seconds.  

#### **2. Video Thumbnail Grid Calculation**  
- Static **thumbnail dimensions**:  
  - **Width:** `320px`  
  - **Height:** `180px` (static, maintaining 16:9 aspect ratio).  

#### **3. Transcoded Video Source Handling**  
- When setting up the video source:  
  - If the **transcoded URL ends with `.mp4`**, assign `type: video/mp4`.  
  - Otherwise, keep the default `type: application/dash+xml`.  
 This is done, as currently the type for transcoded url is set to `type: application/dash+xml`, but for non ABS video type the url could have mp4 extension which would make this type incorrect so the new condition takes care of this case.
 

https://github.com/user-attachments/assets/ae57d28c-4129-42d7-8295-1bf329058569

 
 #### **3. Fix breaking branding style**  
- For safari, the branding image was breaking:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/2485e3bf-103b-4eb2-86a7-b03bbc425e1b" />
