### PR TITLE
Hotfix/wpforms

### DIFF
--- a/admin/class-rtgodam-retranscodemedia.php
+++ b/admin/class-rtgodam-retranscodemedia.php
@@ -124,7 +124,7 @@ class RTGODAM_RetranscodeMedia {
 			$this->capability,
 			'rtgodam_tools',
 			array( $this, 'render_tools_page' ),
-			4
+			3
 		);
 	}
 

--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -172,7 +172,7 @@ class RTGODAM_Transcoder_Admin {
 		$logo_url = plugins_url( 'assets/src/images/godam-logo.png', __DIR__ );
 
 		$button_label = ( 'activate' === $button_type ) ? esc_html__( 'Activate API Key', 'godam' ) : esc_html__( 'Use Video Editor', 'godam' );
-		$button_link  = ( 'activate' === $button_type ) ? admin_url( 'admin.php?page=rtgodam' ) : admin_url( 'admin.php?page=rtgodam_video_editor' );
+		$button_link  = ( 'activate' === $button_type ) ? admin_url( 'admin.php?page=rtgodam_settings' ) : admin_url( 'admin.php?page=rtgodam_video_editor' );
 
 		?>
 		<div class="notice notice-<?php echo esc_attr( $notice_type ); ?> is-dismissible rt-transcoder-api-key-notice">
@@ -231,7 +231,7 @@ class RTGODAM_Transcoder_Admin {
 					<p><strong><?php echo esc_html__( 'Hey, you’re missing out on our advanced features!', 'godam' ); ?></strong></p>
 					<p><?php echo esc_html__( 'Unlock high-speed transcoding, advanced analytics, adaptive streaming, and more by activating your API key.', 'godam' ); ?></p>
 					<p>
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtgodam' ) ); ?>" class="button button-primary">
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=rtgodam_settings' ) ); ?>" class="button button-primary">
 							<?php echo esc_html__( 'Activate API Key', 'godam' ); ?>
 						</a>
 						<a href="https://godam.io/adaptive-bitrate-streaming/" class="button button-secondary" target="_blank">

--- a/godam.php
+++ b/godam.php
@@ -98,7 +98,7 @@ function rtgodam_action_links( $links, $file ) {
 	// Add a few links to the existing links array.
 	$settings_url = sprintf(
 		'<a href="%1$s">%2$s</a>',
-		esc_url( admin_url( 'admin.php?page=rtgodam' ) ),
+		esc_url( admin_url( 'admin.php?page=rtgodam_settings' ) ),
 		esc_html__( 'Settings', 'godam' )
 	);
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -145,7 +145,6 @@ class Pages {
 			3
 		);
 
-
 		add_submenu_page(
 			$this->menu_slug,
 			__( 'Analytics', 'godam' ),
@@ -163,9 +162,9 @@ class Pages {
 			'edit_posts',
 			$this->settings_slug,
 			array( $this, 'render_godam_page' ),
-			7
+			6
 		);
-		
+
 		add_submenu_page(
 			$this->menu_slug,
 			__( 'Help', 'godam' ),
@@ -173,7 +172,7 @@ class Pages {
 			'edit_posts',
 			$this->help_slug,
 			array( $this, 'render_help_page' ),
-			8
+			7
 		);
 	}
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -51,7 +51,7 @@ class Pages {
 	 *
 	 * @var string
 	 */
-	private $dashboard_slug = 'rtgodam_dashboard';
+	private $settings_slug = 'rtgodam_settings';
 
 	/**
 	 * Menu pag ID.
@@ -86,7 +86,7 @@ class Pages {
 	 *
 	 * @var string
 	 */
-	private $dashboard_page_id = 'godam_page_rtgodam_dashboard';
+	private $settings_page_id = 'godam_page_rtgodam_settings';
 
 	/**
 	 * Construct method.
@@ -120,25 +120,17 @@ class Pages {
 			__( 'GoDAM', 'godam' ),
 			'manage_options',
 			$this->menu_slug,
-			array( $this, 'render_godam_page' ),
+			array( $this, 'render_dashboard_page' ),
 			'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTI1LjU1NzggMjAuMDkxMUw4LjA1NTg3IDM3LjU5M0wzLjQ2Mzk3IDMzLjAwMTFDMC44MTg1MjEgMzAuMzU1NiAyLjA4MjEgMjUuODMzNiA1LjcyMjI4IDI0Ljk0NjRMMjUuNTYzMiAyMC4wOTY0TDI1LjU1NzggMjAuMDkxMVoiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik00Ny4zNzczIDIxLjg4NjdMNDUuNTQzOCAyOS4zODc1TDIyLjY5NzIgNTIuMjM0MUwxMS4yNjA1IDQwLjc5NzRMMzQuMTY2MiAxNy44OTE2TDQxLjU3MDMgMTYuMDc5NkM0NS4wNzA2IDE1LjIyNDcgNDguMjMyMyAxOC4zODYzIDQ3LjM3MiAyMS44ODEzTDQ3LjM3NzMgMjEuODg2N1oiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik00My41MDU5IDM4LjEwMzZMMzguNjY2NyA1Ny44OTA3QzM3Ljc3NDEgNjEuNTI1NSAzMy4yNTIxIDYyLjc4OTEgMzAuNjA2NiA2MC4xNDM2TDI2LjAzNjMgNTUuNTczMkw0My41MDU5IDM4LjEwMzZaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K',
 			30
 		);
 
 		add_submenu_page(
 			$this->menu_slug,
-			__( 'Settings', 'godam' ),
-			__( 'Settings', 'godam' ),
+			__( 'Dashboard', 'godam' ),
+			__( 'Dashboard', 'godam' ),
 			'manage_options',
 			$this->menu_slug,
-		);
-
-		add_submenu_page(
-			$this->menu_slug,
-			__( 'Dashboard', 'godam' ),
-			__( 'Dashboard', 'godam' ),
-			'edit_posts',
-			$this->dashboard_slug,
 			array( $this, 'render_dashboard_page' ),
 			1
 		);
@@ -153,6 +145,7 @@ class Pages {
 			3
 		);
 
+
 		add_submenu_page(
 			$this->menu_slug,
 			__( 'Analytics', 'godam' ),
@@ -164,13 +157,23 @@ class Pages {
 		);
 
 		add_submenu_page(
-			'rtgodam',
+			$this->menu_slug,
+			__( 'Settings', 'godam' ),
+			__( 'Settings', 'godam' ),
+			'edit_posts',
+			$this->settings_slug,
+			array( $this, 'render_godam_page' ),
+			7
+		);
+		
+		add_submenu_page(
+			$this->menu_slug,
 			__( 'Help', 'godam' ),
 			__( 'Help', 'godam' ),
 			'edit_posts',
 			$this->help_slug,
 			array( $this, 'render_help_page' ),
-			5
+			8
 		);
 	}
 
@@ -195,7 +198,7 @@ class Pages {
 		$screen = get_current_screen();
 
 		// Check if this is your custom admin page.
-		if ( $screen && in_array( $screen->id, array( $this->menu_page_id, $this->video_editor_page_id, $this->analytics_page_id, $this->help_page_id, $this->dashboard_page_id ) ) ) {
+		if ( $screen && in_array( $screen->id, array( $this->menu_page_id, $this->video_editor_page_id, $this->analytics_page_id, $this->help_page_id, $this->settings_page_id ) ) ) {
 			// Remove admin notices.
 			remove_all_actions( 'admin_notices' );
 			remove_all_actions( 'all_admin_notices' );
@@ -309,7 +312,7 @@ class Pages {
 	public function admin_enqueue_scripts() {
 		$screen = get_current_screen();
 
-		if ( $screen && in_array( $screen->id, array( $this->menu_page_id, $this->video_editor_page_id, $this->analytics_page_id, $this->dashboard_page_id, $this->help_page_id ), true ) ) {
+		if ( $screen && in_array( $screen->id, array( $this->menu_page_id, $this->video_editor_page_id, $this->analytics_page_id, $this->settings_page_id, $this->help_page_id ), true ) ) {
 
 			wp_register_script(
 				'rtgodam-page-style',
@@ -427,27 +430,48 @@ class Pages {
 				);
 			}
 		} elseif ( $screen && $this->menu_page_id === $screen->id ) {
-
 			wp_register_script(
-				'transcoder-page-script-godam',
-				RTGODAM_URL . 'assets/build/pages/godam.min.js',
-				array( 'wp-element', 'wp-i18n' ),
-				filemtime( RTGODAM_PATH . 'assets/build/pages/godam.min.js' ),
+				'd3-js',
+				RTGODAM_URL . '/assets/src/libs/d3.js',
+				array(),
+				RTGODAM_VERSION,
+				false
+			);
+			
+			wp_register_script(
+				'godam-page-script-dashboard',
+				RTGODAM_URL . 'assets/build/pages/dashboard.min.js',
+				array( 'wp-element' ),
+				filemtime( RTGODAM_PATH . 'assets/build/pages/dashboard.min.js' ),
 				true
 			);
 
 			$rtgodam_user_data = rtgodam_get_user_data();
 
-			if ( ! empty( $rtgodam_user_data ) ) {
-				wp_localize_script(
-					'transcoder-page-script-godam',
-					'userData',
-					$rtgodam_user_data
-				);
-			}
+			wp_localize_script(
+				'godam-page-script-dashboard',
+				'userData',
+				$rtgodam_user_data
+			);
 
-			wp_set_script_translations( 'transcoder-page-script-godam', 'godam', RTGODAM_PATH . 'languages' );
-			wp_enqueue_script( 'transcoder-page-script-godam' );
+			wp_localize_script(
+				'godam-page-script-dashboard',
+				'videoData',
+				array(
+					'adminUrl' => admin_url( 'admin.php?page=rtgodam_settings#video-settings' ),
+				)
+			);
+
+			wp_localize_script(
+				'godam-page-script-dashboard',
+				'godamPluginData',
+				array(
+					'flagBasePath' => RTGODAM_URL . 'assets/src/images/flags',
+				)
+			);
+
+			wp_enqueue_script( 'godam-page-script-dashboard' );
+			wp_enqueue_script( 'd3-js' );
 
 		} elseif ( $screen && $this->analytics_page_id === $screen->id ) {
 
@@ -482,7 +506,7 @@ class Pages {
 					'nonce'            => wp_create_nonce( 'wp_rest' ),     // WordPress nonce for API requests.
 					'currentUserId'    => get_current_user_id(),            // Current user ID.
 					'currentUserRoles' => wp_get_current_user()->roles,     // Current user roles.
-					'adminUrl'         => admin_url( 'admin.php?page=rtgodam#video-settings' ),
+					'adminUrl'         => admin_url( 'admin.php?page=rtgodam_settings#video-settings' ),
 				)
 			);
 
@@ -523,50 +547,27 @@ class Pages {
 
 			wp_set_script_translations( 'godam-page-script-help', 'godam', RTGODAM_PATH . 'languages' );
 			wp_enqueue_script( 'godam-page-script-help' );
-		} elseif ( $screen && $this->dashboard_page_id === $screen->id ) {
-
+		} elseif ( $screen && $this->settings_page_id === $screen->id ) {
 			wp_register_script(
-				'd3-js',
-				RTGODAM_URL . '/assets/src/libs/d3.js',
-				array(),
-				RTGODAM_VERSION,
-				false
-			);
-			
-			wp_register_script(
-				'godam-page-script-dashboard',
-				RTGODAM_URL . 'assets/build/pages/dashboard.min.js',
-				array( 'wp-element' ),
-				filemtime( RTGODAM_PATH . 'assets/build/pages/dashboard.min.js' ),
+				'transcoder-page-script-godam',
+				RTGODAM_URL . 'assets/build/pages/godam.min.js',
+				array( 'wp-element', 'wp-i18n' ),
+				filemtime( RTGODAM_PATH . 'assets/build/pages/godam.min.js' ),
 				true
 			);
 
 			$rtgodam_user_data = rtgodam_get_user_data();
 
-			wp_localize_script(
-				'godam-page-script-dashboard',
-				'userData',
-				$rtgodam_user_data
-			);
+			if ( ! empty( $rtgodam_user_data ) ) {
+				wp_localize_script(
+					'transcoder-page-script-godam',
+					'userData',
+					$rtgodam_user_data
+				);
+			}
 
-			wp_localize_script(
-				'godam-page-script-dashboard',
-				'videoData',
-				array(
-					'adminUrl' => admin_url( 'admin.php?page=rtgodam#video-settings' ),
-				)
-			);
-
-			wp_localize_script(
-				'godam-page-script-dashboard',
-				'godamPluginData',
-				array(
-					'flagBasePath' => RTGODAM_URL . 'assets/src/images/flags',
-				)
-			);
-
-			wp_enqueue_script( 'godam-page-script-dashboard' );
-			wp_enqueue_script( 'd3-js' );
+			wp_set_script_translations( 'transcoder-page-script-godam', 'godam', RTGODAM_PATH . 'languages' );
+			wp_enqueue_script( 'transcoder-page-script-godam' );
 		}
 
 		wp_enqueue_style( 'wp-components' );

--- a/inc/classes/rest-api/class-wpforms.php
+++ b/inc/classes/rest-api/class-wpforms.php
@@ -9,6 +9,8 @@
 
 namespace RTGODAM\Inc\REST_API;
 
+use WP_Query;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -21,6 +23,18 @@ class WPForms extends Base {
 	 */
 	public function get_rest_routes() {
 		return array(
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/wpforms',
+				'args'      => array(
+					array(
+						'methods'             => \WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_gforms' ),
+						'permission_callback' => '__return_true',
+						'args'                => $this->get_collection_params(),
+					),
+				),
+			),
 			array(
 				'namespace' => $this->namespace,
 				'route'     => '/' . $this->rest_base . '/wpform',
@@ -49,6 +63,71 @@ class WPForms extends Base {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Get all WPForms.
+	 *
+	 * @param \WP_REST_Request $request Request Object.
+	 * @return \WP_REST_Response
+	 */
+	public function get_gforms( $request ) {
+		// Check if WPForms plugin is active.
+		$is_wpforms_active = is_plugin_active( 'wpforms-lite/wpforms.php' ) || is_plugin_active( 'wpforms/wpforms.php' );
+		if ( ! $is_wpforms_active ) {
+			return new \WP_Error( 'wpforms_not_active', __( 'WPForms plugin is not active.', 'godam' ), array( 'status' => 404 ) );
+		}
+
+		$wpforms = get_posts(
+			array(
+				'post_type'      => 'wpforms',
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+				'include'        => array(
+					'ID',
+					'post_title',
+					'post_excerpt',
+				),
+			),
+		);
+
+		// Fetch all WPForms in a paginated manner.
+		// Using pagination to avoid memory issues with large datasets.
+		$paged    = 1;
+		$per_page = 50;
+		$forms    = array();
+
+		do {
+			$query = new WP_Query(
+				array(
+					'post_type'      => 'wpforms',
+					'posts_per_page' => $per_page,
+					'paged'          => $paged,
+					'post_status'    => 'publish',
+				)
+			);
+
+			if ( ! empty( $query->posts ) ) {
+				$forms = array_merge( $forms, $query->posts );
+				++$paged;
+			} else {
+				break;
+			}
+		} while ( true );
+
+		$wpforms = array();
+
+		if ( ! empty( $forms ) && ! is_wp_error( $forms ) ) {
+			foreach ( $forms as $form ) {
+				$wpforms[] = array(
+					'id'          => $form->ID,
+					'title'       => $form->post_title,
+					'description' => $form->post_excerpt,
+				);
+			}
+		}
+
+		return rest_ensure_response( $wpforms );
 	}
 
 	/**

--- a/pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx
@@ -10,7 +10,7 @@ import { Panel, PanelBody, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const QUALITY_OPTIONS = [
-	{ label: __( 'No compression' ), value: 100 },
+	{ label: __( 'Highest quality' ), value: 100 },
 	{ label: __( 'High quality', 'godam' ), value: 80 },
 	{ label: __( 'Medium quality', 'godam' ), value: 60 },
 	{ label: __( 'Low quality', 'godam' ), value: 40 },

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { hasValidAPIKey, isOnStarterPlan } from '../../../utils';
+import { hasValidAPIKey } from '../../../utils';
 
 const VideoWatermark = ( { handleSettingChange } ) => {
 	const useImage = useSelector( ( state ) => state.mediaSettings.video.use_watermark_image );
@@ -45,7 +45,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 
 	return (
 		<div className="relative">
-			{ ( hasValidAPIKey && isOnStarterPlan ) && (
+			{ ! hasValidAPIKey && (
 				<div className="premium-feature-overlay">
 					<Button
 						className="godam-button"
@@ -69,16 +69,16 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 							className="godam-toggle"
 							label={ __( 'Enable video watermark', 'godam' ) }
 							checked={
-								! hasValidAPIKey || isOnStarterPlan ? false : enableWatermark
+								! hasValidAPIKey ? false : enableWatermark
 							}
 							onChange={ ( value ) => handleSettingChange( 'watermark', value ) }
-							disabled={ isOnStarterPlan || ! hasValidAPIKey }
+							disabled={ ! hasValidAPIKey }
 							help={ __(
 								'If enabled, GoDAM will add a watermark to the transcoded video',
 								'godam',
 							) }
 						/>
-						{ ! isOnStarterPlan && enableWatermark && (
+						{ enableWatermark && (
 							<>
 								<div>
 									<ToggleControl

--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -118,13 +118,7 @@ const VideoEditor = ( { attachmentID } ) => {
 			}
 
 			if ( wpForms && wpForms.length > 0 ) {
-				const _wpForms = wpForms.map( ( form ) => {
-					return {
-						id: form.ID,
-						title: form.post_title,
-					};
-				} );
-				dispatch( setWPForms( _wpForms ) );
+				dispatch( setWPForms( wpForms ) );
 			}
 
 			if ( gravityForms && gravityForms.length > 0 ) {

--- a/pages/video-editor/redux/api/wpforms.js
+++ b/pages/video-editor/redux/api/wpforms.js
@@ -17,7 +17,7 @@ export const wpFormsApi = createApi( {
 	endpoints: ( builder ) => ( {
 		getWPForms: builder.query( {
 			query: () => ( {
-				url: '/wpforms/v1/forms',
+				url: '/godam/v1/wpforms',
 				method: 'GET',
 			} ),
 		} ),


### PR DESCRIPTION
## Added quick fixes for GoDAM release v1.1.3
    
    1. Enable the watermark for the starter plan
    2. Change the video text from 'No Compression' to 'Highest quality'
    3. Implement custom REST API endpoint to fetch a list of WPForms, eventually fix the WPForms issues in the video editor
    4. Change the order of admin pages and replace the update links all across the codebase