### PR TITLE
Settings to add custom CSS for GoDAM Video Block

### DIFF
--- a/inc/classes/rest-api/class-settings.php
+++ b/inc/classes/rest-api/class-settings.php
@@ -28,7 +28,7 @@ class Settings extends Base {
 		 */
 	private function get_default_settings() {
 		return array(
-			'video'   => array(
+			'video'        => array(
 				'sync_from_godam'        => false,
 				'adaptive_bitrate'       => false,
 				'optimize_videos'        => false,
@@ -41,10 +41,13 @@ class Settings extends Base {
 				'watermark_url'          => '',
 				'use_watermark_image'    => false,
 			),
-			'general' => array(
+			'general'      => array(
 				'enable_folder_organization' => true,
 				'brand_image'                => '',
 				'brand_color'                => '#000000',
+			),
+			'video_player' => array(
+				'custom_css' => '',
 			),
 		);
 	}
@@ -273,7 +276,7 @@ class Settings extends Base {
 		$default = $this->get_default_settings();
 
 		return array(
-			'video'   => array(
+			'video'        => array(
 				'sync_from_godam'        => rest_sanitize_boolean( $settings['video']['sync_from_godam'] ?? $default['video']['sync_from_godam'] ),
 				'adaptive_bitrate'       => rest_sanitize_boolean( $settings['video']['adaptive_bitrate'] ?? $default['video']['adaptive_bitrate'] ),
 				'optimize_videos'        => rest_sanitize_boolean( $settings['video']['optimize_videos'] ?? $default['video']['optimize_videos'] ),
@@ -286,10 +289,13 @@ class Settings extends Base {
 				'watermark_url'          => esc_url_raw( $settings['video']['watermark_url'] ?? $default['video']['watermark_url'] ),
 				'use_watermark_image'    => rest_sanitize_boolean( $settings['video']['use_watermark_image'] ?? $default['video']['use_watermark_image'] ),
 			),
-			'general' => array(
+			'general'      => array(
 				'enable_folder_organization' => rest_sanitize_boolean( $settings['general']['enable_folder_organization'] ?? $default['general']['enable_folder_organization'] ),
 				'brand_image'                => sanitize_text_field( $settings['general']['brand_image'] ?? $default['general']['brand_image'] ),
 				'brand_color'                => sanitize_hex_color( $settings['general']['brand_color'] ?? $default['general']['brand_color'] ),
+			),
+			'video_player' => array(
+				'custom_css' => sanitize_textarea_field( $settings['video_player']['custom_css'] ) ?? $default['video_player']['custom_css'],
 			),
 		);
 	}

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -26,12 +26,27 @@ class GoDAM_Player {
 		add_shortcode( 'godam_video', array( $this, 'render' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ) );
+		add_action( 'wp_head', array( $this, 'godam_output_admin_player_css' ) );
+	}
+	
+	/**
+	 * Outputs custom css from video player settings tab input field.
+	 */
+	public function godam_output_admin_player_css() {
+		$godam_settings = get_option( 'rtgodam-settings', array() );
+		$custom_css     = $godam_settings['video_player']['custom_css'];
+		if ( ! empty( $custom_css ) ) {
+			echo '<style id="godam-player-inline-css">' . esc_html( $custom_css ) . '</style>';
+		}
 	}
 
 	/**
 	 * Register scripts and styles for the GoDAM player.
 	 */
 	public function register_scripts() {
+		// Allow external stylesheets to be enqueued.
+		do_action( 'godam_player_enqueue_styles' );
+
 		// Register your scripts and styles here.
 		wp_register_script(
 			'godam-player-frontend-script',

--- a/pages/godam/App.js
+++ b/pages/godam/App.js
@@ -7,7 +7,7 @@ import { useDispatch } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { cog, video } from '@wordpress/icons';
+import { cog, video, code } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -24,6 +24,7 @@ import VideoSettings from './components/tabs/VideoSettings/VideoSettings.jsx';
 
 import { useGetMediaSettingsQuery } from './redux/api/media-settings.js';
 import { setMediaSettings } from './redux/slice/media-settings.js';
+import VideoPlayer from './components/tabs/VideoSettings/VideoPlayer.jsx';
 
 const TABS = [
 	{
@@ -37,6 +38,12 @@ const TABS = [
 		label: __( 'Video Settings', 'godam' ),
 		component: VideoSettings,
 		icon: video,
+	},
+	{
+		id: 'video-player',
+		label: __( 'Video Player', 'godam' ),
+		component: VideoPlayer,
+		icon: code,
 	},
 ];
 

--- a/pages/godam/components/tabs/VideoSettings/CustomVideoPlayerCSS.jsx
+++ b/pages/godam/components/tabs/VideoSettings/CustomVideoPlayerCSS.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	PanelBody,
+	Panel,
+	TextareaControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const CustomVideoPlayerCSS = ( { handleSettingChange } ) => {
+	const customCSS = useSelector(
+		( state ) => state.mediaSettings.video_player?.custom_css,
+	);
+
+	return (
+		<Panel heading={ __( 'Video Thumbnails', 'godam' ) } className="godam-panel">
+			<PanelBody>
+				<div className="godam-form-group">
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label="Custom CSS"
+						onChange={ ( value ) => handleSettingChange( 'custom_css', value ) }
+						placeholder="Placeholder"
+						value={ customCSS }
+						rows={ 30 }
+					/>
+					<div className="help-text">
+						{ __( 'Add custom css for GoDAM Video Block', 'godam' ) }
+					</div>
+				</div>
+			</PanelBody>
+		</Panel>
+	);
+};
+
+export default CustomVideoPlayerCSS;

--- a/pages/godam/components/tabs/VideoSettings/CustomVideoPlayerCSS.jsx
+++ b/pages/godam/components/tabs/VideoSettings/CustomVideoPlayerCSS.jsx
@@ -9,9 +9,9 @@ import { useSelector } from 'react-redux';
 import {
 	PanelBody,
 	Panel,
-	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import Editor from '@monaco-editor/react';
 
 const CustomVideoPlayerCSS = ( { handleSettingChange } ) => {
 	const customCSS = useSelector(
@@ -22,13 +22,15 @@ const CustomVideoPlayerCSS = ( { handleSettingChange } ) => {
 		<Panel heading={ __( 'Video Thumbnails', 'godam' ) } className="godam-panel">
 			<PanelBody>
 				<div className="godam-form-group">
-					<TextareaControl
-						__nextHasNoMarginBottom
-						label="Custom CSS"
+					<Editor
+						id="custom-css"
+						className="code-editor"
+						defaultLanguage="html"
+						defaultValue={ customCSS }
+						options={ {
+							minimap: { enabled: false },
+						} }
 						onChange={ ( value ) => handleSettingChange( 'custom_css', value ) }
-						placeholder="Placeholder"
-						value={ customCSS }
-						rows={ 30 }
 					/>
 					<div className="help-text">
 						{ __( 'Add custom css for GoDAM Video Block', 'godam' ) }

--- a/pages/godam/components/tabs/VideoSettings/VideoPlayer.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoPlayer.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Notice,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { scrollToTop, hasValidAPIKey } from '../../../utils/index.js';
+import { useSaveMediaSettingsMutation } from '../../../redux/api/media-settings.js';
+import { updateMediaSetting } from '../../../redux/slice/media-settings.js';
+import CustomVideoPlayerCSS from './CustomVideoPlayerCSS.jsx';
+
+const VideoPlayer = () => {
+	const dispatch = useDispatch();
+	const [ saveMediaSettings, { isLoading: saveMediaSettingsLoading } ] =
+    useSaveMediaSettingsMutation();
+	const mediaSettings = useSelector( ( state ) => state.mediaSettings );
+
+	const handleSettingChange = ( key, value ) => {
+		dispatch( updateMediaSetting( { category: 'video_player', key, value } ) );
+	};
+
+	const [ notice, setNotice ] = useState( { message: '', status: 'success', isVisible: false } );
+
+	const showNotice = ( message, status = 'success' ) => {
+		setNotice( { message, status, isVisible: true } );
+		scrollToTop();
+	};
+
+	const handleSaveSettings = async () => {
+		try {
+			const response = await saveMediaSettings( {
+				settings: { video_player: mediaSettings?.video_player },
+			} ).unwrap();
+
+			if ( response?.status === 'success' ) {
+				showNotice( __( 'Settings saved successfully.', 'godam' ) );
+			} else {
+				showNotice( __( 'Failed to save settings.', 'godam' ), 'error' );
+			}
+		} catch ( error ) {
+			showNotice( __( 'Failed to save settings.', 'godam' ), 'error' );
+		}
+	};
+
+	return (
+		<>
+			{ notice.isVisible && (
+				<Notice
+					className="mb-4"
+					status={ notice.status }
+					onRemove={ () => setNotice( { ...notice, isVisible: false } ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
+			{
+				hasValidAPIKey && <CustomVideoPlayerCSS handleSettingChange={ handleSettingChange } />
+			}
+			{ hasValidAPIKey && (
+				<Button
+					variant="primary"
+					className="godam-button"
+					onClick={ handleSaveSettings }
+					isBusy={ saveMediaSettingsLoading }
+					disabled={ saveMediaSettingsLoading }
+				>
+					{ __( 'Save Settings', 'godam' ) }
+				</Button>
+			) }
+		</>
+	);
+};
+
+export default VideoPlayer;

--- a/pages/godam/redux/slice/media-settings.js
+++ b/pages/godam/redux/slice/media-settings.js
@@ -19,6 +19,9 @@ const initialState = {
 		brand_color: '#000000',
 		brand_image: '',
 	},
+	video_player: {
+		custom_css: '',
+	},
 };
 
 const mediaSettingsSlice = createSlice( {


### PR DESCRIPTION
 1. Add “Video Player” Settings Page for Custom CSS Injection

This PR introduces a new **"Video Player"** settings menu in the WordPress admin dashboard, allowing users to input **custom CSS** specifically for styling the **GoDAM video block** globally on the frontend.

#### Key Changes:

* Adds a new submenu item under the GoDAM plugin menu titled **"Video Player"**.
* Implements a settings page with a **code editor input** for custom CSS.
* Saves the entered CSS to the **WordPress options table**.
* Injects the saved CSS into the frontend, ensuring it applies globally to all GoDAM video blocks.


<img width="1310" alt="image" src="https://github.com/user-attachments/assets/624a311e-3bac-4684-ad8b-48d3854c15ee" />



2. Provides a hook-based system `godam_player_enqueue_styles` that developers can also use to enqueue their own player-specific styles.

Example for usage:

```
add_action( 'godam_player_enqueue_styles', function () {
	wp_enqueue_style(
	'my-custom-godam-style',
	RTGODAM_URL . 'assets/build/css/custom-css-file.css',
	[],
	filemtime( get_stylesheet_directory() . 'assets/build/css/custom-css-file.css')
	);
} );
```

