### PR TITLE
Implement Global Ads settings

### DIFF
--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -1521,13 +1521,11 @@ function GODAMPlayer( videoRef = null ) {
 				id: 'content_video',
 				adTagUrl,
 			} );
-		} else if ( globalAdsSettings ) {
-			if ( globalAdsSettings?.enable_global_video_ads && globalAdsSettings?.adTagUrl ) {
-				player.ima( {
-					id: 'content_video',
-					adTagUrl: globalAdsSettings.adTagUrl,
-				} );
-			}
+		} else if ( globalAdsSettings?.enable_global_video_ads && globalAdsSettings?.adTagUrl ) {
+			player.ima( {
+				id: 'content_video',
+				adTagUrl: globalAdsSettings.adTagUrl,
+			} );
 		}
 	} );
 }

--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -77,6 +77,10 @@ function GODAMPlayer( videoRef = null ) {
 			video.closest( '.animate-video-loading' ).classList.remove( 'animate-video-loading' );
 		}
 
+		const globalAdsSettings = video.dataset.global_ads_settings
+			? JSON.parse( video.dataset.global_ads_settings )
+			: {};
+
 		const adTagUrl = video.dataset.ad_tag_url;
 		let isVideoClicked = false;
 
@@ -1517,6 +1521,13 @@ function GODAMPlayer( videoRef = null ) {
 				id: 'content_video',
 				adTagUrl,
 			} );
+		} else if ( globalAdsSettings ) {
+			if ( globalAdsSettings?.enable_global_video_ads && globalAdsSettings?.adTagUrl ) {
+				player.ima( {
+					id: 'content_video',
+					adTagUrl: globalAdsSettings.adTagUrl,
+				} );
+			}
 		}
 	} );
 }

--- a/inc/classes/rest-api/class-settings.php
+++ b/inc/classes/rest-api/class-settings.php
@@ -49,6 +49,10 @@ class Settings extends Base {
 			'video_player' => array(
 				'custom_css' => '',
 			),
+			'ads_settings' => array(
+				'enable_global_video_ads' => false,
+				'adTagUrl'                => '',
+			),
 		);
 	}
 
@@ -296,6 +300,10 @@ class Settings extends Base {
 			),
 			'video_player' => array(
 				'custom_css' => sanitize_textarea_field( $settings['video_player']['custom_css'] ) ?? $default['video_player']['custom_css'],
+			),
+			'ads_settings' => array(
+				'enable_global_video_ads' => rest_sanitize_boolean( $settings['ads_settings']['enable_global_video_ads'] ?? $default['ads_settings']['enable_global_video_ads'] ),
+				'adTagUrl'                => esc_url_raw( $settings['ads_settings']['adTagUrl'] ?? $default['ads_settings']['adTagUrl'] ),
 			),
 		);
 	}

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -133,6 +133,8 @@ $easydam_control_bar_color = '#2b333fb3'; // Default color.
 $godam_settings   = get_option( 'rtgodam-settings', array() );
 $brand_color      = isset( $godam_settings['general']['brand_color'] ) ? $godam_settings['general']['brand_color'] : null;
 $appearance_color = isset( $easydam_meta_data['videoConfig']['controlBar']['appearanceColor'] ) ? $easydam_meta_data['videoConfig']['controlBar']['appearanceColor'] : null;
+$ads_settings     = isset( $godam_settings['ads_settings'] ) ? $godam_settings['ads_settings'] : '';
+$ads_settings     = wp_json_encode( $ads_settings );
 
 if ( ! empty( $appearance_color ) ) {
 	$easydam_control_bar_color = $appearance_color;
@@ -262,6 +264,7 @@ if ( $is_shortcode || $is_elementor_widget ) {
 					data-instance-id="<?php echo esc_attr( $instance_id ); ?>"
 					data-controls="<?php echo esc_attr( $video_setup ); ?>"
 					data-job_id="<?php echo esc_attr( $job_id ); ?>"
+					data-global_ads_settings="<?php echo esc_attr( $ads_settings ); ?>"
 				>
 					<?php
 					foreach ( $sources as $source ) :

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -133,7 +133,7 @@ $easydam_control_bar_color = '#2b333fb3'; // Default color.
 $godam_settings   = get_option( 'rtgodam-settings', array() );
 $brand_color      = isset( $godam_settings['general']['brand_color'] ) ? $godam_settings['general']['brand_color'] : null;
 $appearance_color = isset( $easydam_meta_data['videoConfig']['controlBar']['appearanceColor'] ) ? $easydam_meta_data['videoConfig']['controlBar']['appearanceColor'] : null;
-$ads_settings     = isset( $godam_settings['ads_settings'] ) ? $godam_settings['ads_settings'] : '';
+$ads_settings     = isset( $godam_settings['ads_settings'] ) ? $godam_settings['ads_settings'] : array();
 $ads_settings     = wp_json_encode( $ads_settings );
 
 if ( ! empty( $appearance_color ) ) {

--- a/pages/godam/App.js
+++ b/pages/godam/App.js
@@ -21,10 +21,11 @@ import GoDAMFooter from './components/GoDAMFooter.jsx';
 
 import GeneralSettings from './components/tabs/GeneralSettings/GeneralSettings.jsx';
 import VideoSettings from './components/tabs/VideoSettings/VideoSettings.jsx';
+import VideoPlayer from './components/tabs/VideoPlayer/VideoPlayer.jsx';
+import AdsSettings from './components/tabs/AdsSettings/AdsSettings.jsx';
 
 import { useGetMediaSettingsQuery } from './redux/api/media-settings.js';
 import { setMediaSettings } from './redux/slice/media-settings.js';
-import VideoPlayer from './components/tabs/VideoPlayer/VideoPlayer.jsx';
 
 const TABS = [
 	{
@@ -44,6 +45,15 @@ const TABS = [
 		label: __( 'Video Player', 'godam' ),
 		component: VideoPlayer,
 		icon: code,
+	},
+	{
+		id: 'video-ads',
+		label: __( 'Video Ads', 'godam' ),
+		component: AdsSettings,
+		icon: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-badge-ad" viewBox="0 0 16 16">
+			<path d="m3.7 11 .47-1.542h2.004L6.644 11h1.261L5.901 5.001H4.513L2.5 11zm1.503-4.852.734 2.426H4.416l.734-2.426zm4.759.128c-1.059 0-1.753.765-1.753 2.043v.695c0 1.279.685 2.043 1.74 2.043.677 0 1.222-.33 1.367-.804h.057V11h1.138V4.685h-1.16v2.36h-.053c-.18-.475-.68-.77-1.336-.77zm.387.923c.58 0 1.002.44 1.002 1.138v.602c0 .76-.396 1.2-.984 1.2-.598 0-.972-.449-.972-1.248v-.453c0-.795.37-1.24.954-1.24z" />
+			<path d="M14 3a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zM2 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z" />
+		</svg>,
 	},
 ];
 

--- a/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
+++ b/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
@@ -86,7 +86,7 @@ const AdsSettings = () => {
 							label={ __( 'Ad Tag URL', 'godam' ) }
 							help={
 								<div>
-									{ __( 'A VAST ad tag URL is used by a player to retrieve video and audio ads', 'godam' ) }
+									{ __( 'A VAST ad tag URL is used by a player to retrieve video and audio ads ', 'godam' ) }
 									<a href="https://support.google.com/admanager/answer/177207?hl=en" target="_blank" rel="noreferrer noopener" className="text-blue-500 underline">{ __( 'Learn more.', 'godam' ) }</a>
 								</div>
 							}

--- a/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
+++ b/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
@@ -86,7 +86,7 @@ const AdsSettings = () => {
 							label={ __( 'Ad Tag URL', 'godam' ) }
 							help={
 								<div>
-									{ __( 'A VAST ad tag URL is used by a player to retrieve video and audio ads ', 'godam' ) }
+									{ __( 'A VAST ad tag URL is used by a player to retrieve video and audio ads', 'godam' ) }
 									<a href="https://support.google.com/admanager/answer/177207?hl=en" target="_blank" rel="noreferrer noopener" className="text-blue-500 underline">{ __( 'Learn more.', 'godam' ) }</a>
 								</div>
 							}

--- a/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
+++ b/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Notice,
+	ToggleControl,
+	Panel,
+	PanelBody,
+	Button,
+	TextareaControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { scrollToTop } from '../../../utils/index.js';
+import { useSaveMediaSettingsMutation } from '../../../redux/api/media-settings.js';
+import { updateMediaSetting } from '../../../redux/slice/media-settings.js';
+
+const AdsSettings = () => {
+	const dispatch = useDispatch();
+	const [ saveMediaSettings, { isLoading: saveMediaSettingsLoading } ] =
+    useSaveMediaSettingsMutation();
+	const mediaSettings = useSelector( ( state ) => state.mediaSettings );
+
+	const [ notice, setNotice ] = useState( { message: '', status: 'success', isVisible: false } );
+
+	const showNotice = ( message, status = 'success' ) => {
+		setNotice( { message, status, isVisible: true } );
+		scrollToTop();
+	};
+
+	const handleSettingChange = ( key, value ) => {
+		dispatch( updateMediaSetting( { category: 'ads_settings', key, value } ) );
+	};
+
+	const handleSaveSettings = async () => {
+		try {
+			const response = await saveMediaSettings( {
+				settings: { ads_settings: mediaSettings?.ads_settings },
+			} ).unwrap();
+
+			if ( response?.status === 'success' ) {
+				showNotice( __( 'Settings saved successfully.', 'godam' ) );
+			} else {
+				showNotice( __( 'Failed to save settings.', 'godam' ), 'error' );
+			}
+		} catch ( error ) {
+			showNotice( __( 'Failed to save settings.', 'godam' ), 'error' );
+		}
+	};
+
+	return (
+		<>
+			{ notice.isVisible && (
+				<Notice
+					className="mb-4"
+					status={ notice.status }
+					onRemove={ () => setNotice( { ...notice, isVisible: false } ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
+
+			<Panel header={ __( 'Video Ads Settings', 'godam' ) } className="godam-panel">
+				<PanelBody opened>
+					<ToggleControl
+						className="godam-toggle mb-4"
+						label={ __( 'Enable Global Video Ads', 'godam' ) }
+						help={ __( 'Enable or disable video ads on all videos across the site', 'godam' ) }
+						checked={ mediaSettings?.ads_settings?.enable_global_video_ads }
+						onChange={ ( value ) => handleSettingChange( 'enable_global_video_ads', value ) }
+					/>
+
+					{
+						mediaSettings?.ads_settings?.enable_global_video_ads &&
+						<TextareaControl
+							className="godam-input mb-4"
+							label={ __( 'Ad Tag URL', 'godam' ) }
+							help={
+								<div>
+									{ __( 'A VAST ad tag URL is used by a player to retrieve video and audio ads ', 'godam' ) }
+									<a href="https://support.google.com/admanager/answer/177207?hl=en" target="_blank" rel="noreferrer noopener" className="text-blue-500 underline">{ __( 'Learn more.', 'godam' ) }</a>
+								</div>
+							}
+							value={ mediaSettings?.ads_settings?.adTagUrl || '' }
+							onChange={ ( value ) => handleSettingChange( 'adTagUrl', value ) }
+						/>
+					}
+				</PanelBody>
+			</Panel>
+
+			<Button
+				variant="primary"
+				className="godam-button"
+				onClick={ handleSaveSettings }
+				isBusy={ saveMediaSettingsLoading }
+				disabled={ saveMediaSettingsLoading }
+			>
+				{ __( 'Save Settings', 'godam' ) }
+			</Button>
+		</>
+	);
+};
+
+export default AdsSettings;

--- a/pages/godam/redux/slice/media-settings.js
+++ b/pages/godam/redux/slice/media-settings.js
@@ -27,6 +27,10 @@ const initialState = {
 	video_player: {
 		custom_css: VideoCustomCSSTemplate,
 	},
+	ads_settings: {
+		enable_global_video_ads: false,
+		adTagUrl: '',
+	},
 };
 
 const mediaSettingsSlice = createSlice( {


### PR DESCRIPTION
Provide a global Ads settings section on the GoDAM settings page, which will allow the site owner to add their AdSense URL and apply those specific AdSense Unit Ads to all videos across the site.

## Global Ads
https://github.com/user-attachments/assets/1c6c1b14-76da-4690-b184-ae7b708f92e9


## Video specific Ads have more priority over global Ads
https://github.com/user-attachments/assets/1cc09024-cf29-4ba9-a83d-ca84d353174d

Sample **AdTag URL** to test the feature: https://googleads.g.doubleclick.net/pagead/ads?ad_type=video_text_image&client=ca-video-pub-4968145218643279&videoad_start_delay=0&description_url=http%3A%2F%2Fwww.google.com&max_ad_duration=30000&adtest=on

Closes: https://github.com/rtCamp/godam-core/issues/202
