### PR TITLE
Improve Error Handling and Standardize HTTP Response Codes in Media Library API

### DIFF
--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -55,6 +55,12 @@ export default AttachmentDetailsTwoColumn?.extend( {
 					'X-WP-Nonce': window.wpApiSettings?.nonce || '',
 				},
 			} );
+
+			// Check if the response is anything else than 200, then return null.
+			if ( response.status !== 200 ) {
+				return null;
+			}
+
 			return response.ok ? response.json() : null;
 		} catch {
 			return null;

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -214,7 +214,7 @@ class Media_Library extends Base {
 		$exif_data = exif_read_data( $file_path, 0, true );
 
 		if ( false === $exif_data ) {
-			return new \WP_Error( 'exif_data_not_found', 'No EXIF data found.', array( 'status' => 404 ) );
+			return new \WP_Error( 'exif_data_not_found', 'No EXIF data found.', array( 'status' => 204 ) );
 		}
 
 		// Extract and filter the desired EXIF data fields.
@@ -280,13 +280,13 @@ class Media_Library extends Base {
 		$mime_type = get_post_mime_type( $attachment_id );
 
 		if ( ! preg_match( '/^video\//', $mime_type ) ) {
-			return new \WP_Error( 'invalid_attachment', 'Attachment is not a video.', array( 'status' => 400 ) );
+			return new \WP_Error( 'invalid_attachment', 'Attachment is not a video.', array( 'status' => 404 ) );
 		}
 		
 		$thumbnail_array = get_post_meta( $attachment_id, 'rtgodam_media_thumbnails', true );
 		
 		if ( ! is_array( $thumbnail_array ) ) {
-			return new \WP_Error( 'thumbnails_not_found', 'No thumbnails found.', array( 'status' => 404 ) );
+			return new \WP_Error( 'thumbnails_not_found', 'No thumbnails found.', array( 'status' => 204 ) );
 		}
 
 		if ( function_exists( 'wp_get_upload_dir' ) ) {


### PR DESCRIPTION
This pull request makes changes to improve error handling and HTTP response consistency in the media library's JavaScript and PHP code. 

### Improvements to JavaScript error handling:
* [`assets/src/js/media-library/views/attachment-detail-two-column.js`](diffhunk://#diff-baf11ddd018b8c11df101535039fc6814d08271179373964258e686449e35574R58-R63): Added a check for non-200 HTTP response statuses in `AttachmentDetailsTwoColumn` to ensure the method returns `null` for unexpected responses.

### Standardization of HTTP status codes in the REST API:
* [`inc/classes/rest-api/class-media-library.php`](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104L217-R217): Updated the `get_exif_data` method to return a `204` status code instead of `404` when no EXIF data is found, aligning with the "no content" semantics.
* `inc/classes/rest-api/class-media-library.php`: Updated the `get_video_thumbnails` method to:
  - Return a `404` status code instead of `400` when the attachment is not a video.
  - Return a `204` status code instead of `404` when no thumbnails are found, indicating "no content."