### PR TITLE
fix: Video players controls style missing

### DIFF
--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -164,18 +164,42 @@ endif;
 
 $instance_id = 'video_' . bin2hex( random_bytes( 8 ) );
 
+// Create custom inline styles in a more maintainable way.
+$custom_css_properties = array(
+	'--rtgodam-control-bar-color'      => $easydam_control_bar_color,
+	'--rtgodam-control-hover-color'    => $easydam_hover_color,
+	'--rtgodam-control-hover-zoom'     => 1 + $easydam_hover_zoom,
+	'--rtgodam-custom-play-button-url' => $easydam_custom_btn_img ? 'url(' . esc_url( $easydam_custom_btn_img ) . ')' : '',
+);
+
+if ( ! empty( $attributes['aspectRatio'] ) ) {
+	$custom_css_properties['--rtgodam-video-aspect-ratio'] = $attributes['aspectRatio'];
+}
+
+// Build the inline style string, escaping each value.
+$custom_inline_styles = '';
+foreach ( $custom_css_properties as $property => $value ) {
+	if ( ! empty( $value ) ) {
+		$custom_inline_styles .= $property . ': ' . $value . ';';
+	}
+}
+
+// Build the figure attributes for the <figure> element.
+if ( $is_shortcode || $is_elementor_widget ) {
+	$figure_attributes = ! empty( $custom_inline_styles )
+		? 'style="' . esc_attr( $custom_inline_styles ) . '"'
+		: '';
+} else {
+	$additional_attributes = array();
+	if ( ! empty( $custom_inline_styles ) ) {
+		$additional_attributes['style'] = esc_attr( $custom_inline_styles );
+	}
+	$figure_attributes = get_block_wrapper_attributes( $additional_attributes );
+}
 ?>
 
 <?php if ( ! empty( $sources ) ) : ?>
-	<figure 
-	<?php echo $is_shortcode || $is_elementor_widget ? '' : wp_kses_data( get_block_wrapper_attributes() ); ?>
-	style="
-	--rtgodam-control-bar-color: <?php echo esc_attr( $easydam_control_bar_color ); ?>;
-	--rtgodam-control-hover-color: <?php echo esc_attr( $easydam_hover_color ); ?>;
-	--rtgodam-control-hover-zoom: <?php echo esc_attr( 1 + $easydam_hover_zoom ); ?>;
-	--rtgodam-custom-play-button-url: url(<?php echo esc_url( $easydam_custom_btn_img ); ?>);
-	<?php echo $attributes['aspectRatio'] ? '--rtgodam-video-aspect-ratio: ' . esc_attr( $attributes['aspectRatio'] ) : ''; ?>
-	">
+	<figure <?php echo wp_kses_data( $figure_attributes ); ?>>
 		<div class="godam-video-wrapper">
 			<?php if ( $show_overlay && ! empty( $inner_blocks_content ) ) : ?>
 				<div 
@@ -192,9 +216,9 @@ $instance_id = 'video_' . bin2hex( random_bytes( 8 ) );
 
 			<div class="easydam-video-container animate-video-loading">
 				<div class="animate-play-btn">
-				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
-					<path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"/>
-				</svg>
+					<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
+						<path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"/>
+					</svg>
 				</div>
 				<video
 					class="easydam-player video-js vjs-big-play-centered vjs-hidden"
@@ -380,5 +404,4 @@ $instance_id = 'video_' . bin2hex( random_bytes( 8 ) );
 			<figcaption class="wp-element-caption rtgodam-video-caption"><?php echo esc_html( $caption ); ?></figcaption>
 		<?php endif; ?>
 	</figure>
-
 <?php endif; ?>


### PR DESCRIPTION
### Description:

This PR fixes the issue where the GoDAM Video block controls were missing CSS variables when styles were applied via the editor. The problem was caused by inline styles overriding the expected variables.

#### Screenshot:

| Before | After |
|--------|--------|
| <img width="1502" alt="image" src="https://github.com/user-attachments/assets/f7548845-db56-4fe0-bfd1-64ddfe82cb4a" /> | <img width="1499" alt="image" src="https://github.com/user-attachments/assets/18f97be4-a872-4182-8306-966cdaed7e72" /> |

Closes: https://github.com/rtCamp/godam-core/issues/174
