### PR TITLE
Fix: Video editor for vertical layout videos

### DIFF
--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -262,8 +262,8 @@ const VideoEditor = ( { attachmentID } ) => {
 								<VideoJSPlayer
 									options={ {
 										controls: true,
-										fluid: true,
 										preload: 'auto',
+										height: ( window.innerHeight * 0.7 ) + 'px',
 										width: '100%',
 										sources,
 										controlBar: {

--- a/pages/video-editor/video-control.css
+++ b/pages/video-editor/video-control.css
@@ -46,7 +46,7 @@
 }
 
 .vjs-volume-vertical {
-    left: 0px !important;
+    left: 0 !important;
 }
 
 .components-custom-select-control__item-icon {
@@ -55,7 +55,7 @@
 
 .image-overlay-text {
     font-size: 15px;
-    background: white;
+    background: #fff;
     padding: 10px;
     border-radius: 12px;
 }
@@ -127,4 +127,8 @@
     .image-cta-btn {
         margin: 0 auto;
     }
+}
+
+.vjs_video_3-dimensions {
+    width: 100% !important;
 }


### PR DESCRIPTION
This PR fixes the issue with layout for Vertical Videos in the video editor.

## Screenshots

| Before | After |
|---|---|
| ![Image](https://github.com/user-attachments/assets/9f253d53-a1dc-42c3-8740-5969bc7fae55) | ![Image](https://github.com/user-attachments/assets/deb626e4-7cf8-4a2b-8927-66fa50e50f75) |