### PR TITLE
fix: add aria labels to social icons as discernible text for screen readers.

### DIFF
--- a/pages/godam/components/GoDAMFooter.jsx
+++ b/pages/godam/components/GoDAMFooter.jsx
@@ -87,7 +87,7 @@ const GoDAMFooter = () => {
 											text={ icon.tooltip }
 											placement="bottom"
 										>
-											<a href={ icon.url } target="_blank" rel="noreferrer">{ icon.icon }</a>
+											<a href={ icon.url } target="_blank" rel="noreferrer" aria-label={ icon.title }>{ icon.icon }</a>
 										</Tooltip>
 									</li>
 								) )


### PR DESCRIPTION
## Description
This PR adds `aria-labels` to social icons as discernible text for screen readers.

## Screenshots
![2025-06-09_16-32](https://github.com/user-attachments/assets/5239a9d7-9d05-4197-936e-92331960e417)

Closes #425 