### PR TITLE
fix: correct casing of play button position name in select control

### DIFF
--- a/pages/video-editor/components/appearance/Appearance.js
+++ b/pages/video-editor/components/appearance/Appearance.js
@@ -109,6 +109,7 @@ const Appearance = () => {
 				controlBar: {
 					...videoConfig.controlBar,
 					playButtonPosition: e.selectedItem.key,
+					playButtonPositionName: e.selectedItem.name,
 				},
 			} ),
 		);
@@ -374,7 +375,7 @@ const Appearance = () => {
 						] }
 						value={ {
 							key: videoConfig.controlBar.playButtonPosition,
-							name: videoConfig.controlBar.playButtonPosition,
+							name: videoConfig.controlBar.playButtonPositionName,
 						} }
 					/>
 				</div>


### PR DESCRIPTION
## Describe
This PR fixes the fix: correct casing of play button position name in select control.

## Screenshots
1. Before
![2025-06-09_13-15](https://github.com/user-attachments/assets/851b8fec-b7a8-433b-a376-5d9bd87f7874)

2. After
![2025-06-09_13-14](https://github.com/user-attachments/assets/de154fbd-6264-4471-a0a7-483fa8ae560e)

Closes #421 