### PR TITLE
Add default controls for video player if not set from video-editor page

### DIFF
--- a/assets/src/blocks/godam-player/frontend.js
+++ b/assets/src/blocks/godam-player/frontend.js
@@ -69,6 +69,22 @@ function GODAMPlayer( videoRef = null ) {
 				preview: false,
 			};
 
+		if ( ! ( 'controlBar' in videoSetupControls ) ) {
+			videoSetupControls.controlBar = {
+				playToggle: true,
+				volumePanel: true,
+				currentTimeDisplay: true,
+				timeDivider: true,
+				durationDisplay: true,
+				fullscreenToggle: true,
+				subsCapsButton: true,
+				skipButtons: {
+					forward: 10,
+					backward: 10,
+				},
+			};
+		}
+
 		const isPreviewEnabled = videoSetupOptions?.preview;
 
 		const player = videojs( video, videoSetupControls );


### PR DESCRIPTION

Add default video controls, if not added by `Video Editor > Player Settings`
<img width="536" alt="Screenshot 2025-04-22 at 5 02 13 PM" src="https://github.com/user-attachments/assets/8cbba967-8469-411c-b416-838deff30492" />
