### PR TITLE
Prevent duplicate attachments on rapid search input

### DIFF
--- a/pages/video-editor/components/media-grid/MediaGrid.jsx
+++ b/pages/video-editor/components/media-grid/MediaGrid.jsx
@@ -20,6 +20,7 @@ const MediaGrid = ( { search, page, handleAttachmentClick, setPage, attachments,
 	const [ hasMore, setHasMore ] = useState( true );
 	const [ fetching, setFetching ] = useState( false );
 	const observer = useRef();
+	const requestIdRef = useRef( 0 );
 
 	const lastItemRef = useCallback(
 		( node ) => {
@@ -47,10 +48,17 @@ const MediaGrid = ( { search, page, handleAttachmentClick, setPage, attachments,
 	 * Search item for the videos.
 	 */
 	useEffect( () => {
+		const currentRequestId = ++requestIdRef.current;
+
 		setFetching( true );
 
 		const fetch = async () => {
 			const response = await getVideos( { search, page } );
+
+			// Ignore stale responses.
+			if ( requestIdRef.current !== currentRequestId ) {
+				return;
+			}
 
 			const data = response?.data?.data || [];
 


### PR DESCRIPTION
## PR Description

This PR addresses a race condition that caused duplicate or incorrect video attachments to appear in the media grid when users rapidly changed the search input.

## Problem

When multiple asynchronous fetch requests are triggered quickly (e.g., typing 2025, then backspacing to 202, 20, etc.), older responses may resolve after newer ones and incorrectly update the attachments state. This led to duplicated or outdated results being rendered.


## Steps to Reproduce (Using 3G Network)
- Open the `Video Editor` sub-settings in `GoDAM` Settings.
- Open Chrome DevTools → Network tab → Throttle → 3G.
- In the search input, type:
  - 2025 ( Or any other substring present in the `Videos Title` in your library )
  - Then quickly backspace to 202
  - Then re-type 2025 or any variation rapidly
- Observe the media grid:
  - Duplicate attachments appear.
  - Sometimes for wrong substring, no media found is not observed rather any older search result are visible. 


### Result 

> A console.log statement was temporarily added to confirm that stale requests are being denied.


https://github.com/user-attachments/assets/0f7f4673-a623-4674-a0a3-0a5a880d9d88


#### Closes Issue - #599 