### PR TITLE
Add Drag and Drop functionality to list view for Media library

### DIFF
--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -11,6 +11,7 @@ import AttachmentDetailsTwoColumn from './views/attachment-detail-two-column.js'
 import mediaFrameSelect from './views/media-frame-select.js';
 
 import MediaDateRangeFilter from './views/filters/media-date-range-filter-list-view.js';
+import MediaListViewTableDragHandler from './views/attachment-list.js';
 
 import { isFolderOrgDisabled, isUploadPage, addManageMediaButton } from './utility.js';
 
@@ -49,6 +50,8 @@ class MediaLibrary {
 		if ( wp?.media?.view?.MediaFrame?.Select && mediaFrameSelect ) {
 			wp.media.view.MediaFrame.Select = mediaFrameSelect;
 		}
+
+		new MediaListViewTableDragHandler();
 	}
 
 	setupMediaLibraryRoot() {

--- a/assets/src/js/media-library/views/attachment-list.js
+++ b/assets/src/js/media-library/views/attachment-list.js
@@ -1,0 +1,230 @@
+/**
+ * Media Table Row Drag Handler
+ *
+ * A modular, class-based solution for making WordPress media library table rows
+ * draggable with multi-selection support and visual feedback.
+ *
+ * Features:
+ * - Drag and drop functionality for media table rows
+ * - Multi-selection support for list view
+ */
+
+/* global jQuery */
+
+/**
+ * Internal dependencies
+ */
+import { isFolderOrgDisabled } from '../utility';
+
+/**
+ * MediaListViewTableDragHandler Class
+ *
+ * Handles drag and drop functionality for WordPress media library list view items.
+ */
+class MediaListViewTableDragHandler {
+	/**
+	 * Constructor
+	 *
+	 * @param {Object} $ - jQuery instance (optional, defaults to global jQuery)
+	 */
+	constructor( $ = jQuery ) {
+		this.$ = $;
+		this.tableRows = null;
+
+		this.init();
+	}
+
+	/**
+	 * Initialize the drag handler
+	 *
+	 * Sets up drag functionality for all media table rows if folder organization is enabled.
+	 */
+	init() {
+		if ( isFolderOrgDisabled() ) {
+			return;
+		}
+
+		this.tableRows = document.querySelectorAll( '.wp-list-table.media tbody tr' );
+		this.setupDragHandlers();
+	}
+
+	/**
+	 * Set up drag handlers for all table rows
+	 *
+	 * Iterates through each table row and applies drag functionality.
+	 */
+	setupDragHandlers() {
+		this.tableRows.forEach( ( row ) => {
+			this.setupRowDragHandler( this.$( row ) );
+		} );
+	}
+
+	/**
+	 * Set up drag handler for a single table row
+	 *
+	 * @param {jQuery} $row - jQuery object representing the table row
+	 */
+	setupRowDragHandler( $row ) {
+		this.addDragHandle( $row );
+		this.makeDraggable( $row );
+	}
+
+	/**
+	 * Add drag handle icon to the check column
+	 *
+	 * @param {jQuery} $row - jQuery object representing the table row
+	 */
+	addDragHandle( $row ) {
+		const checkColumn = $row.find( '.check-column' );
+
+		if ( checkColumn.length === 0 ) {
+			return;
+		}
+
+		const dragHandle = this.createDragHandle();
+		checkColumn.append( dragHandle );
+	}
+
+	/**
+	 * Create drag handle element
+	 *
+	 * @return {jQuery} jQuery object representing the drag handle
+	 */
+	createDragHandle() {
+		return this.$( '<span>', {
+			class: 'drag-handle',
+			html: '⋮⋮', // Visual indicator for draggable
+			css: {
+				cursor: 'grab',
+				padding: '5px',
+				color: '#666',
+				fontSize: '14px',
+				display: 'inline-block',
+				marginLeft: '5px',
+				verticalAlign: 'middle',
+			},
+			title: 'Drag to move',
+		} );
+	}
+
+	/**
+	 * Make a table row draggable
+	 *
+	 * @param {jQuery} $row - jQuery object representing the table row
+	 */
+	makeDraggable( $row ) {
+		$row.draggable( {
+			cursor: 'move',
+			helper: () => this.createDragHelper( $row ),
+			opacity: 0.7,
+			appendTo: 'body',
+			cursorAt: { top: 5, left: 5 },
+		} );
+	}
+
+	/**
+	 * Create drag helper element
+	 *
+	 * @param {jQuery} $row - jQuery object representing the current row being dragged
+	 * @return {jQuery} jQuery object representing the drag helper
+	 */
+	createDragHelper( $row ) {
+		const draggedItems = this.getDraggedItems( $row );
+		const itemCount = draggedItems.length;
+		const helperText = `Moving ${ itemCount } item${ itemCount > 1 ? 's' : '' }`;
+
+		// Store dragged items data for later use
+		$row.data( 'draggedItems', draggedItems );
+
+		return this.$( '<div>', {
+			text: helperText,
+			css: {
+				background: '#333',
+				color: '#fff',
+				padding: '8px 12px',
+				borderRadius: '4px',
+				fontSize: '14px',
+				fontWeight: 'bold',
+				boxShadow: '0 2px 5px rgba(0,0,0,0.3)',
+				zIndex: 160001,
+				pointerEvents: 'none',
+				position: 'relative',
+				whiteSpace: 'nowrap',
+			},
+		} );
+	}
+
+	/**
+	 * Get array of item IDs being dragged
+	 *
+	 * @param {jQuery} $row - jQuery object representing the current row
+	 * @return {Array} Array of item IDs being dragged
+	 */
+	getDraggedItems( $row ) {
+		const selectedCheckboxes = this.$( '.wp-list-table.media tbody input[type="checkbox"]:checked' );
+		let draggedItemIds = [];
+
+		// Collect selected item IDs
+		selectedCheckboxes.each( ( index, checkbox ) => {
+			const itemId = this.$( checkbox ).val();
+			if ( itemId ) {
+				draggedItemIds.push( itemId );
+			}
+		} );
+
+		// If no items are selected, use the current row's item ID
+		if ( draggedItemIds.length === 0 ) {
+			const currentCheckbox = $row.find( 'input[type="checkbox"]' );
+			const currentItemId = currentCheckbox.val();
+			if ( currentItemId ) {
+				draggedItemIds = [ currentItemId ];
+			}
+		}
+
+		return draggedItemIds;
+	}
+
+	/**
+	 * Refresh drag handlers
+	 *
+	 * Useful when new rows are added dynamically to the table.
+	 *
+	 * Note: not used in the current implementation, but can be useful
+	 */
+	refresh() {
+		this.destroy();
+		this.init();
+	}
+
+	/**
+	 * Destroy drag handlers
+	 *
+	 * Removes all drag functionality.
+	 *
+	 * Note: not used in the current implementation, but can be useful
+	 */
+	destroy() {
+		if ( this.tableRows ) {
+			this.tableRows.forEach( ( row ) => {
+				const $row = this.$( row );
+				if ( $row.hasClass( 'ui-draggable' ) ) {
+					$row.draggable( 'destroy' );
+				}
+				$row.find( '.drag-handle' ).remove();
+			} );
+		}
+	}
+
+	/**
+	 * Get dragged items data from a row
+	 *
+	 * @param {jQuery} $row - jQuery object representing the table row
+	 * @return {Array} Array of dragged item IDs
+	 */
+	getDraggedItemsData( $row ) {
+		return $row.data( 'draggedItems' ) || [];
+	}
+}
+
+export default MediaListViewTableDragHandler;
+

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -156,11 +156,12 @@ const FolderTree = () => {
 		 */
 		const setupDroppable = () => {
 			jQuery( '.tree-item' ).droppable( {
-				accept: 'li.attachment, th.check-column',
+				accept: 'li.attachment, tr',
 				hoverClass: 'droppable-hover',
 				tolerance: 'pointer',
 				drop: async ( event, ui ) => {
 					const draggedItems = ui.draggable.data( 'draggedItems' );
+
 					if ( draggedItems ) {
 						const targetFolderId = jQuery( event.target ).data( 'id' );
 
@@ -190,7 +191,8 @@ const FolderTree = () => {
 							 */
 							if ( selectedFolder.id !== -1 ) {
 								draggedItems.forEach( ( attachmentId ) => {
-									jQuery( `li.attachment[data-id="${ attachmentId }"]` ).remove();
+									jQuery( `li.attachment[data-id="${ attachmentId }"]` ).remove(); // for attachment grid view.
+									jQuery( `tr#post-${ attachmentId }` ).remove(); // for attachment list view.
 								} );
 							}
 						} catch {


### PR DESCRIPTION
## Description
This pull request introduces drag-and-drop functionality to the WordPress media library's list view. The changes include implementing a new `MediaListViewTableDragHandler` class, integrating it into the media library, and updating folder tree logic to support list view drag-and-drop.

### New Feature: Drag-and-Drop for Media Library List View
* **`MediaListViewTableDragHandler` class added**: Implements drag-and-drop functionality for media table rows, including multi-selection support, visual feedback, and drag handles.

### Folder Tree Updates for Drag-and-Drop
* **Updated droppable logic**: Modified the `accept` parameter in the folder tree's `droppable` setup to include table rows (`tr`) for list view compatibility.

## Screenrecording

https://github.com/user-attachments/assets/eee697c9-43b5-4666-ae17-0d7c2162c749

