### PR TITLE
update: update `WordPress.PHP.DisallowShortTernary` to `Universal.Operators.DisallowShortTernary` in phpcs.xml

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
-		<exclude name="WordPress.PHP.DisallowShortTernary" />
+		<exclude name="Universal.Operators.DisallowShortTernary" />
 	</rule>
 
 	<rule ref="WordPress-Docs">


### PR DESCRIPTION
Refer https://github.com/WordPress/WordPress-Coding-Standards/blob/38168bc542ec3565c04f2a88498a2024cdfd9ba1/CHANGELOG.md?plain=1#L261