### PR TITLE
Fix control bar for videos with no chapters

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -762,7 +762,7 @@
 	position: relative !important;
 }
 
-.video-js .vjs-load-progress div {
+.video-js .chapter-load-progress div {
     background: var(--rtgodam-control-bar-color);
 	opacity: 1;
 }

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -767,6 +767,10 @@
 	opacity: 1;
 }
 
+.video-js .vjs-load-progress div {
+	background-color: unset;
+}
+
 .chapter-segment {
 	position: absolute;
 	top: 0;

--- a/assets/src/js/godam-player/chapters.js
+++ b/assets/src/js/godam-player/chapters.js
@@ -35,6 +35,12 @@ export function createChapterMarkers( player, chapters ) {
 	}
 	const playProgress = player.el().querySelector( '.vjs-play-progress' );
 
+	const loadProgress = player.el().querySelector( '.vjs-load-progress' );
+
+	if ( loadProgress ) {
+		loadProgress.classList.add( 'chapter-load-progress' );
+	}
+
 	playProgress.style.height = 'unset';// Reset height to allow markers to be drawn.
 
 	// Set end time for last chapter


### PR DESCRIPTION
The control bar for videos with no chapter appears like this:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/3a632970-3929-423b-bf6a-97947b755337" />

This PR fixes the issue by removing the unnecessary styles applied on control bar through conditional rendering of styles.
<img width="645" alt="image" src="https://github.com/user-attachments/assets/bbb77945-513b-4e56-aad4-4b8b9679aaf9" />
