### PR TITLE
Feat GH 469: Update the admin notice on plugin activation to link to the video editor settings for license activation

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -69,12 +69,10 @@ class RTGODAM_Transcoder_Admin {
 		// Otherwise, show regular admin notice.
 		if ( empty( $api_key ) ) {
 			$this->render_admin_notice(
-				wp_kses_post(
-					sprintf(
-						// translators: %s is the URL to the plugin settings page where the API key can be activated.
-						__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
-						esc_url( $video_editor_settings_url )
-					),
+				sprintf(
+					// translators: %s is the URL to the plugin settings page where the API key can be activated.
+					__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
+					esc_url( $video_editor_settings_url )
 				),
 				'warning',
 				true,
@@ -89,12 +87,10 @@ class RTGODAM_Transcoder_Admin {
 
 		if ( empty( $usage_data ) ) {
 			$this->render_admin_notice(
-				wp_kses_post(
-					sprintf(
-						// translators: %s is the URL to the plugin settings page where the API key can be activated.
-						__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
-						esc_url( $video_editor_settings_url )
-					),
+				sprintf(
+					// translators: %s is the URL to the plugin settings page where the API key can be activated.
+					__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
+					esc_url( $video_editor_settings_url )
 				),
 				'warning',
 				true,
@@ -155,12 +151,10 @@ class RTGODAM_Transcoder_Admin {
 				return;
 			} else {
 				$this->render_admin_notice(
-					wp_kses_post(
-						sprintf(
-							// translators: %s is the URL to the plugin settings page where the API key can be activated.
-							__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
-							esc_url( $video_editor_settings_url )
-						),
+					sprintf(
+						// translators: %s is the URL to the plugin settings page where the API key can be activated.
+						__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
+						esc_url( $video_editor_settings_url )
 					),
 					'error',
 					true,
@@ -172,12 +166,10 @@ class RTGODAM_Transcoder_Admin {
 
 		// Default fallback notice (if none of the above conditions are met).
 		$this->render_admin_notice(
-			wp_kses_post(
-				sprintf(
-					// translators: %s is the URL to the plugin settings page where the API key can be activated.
-					__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
-					esc_url( $video_editor_settings_url )
-				),
+			sprintf(
+				// translators: %s is the URL to the plugin settings page where the API key can be activated.
+				__( 'Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock transcoding and other features, <a href="%s">please activate your api key.</a>', 'godam' ),
+				esc_url( $video_editor_settings_url )
 			),
 			'warning',
 			true,


### PR DESCRIPTION
## Closing Issue

Closes - #479

## Before

<img width="1440" alt="Image" src="https://github.com/user-attachments/assets/4515215e-508b-4646-937a-17ee59b3e814" />

## After 

<img width="1440" alt="Screenshot 2025-06-23 at 11 40 12 AM" src="https://github.com/user-attachments/assets/54855ee1-e1d9-4f54-aace-633fc138352d" />
