### PR TITLE
Update branch references from master to main

### DIFF
--- a/.github/hosts.yml
+++ b/.github/hosts.yml
@@ -1,4 +1,4 @@
-master:
+main:
   hostname: "easydam.rt.gw"
   user: "root"
   deploy_path: "/opt/easyengine/sites/easydam.rt.gw/app/htdocs/plugin"

--- a/.github/workflows/deploy_on_push.yml
+++ b/.github/workflows/deploy_on_push.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   workflow_dispatch:
 name: Deploy on Push


### PR DESCRIPTION
This pull request includes changes to update branch references from `master` to `main` in configuration files.

Branch reference updates:

* [`.github/hosts.yml`](diffhunk://#diff-793eb4471e1092126a5ab929b14fee9b2567346f5255f968b9c354c7c63dfb0dL1-R1): Changed the branch reference from `master` to `main`.
* [`.github/workflows/deploy_on_push.yml`](diffhunk://#diff-044e2a519ecdf2d11c1895357aa1cc256ad3bf9063b1bf622dd860b664c17b3cL4-R4): Updated the branch reference from `master` to `main` under the `push` event.