### PR TITLE
Fix the conditional logic to load ad server and self-hosted ads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ vendor/
 /pages/build/
 godam-build.zip
 godam-build
+godam.zip

--- a/assets/src/blocks/godam-player/render.php
+++ b/assets/src/blocks/godam-player/render.php
@@ -107,11 +107,11 @@ $ads_layers = array_filter(
 );
 $ad_tag_url = '';
 
-$ad_server = isset( $easydam_meta_data['videoConfig']['adServer'] ) ? sanitize_text_field( $easydam_meta_data['videoConfig']['adServer'] ) : '';
+$ad_server = isset( $easydam_meta_data['videoConfig']['adServer'] ) ? sanitize_text_field( $easydam_meta_data['videoConfig']['adServer'] ) : 'self-hosted';
 
-if ( ! empty( $ad_server ) ) :
+if ( ! empty( $ad_server ) && 'ad-server' === $ad_server ) :
 	$ad_tag_url = isset( $easydam_meta_data['videoConfig']['adTagURL'] ) ? $easydam_meta_data['videoConfig']['adTagURL'] : '';
-elseif ( ! empty( $ads_layers ) ) :
+elseif ( ! empty( $ads_layers ) && 'self-hosted' === $ad_server ) :
 	$ad_tag_url = get_rest_url( get_current_blog_id(), '/godam/v1/adTagURL/' ) . $attachment_id;
 endif;
 

--- a/pages/video-editor/redux/slice/videoSlice.js
+++ b/pages/video-editor/redux/slice/videoSlice.js
@@ -16,7 +16,7 @@ const slice = createSlice( {
 			sources: [],
 			playbackRates: [ 0.5, 1, 1.5, 2 ],
 			captions: [],
-			adServer: false,
+			adServer: 'self-hosted',
 			controlBar: {
 				playToggle: true, // Play/Pause button
 				volumePanel: true,


### PR DESCRIPTION
**Issue:** Ad server and self-hosted ads are not loading properly because of the wrong conditional logic used to render ads.

**Solution:** Set the default adServer value and fix the condition to render ads.