### PR TITLE
FIX: Remove `0` being printed on false condition.

### DIFF
--- a/pages/video-editor/components/cta/ImageCTA.js
+++ b/pages/video-editor/components/cta/ImageCTA.js
@@ -142,7 +142,7 @@ const ImageCTA = ( { layerID } ) => {
 				>
 					{ __( 'Upload', 'godam' ) }
 				</Button> }
-				{ layer?.image && ! selectedImageUrl && ( <div className="mt-6 rounded-xl w-[160px] h-[160px] animate-pulse bg-gray-200"></div> ) }
+				{ ( layer?.image !== 0 && ! selectedImageUrl ) && ( <div className="mt-6 rounded-xl w-[160px] h-[160px] animate-pulse bg-gray-200"></div> ) }
 				{ selectedImageUrl && (
 					<div className="flex mt-4">
 						<img


### PR DESCRIPTION
## Summary
This PR fixes an issue where the value 0 was being rendered after removing the image from the ImageCTA component, due to an incorrect condition check.

<img width="405" alt="Screenshot 2025-07-02 at 6 33 44 PM" src="https://github.com/user-attachments/assets/5fd4947c-b869-4e66-bbdf-1df7807bf7de" />
