### PR TITLE
HOTFIX: Ensure numeric attachmentId.

### DIFF
--- a/pages/video-editor/utils/index.js
+++ b/pages/video-editor/utils/index.js
@@ -29,7 +29,7 @@ function createGoDAMVideoBlockMarkup( attrs ) {
 
 function createVideoAttributes( attachmentId, mediaData ) {
 	const baseAttrs = {
-		id: attachmentId,
+		id: Number( attachmentId ),
 		aspectRatio: '16/9',
 	};
 


### PR DESCRIPTION
## Summary
- Solves the missing `id` issues after copying GoDAM block.