### PR TITLE
chore: add requires at least plugin header

### DIFF
--- a/godam.php
+++ b/godam.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and optimize digital assets with GoDAM – featuring transcoding, adaptive streaming, interactive video layers, gravity forms integration, and ad integration.
  * Version: 1.1.0
+ * Requires at least: 6.5
  * Text Domain: godam
  * Author: rtCamp
  * Author URI: https://rtcamp.com/?utm_source=dashboard&utm_medium=plugin&utm_campaign=godam


### PR DESCRIPTION
This PR adds the missing `Requires at least` plugin header in the main plugin file.

Reference: https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields

Closes #402 