### PR TITLE
Fix: Unsupported video shows error

### DIFF
--- a/pages/video-editor/VideoJSPlayer.js
+++ b/pages/video-editor/VideoJSPlayer.js
@@ -325,7 +325,11 @@ export const VideoJS = ( props ) => {
 	}, [ layers, chapters ] );
 
 	useEffect( () => {
-		if ( playerRef.current ) {
+		if ( ! playerRef.current ) {
+			return;
+		}
+
+		try {
 			const player = playerRef.current;
 
 			// player.sources( options.sources );
@@ -342,6 +346,8 @@ export const VideoJS = ( props ) => {
 			} else if ( ! options.controlBar.playToggle && volumePanel ) {
 				player.controlBar.removeChild( 'volumePanel' );
 			}
+		} catch {
+			// Ignoring - "No compatible source was found for this media" error will be shown on the video element.
 		}
 	}, [ options ] );
 


### PR DESCRIPTION
## Description
- When I try to upload media files with the extensions `.MOV`, `.AVI`, or `.WMV` (these are the formats I’ve tested so far), the video does not display on the Video Editor page. Instead, an error appears in the browser console, and the editor remains blank. (This can only be replicated in local env)
- I fixed this using a `try-catch` block.
- Note: There is no need to log or display the error.
  - Reason: If the video is not compatible, the message `No compatible source was found for this media` will be shown automatically.

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/e03d164a-3dac-433b-aa13-0d59f4109eda" />


Before

https://github.com/user-attachments/assets/542660b4-590d-44f5-9f70-c5851c850239

After

https://github.com/user-attachments/assets/64794a48-f9b1-4d2d-a010-46ff5015193e

<img width="812" alt="image" src="https://github.com/user-attachments/assets/bafc5cf2-6b76-4c5a-a40d-afc04f37bb61" />



## Related Issue
- #464 