### PR TITLE
Fix the empty video track issue for newly uploaded video

### DIFF
--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -264,9 +264,10 @@ $alignment_styles = "display: flex; flex-direction: column; justify-content: {$j
 						endif;
 					endforeach;
 
-					if ( isset( $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) &&
-						$easydam_meta_data['videoConfig']['controlBar']['subsCapsButton']
-					) {
+					$display_caption = ( ! isset( $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) ) || 
+						( isset( $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) && $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] );
+
+					if ( $display_caption ) {
 						foreach ( $tracks as $track ) :
 							if ( ! empty( $track['src'] ) && ! empty( $track['kind'] ) ) :
 								?>


### PR DESCRIPTION
### Issue
Captions and the caption toggle button are not appearing for newly uploaded videos, even if captions have been added separately.

### Solution
The issue occurs because newly uploaded videos lack the necessary metadata to display captions. Once the video is saved through the video editor, the metadata is generated, and captions appear correctly. To fix this, a default setting has been added to ensure captions are displayed by default, even when the required metadata hasn’t been generated yet.

<img width="676" alt="Screenshot 2025-06-23 at 7 19 31 PM" src="https://github.com/user-attachments/assets/6e485719-f21a-45c9-904f-2f295927781a" />
