### PR TITLE
fix: add camera dropdown for multiple cameras in GF GoDAM Recorder Field

### DIFF
--- a/assets/src/js/gf-godam-recorder.js
+++ b/assets/src/js/gf-godam-recorder.js
@@ -226,6 +226,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				modes: [ 'video-audio' ],
 				mirror: false,
 				showRecordingLength: true,
+				showVideoSourceDropdown: true,
 			} );
 		}
 


### PR DESCRIPTION
## Description
This PR adds a dropdown for multiple cameras in `GF GoDAM Recorder Field`.

## Screenshot
![2025-07-03_19-20](https://github.com/user-attachments/assets/8185dba7-2f7f-4fb8-a5e5-bd0761b0f303)

## Reference
1. https://uppy.io/docs/webcam/#showvideosourcedropdown

Closes - #611
