### PR TITLE
GH-547 feat: Show Description for Autoplay Video Block

### DIFF
--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -58,7 +58,6 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				__nextHasNoMarginBottom
 				label={ __( 'Autoplay', 'godam' ) }
 				onChange={ ( e ) => {
-					// When autoplay is enabled, mute the video.
 					/**
 					 * When autoplay is enabled, mute the video.
 					 * This behaviour follows core/video block.

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -15,10 +15,19 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 	const { autoplay, controls, loop, muted, preload } =
 		attributes;
 
-	// Show a specific help for autoplay.
+	// Show a specific help for autoplay setting.
 	const getAutoplayHelp = useMemo( () => {
-		if ( ! autoplay && ! muted ) {
-			return __( 'Autoplay only works when video is muted.', 'godam' );
+		if ( autoplay && muted ) {
+			return __( 'Autoplay may cause usability issues for some users.', 'godam' );
+		}
+
+		return null;
+	}, [ autoplay, muted ] );
+
+	// Show a specific help for muted setting.
+	const getMutedHelp = useMemo( () => {
+		if ( autoplay && muted ) {
+			return __( 'Muted because of Autoplay.', 'godam' );
 		}
 
 		return null;
@@ -48,9 +57,16 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Autoplay', 'godam' ) }
-				onChange={ toggleFactory.autoplay }
+				onChange={ ( e ) => {
+					// When autoplay is enabled, mute the video.
+					/**
+					 * When autoplay is enabled, mute the video.
+					 * This behaviour follows core/video block.
+					 */
+					toggleFactory.muted( e );
+					toggleFactory.autoplay( e );
+				} }
 				checked={ !! autoplay }
-				disabled={ ! muted }
 				help={ getAutoplayHelp }
 			/>
 			<ToggleControl
@@ -62,14 +78,10 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Muted', 'godam' ) }
-				onChange={ ( e ) => {
-					if ( ! e ) {
-						// If not muted, disable the autoplay.
-						toggleFactory.autoplay( false );
-					}
-					toggleFactory.muted( e );
-				} }
+				onChange={ toggleFactory.muted }
+				disabled={ autoplay }
 				checked={ !! muted }
+				help={ getMutedHelp }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom


### PR DESCRIPTION
## Description
- Most browser does not allow autoplay of videos if they are unmuted.
- Therefore, in the video block autoplay is automatically disable if the video is unmuted.
  - An appropriate help message is also shown, instructing the user to mute the video first.

New - Follow core/video behaviour for autoplay and muted toggles.

https://github.com/user-attachments/assets/84941173-a4bd-4a74-8bbd-e59d51138923



## Issue

- #547 