### PR TITLE
Fix video editor warnings

### DIFF
--- a/pages/video-editor/components/SidebarLayers.js
+++ b/pages/video-editor/components/SidebarLayers.js
@@ -309,9 +309,11 @@ const SidebarLayers = ( { currentTime, onSelectLayer, onPauseVideo, duration } )
 										return layerData?.tooltipMessage;
 									}
 
-									return (
-										layerData?.tooltipMessage ?? ''
-									);
+									if ( layerData?.isActive === false ) {
+										return layerData?.tooltipMessage ?? '';
+									}
+
+									return '';
 								} )();
 
 								if ( '' !== tooltipMessage ) {


### PR DESCRIPTION
**Issue:** Ads, Polls, and WooCommerce layer are showing warning message on video editor, even if related plugins are active

![video wanring](https://github.com/user-attachments/assets/2b2101a4-6384-4697-89fe-1d5a2668ec15)
