### PR TITLE
GH-547 feat: Show Description for Autoplay Video Block

### DIFF
--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -49,6 +49,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				label={ __( 'Autoplay', 'godam' ) }
 				onChange={ toggleFactory.autoplay }
 				checked={ !! autoplay }
+				disabled={ ! muted }
 				help={ getAutoplayHelp }
 			/>
 			<ToggleControl
@@ -60,7 +61,13 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Muted', 'godam' ) }
-				onChange={ toggleFactory.muted }
+				onChange={ ( e ) => {
+					if ( ! e ) {
+						// If not muted, disable the autoplay.
+						toggleFactory.autoplay( false );
+					}
+					toggleFactory.muted( e );
+				} }
 				checked={ !! muted }
 			/>
 			<ToggleControl

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -3,7 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { ToggleControl, SelectControl } from '@wordpress/components';
-import { useMemo, useCallback, Platform } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 
 const options = [
 	{ value: 'auto', label: __( 'Auto', 'godam' ) },
@@ -15,13 +15,24 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 	const { autoplay, controls, loop, muted, preload } =
 		attributes;
 
-	const autoPlayHelpText = __( 'Autoplay may cause usability issues for some users.', 'godam' );
-	const getAutoplayHelp = Platform.select( {
-		web: useCallback( ( checked ) => {
-			return checked ? autoPlayHelpText : null;
-		}, [] ),
-		native: autoPlayHelpText,
-	} );
+	// Show a specific help for autoplay.
+	const getAutoplayHelp = useMemo( () => {
+		const autoPlayHelpText = __( 'Autoplay may cause usability issues for some users.', 'godam' );
+
+		// Show help text if autoplay and muted is on.
+		if ( autoplay && muted ) {
+			return autoPlayHelpText;
+		}
+
+		const disabledAutoPlayHelpText = __( 'Autoplay only works when video is muted.', 'godam' );
+
+		// Show disabled help text if video is not muted.
+		if ( ! autoplay && ! muted ) {
+			return disabledAutoPlayHelpText;
+		}
+
+		return null;
+	}, [ autoplay, muted ] );
 
 	const toggleFactory = useMemo( () => {
 		const toggleAttribute = ( attribute ) => {

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -17,18 +17,8 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 
 	// Show a specific help for autoplay.
 	const getAutoplayHelp = useMemo( () => {
-		const autoPlayHelpText = __( 'Autoplay may cause usability issues for some users.', 'godam' );
-
-		// Show help text if autoplay and muted is on.
-		if ( autoplay && muted ) {
-			return autoPlayHelpText;
-		}
-
-		const disabledAutoPlayHelpText = __( 'Autoplay only works when video is muted.', 'godam' );
-
-		// Show disabled help text if video is not muted.
 		if ( ! autoplay && ! muted ) {
-			return disabledAutoPlayHelpText;
+			return __( 'Autoplay only works when video is muted.', 'godam' );
 		}
 
 		return null;


### PR DESCRIPTION
## Description
- Most browser does not allow autoplay of videos if they are unmuted.
- Therefore, in the video block autoplay is automatically disable if the video is unmuted.
  - An appropriate help message is also shown, instructing the user to mute the video first.


https://github.com/user-attachments/assets/fe8c66f7-c0f8-4267-bc22-9f1958c1ec07


## Issue

- #547 