### PR TITLE
Fix: Prevent Block transcoding on localhost and blacklisted IPs

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -283,8 +283,8 @@ class RTGODAM_Transcoder_Handler {
 			$transcoding_url = $this->transcoding_api_url . 'resource/Transcoder Job';
 
 			// Block if blacklisted ip address.
-			$key       = 'REMOTE_ADDR';
-			$client_ip = isset( $_SERVER[ $key ] ) ? filter_var( $_SERVER[ $key ], FILTER_VALIDATE_IP ) : '';
+			$remote_address_key = 'REMOTE_ADDR';
+			$client_ip          = isset( $_SERVER[ $remote_address_key ] ) ? filter_var( $_SERVER[ $remote_address_key ], FILTER_VALIDATE_IP ) : '';
 			if ( ! empty( $client_ip ) && in_array( $client_ip, rtgodam_get_blacklist_ip_addresses(), true ) ) {
 				return $metadata;
 			}

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -282,6 +282,13 @@ class RTGODAM_Transcoder_Handler {
 
 			$transcoding_url = $this->transcoding_api_url . 'resource/Transcoder Job';
 
+			// Block if blacklisted ip address.
+			$key       = 'REMOTE_ADDR';
+			$client_ip = isset( $_SERVER[ $key ] ) ? filter_var( $_SERVER[ $key ], FILTER_VALIDATE_IP ) : '';
+			if ( ! empty( $client_ip ) && in_array( $client_ip, rtgodam_get_blacklist_ip_addresses(), true ) ) {
+				return $metadata;
+			}
+
 			$upload_page = wp_remote_post( $transcoding_url, $args );
 
 			if ( ! is_wp_error( $upload_page ) &&


### PR DESCRIPTION
Closes #621 

## What?
Added a check in `wp_media_transcoding` function which returns early if the IP address is a blacklisted IP address.

## Why?
When media files are uploaded from the local development environment, a request is automatically sent to GoDAM Core to transcode the media. However, since the media is stored locally, Frappe is unable to download the file for processing. As a result:

- The transcoding process fails silently or stalls.
- Frappe is unable to send status updates back to GoDAM Plugin.
- Unnecessary entries are created in the Frappe app related to transcoding, which leads to clutter and potential confusion.

## Testing
### On local setup
When adding a media, the transcoding does not happen and the request is not made.

<img width="1162" alt="Screenshot 2025-07-09 at 7 54 54 PM" src="https://github.com/user-attachments/assets/ff301f51-7d66-449a-ac6e-ef55c42652cc" />


### On Hosted site
When adding a media, transcoding is done as expected.

<img width="1118" alt="Screenshot 2025-07-09 at 7 56 08 PM" src="https://github.com/user-attachments/assets/0d28395a-46ba-477e-a319-604e2e8a0447" />


## Additional Info

Initially I tried returning an `WP_Error` in the function which verifies the license. But that lead to a 403 error in browser console. For this reason and for separation of concerns, I chose the current approach.

> [!NOTE]
> The `rtgodam_get_blacklist_ip_addresses` function used in this fix was already present in the code but was unused. I utilized it so that we can block all the IPs including localhost in one go without duplicating the code.

> [!CAUTION]
> The IP address is fetched via `$_SERVER[REMOTE_ADDR]` which can be modified by the user. Hence a check on the server side is also required to ensure fool-proof blacklisting.

cc: @subodhr258 @nayemDevs @pooja-muchandikar 