### PR TITLE
GH 628: Fix uppy object to enforce max file size restrictions

### DIFF
--- a/assets/src/js/godam-recorder/index.js
+++ b/assets/src/js/godam-recorder/index.js
@@ -84,8 +84,8 @@ class UppyVideoUploader {
 			restrictions: {
 				maxNumberOfFiles: 1,
 				allowedFileTypes: [ 'video/*' ],
+				maxFileSize: this.maxFileSize,
 			},
-			maxFileSize: this.maxFileSize,
 		} );
 	}
 


### PR DESCRIPTION
## Issue

- Closes - #628 