### PR TITLE
Fix the breaking styles for video block and video-editor

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -337,51 +337,56 @@ function VideoEdit( {
 						setAttributes={ setAttributes }
 						attributes={ attributes }
 					/>
-					<MediaUploadCheck>
-						<div className="editor-video-poster-control">
-							<BaseControl.VisualLabel>
-								{ __( 'Poster image', 'godam' ) }
-							</BaseControl.VisualLabel>
-							<MediaUpload
-								title={ __( 'Select poster image', 'godam' ) }
-								onSelect={ onSelectPoster }
-								allowedTypes={ VIDEO_POSTER_ALLOWED_MEDIA_TYPES }
-								render={ ( { open } ) => (
+					<BaseControl
+						id={ `video-block__poster-image-${ instanceId }` }
+						label={ __( 'Poster image', 'godam' ) }
+						__nextHasNoMarginBottom
+					>
+						<MediaUploadCheck>
+							<div className="editor-video-poster-control">
+								<MediaUpload
+									title={ __( 'Select poster image', 'godam' ) }
+									onSelect={ onSelectPoster }
+									allowedTypes={ VIDEO_POSTER_ALLOWED_MEDIA_TYPES }
+									render={ ( { open } ) => (
+										<Button
+											__next40pxDefaultSize
+											variant="primary"
+											onClick={ open }
+											ref={ posterImageButton }
+											aria-describedby={ videoPosterDescription }
+										>
+											{ ! poster ? __( 'Select', 'godam' ) : __( 'Replace', 'godam' ) }
+										</Button>
+									) }
+								/>
+								<p id={ videoPosterDescription } hidden>
+									{ poster
+										? sprintf(
+											/* translators: %s: poster image URL. */
+											__( 'The current poster image url is %s', 'godam' ),
+											poster,
+										)
+										: __( 'There is no poster image currently selected', 'godam' ) }
+								</p>
+								{ !! poster && (
 									<Button
 										__next40pxDefaultSize
-										variant="primary"
-										onClick={ open }
-										ref={ posterImageButton }
-										aria-describedby={ videoPosterDescription }
+										onClick={ onRemovePoster }
+										variant="tertiary"
 									>
-										{ ! poster ? __( 'Select', 'godam' ) : __( 'Replace', 'godam' ) }
+										{ __( 'Remove', 'godam' ) }
 									</Button>
 								) }
-							/>
-							<p id={ videoPosterDescription } hidden>
-								{ poster
-									? sprintf(
-										/* translators: %s: poster image URL. */
-										__( 'The current poster image url is %s', 'godam' ),
-										poster,
-									)
-									: __( 'There is no poster image currently selected', 'godam' ) }
-							</p>
-							{ !! poster && (
-								<Button
-									__next40pxDefaultSize
-									onClick={ onRemovePoster }
-									variant="tertiary"
-								>
-									{ __( 'Remove', 'godam' ) }
-								</Button>
-							) }
-						</div>
-					</MediaUploadCheck>
-					<div className="editor-video-customisation-cta">
-						<BaseControl.VisualLabel>
-							{ __( 'Customise Video', 'godam' ) }
-						</BaseControl.VisualLabel>
+							</div>
+						</MediaUploadCheck>
+					</BaseControl>
+
+					<BaseControl
+						id={ `video-block__video-editor-${ instanceId }` }
+						label={ __( 'Customise Video', 'godam' ) }
+						__nextHasNoMarginBottom
+					>
 						<Button
 							__next40pxDefaultSize
 							href={ `${ window?.pluginInfo?.adminUrl }admin.php?page=rtgodam_video_editor&id=${ id }` }
@@ -393,18 +398,25 @@ function VideoEdit( {
 						>
 							{ __( 'Customise', 'godam' ) }
 						</Button>
-					</div>
+					</BaseControl>
 
-					<Button
-						__next40pxDefaultSize
-						onClick={ () => setIsSEOModelOpen( true ) }
-						variant="primary"
-						className="editor-video-customisation-cta"
-						icon={ search }
-						iconPosition="right"
+					<BaseControl
+						id={ `video-block__video-seo-${ instanceId }` }
+						label={ __( 'SEO Settings', 'godam' ) }
+						__nextHasNoMarginBottom
 					>
-						{ __( 'SEO Settings', 'godam' ) }
-					</Button>
+						<Button
+							__next40pxDefaultSize
+							onClick={ () => setIsSEOModelOpen( true ) }
+							variant="primary"
+							className="editor-video-customisation-cta"
+							icon={ search }
+							iconPosition="right"
+						>
+							{ __( 'SEO Settings', 'godam' ) }
+						</Button>
+					</BaseControl>
+
 				</PanelBody>
 			</InspectorControls>
 

--- a/pages/video-editor/App.js
+++ b/pages/video-editor/App.js
@@ -8,7 +8,7 @@ import React, { useEffect, useState } from 'react';
  */
 import VideoEditor from './VideoEditor';
 import './style.scss';
-import '../../assets/build/css/godam-player.css';
+import '../../assets/src/css/godam-player.scss';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
This pull request refactors the `VideoEdit` component in `godam-player` to improve code readability and maintainability by restructuring `BaseControl` usage. Additionally, it updates a CSS import in the `video-editor` app to align with the project's file structure.

### Refactoring of `VideoEdit` component:

* Replaced `BaseControl.VisualLabel` with `BaseControl` components for better semantic structure and consistent styling:
  - Added `BaseControl` for the "Poster image" section, moving the label directly into the control.
  - Added `BaseControl` for the "Customise Video" section, replacing the previous `div` wrapper.
  - Added `BaseControl` for the "SEO Settings" section, improving consistency with other controls. [[1]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L396-R407) [[2]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66R418-R419)

### CSS import update:

* Updated the CSS import in `pages/video-editor/App.js` to use the SCSS source file (`godam-player.scss`) instead of the pre-built CSS file, enabling easier customization and alignment with SCSS workflows.