### PR TITLE
GH-545 Remove default edit button from shortcode output.

### DIFF
--- a/inc/classes/rest-api/class-forminator-forms.php
+++ b/inc/classes/rest-api/class-forminator-forms.php
@@ -170,6 +170,9 @@ class Forminator_Forms extends Base {
 		// Remove the display:none style manually as we don't need heavy JS and AJAX from forms in admin panel.
 		$forminator_form = str_replace( 'style="display: none;"', '', $forminator_form );
 
+		// Remove edit link from shortcode output as we have custom edit button from js.
+		$forminator_form = preg_replace( '/<a[^>]+class="forminator-module-edit-link"[^>]*>.*?<\/a>/i', '', $forminator_form );
+
 		return new WP_REST_Response( $forminator_form );
 	}
 }


### PR DESCRIPTION
Part of #545 

Removes default `Edit Form` link from shortcode output. 


**Before**

<img width="1385" alt="image" src="https://github.com/user-attachments/assets/24c01204-b5f9-42bf-99f5-8e5208076182" />

**After**

![image](https://github.com/user-attachments/assets/c6a8bfc1-7db3-45df-ab46-1339db6fb681)
