### PR TITLE
Fix: Rendering of anti-spam fields in the video editor page for wpforms

### DIFF
--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -672,7 +672,7 @@ class Pages {
 	/**
 	 * Save current rest api request.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.2.0
 	 *
 	 * @param mixed           $result Response to replace the requested version with. Can be anything a normal endpoint can return, or null to not hijack the request.
 	 * @param \WP_REST_Server $server Server instance.
@@ -692,7 +692,7 @@ class Pages {
 	/**
 	 * Remove anti-spam settings from wpforms.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.2.0
 	 *
 	 * @param array $form_data Form data to be modified.
 	 *


### PR DESCRIPTION
* fix: disable rendering of antispam fields in the video editor page for wpforms

* fix: phpcs errrors

* fix: typo

* reset global  godam current request variable

* remove vscode configuration files