### PR TITLE
fix: change video editor menu case

### DIFF
--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -20,7 +20,7 @@ class Pages {
 
 	/**
 	 * Hardcoded Slugs
-	 * 
+	 *
 	 * @var string
 	 */
 	private $menu_slug = 'rtgodam';
@@ -145,8 +145,8 @@ class Pages {
 
 		add_submenu_page(
 			$this->menu_slug,
-			__( 'Video editor', 'godam' ),
-			__( 'Video editor', 'godam' ),
+			__( 'Video Editor', 'godam' ),
+			__( 'Video Editor', 'godam' ),
 			'edit_posts',
 			$this->video_editor_slug,
 			array( $this, 'render_video_editor_page' ),
@@ -453,7 +453,7 @@ class Pages {
 
 			/**
 			 * We are using the D3.js library for the analytics page.
-			 * 
+			 *
 			 * License: https://github.com/d3/d3/blob/main/LICENSE
 			 */
 			wp_register_script(
@@ -532,7 +532,7 @@ class Pages {
 				RTGODAM_VERSION,
 				false
 			);
-			
+
 			wp_register_script(
 				'godam-page-script-dashboard',
 				RTGODAM_URL . 'assets/build/pages/dashboard.min.js',
@@ -609,7 +609,7 @@ class Pages {
 			'gravity-forms-basic'            => 'gravityforms/assets/css/dist/basic.min.css',
 			'common-css-utilities'           => 'gravityforms/assets/css/dist/common-css-utilities.min.css',
 		);
-	
+
 		foreach ( $gravity_forms_styles as $handle => $path ) {
 			wp_enqueue_style(
 				$handle,
@@ -617,7 +617,7 @@ class Pages {
 				array(),
 				RTGODAM_VERSION
 			);
-		} 
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR changes the `Video editor` menu to `Video Editor`. Conforming, to the way WP names it's sub menus. 

## Examples
1. `Posts -> Add Post`
2. `Pages -> Add Page`

## Screenshots
![2025-06-09_15-40](https://github.com/user-attachments/assets/992675a1-c4df-456f-a478-78702502e7a0)
