### PR TITLE
Video Editor: Prevent redirection to a non-existent page

### DIFF
--- a/pages/video-editor/components/media-grid/MediaGrid.jsx
+++ b/pages/video-editor/components/media-grid/MediaGrid.jsx
@@ -88,7 +88,7 @@ const MediaGrid = ( { search, page, handleAttachmentClick, setPage, attachments,
 				<p className="text-sm text-gray-500 m-0 text-center">
 					{ __( 'Upload videos from WordPress ', 'godam' ) }
 					<a
-						href={ `${ window?.videoData?.admin_url }upload.php` }
+						href={ `${ window?.videoData?.adminUrl }upload.php` }
 						target="_blank"
 						rel="noopener noreferrer"
 						className="text-blue-500 underline"


### PR DESCRIPTION
### Description

Closes: #458 

This PR updates the anchor used to navigate to the `media library` by replacing `admin_url` with `adminUrl` to prevent redirection to a non-existent page.

### Screenshots

|Before|After|
|-|-|
|<img width="537" alt="anchor" src="https://github.com/user-attachments/assets/1de8fd89-4658-4a4c-9c2d-06c87069d030" />|<img width="537" alt="after" src="https://github.com/user-attachments/assets/3aade58e-8d56-4340-819e-c6d9a20d90f0" />|

