### PR TITLE
Add PHP setup and POT file generation steps to release workflow

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -17,6 +17,17 @@ jobs:
       run: |
         npm install
         npm run build:prod
+
+    - name: Setup PHP with composer v2
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        tools: composer:v2
+
+    - name: Generate POT file
+      shell: bash
+      run: composer run pot
+
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@2.3.0


### PR DESCRIPTION
This pull request updates the `.github/workflows/release_on_tag.yml` file to enhance the release process by adding steps for setting up PHP and generating a POT file.

Enhancements to the release workflow:

* Added a step to set up PHP 8.4 with Composer v2 using the `shivammathur/setup-php@v2` action.
* Included a step to generate a POT file by running `composer run pot` with a Bash shell.