### PR TITLE
Fix/save api key

### DIFF
--- a/admin/class-rtgodam-retranscodemedia.php
+++ b/admin/class-rtgodam-retranscodemedia.php
@@ -54,15 +54,15 @@ class RTGODAM_RetranscodeMedia {
 	 */
 	public function __construct() {
 
-		$this->api_key        = get_site_option( 'rtgodam-api-key' );
-		$this->stored_api_key = get_site_option( 'rtgodam-api-key-stored' );
+		$this->api_key        = get_option( 'rtgodam-api-key' );
+		$this->stored_api_key = get_option( 'rtgodam-api-key-stored' );
 
 		$api_check = rtgodam_verify_api_key( $this->api_key );
 		if ( is_wp_error( $api_check ) ) {
 			return; // Abort initializing retranscoding if api is invalid.
 		}
 
-		$this->usage_info = get_site_option( 'rtgodam-usage' );
+		$this->usage_info = get_option( 'rtgodam-usage' );
 		// Load Rest Endpoints.
 		$this->load_rest_endpoints();
 
@@ -392,7 +392,7 @@ class RTGODAM_RetranscodeMedia {
 				$files     = array();
 
 				// Create the list of image IDs.
-				$usage_info = get_site_option( 'rtgodam-usage' );
+				$usage_info = get_option( 'rtgodam-usage' );
 				$ids        = rtgodam_filter_input( INPUT_GET, 'ids', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				if ( ! empty( $ids ) ) {
 					$media = array_map( 'intval', explode( ',', trim( $ids, ',' ) ) );

--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -51,10 +51,10 @@ class RTGODAM_Transcoder_Admin {
 		}
 
 		// Get the api key key from the site options.
-		$api_key = get_site_option( 'rtgodam-api-key', '' );
+		$api_key = get_option( 'rtgodam-api-key', '' );
 
 		// Get plugin activation time.
-		$activation_time       = get_site_option( 'rtgodam_plugin_activation_time', 0 );
+		$activation_time       = get_option( 'rtgodam_plugin_activation_time', 0 );
 		$days_since_activation = ( time() - $activation_time ) / DAY_IN_SECONDS;
 
 		// If more than 3 days have passed and no api key is activated, show scheduled notice.
@@ -75,7 +75,7 @@ class RTGODAM_Transcoder_Admin {
 		}
 
 		// Get stored usage data.
-		$usage_data = get_site_option( 'rtgodam-usage', array() );
+		$usage_data = get_option( 'rtgodam-usage', array() );
 		$usage_data = isset( $usage_data[ $api_key ] ) ? (array) $usage_data[ $api_key ] : null;
 
 		if ( empty( $usage_data ) ) {

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -113,7 +113,7 @@ class RTGODAM_Transcoder_Handler {
 	 */
 	public function __construct( $no_init = false ) {
 
-		$this->api_key          = get_site_option( 'rtgodam-api-key' );
+		$this->api_key          = get_option( 'rtgodam-api-key' );
 		$this->easydam_settings = get_option( 'rtgodam-settings', array() );
 
 		$default_settings = array(
@@ -149,7 +149,7 @@ class RTGODAM_Transcoder_Handler {
 		}
 
 		if ( $this->api_key ) {
-			$usage_info = get_site_option( 'rtgodam-usage' );
+			$usage_info = get_option( 'rtgodam-usage' );
 
 			if ( isset( $usage_info ) && is_array( $usage_info ) && array_key_exists( $this->api_key, $usage_info ) ) {
 				if ( is_object( $usage_info[ $this->api_key ] ) && isset( $usage_info[ $this->api_key ]->status ) && 'Active' === $usage_info[ $this->api_key ]->status ) {
@@ -367,7 +367,7 @@ class RTGODAM_Transcoder_Handler {
 	public function update_usage( $key ) {
 
 		$response = rtgodam_verify_api_key( $key );
-		update_site_option( 'rtgodam-usage', array( $key => (object) $response['data'] ) );
+		update_option( 'rtgodam-usage', array( $key => (object) $response['data'] ) );
 
 		return $response;
 	}

--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -406,9 +406,10 @@ function rtgodam_verify_api_key( $api_key, $save = false ) {
 		$account_token = $body['message']['account_token'];
 		if ( $save ) {
 			// Save the API key in the site options only if it is verified.
-			update_site_option( 'rtgodam-api-key', $api_key );
-			update_site_option( 'rtgodam-api-key-stored', $api_key );
-			update_site_option( 'rtgodam-account-token', $account_token );
+			update_option( 'rtgodam-api-key', $api_key );
+			update_option( 'rtgodam-api-key-stored', $api_key );
+			update_option( 'rtgodam-account-token', $account_token );
+			delete_option( 'rtgodam_user_data' );
 
 			// Update usage data.
 			$handler = new \RTGODAM_Transcoder_Handler( false );
@@ -552,7 +553,7 @@ function rtgodam_get_localize_array() {
 		$localize_array['author'] = get_the_author();
 	}
 
-	$localize_array['token'] = get_site_option( 'rtgodam-account-token', 'unverified' );
+	$localize_array['token'] = get_option( 'rtgodam-account-token', 'unverified' );
 
 	return $localize_array;
 }

--- a/godam.php
+++ b/godam.php
@@ -117,7 +117,7 @@ add_filter( 'network_admin_plugin_action_links', 'rtgodam_action_links', 11, 2 )
  * Runs when the plugin is activated.
  */
 function rtgodam_plugin_activate() {
-	update_site_option( 'rtgodam_plugin_activation_time', time() );
+	update_option( 'rtgodam_plugin_activation_time', time() );
 }
 
 register_activation_hook( __FILE__, 'rtgodam_plugin_activate' );
@@ -126,7 +126,7 @@ register_activation_hook( __FILE__, 'rtgodam_plugin_activate' );
  * Runs when the plugin is deactivated.
  */
 function rtgodam_plugin_deactivate() {
-	delete_site_option( 'rtgodam_plugin_activation_time' );
+	delete_option( 'rtgodam_plugin_activation_time' );
 }
 
 register_deactivation_hook( __FILE__, 'rtgodam_plugin_deactivate' );

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -357,8 +357,8 @@ class Media_Library_Ajax {
 	 */
 	public function handle_media_deletion( $attachment_id ) {
 		$job_id        = get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true );
-		$account_token = get_site_option( 'rtgodam-account-token', '' );
-		$api_key       = get_site_option( 'rtgodam-api-key', '' );
+		$account_token = get_option( 'rtgodam-account-token', '' );
+		$api_key       = get_option( 'rtgodam-api-key', '' );
 
 		// Ensure all required data is available.
 		if ( empty( $job_id ) || empty( $account_token ) || empty( $api_key ) ) {

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -74,7 +74,7 @@ class Analytics extends Base {
 		// Define API URL for fetching analytics.
 		$analytics_endpoint = RTGODAM_ANALYTICS_BASE . '/processed-analytics/fetch/';
 
-		$account_token = get_site_option( 'rtgodam-account-token', 'unverified' );
+		$account_token = get_option( 'rtgodam-account-token', 'unverified' );
 
 		// Check if API key is valid.
 		if ( empty( $account_token ) || 'unverified' === $account_token ) {

--- a/inc/classes/rest-api/class-settings.php
+++ b/inc/classes/rest-api/class-settings.php
@@ -162,11 +162,11 @@ class Settings extends Base {
 	 */
 	public function deactivate_api_key() {
 		// Delete the API key from the database.
-		$deleted_key   = delete_site_option( 'rtgodam-api-key' );
-		$deleted_token = delete_site_option( 'rtgodam-account-token' );
+		$deleted_key   = delete_option( 'rtgodam-api-key' );
+		$deleted_token = delete_option( 'rtgodam-account-token' );
 		
 		// Delete the user data from the site_option.
-		delete_site_option( 'rtgodam_user_data' );
+		delete_option( 'rtgodam_user_data' );
 
 		if ( $deleted_key || $deleted_token ) {
 			return new \WP_REST_Response(
@@ -193,7 +193,7 @@ class Settings extends Base {
 	 * @return \WP_REST_Response
 	 */
 	public function get_api_key() {
-		$api_key = get_site_option( 'rtgodam-api-key', '' );
+		$api_key = get_option( 'rtgodam-api-key', '' );
 
 		return new \WP_REST_Response(
 			array(

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -242,10 +242,9 @@ function rtgodam_get_user_data( $timeout = 300 ) {
 
 		if ( ! is_wp_error( $usage_data ) ) {
 			$rtgodam_user_data = array_merge( $rtgodam_user_data, $usage_data );
-		} else if ( ! $valid_api_key ) {
+		} elseif ( ! $valid_api_key ) {
 			$rtgodam_user_data['storageBandwidthError'] = __( 'Oops! It looks like your API key is incorrect or has expired. Please update it and try again.', 'godam' );
-		}
-		else {
+		} else {
 			$rtgodam_user_data['storageBandwidthError'] = $usage_data->get_error_message();
 		}
 

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -209,10 +209,11 @@ function rtgodam_image_cta_html( $layer ) {
  * @param int $timeout The time in seconds after which the user data should be refreshed.
  */
 function rtgodam_get_user_data( $timeout = 300 ) {
-	$rtgodam_user_data = get_site_option( 'rtgodam_user_data', false );
-	$api_key           = get_site_option( 'rtgodam-api-key', '' );
+	$rtgodam_user_data = get_option( 'rtgodam_user_data', false );
+	$api_key           = get_option( 'rtgodam-api-key', '' );
 
 	if (
+		empty( $rtgodam_user_data ) ||
 		( empty( $rtgodam_user_data ) && ! empty( $api_key ) ) ||
 		( isset( $rtgodam_user_data['timestamp'] ) && ( time() - $rtgodam_user_data['timestamp'] ) > $timeout )
 	) {
@@ -241,14 +242,17 @@ function rtgodam_get_user_data( $timeout = 300 ) {
 
 		if ( ! is_wp_error( $usage_data ) ) {
 			$rtgodam_user_data = array_merge( $rtgodam_user_data, $usage_data );
-		} else {
+		} else if ( ! $valid_api_key ) {
+			$rtgodam_user_data['storageBandwidthError'] = __( 'Oops! It looks like your API key is incorrect or has expired. Please update it and try again.', 'godam' );
+		}
+		else {
 			$rtgodam_user_data['storageBandwidthError'] = $usage_data->get_error_message();
 		}
 
 		$rtgodam_user_data['timestamp'] = time();
 
 		// Save the userData in wp_options.
-		update_site_option( 'rtgodam_user_data', $rtgodam_user_data );
+		update_option( 'rtgodam_user_data', $rtgodam_user_data );
 	}
 
 	return $rtgodam_user_data;
@@ -261,7 +265,7 @@ function rtgodam_get_user_data( $timeout = 300 ) {
  */
 function rtgodam_get_usage_data() {
 
-	$api_key = get_site_option( 'rtgodam-api-key', '' );
+	$api_key = get_option( 'rtgodam-api-key', '' );
 
 	if ( empty( $api_key ) ) {
 		return new \WP_Error( 'rtgodam_api_error', 'API key not found ( try refreshing the page )' );

--- a/pages/godam/App.js
+++ b/pages/godam/App.js
@@ -89,6 +89,16 @@ const App = () => {
 				}
 
 				setMediaSettings( settingsData );
+
+				const hash = window.location.hash;
+				if ( hash ) {
+					const tabId = hash.substring( 1 ); // Remove the '#' from the hash.
+					const validTab = tabs.find( ( tab ) => tab.id === tabId );
+
+					if ( validTab ) {
+						setActiveTab( tabId );
+					}
+				}
 			} catch ( error ) {
 				console.error( 'Failed to fetch data:', error );
 			} finally {
@@ -98,17 +108,6 @@ const App = () => {
 
 		fetchSettings();
 	}, [ dispatch ] );
-
-	useEffect( () => {
-		const hash = window.location.hash;
-		if ( hash ) {
-			const tabId = hash.substring( 1 ); // Remove the '#' from the hash.
-			const validTab = tabs.find( ( tab ) => tab.id === tabId );
-			if ( validTab ) {
-				setActiveTab( tabId );
-			}
-		}
-	}, [] );
 
 	const saveMediaSettings = async ( updatedSettings ) => {
 		try {
@@ -162,7 +161,7 @@ const App = () => {
 						<div className="w-full">
 							{
 								tabs.map( ( tab ) => (
-									activeTab === tab.id &&
+									activeTab === tab.id && (
 										<tab.component
 											key={ tab.id }
 											isPremiumUser={ isPremiumUser }
@@ -172,6 +171,7 @@ const App = () => {
 											setAPIKey={ setAPIKey }
 											verifyAPIKeyFromURL={ verifyAPIKeyFromURL }
 										/>
+									)
 								) )
 							}
 						</div>

--- a/pages/godam/GeneralSettings.js
+++ b/pages/godam/GeneralSettings.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { ToggleControl, Button, Notice, Panel, PanelBody, ColorPicker } from '@wordpress/components';
+import { ToggleControl, Button, Notice, Panel, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
 /**
  * External dependencies
  */

--- a/pages/godam/VideoSettings.js
+++ b/pages/godam/VideoSettings.js
@@ -261,6 +261,12 @@ const VideoSettings = ( { isPremiumUser, mediaSettings, apiKey, setAPIKey, saveM
 	const isValidAPIKey = window.userData?.valid_api_key;
 	const isStarterPlan = window.userData?.user_data?.active_plan === 'Starter';
 
+	// Allowed user with starte plan to use watermark
+	const allowWatermark = isValidAPIKey;
+
+	// Note: To disable watermark for starter plan uncomment the below line.
+	// const allowWatermark = isValidAPIKey && ! isStarterPlan;
+
 	const [ isDirty, setIsDirty ] = useState( false );
 
 	useEffect( () => {
@@ -622,7 +628,7 @@ const VideoSettings = ( { isPremiumUser, mediaSettings, apiKey, setAPIKey, saveM
 
 				<div className="relative">
 					{
-						( ! isValidAPIKey || isStarterPlan ) && (
+						( ! allowWatermark ) && (
 							<div className="premium-feature-overlay">
 								<Button icon={ unlock } href="https://app.godam.io/subscription/plans" target="_blank" variant="primary">{ __( 'Upgrade to unlock', 'godam' ) }</Button>
 							</div>
@@ -641,12 +647,12 @@ const VideoSettings = ( { isPremiumUser, mediaSettings, apiKey, setAPIKey, saveM
 								<ToggleControl
 									__nextHasNoMarginBottom
 									label="Disable video watermark"
-									checked={ ( ! isValidAPIKey || isStarterPlan ) ? false : disableWatermark }
+									checked={ ! allowWatermark ? false : disableWatermark }
 									onChange={ ( value ) => setDisableWatermark( value ) }
-									disabled={ isStarterPlan || ! isValidAPIKey }
+									disabled={ ! allowWatermark }
 									help={ __( 'If enabled, GoDAM will add a watermark to the transcoded video', 'godam' ) }
 								/>
-								{ ! isStarterPlan && ! disableWatermark && (
+								{ allowWatermark && ! disableWatermark && (
 									<>
 										<div>
 											<ToggleControl


### PR DESCRIPTION
## Resolve API Key Save and Settings Storage Issues
**Fixes:**
- Addressed an edge case where users couldn't save a new API key if the previous one had expired.
- Corrected the settings storage mechanism to ensure data is saved per site instead of network-wide, preventing conflicts between sites in a multisite setup.
- Enabled the watermark feature for users on the Starter plan.