### PR TITLE
FEAT: Add functionality to copy GoDAM Video block

### DIFF
--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -9,7 +9,7 @@ import { useSelector, useDispatch } from 'react-redux';
  */
 import { Button, TabPanel, Snackbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { seen } from '@wordpress/icons';
+import { copy, seen } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,12 +30,15 @@ import './video-editor.scss';
 import { useGetAttachmentMetaQuery, useSaveAttachmentMetaMutation } from './redux/api/attachment';
 import { useFetchForms } from './components/forms/fetchForms';
 import Chapters from './components/chapters/Chapters';
+import { copyGoDAMVideoBlock } from './utils/index';
 
 const VideoEditor = ( { attachmentID } ) => {
 	const [ currentTime, setCurrentTime ] = useState( 0 );
 	const [ showSaveMessage, setShowSaveMessage ] = useState( false );
 	const [ sources, setSources ] = useState( [] );
 	const [ duration, setDuration ] = useState( 0 );
+	const [ snackbarMessage, setSnackbarMessage ] = useState( '' );
+	const [ showSnackbar, setShowSnackbar ] = useState( false );
 
 	const playerRef = useRef( null );
 
@@ -184,6 +187,21 @@ const VideoEditor = ( { attachmentID } ) => {
 		return `${ minsStr }:${ secsStr }`;
 	};
 
+	const handleCopyGoDAMVideoBlock = async () => {
+		const result = await copyGoDAMVideoBlock( attachmentID );
+		if ( result ) {
+			setSnackbarMessage( __( 'GoDAM Video Block copied to clipboard', 'godam' ) );
+			setShowSnackbar( true );
+		} else {
+			setSnackbarMessage( __( 'Failed to copy GoDAM Video Block', 'godam' ) );
+			setShowSnackbar( true );
+		}
+	};
+
+	const handleOnSnackbarRemove = () => {
+		setShowSnackbar( false );
+	};
+
 	const tabConfig = [
 		{
 			name: 'layers',
@@ -292,8 +310,26 @@ const VideoEditor = ( { attachmentID } ) => {
 						)
 					}
 
+					{ showSnackbar && (
+						<Snackbar className="absolute bottom-4 right-4 opacity-70 z-50"
+							onRemove={ handleOnSnackbarRemove }
+						>
+							{ snackbarMessage }
+						</Snackbar>
+					) }
+
 					<div className="absolute top-4 left-4 right-4">
-						<div className="flex justify-end items-center">
+						<div className="flex space-x-2 justify-end items-center">
+							<Button
+								variant="secondary"
+								icon={ copy }
+								iconPosition="left"
+								onClick={ handleCopyGoDAMVideoBlock }
+								size="compact"
+								className="godam-button"
+							>
+								{ __( 'Copy Block', 'godam' ) }
+							</Button>
 							<Button
 								variant="secondary"
 								href={ `/?godam_page=video-preview&id=${ attachmentID }` }

--- a/pages/video-editor/components/media-grid/MediaItem.jsx
+++ b/pages/video-editor/components/media-grid/MediaItem.jsx
@@ -69,6 +69,9 @@ const MediaItem = forwardRef( ( { item, handleAttachmentClick }, ref ) => {
 
 				<DropdownMenu
 					className="godam-video-list__video__thumbnail__overlay"
+					menuProps={ {
+						className: 'godam-video-list__video__thumbnail__overlay__menu',
+					} }
 					controls={ [
 						{
 							icon: <Icon icon={ seen } />,

--- a/pages/video-editor/components/media-grid/MediaItem.jsx
+++ b/pages/video-editor/components/media-grid/MediaItem.jsx
@@ -1,27 +1,47 @@
 /**
  * External dependencies
  */
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { DropdownMenu } from '@wordpress/components';
-import { Icon, moreHorizontalMobile, seen, link, chartBar } from '@wordpress/icons';
+import { DropdownMenu, Snackbar } from '@wordpress/components';
+import { Icon, moreHorizontalMobile, seen, link, chartBar, video, copy } from '@wordpress/icons';
+import { createPortal } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import NoThumbnailImage from '../../assets/no-thumbnail.jpg';
+import { copyGoDAMVideoBlock } from '../../utils';
 
 const MediaItem = forwardRef( ( { item, handleAttachmentClick }, ref ) => {
+	const [ snackbarMessage, setSnackbarMessage ] = useState( '' );
+	const [ showSnackbar, setShowSnackbar ] = useState( false );
+
 	const handleItemClick = ( e ) => {
 		if ( e.target.closest( '.godam-video-list__video__thumbnail__overlay' ) ) {
 			return;
 		}
 
 		handleAttachmentClick( item.id );
+	};
+
+	const handleCopyGoDAMVideoBlock = async () => {
+		const result = await copyGoDAMVideoBlock( item.id );
+		if ( result ) {
+			setSnackbarMessage( __( 'GoDAM Video Block copied to clipboard', 'godam' ) );
+			setShowSnackbar( true );
+		} else {
+			setSnackbarMessage( __( 'Failed to copy GoDAM Video Block', 'godam' ) );
+			setShowSnackbar( true );
+		}
+	};
+
+	const handleOnSnackbarRemove = () => {
+		setShowSnackbar( false );
 	};
 
 	return (
@@ -58,6 +78,20 @@ const MediaItem = forwardRef( ( { item, handleAttachmentClick }, ref ) => {
 							title: __( 'Preview template', 'godam' ),
 						},
 						{
+							icon: <Icon icon={ video } />,
+							onClick: () => {
+								window.open( `/?godam_page=video-preview&id=${ item.id }`, '_blank' );
+							},
+							title: __( 'Preview Video', 'godam' ),
+						},
+						{
+							icon: <Icon icon={ copy } />,
+							onClick: () => {
+								handleCopyGoDAMVideoBlock( item.id );
+							},
+							title: __( 'Copy Video Block', 'godam' ),
+						},
+						{
 							icon: <Icon icon={ link } />,
 							onClick: () => {
 								navigator.clipboard.writeText( item?.url );
@@ -83,6 +117,14 @@ const MediaItem = forwardRef( ( { item, handleAttachmentClick }, ref ) => {
 				<h3 className="text-sm">{ item?.title }</h3>
 				{ item?.description && <p className="text-xs">{ item?.description }</p> }
 			</div>
+
+			{ showSnackbar && createPortal(
+				<Snackbar className="fixed bottom-4 right-4 opacity-70 z-50"
+					onRemove={ handleOnSnackbarRemove }
+				>
+					{ snackbarMessage }
+				</Snackbar>, document.body )
+			}
 		</div>
 	);
 } );

--- a/pages/video-editor/style.scss
+++ b/pages/video-editor/style.scss
@@ -259,7 +259,7 @@
 			white-space: nowrap;
 		}
 		&:hover {
-			
+
 			.chapter-indicator--duration {
 				display: block;
 				position: absolute;
@@ -284,6 +284,12 @@
 
 	@media screen and (max-width: 782px) {
 		margin-left: 0;
+	}
+}
+
+.godam-video-list__video__thumbnail__overlay__menu {
+	.components-button.has-icon.has-text {
+		justify-content: flex-start !important;
 	}
 }
 

--- a/pages/video-editor/utils/index.js
+++ b/pages/video-editor/utils/index.js
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+const MEDIA_ENDPOINT = '/wp-json/wp/v2/media';
+
+function createBlockDelimiter( { blockName, attrs = {}, innerHTML = '' } ) {
+	const name = blockName.replace( /^core\//, '' );
+	const hasAttributes = Object.keys( attrs ).length > 0;
+	const attrString = hasAttributes ? ` ${ JSON.stringify( attrs ) }` : '';
+
+	if ( ! innerHTML ) {
+		return `<!-- wp:${ name }${ attrString } /-->`;
+	}
+
+	return `<!-- wp:${ name }${ attrString } -->${ innerHTML }<!-- /wp:${ name } -->`;
+}
+
+function createGoDAMVideoBlockMarkup( attrs ) {
+	const innerHTML = `<div class="wp-block-godam-video"></div>`;
+
+	return createBlockDelimiter( {
+		blockName: 'godam/video',
+		attrs,
+		innerHTML,
+	} );
+}
+
+function createVideoAttributes( attachmentId, mediaData ) {
+	const baseAttrs = {
+		id: attachmentId,
+		aspectRatio: '16/9',
+	};
+
+	if ( ! mediaData ) {
+		return baseAttrs;
+	}
+
+	const { source_url: sourceUrl, mime_type: mimeType } = mediaData;
+
+	if ( sourceUrl ) {
+		return {
+			...baseAttrs,
+			src: sourceUrl,
+			sources: [ {
+				src: sourceUrl,
+				type: mimeType,
+			} ],
+		};
+	}
+
+	return baseAttrs;
+}
+
+async function fetchMediaData( attachmentId ) {
+	try {
+		const endpoint = `${ MEDIA_ENDPOINT }/${ attachmentId }`;
+		return await apiFetch( { path: endpoint } );
+	} catch ( error ) {
+		return null;
+	}
+}
+
+export const copyGoDAMVideoBlock = async ( attachmentId ) => {
+	// Check clipboard API availability.
+	if ( ! navigator.clipboard?.writeText ) {
+		return false;
+	}
+
+	try {
+		const mediaData = await fetchMediaData( attachmentId );
+
+		const attrs = createVideoAttributes( attachmentId, mediaData );
+
+		const html = createGoDAMVideoBlockMarkup( attrs );
+
+		await navigator.clipboard.writeText( html );
+
+		return true;
+	} catch ( error ) {
+		return false;
+	}
+};


### PR DESCRIPTION
## Summary
This PR adds update to copy the `GoDAM Video` block to clipboard from the Video Editor page.

Ref:

https://github.com/user-attachments/assets/3a0d3ee9-a9db-4153-8433-87962206cf96


