### PR TITLE
Add pagination to Media Library

### DIFF
--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -59,7 +59,7 @@ class Media_Library_Ajax {
 		}
 
 		if ( isset( $query_args['post_mime_type'] ) && is_array( $query_args['post_mime_type'] ) ) {
-			
+
 			$post_mime_type = $query_args['post_mime_type'][0];
 			$mime_type      = '';
 			if ( false === strpos( $post_mime_type, 'godam/' ) ) {
@@ -115,7 +115,7 @@ class Media_Library_Ajax {
 					'headers' => array(
 						'Content-Type' => 'application/json',
 					),
-				) 
+				)
 			);
 
 			if ( is_wp_error( $response ) ) {
@@ -145,7 +145,7 @@ class Media_Library_Ajax {
 	 */
 	public function prepare_godam_media_item( $item ) {
 		// Ensure $item is an array.
-		$item = (array) $item; 
+		$item = (array) $item;
 
 		if ( empty( $item['name'] ) || empty( $item['file_origin'] ) ) {
 			return array();

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -39,6 +39,8 @@ use RTGODAM\Inc\Cron_Jobs\Retranscode_Failed_Media;
 
 use RTGODAM\Inc\Video_Metadata;
 
+use RTGODAM\Inc\Media_Library\Media_Folders_REST_API;
+
 /**
  * Class Plugin.
  */
@@ -77,6 +79,8 @@ class Plugin {
 
 		// Load Elementor widgets.
 		$this->load_elementor_widgets();
+
+		$this->load_media_library();
 	}
 
 	/**
@@ -120,8 +124,17 @@ class Plugin {
 	}
 
 	/**
+	 * Load all the classes related to the media library.
+	 *
+	 * @return void
+	 */
+	private function load_media_library() {
+		Media_Folders_REST_API::get_instance();
+	}
+
+	/**
 	 * Registers the elementor widgets if required.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function load_elementor_widgets() {

--- a/inc/classes/media-library/class-media-folder-create-zip.php
+++ b/inc/classes/media-library/class-media-folder-create-zip.php
@@ -56,7 +56,6 @@ class Media_Folder_Create_Zip {
 	 * @return array Array of attachment objects.
 	 */
 	private function get_taxonomy_attachments( $folder_id ) {
-		// Get attachments associated with the folder.
 		$args = array(
 			'post_type'      => 'attachment',
 			'post_status'    => 'inherit',
@@ -67,10 +66,14 @@ class Media_Folder_Create_Zip {
 					'terms'    => $folder_id,
 				),
 			),
-			'posts_per_page' => -1, // Get all attachments.
+			'posts_per_page' => -1,
+			'no_found_rows'  => true, // Improve performance when pagination isn't needed.
+			'fields'         => 'all', // Return full post objects.
 		);
 
-		return get_posts( $args );
+		$query = new \WP_Query( $args );
+
+		return $query->posts;
 	}
 
 	/**

--- a/inc/classes/media-library/class-media-folder-create-zip.php
+++ b/inc/classes/media-library/class-media-folder-create-zip.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Media Folders REST API class.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Media_Library;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Media_Folder_Create_Zip
+ */
+class Media_Folder_Create_Zip {
+
+	use Singleton;
+
+	/**
+	 * Create a ZIP file from the attachments in a media folder.
+	 *
+	 * @param int    $folder_id - The ID of the media folder.
+	 * @param string $zip_name - The name of the ZIP file to create. Defaults to 'media-folder.zip'.
+	 * @return array|\WP_Error - Returns an array with the ZIP file details on success, or a WP_Error object on failure.
+	 */
+	public function create_zip( $folder_id, $zip_name = 'media-folder.zip' ) {
+		// Ensure the folder ID is valid.
+		if ( ! is_numeric( $folder_id ) || $folder_id <= 0 ) {
+			return new \WP_Error( 'invalid_folder_id', __( 'Invalid folder ID provided.', 'godam' ), array( 'status' => 400 ) );
+		}
+
+		$attachments = $this->get_taxonomy_attachments( $folder_id );
+
+		if ( empty( $attachments ) || is_wp_error( $attachments ) ) {
+			return new \WP_Error( 'no_attachments', __( 'No attachments found in this folder.', 'godam' ), array( 'status' => 404 ) );
+		}
+
+		// Create the ZIP file.
+		$zip_name = sanitize_file_name( $zip_name );
+
+		$result = $this->create_zip_file( $attachments, $zip_name );
+
+		if ( is_wp_error( $result ) ) {
+			return $result; // Return the error if ZIP creation failed.
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get attachments associated with a specific media folder.
+	 *
+	 * @param int $folder_id The ID of the media folder.
+	 * @return array Array of attachment objects.
+	 */
+	private function get_taxonomy_attachments( $folder_id ) {
+		// Get attachments associated with the folder.
+		$args = array(
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				array(
+					'taxonomy' => 'media-folder',
+					'field'    => 'term_id',
+					'terms'    => $folder_id,
+				),
+			),
+			'posts_per_page' => -1, // Get all attachments.
+		);
+
+		return get_posts( $args );
+	}
+
+	/**
+	 * Create a ZIP file from the provided attachments.
+	 *
+	 * @param array  $attachments Array of attachment objects.
+	 * @param string $zip_name    Name of the ZIP file to create.
+	 * @return array|\WP_Error    Array with ZIP file details or WP_Error on failure.
+	 */
+	private function create_zip_file( $attachments, $zip_name ) {
+		// Get upload directory info.
+		$upload_dir = wp_get_upload_dir();
+
+		// Create godam directory if it doesn't exist.
+		$godam_dir = $upload_dir['basedir'] . '/godam';
+		$godam_url = $upload_dir['baseurl'] . '/godam';
+
+		if ( ! file_exists( $godam_dir ) ) {
+			if ( ! wp_mkdir_p( $godam_dir ) ) {
+				return new \WP_Error( 'directory_creation_failed', __( 'Failed to create godam directory.', 'godam' ), array( 'status' => 500 ) );
+			}
+		}
+
+		// Ensure zip_name has .zip extension.
+		if ( ! str_ends_with( $zip_name, '.zip' ) ) {
+			$zip_name .= '.zip';
+		}
+
+		// Full path to the ZIP file.
+		$zip_path = $godam_dir . '/' . $zip_name;
+
+		// Create a new ZipArchive instance.
+		$zip        = new \ZipArchive();
+		$zip_result = $zip->open( $zip_path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE );
+
+		if ( true !== $zip_result ) {
+			return new \WP_Error(
+				'zip_creation_failed',
+				/* translators: %d is the error code returned by ZipArchive::open */
+				sprintf( __( 'Failed to create ZIP file. Error code: %d', 'godam' ), $zip_result ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$added_files   = 0;
+		$skipped_files = 0;
+
+		foreach ( $attachments as $attachment ) {
+			$file_path = get_attached_file( $attachment->ID );
+
+			if ( ! $file_path || ! file_exists( $file_path ) ) {
+				++$skipped_files;
+				continue;
+			}
+
+			$filename = basename( $file_path );
+
+			// Handle duplicate filenames by adding attachment ID prefix.
+			$zip_filename = $attachment->ID . '_' . $filename;
+
+			if ( $zip->addFile( $file_path, $zip_filename ) ) {
+				++$added_files;
+			} else {
+				++$skipped_files;
+			}
+		}
+
+		$zip->close();
+
+		// Check if any files were added.
+		if ( 0 === $added_files ) {
+			// Delete empty ZIP file.
+			if ( file_exists( $zip_path ) ) {
+				unlink( $zip_path ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink -- using `wp-content/uploads/` folder create only.
+
+			}
+			return new \WP_Error(
+				'no_files_added',
+				__( 'No valid files found to add to ZIP.', 'godam' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Generate the URL for the ZIP file.
+		$zip_url = $godam_url . '/' . $zip_name;
+
+		// Optional: Schedule cleanup after 24 hours.
+		wp_schedule_single_event( time() + DAY_IN_SECONDS, 'godam_cleanup_zip', array( $zip_path ) );
+
+		return array(
+			'zip_url'       => $zip_url,
+			'zip_path'      => $zip_path,
+			'zip_name'      => $zip_name,
+			'added_files'   => $added_files,
+			'skipped_files' => $skipped_files,
+			'message'       => sprintf(
+				/* translators: %1$d is the number of files added, %2$d is the number of files skipped */
+				__( 'ZIP file created successfully. %1$d files added, %2$d files skipped.', 'godam' ),
+				$added_files,
+				$skipped_files
+			),
+			'status'        => 'success',
+		);
+	}
+
+	/**
+	 * Cleanup the ZIP file after a scheduled time.
+	 *
+	 * @param string $zip_path The path to the ZIP file to be cleaned up.
+	 */
+	public function godam_cleanup_zip_file( $zip_path ) {
+		if ( file_exists( $zip_path ) ) {
+			unlink( $zip_path ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink -- using `wp-content/uploads/` folder cleanup only.
+		}
+	}
+}

--- a/inc/classes/media-library/class-media-folder-utils.php
+++ b/inc/classes/media-library/class-media-folder-utils.php
@@ -96,6 +96,24 @@ class Media_Folder_Utils {
 	}
 
 	/**
+	 * Invalidate attachment count cache for multiple folders
+	 *
+	 * @param array $folder_ids - An array of media folder IDs.
+	 */
+	public function invalidate_multiple_attachment_count_cache( $folder_ids ) {
+		if ( empty( $folder_ids ) || ! is_array( $folder_ids ) ) {
+			return;
+		}
+
+		foreach ( $folder_ids as $folder_id ) {
+			$folder_id = absint( $folder_id );
+			if ( $folder_id > 0 ) {
+				$this->invalidate_attachment_count_cache( $folder_id );
+			}
+		}
+	}
+
+	/**
 	 * Clear all attachment count caches
 	 * Useful for bulk operations or when you want to force refresh all counts
 	 */

--- a/inc/classes/media-library/class-media-folder-utils.php
+++ b/inc/classes/media-library/class-media-folder-utils.php
@@ -24,9 +24,9 @@ class Media_Folder_Utils {
 	private const CACHE_GROUP = 'godam_media_folders';
 
 	/**
-	 * Default cache expiration time (15 minutes)
+	 * Default cache expiration time (15 days)
 	 */
-	private const CACHE_EXPIRATION = 15 * MINUTE_IN_SECONDS;
+	private const CACHE_EXPIRATION = 15 * DAY_IN_SECONDS;
 
 	/**
 	 * Get the count of attachments in a folder with caching

--- a/inc/classes/media-library/class-media-folder-utils.php
+++ b/inc/classes/media-library/class-media-folder-utils.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Media Folder Utilities class - Centralized helper functions for media folder operations.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Media_Library;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Media_Folder_Utils
+ */
+class Media_Folder_Utils {
+
+	use Singleton;
+
+	/**
+	 * Cache group for media folder operations
+	 */
+	private const CACHE_GROUP = 'godam_media_folders';
+
+	/**
+	 * Default cache expiration time (15 minutes)
+	 */
+	private const CACHE_EXPIRATION = 15 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Get the count of attachments in a folder with caching
+	 *
+	 * @param int  $folder_id - The ID of the media folder.
+	 * @param bool $force_refresh - Whether to bypass cache and get fresh count.
+	 * @return int - The count of attachments in the folder.
+	 */
+	public function get_attachment_count( $folder_id, $force_refresh = false ) {
+		$folder_id = absint( $folder_id );
+
+		if ( $folder_id <= 0 ) {
+			return 0;
+		}
+
+		// Create a unique cache key for this folder.
+		$cache_key = 'attachment_count_' . $folder_id;
+
+		// Try to get cached count first (unless force refresh is requested).
+		if ( ! $force_refresh ) {
+			$cached_count = get_transient( $cache_key );
+
+			if ( false !== $cached_count ) {
+				return absint( $cached_count );
+			}
+		}
+
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Use direct SQL query for better performance.
+		$count = $wpdb->get_var(
+			$wpdb->prepare(
+				"
+			SELECT COUNT(DISTINCT p.ID)
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			WHERE p.post_type = 'attachment'
+			AND p.post_status = 'inherit'
+			AND tt.taxonomy = 'media-folder'
+			AND tt.term_id = %d
+		",
+				$folder_id
+			)
+		);
+
+		$count = absint( $count );
+
+		// Cache the result.
+		set_transient( $cache_key, $count, self::CACHE_EXPIRATION );
+
+		return $count;
+	}
+
+	/**
+	 * Invalidate attachment count cache for a specific folder
+	 *
+	 * @param int $folder_id - The ID of the media folder.
+	 */
+	public function invalidate_attachment_count_cache( $folder_id ) {
+		$folder_id = absint( $folder_id );
+
+		if ( $folder_id > 0 ) {
+			$cache_key = 'attachment_count_' . $folder_id;
+			delete_transient( $cache_key );
+		}
+	}
+
+	/**
+	 * Clear all attachment count caches
+	 * Useful for bulk operations or when you want to force refresh all counts
+	 */
+	public function clear_all_attachment_count_caches() {
+		global $wpdb;
+
+		// Get all transient keys related to attachment counts.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Direct SQL query to fetch transient keys.
+		$transient_keys = $wpdb->get_col(
+			"SELECT option_name FROM {$wpdb->options}
+			WHERE option_name LIKE '_transient_attachment_count_%'"
+		);
+
+		foreach ( $transient_keys as $key ) {
+			$transient_name = str_replace( '_transient_', '', $key );
+			delete_transient( $transient_name );
+		}
+	}
+
+	/**
+	 * Check if a folder exists and is valid
+	 *
+	 * @param int $folder_id - The ID of the media folder.
+	 * @return bool - Whether the folder exists and is valid.
+	 */
+	public function is_valid_folder( $folder_id ) {
+		$folder_id = absint( $folder_id );
+
+		if ( $folder_id <= 0 ) {
+			return false;
+		}
+
+		$term = get_term( $folder_id, 'media-folder' );
+
+		return ! is_wp_error( $term ) && ! empty( $term );
+	}
+
+	/**
+	 * Get folder information with attachment count
+	 *
+	 * @param int  $folder_id - The ID of the media folder.
+	 * @param bool $force_refresh - Whether to bypass cache for the count.
+	 * @return array|\WP_Error - Folder information with count, or WP_Error on failure.
+	 */
+	public function get_folder_info( $folder_id, $force_refresh = false ) {
+		$folder_id = absint( $folder_id );
+
+		if ( $folder_id <= 0 ) {
+			return new \WP_Error( 'invalid_folder_id', __( 'Invalid folder ID provided.', 'godam' ) );
+		}
+
+		$term = get_term( $folder_id, 'media-folder' );
+
+		if ( is_wp_error( $term ) || empty( $term ) ) {
+			return new \WP_Error( 'folder_not_found', __( 'Media folder not found.', 'godam' ) );
+		}
+
+		$attachment_count = $this->get_attachment_count( $folder_id, $force_refresh );
+
+		return array(
+			'id'               => $term->term_id,
+			'name'             => $term->name,
+			'slug'             => $term->slug,
+			'description'      => $term->description,
+			'attachment_count' => $attachment_count,
+			'parent'           => $term->parent,
+		);
+	}
+}

--- a/inc/classes/media-library/class-media-folders-rest-api.php
+++ b/inc/classes/media-library/class-media-folders-rest-api.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Media Folders REST API class.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Media_Library;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Media_Folders_REST_API
+ */
+class Media_Folders_REST_API {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Setup hooks for the class.
+	 */
+	private function setup_hooks() {
+		add_filter( 'rest_prepare_media-folder', array( $this, 'add_data_to_media_folder_rest_api' ), 10, 2 );
+
+		add_action( 'added_term_relationship', array( $this, 'invalidate_folder_count_cache' ), 10, 3 );
+		add_action( 'deleted_term_relationships', array( $this, 'invalidate_folder_count_cache' ), 10, 3 );
+	}
+
+	/**
+	 * Add additional data to the media folder REST API response.
+	 *
+	 * @param \WP_REST_Response $response The response object.
+	 * @param \WP_Term          $term     The term object.
+	 * @return \WP_REST_Response
+	 */
+	public function add_data_to_media_folder_rest_api( $response, $term ) {
+		// Add the attachment count to the response.
+		$response->data['attachmentCount'] = (int) $this->get_term_attachment_count( $term->term_id );
+
+		return $response;
+	}
+
+	/**
+	 * Get the count of attachments in a media folder.
+	 *
+	 * Caches the count for a 15 day to improve performance.
+	 *
+	 * @param int $term_id The term ID of the media folder.
+	 * @return int The count of attachments in the media folder.
+	 */
+	private function get_term_attachment_count( $term_id ) {
+
+		$cache_key    = 'media_folder_count_' . $term_id;
+		$cached_count = get_transient( $cache_key );
+
+		if ( false !== $cached_count ) {
+			return $cached_count;
+		}
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'fields'         => 'ids',
+				'posts_per_page' => 1, // We only need count.
+				'no_found_rows'  => false, // Important to get found_posts.
+				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query,WordPress.DB.SlowDBQuery.slow_db_query_tax_query_no_cache
+					array(
+						'taxonomy'         => 'media-folder',
+						'field'            => 'term_id',
+						'terms'            => $term_id,
+						'include_children' => false,
+					),
+				),
+			)
+		);
+
+		if ( ! $query->have_posts() ) {
+			return 0;
+		}
+
+		$attachment_count = (int) $query->found_posts;
+
+		set_transient( $cache_key, $attachment_count, 15 * DAY_IN_SECONDS );
+
+		return $attachment_count;
+	}
+
+	/**
+	 * Invalidate the media folder count cache when attachments are added or removed.
+	 *
+	 * @param array  $object_ids The IDs of the objects being modified.
+	 * @param int    $term_id    The term ID of the media folder.
+	 * @param string $taxonomy   The taxonomy being modified.
+	 */
+	public function invalidate_folder_count_cache( $object_ids, $term_id, $taxonomy ) {
+		if ( 'media-folder' !== $taxonomy ) {
+			return;
+		}
+
+		// Invalidate the cache for this term.
+		delete_transient( 'media_folder_count_' . $term_id );
+
+		// Optionally, you can also invalidate the cache for all terms in this taxonomy.
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'media-folder',
+				'hide_empty' => false,
+			)
+		);
+
+		foreach ( $terms as $term ) {
+			delete_transient( 'media_folder_count_' . $term->term_id );
+		}
+	}
+}

--- a/inc/classes/media-library/class-media-folders-rest-api.php
+++ b/inc/classes/media-library/class-media-folders-rest-api.php
@@ -30,9 +30,6 @@ class Media_Folders_REST_API {
 	 */
 	private function setup_hooks() {
 		add_filter( 'rest_prepare_media-folder', array( $this, 'add_data_to_media_folder_rest_api' ), 10, 2 );
-
-		add_action( 'added_term_relationship', array( $this, 'invalidate_folder_count_cache' ), 10, 3 );
-		add_action( 'deleted_term_relationships', array( $this, 'invalidate_folder_count_cache' ), 10, 3 );
 	}
 
 	/**

--- a/inc/classes/media-library/class-media-folders-rest-api.php
+++ b/inc/classes/media-library/class-media-folders-rest-api.php
@@ -8,6 +8,7 @@
 namespace RTGODAM\Inc\Media_Library;
 
 use RTGODAM\Inc\Traits\Singleton;
+use RTGODAM\Inc\Taxonomies\Media_Folders;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,6 +31,9 @@ class Media_Folders_REST_API {
 	 */
 	private function setup_hooks() {
 		add_filter( 'rest_prepare_media-folder', array( $this, 'add_data_to_media_folder_rest_api' ), 10, 2 );
+
+		add_action( 'set_object_terms', array( $this, 'invalidate_attachment_count_cache' ), 10, 4 );
+		add_action( 'deleted_term_relationships', array( $this, 'invalidate_all_attachment_count_cache' ), 10, 3 );
 	}
 
 	/**
@@ -44,5 +48,43 @@ class Media_Folders_REST_API {
 		$response->data['attachmentCount'] = (int) Media_Folder_Utils::get_instance()->get_attachment_count( $term->term_id );
 
 		return $response;
+	}
+
+	/**
+	 * Invalidate the attachment count cache when attachments are added or removed from a media folder.
+	 *
+	 * @param int    $object_id  Object ID.
+	 * @param array  $terms      An array of object term IDs or slugs.
+	 * @param array  $tt_ids     An array of term taxonomy IDs.
+	 * @param string $taxonomy   Taxonomy slug.
+	 */
+	public function invalidate_attachment_count_cache( $object_id, $terms, $tt_ids, $taxonomy ) {
+
+		if ( 'media-folder' === $taxonomy ) {
+			// Filter term IDs to ensure they're integers (not slugs).
+			$term_ids = array_filter( $terms, 'is_numeric' );
+			$term_ids = array_map( 'intval', $term_ids );
+
+			// Invalidate cache for each term ID.
+			foreach ( $term_ids as $term_id ) {
+				Media_Folder_Utils::get_instance()->invalidate_attachment_count_cache( $term_id );
+			}
+		}
+	}
+
+	/**
+	 * Invalidate all attachment count caches when a term is deleted.
+	 *
+	 * @param int    $object_id The term ID.
+	 * @param array  $tt_ids  An array of term taxonomy IDs.
+	 * @param string $taxonomy The taxonomy slug.
+	 */
+	public function invalidate_all_attachment_count_cache( $object_id, $tt_ids, $taxonomy ) {
+		// TODO: Cache invalidation logic can be optimized to only clear the specific folder's cache.
+		// For now, we clear all caches for the media folders taxonomy.
+		// That is because the invalidation logic when folder is removed from an attachment is tricky.
+		if ( 'media-folder' === $taxonomy ) {
+			Media_Folder_Utils::get_instance()->clear_all_attachment_count_caches();
+		}
 	}
 }

--- a/inc/classes/media-library/class-media-folders-rest-api.php
+++ b/inc/classes/media-library/class-media-folders-rest-api.php
@@ -44,82 +44,8 @@ class Media_Folders_REST_API {
 	 */
 	public function add_data_to_media_folder_rest_api( $response, $term ) {
 		// Add the attachment count to the response.
-		$response->data['attachmentCount'] = (int) $this->get_term_attachment_count( $term->term_id );
+		$response->data['attachmentCount'] = (int) Media_Folder_Utils::get_instance()->get_attachment_count( $term->term_id );
 
 		return $response;
-	}
-
-	/**
-	 * Get the count of attachments in a media folder.
-	 *
-	 * Caches the count for a 15 day to improve performance.
-	 *
-	 * @param int $term_id The term ID of the media folder.
-	 * @return int The count of attachments in the media folder.
-	 */
-	private function get_term_attachment_count( $term_id ) {
-
-		$cache_key    = 'media_folder_count_' . $term_id;
-		$cached_count = get_transient( $cache_key );
-
-		if ( false !== $cached_count ) {
-			return $cached_count;
-		}
-
-		$query = new \WP_Query(
-			array(
-				'post_type'      => 'attachment',
-				'post_status'    => 'inherit',
-				'fields'         => 'ids',
-				'posts_per_page' => 1, // We only need count.
-				'no_found_rows'  => false, // Important to get found_posts.
-				'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query,WordPress.DB.SlowDBQuery.slow_db_query_tax_query_no_cache
-					array(
-						'taxonomy'         => 'media-folder',
-						'field'            => 'term_id',
-						'terms'            => $term_id,
-						'include_children' => false,
-					),
-				),
-			)
-		);
-
-		if ( ! $query->have_posts() ) {
-			return 0;
-		}
-
-		$attachment_count = (int) $query->found_posts;
-
-		set_transient( $cache_key, $attachment_count, 15 * DAY_IN_SECONDS );
-
-		return $attachment_count;
-	}
-
-	/**
-	 * Invalidate the media folder count cache when attachments are added or removed.
-	 *
-	 * @param array  $object_ids The IDs of the objects being modified.
-	 * @param int    $term_id    The term ID of the media folder.
-	 * @param string $taxonomy   The taxonomy being modified.
-	 */
-	public function invalidate_folder_count_cache( $object_ids, $term_id, $taxonomy ) {
-		if ( 'media-folder' !== $taxonomy ) {
-			return;
-		}
-
-		// Invalidate the cache for this term.
-		delete_transient( 'media_folder_count_' . $term_id );
-
-		// Optionally, you can also invalidate the cache for all terms in this taxonomy.
-		$terms = get_terms(
-			array(
-				'taxonomy'   => 'media-folder',
-				'hide_empty' => false,
-			)
-		);
-
-		foreach ( $terms as $term ) {
-			delete_transient( 'media_folder_count_' . $term->term_id );
-		}
 	}
 }

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -168,7 +168,7 @@ class Media_Library extends Base {
 		$per_page = min( 100, max( 1, (int) $request->get_param( 'per_page' ) ) );
 		$offset   = ( $page - 1 ) * $per_page;
 	
-		$terms = get_terms(
+		$top_level_terms = get_terms(
 			array(
 				'taxonomy'   => 'media-folder',
 				'hide_empty' => false,
@@ -176,8 +176,11 @@ class Media_Library extends Base {
 				'order'      => 'ASC',
 				'number'     => $per_page,
 				'offset'     => $offset,
+				'parent'     => 0,
 			) 
 		);
+		
+		$all_terms = $top_level_terms;
 	
 		$total_terms = wp_count_terms(
 			array(
@@ -189,7 +192,21 @@ class Media_Library extends Base {
 	
 		$results = array();
 	
-		foreach ( $terms as $term ) {
+		foreach ( $top_level_terms as $term ) {
+			$child_terms = get_terms(
+				array(
+					'taxonomy'   => 'media-folder',
+					'hide_empty' => false,
+					'orderby'    => 'name',
+					'order'      => 'ASC',
+					'parent'     => (int) $term->term_id,
+				) 
+			);
+		
+			$all_terms = array_merge( $all_terms, $child_terms );
+		}
+
+		foreach ( $all_terms as $term ) {
 			$locked   = get_term_meta( $term->term_id, 'locked', true );
 			$bookmark = get_term_meta( $term->term_id, 'bookmark', true );
 	

--- a/inc/classes/taxonomies/class-media-folders.php
+++ b/inc/classes/taxonomies/class-media-folders.php
@@ -102,5 +102,15 @@ class Media_Folders extends Base {
 				'show_in_rest' => true,
 			)
 		);
+
+		register_term_meta(
+			static::SLUG,
+			'bookmark',
+			array(
+				'type'         => 'boolean',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
 	}
 }

--- a/inc/classes/taxonomies/class-media-folders.php
+++ b/inc/classes/taxonomies/class-media-folders.php
@@ -22,6 +22,17 @@ class Media_Folders extends Base {
 	const SLUG = 'media-folder';
 
 	/**
+	 * Setup hooks for the taxonomy.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+		parent::setup_hooks();
+
+		add_action( 'init', array( $this, 'register_term_meta' ) );
+	}
+
+	/**
 	 * Labels for taxonomy.
 	 *
 	 * @return array
@@ -74,5 +85,22 @@ class Media_Folders extends Base {
 		);
 
 		return array_merge( $args, $extra );
+	}
+
+	/**
+	 * Register term meta for media folder count.
+	 *
+	 * This meta will store the count of attachments in each media folder.
+	 */
+	public function register_term_meta() {
+		register_term_meta(
+			static::SLUG,
+			'locked',
+			array(
+				'type'         => 'boolean',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
 	}
 }

--- a/inc/helpers/autoloader.php
+++ b/inc/helpers/autoloader.php
@@ -54,6 +54,7 @@ function autoloader( $file_resource = '' ) {
 				$file_name = sprintf( 'trait-%s', trim( strtolower( $path[2] ) ) );
 				break;
 			case 'providers':
+			case 'media-library': // phpcs:ignore
 			case 'meta-boxes': // phpcs:ignore
 			case 'rest-controller': // phpcs:ignore
 			case 'taxonomies': // phpcs:ignore

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -17,6 +17,7 @@ import FolderTree from './components/folder-tree/FolderTree.jsx';
 import { changeSelectedFolder, openModal } from './redux/slice/folders';
 import { FolderCreationModal, RenameModal, DeleteModal } from './components/modal/index.jsx';
 import { triggerFilterChange } from './data/media-grid.js';
+import BookmarkTab from './components/folder-tree/BookmarkTab.jsx';
 
 const App = () => {
 	const dispatch = useDispatch();
@@ -88,6 +89,7 @@ const App = () => {
 				</button>
 			</div>
 
+			<BookmarkTab />
 			<FolderTree />
 
 			<FolderCreationModal />

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Button, ButtonGroup } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 const { __ } = wp.i18n;
 /**
  * Internal dependencies
@@ -42,17 +42,17 @@ const App = () => {
 				variant="primary"
 				text={ __( 'New Folder', 'godam' ) }
 				className="button--full mb-spacing"
-				onClick={ () => dispatch( openModal( 'folderCreation' ) ) }
+				onClick={ () => dispatch( openModal( { type: 'folderCreation', item: selectedFolder } ) ) }
 			/>
 
-			<ButtonGroup className="button-group mb-spacing">
+			<div className="button-group mb-spacing">
 				<Button
 					icon="edit"
 					__next40pxDefaultSize
 					variant="secondary"
 					text={ __( 'Rename', 'godam' ) }
 					className="button--half"
-					onClick={ () => dispatch( openModal( 'rename' ) ) }
+					onClick={ () => dispatch( openModal( { type: 'rename', item: selectedFolder } ) ) }
 					disabled={ [ -1, 0 ].includes( selectedFolder.id ) }
 				/>
 				<Button
@@ -62,10 +62,10 @@ const App = () => {
 					text={ __( 'Delete', 'godam' ) }
 					className="button--half"
 					isDestructive={ true }
-					onClick={ () => dispatch( openModal( 'delete' ) ) }
+					onClick={ () => dispatch( openModal( { type: 'delete', item: selectedFolder } ) ) }
 					disabled={ [ -1, 0 ].includes( selectedFolder.id ) }
 				/>
-			</ButtonGroup>
+			</div>
 
 			<div className="folder-list">
 				<button

--- a/pages/media-library/components/folder-tree/BookmarkItem.jsx
+++ b/pages/media-library/components/folder-tree/BookmarkItem.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon, file, lock } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { changeSelectedFolder } from '../../redux/slice/folders';
+import { triggerFilterChange } from '../../data/media-grid';
+import './css/tree-item.scss';
+
+const BookmarkItem = ( { item, index } ) => {
+	const dispatch = useDispatch();
+
+	const selectedFolderID = useSelector( ( state ) => state.FolderReducer.selectedFolder?.id );
+
+	/**
+	 * Handle click on the tree item to change the selected folder
+	 * and trigger the filter change in the media grid.
+	 */
+	const handleClick = () => {
+		triggerFilterChange( item.id );
+
+		dispatch( changeSelectedFolder( { item } ) );
+	};
+
+	return (
+		<>
+			<div
+				className={ `tree-item ${ item.id === selectedFolderID ? 'tree-item--active' : '' }` }
+				data-id={ item.id }
+			>
+				<button
+					className={ 'tree-item__button' }
+					data-index={ index }
+					onClick={ () => handleClick() }
+				>
+					<div className="tree-item__content">
+						<Icon icon={ item.meta?.locked ? lock : file } />
+						<span className="tree-item__text">{ item.name }</span>
+
+						<span className="tree-item__count">
+							{ item.attachmentCount ?? 0 }
+						</span>
+					</div>
+				</button>
+			</div>
+		</>
+	);
+};
+
+export default BookmarkItem;

--- a/pages/media-library/components/folder-tree/BookmarkTab.jsx
+++ b/pages/media-library/components/folder-tree/BookmarkTab.jsx
@@ -1,0 +1,96 @@
+
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Panel, PanelBody, Notice } from '@wordpress/components';
+import { lock as bookmarkIcon, starFilled } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import BookmarkItem from './BookmarkItem.jsx';
+import './css/bookmark.scss';
+
+const BookmarkTab = () => {
+	const folders = useSelector( ( state ) => state.FolderReducer.folders );
+
+	// Get all the bookmarks from folder where `meta.bookmark` is true
+	// and sort them by name (case-insensitive)
+	const bookmarks = folders
+		?.filter( ( folder ) => folder.meta?.bookmark )
+		?.sort( ( a, b ) => a.name.toLowerCase().localeCompare( b.name.toLowerCase() ) ) || [];
+
+	// Empty state with better messaging and action
+	if ( ! bookmarks || bookmarks.length === 0 ) {
+		return (
+			<div className="godam-bookmark-tab godam-bookmark-tab--empty">
+				<Panel className="godam-bookmark-panel">
+					<PanelBody
+						title={ __( 'Bookmarks', 'godam' ) }
+						icon={ bookmarkIcon }
+						initialOpen={ true }
+					>
+						<div className="godam-bookmark-tab__empty-state">
+							<div className="godam-bookmark-tab__empty-icon">
+								{ starFilled }
+							</div>
+							<h4>{ __( 'No bookmarks yet', 'godam' ) }</h4>
+						</div>
+					</PanelBody>
+				</Panel>
+			</div>
+		);
+	}
+
+	// Success state with bookmarks
+	return (
+		<div className="godam-bookmark-tab">
+			<Panel className="godam-bookmark-panel">
+				<PanelBody
+					title={
+						sprintf(
+							/* translators: %d: number of bookmarks */
+							__( 'Bookmarks (%d)', 'godam' ),
+							bookmarks.length,
+						)
+					}
+					icon={ bookmarkIcon }
+					initialOpen={ true }
+				>
+					{ bookmarks.length > 5 && (
+						<Notice
+							status="info"
+							isDismissible={ false }
+							className="godam-bookmark-tab__notice"
+						>
+							{ sprintf(
+								/* translators: %d: number of bookmarks */
+								__( 'You have %d bookmarks. Consider organizing them into categories.', 'godam' ),
+								bookmarks.length,
+							) }
+						</Notice>
+					) }
+
+					<div className="godam-bookmark-tab__list">
+						{ bookmarks.map( ( bookmark, index ) => (
+							<BookmarkItem
+								item={ bookmark }
+								key={ bookmark.id }
+								index={ index }
+								totalCount={ bookmarks.length }
+							/>
+						) ) }
+					</div>
+				</PanelBody>
+			</Panel>
+		</div>
+	);
+};
+
+export default BookmarkTab;

--- a/pages/media-library/components/folder-tree/ContextMenu.jsx
+++ b/pages/media-library/components/folder-tree/ContextMenu.jsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+/**
+ * Internal dependencies
+ */
+import { hideContextMenu, openModal } from '../../redux/slice/folders';
+
+/*
+ * Internal dependencies
+ */
+import './css/context-menu.scss';
+
+const ContextMenu = () => {
+	const dispatch = useDispatch();
+	const contextMenuRef = useRef( null );
+	const { isOpen, position, item: targetItem } = useSelector( ( state ) => state.FolderReducer.contextMenu );
+
+	useEffect( () => {
+		const handleClickOutside = ( event ) => {
+			if ( contextMenuRef.current && ! contextMenuRef.current.contains( event.target ) ) {
+				dispatch( hideContextMenu() );
+			}
+		};
+
+		const handleEscapeKey = ( event ) => {
+			if ( event.key === 'Escape' ) {
+				dispatch( hideContextMenu() );
+			}
+		};
+
+		if ( isOpen ) {
+			document.addEventListener( 'mousedown', handleClickOutside );
+			document.addEventListener( 'keydown', handleEscapeKey );
+		}
+
+		return () => {
+			document.removeEventListener( 'mousedown', handleClickOutside );
+			document.removeEventListener( 'keydown', handleEscapeKey );
+		};
+	}, [ isOpen, dispatch ] );
+
+	const handleMenuAction = ( action ) => {
+		switch ( action ) {
+			case 'rename':
+				dispatch( openModal( { type: 'rename', item: targetItem } ) );
+				break;
+			case 'delete':
+				dispatch( openModal( { type: 'delete', item: targetItem } ) );
+				break;
+			case 'newFolder':
+				dispatch( openModal( { type: 'folderCreation', item: targetItem } ) );
+				break;
+			default:
+				dispatch( hideContextMenu() );
+				break;
+		}
+	};
+
+	if ( ! isOpen || ! targetItem ) {
+		return null;
+	}
+
+	return (
+		<div
+			ref={ contextMenuRef }
+			className="context-menu"
+			style={ {
+				position: 'fixed',
+				top: position.y,
+				left: position.x,
+				zIndex: 9999,
+			} }
+		>
+			<ul className="context-menu__list">
+				<button
+					className="context-menu__item"
+					onClick={ () => handleMenuAction( 'rename' ) }
+				>
+					Rename Folder
+				</button>
+				<button
+					className="context-menu__item"
+					onClick={ () => handleMenuAction( 'newFolder' ) }
+				>
+					New Subfolder
+				</button>
+				<button
+					className="context-menu__item context-menu__item--danger"
+					onClick={ () => handleMenuAction( 'delete' ) }
+				>
+					Delete Folder
+				</button>
+			</ul>
+		</div>
+	);
+};
+
+export default ContextMenu;

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -208,15 +208,6 @@ const FolderTree = () => {
 
 						const targetFolder = data.find( ( folder ) => folder.id === targetFolderId );
 
-						// Check if the target folder exists.
-						if ( ! targetFolder ) {
-							dispatch( updateSnackbar( {
-								message: __( 'Target folder not found', 'godam' ),
-								type: 'error',
-							} ) );
-							return;
-						}
-
 						// do not allow assigning items to a locked folder.
 						if ( targetFolder?.meta?.locked ) {
 							dispatch( updateSnackbar( {

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -18,12 +18,13 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import TreeItem from './TreeItem.jsx';
 import TreeItemPreview from './TreeItemPreview.jsx';
+import ContextMenu from './ContextMenu.jsx';
+import SnackbarComp from './SnackbarComp.jsx';
 
 import { setTree, updateSnackbar } from '../../redux/slice/folders.js';
 import { utilities } from '../../data/utilities';
 
 import { useAssignFolderMutation, useGetFoldersQuery, useUpdateFolderMutation } from '../../redux/api/folders.js';
-import SnackbarComp from './SnackbarComp.jsx';
 
 import './css/tree.scss';
 
@@ -301,6 +302,7 @@ const FolderTree = () => {
 			</DragOverlay>
 
 			<SnackbarComp />
+			<ContextMenu />
 
 		</DndContext>
 	);

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -172,8 +172,6 @@ const FolderTree = () => {
 		dispatch( setTree( updatedFolders ) );
 	}, [ data, dispatch ] );
 
-	const selectedFolderId = useMemo( () => selectedFolder?.id, [ selectedFolder?.id ] );
-
 	useEffect( () => {
 		/**
 		 * Initialize and manage droppable functionality for tree items.
@@ -195,7 +193,36 @@ const FolderTree = () => {
 						/**
 						 * Prevent assigning items to the same folder they are already in.
 						 */
-						if ( selectedFolderId === targetFolderId ) {
+						if ( selectedFolder?.id === targetFolderId ) {
+							return;
+						}
+
+						// do not allow assigning item to other folder from the locked folder.
+						if ( selectedFolder?.meta?.locked ) {
+							dispatch( updateSnackbar( {
+								message: __( 'This folder is locked and cannot be modified', 'godam' ),
+								type: 'error',
+							} ) );
+							return;
+						}
+
+						const targetFolder = data.find( ( folder ) => folder.id === targetFolderId );
+
+						// Check if the target folder exists.
+						if ( ! targetFolder ) {
+							dispatch( updateSnackbar( {
+								message: __( 'Target folder not found', 'godam' ),
+								type: 'error',
+							} ) );
+							return;
+						}
+
+						// do not allow assigning items to a locked folder.
+						if ( targetFolder?.meta?.locked ) {
+							dispatch( updateSnackbar( {
+								message: __( 'This folder is locked and cannot be modified', 'godam' ),
+								type: 'error',
+							} ) );
 							return;
 						}
 
@@ -216,14 +243,14 @@ const FolderTree = () => {
 							/**
 							 * Remove the dragged items from the attachment view if they are meant to be removed.
 							 */
-							if ( selectedFolderId !== -1 ) {
+							if ( selectedFolder?.id !== -1 ) {
 								draggedItems.forEach( ( attachmentId ) => {
 									jQuery( `li.attachment[data-id="${ attachmentId }"]` ).remove(); // for attachment grid view.
 									jQuery( `tr#post-${ attachmentId }` ).remove(); // for attachment list view.
 								} );
 
 								// Update the folder tree count that reflects the new state.
-								updateAttachmentCountOfFolders( selectedFolderId, targetFolderId, draggedItems.length );
+								updateAttachmentCountOfFolders( selectedFolder?.id, targetFolderId, draggedItems.length );
 							}
 						} catch {
 							dispatch( updateSnackbar( {
@@ -250,7 +277,7 @@ const FolderTree = () => {
 				} );
 			}
 		};
-	}, [ data, assignFolderMutation, dispatch, selectedFolderId, updateAttachmentCountOfFolders ] );
+	}, [ data, assignFolderMutation, dispatch, selectedFolder, updateAttachmentCountOfFolders ] );
 
 	if ( isLoading ) {
 		return <div>{ __( 'Loading…', 'godam' ) }</div>;

--- a/pages/media-library/components/folder-tree/TreeItem.jsx
+++ b/pages/media-library/components/folder-tree/TreeItem.jsx
@@ -75,6 +75,10 @@ const TreeItem = ( { item, index, depth } ) => {
 					<div className="tree-item__content">
 						<Icon icon={ file } />
 						<span className="tree-item__text">{ item.name }</span>
+
+						<span className="tree-item__count">
+							{ item.attachmentCount ?? 0 }
+						</span>
 					</div>
 
 					{ item.children?.length > 0 &&

--- a/pages/media-library/components/folder-tree/TreeItem.jsx
+++ b/pages/media-library/components/folder-tree/TreeItem.jsx
@@ -13,7 +13,7 @@ import { Icon, file, chevronDown, chevronUp } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { toggleOpenClose, changeSelectedFolder } from '../../redux/slice/folders';
+import { toggleOpenClose, changeSelectedFolder, showContextMenu } from '../../redux/slice/folders';
 import { triggerFilterChange } from '../../data/media-grid';
 import './css/tree-item.scss';
 
@@ -46,6 +46,21 @@ const TreeItem = ( { item, index, depth } ) => {
 		dispatch( toggleOpenClose( { id: item.id } ) );
 	};
 
+	/**
+	 * Handle right-click context menu for the tree item.
+	 *
+	 * @param {Event} e - The event object.
+	 */
+	const handleContextMenu = ( e ) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		dispatch( showContextMenu( {
+			position: { x: e.clientX, y: e.clientY },
+			item,
+		} ) );
+	};
+
 	const style = {
 		transform: CSS.Transform.toString( transform ),
 		transition,
@@ -63,6 +78,7 @@ const TreeItem = ( { item, index, depth } ) => {
 				style={ style }
 				{ ...attributes }
 				{ ...listeners }
+				onContextMenu={ handleContextMenu }
 			>
 				<button
 					style={ { paddingLeft: `${ depth * indentPerLevel }px` } }

--- a/pages/media-library/components/folder-tree/TreeItem.jsx
+++ b/pages/media-library/components/folder-tree/TreeItem.jsx
@@ -8,7 +8,7 @@ import { CSS } from '@dnd-kit/utilities';
 /**
  * WordPress dependencies
  */
-import { Icon, file, chevronDown, chevronUp } from '@wordpress/icons';
+import { Icon, file, lock, chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -89,7 +89,7 @@ const TreeItem = ( { item, index, depth } ) => {
 					onClick={ () => handleClick() }
 				>
 					<div className="tree-item__content">
-						<Icon icon={ file } />
+						<Icon icon={ item.meta?.locked ? lock : file } />
 						<span className="tree-item__text">{ item.name }</span>
 
 						<span className="tree-item__count">

--- a/pages/media-library/components/folder-tree/css/bookmark.scss
+++ b/pages/media-library/components/folder-tree/css/bookmark.scss
@@ -1,0 +1,185 @@
+/* BookmarkTab Component Styles - WordPress Style */
+.godam-bookmark-tab {
+	margin: 0;
+	padding: 0;
+}
+
+/* Panel Styling */
+.godam-bookmark-panel {
+	border: none;
+	box-shadow: none;
+	background: transparent;
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+}
+
+.godam-bookmark-panel .components-panel__body {
+	background: #fff;
+	margin-bottom: 16px;
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+}
+
+.godam-bookmark-panel .components-panel__body .components-panel__body-title {
+	padding: 12px 16px;
+	background: #f6f7f7;
+}
+
+.godam-bookmark-panel .components-panel__body-toggle {
+	font-weight: 600;
+	color: #1d2327;
+}
+
+.godam-bookmark-panel .components-panel__body-toggle:hover {
+	color: #135e96;
+}
+
+.godam-bookmark-panel .components-panel__body-content {
+	padding: 0;
+}
+
+/* Loading State */
+.godam-bookmark-tab__loading {
+	padding: 32px 16px;
+	text-align: center;
+}
+
+.godam-bookmark-tab__loading .components-spinner {
+	margin-bottom: 12px;
+}
+
+.godam-bookmark-tab__loading p {
+	margin: 0;
+	color: #646970;
+	font-size: 14px;
+}
+
+/* Empty State */
+.godam-bookmark-tab__empty-state {
+	padding: 32px 16px;
+	text-align: center;
+}
+
+.godam-bookmark-tab__empty-icon {
+	margin-bottom: 16px;
+	opacity: 0.4;
+}
+
+.godam-bookmark-tab__empty-icon svg {
+	width: 48px;
+	height: 48px;
+	color: #646970;
+}
+
+.godam-bookmark-tab__empty-state h4 {
+	margin: 0 0 8px 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: #1d2327;
+}
+
+.godam-bookmark-tab__empty-state p {
+	margin: 0;
+	color: #646970;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+/* Notice */
+.godam-bookmark-tab__notice {
+	margin: 0 16px 16px 16px;
+}
+
+.godam-bookmark-item {
+	padding: 12px 16px;
+	border-bottom: 1px solid #dcdcde;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.godam-bookmark-item:last-child {
+	border-bottom: none;
+}
+
+.godam-bookmark-item:hover {
+	background-color: #f6f7f7;
+}
+
+/* Bookmark Icon */
+.godam-bookmark-item__icon {
+	flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+}
+
+.godam-bookmark-item__icon svg {
+	width: 100%;
+	height: 100%;
+	color: #2271b1;
+}
+
+/* Bookmark Content */
+.godam-bookmark-item__content {
+	flex: 1;
+	min-width: 0;
+}
+
+.godam-bookmark-item__name {
+	margin: 0 0 4px 0;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1d2327;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.godam-bookmark-item__path {
+	margin: 0;
+	font-size: 12px;
+	color: #646970;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* Bookmark Actions */
+.godam-bookmark-item__actions {
+	flex-shrink: 0;
+	opacity: 0;
+	display: flex;
+	gap: 4px;
+}
+
+.godam-bookmark-item:hover .godam-bookmark-item__actions {
+	opacity: 1;
+}
+
+.godam-bookmark-item__actions button {
+	padding: 4px;
+	border: 1px solid #8c8f94;
+	background: #f6f7f7;
+	cursor: pointer;
+	color: #50575e;
+}
+
+.godam-bookmark-item__actions button:hover {
+	background: #fff;
+	border-color: #8c8f94;
+	color: #1d2327;
+}
+
+.godam-bookmark-item__actions button.is-destructive:hover {
+	background: #d63638;
+	border-color: #d63638;
+	color: #fff;
+}
+
+.godam-bookmark-item__actions button svg {
+	width: 16px;
+	height: 16px;
+}

--- a/pages/media-library/components/folder-tree/css/context-menu.scss
+++ b/pages/media-library/components/folder-tree/css/context-menu.scss
@@ -1,0 +1,40 @@
+.context-menu {
+	background: #fff;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+	min-width: 150px;
+
+	&__list {
+		list-style: none;
+		margin: 0;
+		padding: 4px 0;
+
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	&__item {
+
+		border: none;
+		background: transparent;
+
+		padding: 8px 12px;
+		cursor: pointer;
+		font-size: 14px;
+		transition: background-color 0.2s;
+
+		&:hover {
+		background-color: #f5f5f5;
+		}
+
+		&--danger {
+		color: #d63638;
+
+		&:hover {
+			background-color: #f0f0f0;
+		}
+		}
+	}
+}

--- a/pages/media-library/components/folder-tree/css/snackbar.scss
+++ b/pages/media-library/components/folder-tree/css/snackbar.scss
@@ -4,8 +4,6 @@
 	bottom: 1rem;
 	right: 1rem;
 
-
-
 	&.success {
 		background-color: #4CAF50;
 	}

--- a/pages/media-library/components/folder-tree/css/tree-item.scss
+++ b/pages/media-library/components/folder-tree/css/tree-item.scss
@@ -92,4 +92,26 @@
 		font-size: 0.875rem;
 		color: #4a4a4a;
 	}
+
+	&__count {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: #1f2937;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		width: 1.5rem;
+		height: 1.5rem;
+		min-width: 1.5rem;
+		border-radius: 0.5rem;
+
+		background-color: #dbeafe;
+
+		margin-left: 0.5rem;
+
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	}
+
 }

--- a/pages/media-library/components/folder-tree/css/tree.scss
+++ b/pages/media-library/components/folder-tree/css/tree.scss
@@ -2,11 +2,10 @@
 	display: flex;
 	justify-content: center;
 	width: 100%;
+	height: calc(100vh - 300px);
+	overflow: scroll;
 
 	.tree {
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
 		width: 100%;
 	}
 }

--- a/pages/media-library/components/modal/DeleteModal.jsx
+++ b/pages/media-library/components/modal/DeleteModal.jsx
@@ -24,7 +24,7 @@ const DeleteModal = () => {
 	const dispatch = useDispatch();
 
 	const isOpen = useSelector( ( state ) => state.FolderReducer.modals.delete );
-	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
+	const selectedFolder = useSelector( ( state ) => state.FolderReducer.modals.item );
 
 	const [ deleteFolderMutation ] = useDeleteFolderMutation();
 	const ref = useRef( null );
@@ -79,7 +79,7 @@ const DeleteModal = () => {
 	};
 
 	return (
-		isOpen && (
+		( isOpen && selectedFolder ) && (
 			<Modal
 				title={ __( 'Confirm Delete', 'godam' ) }
 				onRequestClose={ () => dispatch( closeModal( 'delete' ) ) }

--- a/pages/media-library/components/modal/FolderCreationModal.jsx
+++ b/pages/media-library/components/modal/FolderCreationModal.jsx
@@ -28,7 +28,7 @@ const FolderCreationModal = () => {
 	const dispatch = useDispatch();
 
 	const isOpen = useSelector( ( state ) => state.FolderReducer.modals.folderCreation );
-	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
+	const selectedFolder = useSelector( ( state ) => state.FolderReducer.modals.item );
 
 	useEffect( () => {
 		if ( isOpen ) {
@@ -87,7 +87,7 @@ const FolderCreationModal = () => {
 	};
 
 	return (
-		isOpen && (
+		( isOpen && selectedFolder ) && (
 			<Modal
 				title={ __( 'Create a new folder', 'godam' ) }
 				onRequestClose={ () => dispatch( closeModal( 'folderCreation' ) ) }

--- a/pages/media-library/components/modal/RenameModal.jsx
+++ b/pages/media-library/components/modal/RenameModal.jsx
@@ -25,7 +25,7 @@ const RenameModal = () => {
 	const dispatch = useDispatch();
 
 	const isOpen = useSelector( ( state ) => state.FolderReducer.modals.rename );
-	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
+	const selectedFolder = useSelector( ( state ) => state.FolderReducer.modals.item );
 
 	const [ updateFolder ] = useUpdateFolderMutation();
 
@@ -78,7 +78,7 @@ const RenameModal = () => {
 	};
 
 	return (
-		isOpen && (
+		( isOpen && selectedFolder ) && (
 			<Modal
 				title={ __( 'Rename folder', 'godam' ) }
 				onRequestClose={ () => dispatch( closeModal( 'rename' ) ) }

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -10,13 +10,25 @@ export const folderApi = createApi( {
 	baseQuery: fetchBaseQuery( { baseUrl: restURL } ),
 	endpoints: ( builder ) => ( {
 		getFolders: builder.query( {
-			query: () => ( {
-				url: 'wp/v2/media-folder',
+			query: ( { page = 1, perPage = 100 } = {} ) => ( {
+				url: 'godam/v1/media-library/media-folders',
 				params: {
-					_fields: 'id,name,parent,attachmentCount,meta',
-					per_page: 100, // Note: 100 is the max per page. Implement pagination if total folders > 100
+					page,
+					per_page: perPage,
+				},
+				headers: {
+					'X-WP-Nonce': window.MediaLibrary?.nonce || '',
 				},
 			} ),
+			transformResponse: ( response, meta ) => {
+				const total = parseInt( meta?.response?.headers.get( 'X-WP-Total' ) || '0', 10 );
+				const totalPages = parseInt( meta?.response?.headers.get( 'X-WP-TotalPages' ) || '1', 10 );
+				return {
+					folders: response,
+					total,
+					totalPages,
+				};
+			},
 		} ),
 		createFolder: builder.mutation( {
 			query: ( data ) => ( {

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -13,7 +13,7 @@ export const folderApi = createApi( {
 			query: () => ( {
 				url: 'wp/v2/media-folder',
 				params: {
-					_fields: 'id,name,parent',
+					_fields: 'id,name,parent,attachmentCount',
 					per_page: 100, // Note: 100 is the max per page. Implement pagination if total folders > 100
 				},
 			} ),

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -63,6 +63,15 @@ export const folderApi = createApi( {
 				},
 			} ),
 		} ),
+		downloadZip: builder.mutation( {
+			query: ( { folderId } ) => ( {
+				url: `godam/v1/media-library/download-folder/${ folderId }`,
+				method: 'POST',
+				headers: {
+					'X-WP-Nonce': window.MediaLibrary.nonce,
+				},
+			} ),
+		} ),
 	} ),
 } );
 
@@ -72,4 +81,5 @@ export const {
 	useUpdateFolderMutation,
 	useDeleteFolderMutation,
 	useAssignFolderMutation,
+	useDownloadZipMutation,
 } = folderApi;

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -13,7 +13,7 @@ export const folderApi = createApi( {
 			query: () => ( {
 				url: 'wp/v2/media-folder',
 				params: {
-					_fields: 'id,name,parent,attachmentCount',
+					_fields: 'id,name,parent,attachmentCount,meta',
 					per_page: 100, // Note: 100 is the max per page. Implement pagination if total folders > 100
 				},
 			} ),

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -34,11 +34,22 @@ const slice = createSlice( {
 			folderCreation: false,
 			rename: false,
 			delete: false,
+
+			item: null,
 		},
 
 		snackbar: {
 			message: '',
 			type: 'success',
+		},
+
+		contextMenu: {
+			isOpen: false,
+			position: {
+				x: 0,
+				y: 0,
+			},
+			item: null,
 		},
 	},
 	reducers: {
@@ -46,9 +57,14 @@ const slice = createSlice( {
 			state.selectedFolder = action.payload.item;
 		},
 		openModal: ( state, action ) => {
-			const modalName = action.payload;
-			if ( state.modals.hasOwnProperty( modalName ) ) {
-				state.modals[ modalName ] = true;
+			const { type, item } = action.payload;
+
+			if ( type in state.modals ) {
+				state.modals[ type ] = true;
+			}
+
+			if ( item ) {
+				state.modals.item = item;
 			}
 		},
 		closeModal: ( state, action ) => {
@@ -56,6 +72,8 @@ const slice = createSlice( {
 			if ( state.modals.hasOwnProperty( modalName ) ) {
 				state.modals[ modalName ] = false;
 			}
+
+			state.modals.item = null;
 		},
 		updateSnackbar: ( state, action ) => {
 			state.snackbar.message = action.payload.message;
@@ -81,18 +99,18 @@ const slice = createSlice( {
 			state.folders.push( newItem );
 		},
 		renameFolder: ( state, action ) => {
-			if ( ! state.selectedFolder ) {
+			if ( ! state.modals.item ) {
 				return;
 			}
 
-			const folder = state.folders.find( ( item ) => item.id === state.selectedFolder.id );
+			const folder = state.folders.find( ( item ) => item.id === state.modals.item.id );
 
 			if ( folder ) {
 				folder.name = action.payload.name;
 			}
 		},
 		deleteFolder: ( state ) => {
-			if ( ! state.selectedFolder ) {
+			if ( ! state.modals.item ) {
 				return;
 			}
 
@@ -107,16 +125,26 @@ const slice = createSlice( {
 				} );
 			}
 
-			findChildren( state.selectedFolder.id );
+			findChildren( state.modals.item.id );
 
 			state.folders = state.folders.filter( ( item ) => ! idsToDelete.has( item.id ) );
 
-			state.selectedFolder = {
+			state.modals.item = {
 				id: -1,
 			};
 		},
 		setTree: ( state, action ) => {
 			state.folders = action.payload;
+		},
+		showContextMenu: ( state, action ) => {
+			state.contextMenu.isOpen = true;
+			state.contextMenu.position = action.payload.position;
+			state.contextMenu.item = action.payload.item;
+		},
+		hideContextMenu: ( state ) => {
+			state.contextMenu.isOpen = false;
+			state.contextMenu.position = { x: 0, y: 0 };
+			state.contextMenu.item = null;
 		},
 	},
 } );
@@ -131,6 +159,8 @@ export const {
 	renameFolder,
 	deleteFolder,
 	setTree,
+	showContextMenu,
+	hideContextMenu,
 } = slice.actions;
 
 export default slice.reducer;

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -146,6 +146,13 @@ const slice = createSlice( {
 			state.contextMenu.position = { x: 0, y: 0 };
 			state.contextMenu.item = null;
 		},
+		lockFolder: ( state, action ) => {
+			const folder = state.folders.find( ( item ) => item.id === action.payload.id );
+
+			if ( folder ) {
+				folder.meta.locked = ! folder.meta.locked;
+			}
+		},
 	},
 } );
 
@@ -161,6 +168,7 @@ export const {
 	setTree,
 	showContextMenu,
 	hideContextMenu,
+	lockFolder,
 } = slice.actions;
 
 export default slice.reducer;

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -153,6 +153,17 @@ const slice = createSlice( {
 				folder.meta.locked = ! folder.meta.locked;
 			}
 		},
+		addBookmark: ( state, action ) => {
+			const folder = state.folders.find( ( item ) => item.id === action.payload.id );
+
+			if ( folder ) {
+				if ( ! folder.meta ) {
+					folder.meta = {};
+				}
+
+				folder.meta.bookmark = ! folder.meta.bookmark;
+			}
+		},
 	},
 } );
 
@@ -169,6 +180,7 @@ export const {
 	showContextMenu,
 	hideContextMenu,
 	lockFolder,
+	addBookmark,
 } = slice.actions;
 
 export default slice.reducer;


### PR DESCRIPTION
Resolves issue: https://github.com/rtCamp/godam/issues/478

- [x] Implementing pagination with a "Load More Folders" button to fetch additional folders beyond the initial page.


https://github.com/user-attachments/assets/5048d8e0-ec8f-4967-8625-6afef628c0a5


- [x] Making the folder list (tree-container) scrollable, ensuring it remains usable even when the number of folders exceeds the viewport height.

https://github.com/user-attachments/assets/07fde26f-4c5e-4022-b0bd-e1886fe646f2


**Implementation Details**
Updated getFolders RTK Query endpoint to support page and perPage parameters, and handle pagination metadata (X-WP-TotalPages).

In FolderTree component:

Uses useState to track page and load more folders incrementally.

Accumulates all loaded folders in allFolders, avoiding duplication.

Renders a "Load More" button only if more pages are available.

Applied CSS to .tree-container to enable vertical scrolling when folder count overflows.