### PR TITLE
 feat: Add Media Pre-selection for Image Replacements

### DIFF
--- a/inc/classes/rest-api/class-settings.php
+++ b/inc/classes/rest-api/class-settings.php
@@ -39,11 +39,13 @@ class Settings extends Base {
 				'watermark'              => false,
 				'watermark_text'         => '',
 				'watermark_url'          => '',
+				'watermark_image_id'     => null,
 				'use_watermark_image'    => false,
 			),
 			'general'      => array(
 				'enable_folder_organization' => true,
 				'brand_image'                => '',
+				'brand_image_id'             => null,
 				'brand_color'                => '#000000',
 			),
 			'video_player' => array(
@@ -287,11 +289,13 @@ class Settings extends Base {
 				'watermark'              => rest_sanitize_boolean( $settings['video']['watermark'] ?? $default['video']['watermark'] ),
 				'watermark_text'         => sanitize_text_field( $settings['video']['watermark_text'] ?? $default['video']['watermark_text'] ),
 				'watermark_url'          => esc_url_raw( $settings['video']['watermark_url'] ?? $default['video']['watermark_url'] ),
+				'watermark_image_id'     => absint( $settings['video']['watermark_image_id'] ?? $default['video']['watermark_image_id'] ),
 				'use_watermark_image'    => rest_sanitize_boolean( $settings['video']['use_watermark_image'] ?? $default['video']['use_watermark_image'] ),
 			),
 			'general'      => array(
 				'enable_folder_organization' => rest_sanitize_boolean( $settings['general']['enable_folder_organization'] ?? $default['general']['enable_folder_organization'] ),
 				'brand_image'                => sanitize_text_field( $settings['general']['brand_image'] ?? $default['general']['brand_image'] ),
+				'brand_image_id'             => absint( $settings['general']['brand_image_id'] ?? $default['general']['brand_image_id'] ),
 				'brand_color'                => sanitize_hex_color( $settings['general']['brand_color'] ?? $default['general']['brand_color'] ),
 			),
 			'video_player' => array(

--- a/pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx
@@ -21,13 +21,26 @@ const BrandImageSelector = ( { mediaSettings, handleSettingChange } ) => {
 			const attachment = fileFrame.state().get( 'selection' ).first().toJSON();
 
 			handleSettingChange( 'brand_image', attachment.url );
+			handleSettingChange( 'brand_image_id', attachment.id );
 		} );
+
+		if ( mediaSettings?.general?.brand_image_id ) {
+			const attachment = wp.media.attachment( mediaSettings.general.brand_image_id );
+			attachment.fetch();
+
+			fileFrame.on( 'open', function() {
+				const selection = fileFrame.state().get( 'selection' );
+				selection.reset();
+				selection.add( attachment );
+			} );
+		}
 
 		fileFrame.open();
 	};
 
 	const removeBrandImage = () => {
 		handleSettingChange( 'brand_image', '' );
+		handleSettingChange( 'brand_image_id', null );
 	};
 
 	return (

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -20,6 +20,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 	const watermarkText = useSelector( ( state ) => state.mediaSettings.video.watermark_text );
 	const enableWatermark = useSelector( ( state ) => state.mediaSettings.video.watermark );
 	const selectedMedia = useSelector( ( state ) => state.mediaSettings.video.watermark_url );
+	const watermarkImageId = useSelector( ( state ) => state.mediaSettings.video.watermark_image_id );
 
 	const openMediaPicker = () => {
 		const fileFrame = wp.media( {
@@ -37,8 +38,20 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 			const attachment = fileFrame.state().get( 'selection' ).first().toJSON();
 			if ( attachment.type === 'image' ) {
 				handleSettingChange( 'watermark_url', attachment.url );
+				handleSettingChange( 'watermark_image_id', attachment.id );
 			}
 		} );
+
+		if ( watermarkImageId ) {
+			const attachment = wp.media.attachment( watermarkImageId );
+			attachment.fetch();
+
+			fileFrame.on( 'open', function() {
+				const selection = fileFrame.state().get( 'selection' );
+				selection.reset();
+				selection.add( attachment );
+			} );
+		}
 
 		fileFrame.open();
 	};
@@ -120,9 +133,10 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 													<Button
 														isDestructive
 														className="godam-button"
-														onClick={ () =>
-															handleSettingChange( 'watermark_url', '' )
-														}
+														onClick={ () => {
+															handleSettingChange( 'watermark_url', '' );
+															handleSettingChange( 'watermark_image_id', null );
+														} }
 														variant="secondary"
 													>
 														{ __( 'Remove Watermark', 'godam' ) }

--- a/pages/godam/redux/slice/media-settings.js
+++ b/pages/godam/redux/slice/media-settings.js
@@ -18,11 +18,13 @@ const initialState = {
 		use_watermark_image: false,
 		watermark_text: '',
 		watermark_url: '',
+		watermark_image_id: null,
 	},
 	general: {
 		enable_folder_organization: true,
 		brand_color: '#000000',
 		brand_image: '',
+		brand_image_id: null,
 	},
 	video_player: {
 		custom_css: VideoCustomCSSTemplate,

--- a/pages/video-editor/components/appearance/Appearance.js
+++ b/pages/video-editor/components/appearance/Appearance.js
@@ -139,6 +139,16 @@ const Appearance = () => {
 			multiple: false, // Disable multiple selection
 		} );
 
+		fileFrame.on( 'open', function() {
+			const selection = fileFrame.state().get( 'selection' );
+
+			if ( videoConfig.controlBar.customPlayBtnImgId ) {
+				const attachment = wp.media.attachment( videoConfig.controlBar.customPlayBtnImgId );
+				attachment.fetch();
+				selection.add( attachment );
+			}
+		} );
+
 		fileFrame.on( 'select', function() {
 			const attachment = fileFrame.state().get( 'selection' ).first().toJSON();
 			const playButtonElement = document.querySelector( '.vjs-big-play-button' );
@@ -148,6 +158,7 @@ const Appearance = () => {
 					controlBar: {
 						...videoConfig.controlBar,
 						customPlayBtnImg: attachment.url,
+						customPlayBtnImgId: attachment.id,
 					},
 				} ),
 			);
@@ -191,6 +202,16 @@ const Appearance = () => {
 			multiple: false, // Disable multiple selection
 		} );
 
+		fileFrame.on( 'open', function() {
+			const selection = fileFrame.state().get( 'selection' );
+
+			if ( videoConfig.controlBar.customBrandImgId ) {
+				const attachment = wp.media.attachment( videoConfig.controlBar.customBrandImgId );
+				attachment.fetch();
+				selection.add( attachment );
+			}
+		} );
+
 		fileFrame.on( 'select', function() {
 			const attachment = fileFrame.state().get( 'selection' ).first().toJSON();
 			const brandImg = document.querySelector( '#branding-icon' );
@@ -200,6 +221,7 @@ const Appearance = () => {
 					controlBar: {
 						...videoConfig.controlBar,
 						customBrandImg: attachment.url,
+						customBrandImgId: attachment.id,
 					},
 				} ),
 			);
@@ -218,6 +240,7 @@ const Appearance = () => {
 				controlBar: {
 					...videoConfig.controlBar,
 					customBrandImg: '',
+					customBrandImgId: null,
 				},
 			} ),
 		);
@@ -233,6 +256,7 @@ const Appearance = () => {
 				controlBar: {
 					...videoConfig.controlBar,
 					customPlayBtnImg: '',
+					customPlayBtnImgId: null,
 				},
 			} ),
 		);


### PR DESCRIPTION
This PR enhances the user experience when replacing images by implementing pre-selection in the WordPress media library. When users click the "Replace" button for Brand Logo, Video Watermark, or Custom Play Button, the media library now pre-selects the current image.

Changes Made
- Added image ID storage in the Redux store for all media components
- Updated PHP REST API class to store and retrieve image IDs
- Implemented pre-selection functionality in:
    - Brand Logo component (General Settings)
    - Watermark component (Video Settings)
    - Custom Play Button, Custom Brand Logo (Video Editor Player Settings)