### PR TITLE
Minor fixes to single analytics screen

### DIFF
--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -16,6 +16,7 @@ import {
 	useFetchProcessedAnalyticsHistoryQuery,
 } from './redux/api/analyticsApi';
 import { calculateEngagementRate, calculatePlayRate } from './helper';
+import DOMPurify from 'isomorphic-dompurify';
 
 /**
  * WordPress dependencies
@@ -214,13 +215,6 @@ const Analytics = ( { attachmentID } ) => {
 		return 'left-greater right-greater';
 	};
 
-	function decodeHtmlCharCodes( text ) {
-		// Create a temporary DOM element
-		const textarea = document.createElement( 'textarea' );
-		textarea.innerHTML = text;
-		return textarea.value;
-	}
-
 	return (
 		<div className="godam-analytics-container">
 			<GodamHeader />
@@ -248,8 +242,7 @@ const Analytics = ( { attachmentID } ) => {
 			{ attachmentData && (
 				<div id="analytics-content" className="hidden">
 					<div className="p-10 flex gap-3 items-center">
-						<h2 className="text-2xl m-0 capitalize">
-							{ decodeHtmlCharCodes( attachmentData?.title?.rendered ) }
+						<h2 className="text-2xl m-0 capitalize" dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( attachmentData?.title?.rendered ) } }>
 						</h2>
 						{ attachmentData?.media_details?.length_formatted &&
 							<span className="h-[26px] px-2 bg-white flex items-center rounded-sm">

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -214,6 +214,13 @@ const Analytics = ( { attachmentID } ) => {
 		return 'left-greater right-greater';
 	};
 
+	function decodeHtmlCharCodes( text ) {
+		// Create a temporary DOM element
+		const textarea = document.createElement( 'textarea' );
+		textarea.innerHTML = text;
+		return textarea.value;
+	}
+
 	return (
 		<div className="godam-analytics-container">
 			<GodamHeader />
@@ -242,11 +249,13 @@ const Analytics = ( { attachmentID } ) => {
 				<div id="analytics-content" className="hidden">
 					<div className="p-10 flex gap-3 items-center">
 						<h2 className="text-2xl m-0 capitalize">
-							{ attachmentData?.title?.rendered }
+							{ decodeHtmlCharCodes( attachmentData?.title?.rendered ) }
 						</h2>
-						<span className="h-[26px] px-2 bg-white flex items-center rounded-sm">
-							{ attachmentData?.media_details?.length_formatted }
-						</span>
+						{ attachmentData?.media_details?.length_formatted &&
+							<span className="h-[26px] px-2 bg-white flex items-center rounded-sm">
+								{ attachmentData?.media_details?.length_formatted }
+							</span>
+						}
 					</div>
 
 					<div className="subheading-container">


### PR DESCRIPTION
1. Fix special characters in title
2. Prevent rendering duration if not available

Before:
![image](https://github.com/user-attachments/assets/a7ab36a5-b2cb-40a6-bf86-1da8a1398ab0)

After:
<img width="727" alt="image" src="https://github.com/user-attachments/assets/ea576516-3d61-4492-84f1-cedb939e8351" />