### PR TITLE
Fix: Updates GoDAM Player name to GoDAM Video for Elementor

### DIFF
--- a/assets/src/js/elementor/frontend.js
+++ b/assets/src/js/elementor/frontend.js
@@ -2,4 +2,4 @@
 /**
  * Internal dependencies
  */
-import './widgets/godam-player.js';
+import './widgets/godam-video.js';

--- a/assets/src/js/elementor/widgets/godam-video.js
+++ b/assets/src/js/elementor/widgets/godam-video.js
@@ -23,7 +23,7 @@ window.addEventListener( 'elementor/frontend/init', () => {
 	if ( window.elementorFrontend && window.GODAMPlayer ) {
 		// eslint-disable-next-line no-undef
 		elementorFrontend.hooks.addAction(
-			'frontend/element_ready/godam-player.default',
+			'frontend/element_ready/godam-video.default',
 			( ) => {
 				window.GODAMPlayer();
 			},
@@ -35,7 +35,7 @@ window.addEventListener( 'elementor/frontend/init', () => {
 		elementor.hooks.addAction(
 			'panel/open_editor/widget',
 			( panel, model ) => {
-				if ( model.get( 'widgetType' ) !== 'godam-player' ) {
+				if ( model.get( 'widgetType' ) !== 'godam-video' ) {
 					return;
 				}
 

--- a/inc/classes/class-elementor-widgets.php
+++ b/inc/classes/class-elementor-widgets.php
@@ -10,7 +10,7 @@ namespace RTGODAM\Inc;
 use RTGODAM\Inc\Elementor_Controls\Godam_Media;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Audio;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Gallery;
-use RTGODAM\Inc\Elementor_Widgets\GoDAM_Player;
+use RTGODAM\Inc\Elementor_Widgets\GoDAM_Video;
 use RTGODAM\Inc\Traits\Singleton;
 
 /**
@@ -115,7 +115,7 @@ class Elementor_Widgets {
 	 * Register Widgets.
 	 */
 	public function widgets_registered() {
-		\Elementor\Plugin::$instance->widgets_manager->register( new GoDAM_Player() );
+		\Elementor\Plugin::$instance->widgets_manager->register( new GoDAM_Video() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Gallery() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Audio() );
 	}

--- a/inc/classes/elementor-widgets/class-godam-video.php
+++ b/inc/classes/elementor-widgets/class-godam-video.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Register Custom Widget - GoDAM Audio
+ * Register Custom Widget - GoDAM Video.
  *
  * @package GoDAM
  */
@@ -10,9 +10,9 @@ namespace RTGODAM\Inc\Elementor_Widgets;
 use Elementor\Controls_Manager;
 
 /**
- * GoDAM Gallery Widget.
+ * GoDAM Video Widget.
  */
-class GoDAM_Player extends Base {
+class GoDAM_Video extends Base {
 
 	/**
 	 * Default config for GoDAM Video Widget.
@@ -21,8 +21,8 @@ class GoDAM_Player extends Base {
 	 */
 	public function set_default_config() {
 		return array(
-			'name'            => 'godam-player',
-			'title'           => _x( 'GoDAM Player', 'Widget Title', 'godam' ),
+			'name'            => 'godam-video',
+			'title'           => _x( 'GoDAM Video', 'Widget Title', 'godam' ),
 			'icon'            => 'eicon-video',
 			'categories'      => array( 'godam' ),
 			'keywords'        => array( 'godam', 'video' ),


### PR DESCRIPTION
This PR updates the name of GoDAM Player to GoDAM Video, non breaking change.
![abhinav-belhekar rt gw_wp-admin_post php_post=634 action=elementor](https://github.com/user-attachments/assets/cedbc9a2-1896-47d1-bbe6-81cea27779bd)
