### PR TITLE
Fix the video quality control position issue

### DIFF
--- a/assets/src/blocks/godam-player/frontend.js
+++ b/assets/src/blocks/godam-player/frontend.js
@@ -81,7 +81,7 @@ function GODAMPlayer( videoRef = null ) {
 			if ( captionControlBtn ) {
 				const qualityControlBtn = playerElement.querySelector( '.vjs-control-bar .vjs-quality-menu-wrapper' );
 				if ( qualityControlBtn ) {
-					qualityControlBtn.style.setProperty( 'right', '80px' );
+					qualityControlBtn.classList.add( 'mobile-right-80' );
 				}
 			}
 		} );

--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -662,6 +662,10 @@
 				right: calc(3 * 40px);
 				height: 3em !important;
 			}
+
+			.mobile-right-80 {
+				right: 80px;
+			}
 	
 			.vjs-time-control {
 				&.vjs-current-time {


### PR DESCRIPTION
## Fix the video quality menu position issue for the 

This pull request includes changes to the `assets/src/blocks/godam-player/frontend.js` and `assets/src/blocks/godam-player/style.scss` files to improve the styling and positioning of video player controls. The most important changes include adding a new CSS class for mobile styling and updating the JavaScript to use this new class.

Styling and positioning improvements:

* [`assets/src/blocks/godam-player/frontend.js`](diffhunk://#diff-c70aba2f27ec57bbfc39499d63cd47924dda4977ea32a0a96466c617da022f7fL84-R84): Updated the code to add the `mobile-right-80` class to the quality control button instead of directly setting the `right` property.
* [`assets/src/blocks/godam-player/style.scss`](diffhunk://#diff-89e92fdab13aad2dda8bfe013f74d8961d1e5fad2e34d617cd41a3d29c67c9caR666-R669): Added a new CSS class `mobile-right-80` to set the `right` property to `80px`.desktop screen size