### PR TITLE
Fix: Open admin sidebar on VideoEditor page

### DIFF
--- a/pages/video-editor/components/media-grid/MediaGrid.jsx
+++ b/pages/video-editor/components/media-grid/MediaGrid.jsx
@@ -72,6 +72,18 @@ const MediaGrid = ( { search, page, handleAttachmentClick, setPage, attachments,
 		return () => clearTimeout( debounce );
 	}, [ getVideos, setAttachments, search, page ] );
 
+	useEffect( () => {
+		const body = document.querySelector( 'body' );
+
+		// Return early if admin sidebar is already open.
+		if ( ! body || ! body.classList.contains( 'folded' ) ) {
+			return;
+		}
+
+		// Open the admin sidebar.
+		body.classList.remove( 'folded' );
+	}, [] );
+
 	if ( ! fetching && attachments.length === 0 ) {
 		return (
 			<div className="flex justify-end items-center flex-col mt-8">


### PR DESCRIPTION
## Description
- If we navigate to VideoEditor Page open a video, the Admin dashboard main sidebar will be automatically collapsed, but if we go back using the browser back button to the VideoEditor page it will remain collapsed.
- Ideally it should reopen, so that state is conserved.

## Fix
- Once VideoEditor page is loaded, we will check if the sidebar is still closed by the `folded` class introduced by us. If it's present we can safely remove it from the body tag.

Before


https://github.com/user-attachments/assets/70d28173-a556-46ad-b573-7a958de0ef18



After


https://github.com/user-attachments/assets/5c62dd27-d9ca-46e5-9d22-4de9eccefbca

## Related Issue
- #506 