### PR TITLE
Fix: Add default button texts for Product Hotspot

### DIFF
--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -4,6 +4,10 @@
  * External dependencies
  */
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
  * VideoJs dependencies
  */
 import 'video.js/dist/video-js.css';
@@ -1181,7 +1185,11 @@ function GODAMPlayer( videoRef = null ) {
 				productLink.target = '_blank';
 				productLink.rel = 'noopener noreferrer';
 				productLink.style.background = hotspot.backgroundColor;
-				productLink.textContent = hotspot.shopText;
+
+				// Product Button Label.
+				const defaultLabel = hotspot.addToCart ? __( 'View Product', 'godam' ) : __( 'Buy Now', 'godam' );
+				const shopText = hotspot.shopText?.trim();
+				productLink.textContent = shopText ? shopText : defaultLabel;
 				productDetailsDiv.appendChild( productLink );
 
 				hotspotContent.appendChild( productBoxDiv );

--- a/pages/video-editor/components/layers/WoocommerceLayer.js
+++ b/pages/video-editor/components/layers/WoocommerceLayer.js
@@ -286,7 +286,9 @@ const WoocommerceLayer = ( { layerID, goBack } ) => {
 							<div className="mt-3">
 								<TextControl
 									label={ __( 'Shop Button', 'godam' ) }
-									placeholder={ __( 'Click Me!', 'godam' ) }
+									placeholder={ productHotspot.addToCart
+										? __( 'View Product', 'godam' )
+										: __( 'Buy Now', 'godam' ) }
 									value={ productHotspot.shopText }
 									onChange={ ( val ) =>
 										updateField(
@@ -528,7 +530,15 @@ const WoocommerceLayer = ( { layerID, goBack } ) => {
 														rel="noopener noreferrer"
 														style={ { background: productHotspot.backgroundColor } }
 													>
-														{ productHotspot.shopText }
+														{ ( () => {
+															const defaultLabel = productHotspot.addToCart
+																? __( 'View Product', 'godam' )
+																: __( 'Buy Now', 'godam' );
+
+															const shopText = productHotspot.shopText?.trim();
+
+															return shopText ? shopText : defaultLabel;
+														} )() }
 													</a>
 												</div>
 											</div>


### PR DESCRIPTION
## Fixes
- Adds default value to the button in Product Hotspot if `productHotspot.shopText` is empty or null.
- If `Link to Product Page` toggle is linked to Cart, the default label is : `Buy Now`.
- If `Link to Product Page` toggle is linked to Product Page, the default label is : `View Product`.

## Screenshots
<img width="575" height="352" alt="Screenshot 2025-07-14 at 6 23 55 PM" src="https://github.com/user-attachments/assets/3696c440-ee57-4b95-b25f-767ad4c5a868" />
<img width="418" height="326" alt="Screenshot 2025-07-14 at 6 24 07 PM" src="https://github.com/user-attachments/assets/41e6fc12-52a3-4422-adc7-9b4cb3167207" />
<img width="373" height="202" alt="Screenshot 2025-07-14 at 6 24 27 PM" src="https://github.com/user-attachments/assets/95707540-9cd1-4a8b-976a-275f6bb7021a" />
<img width="367" height="177" alt="Screenshot 2025-07-14 at 6 24 39 PM" src="https://github.com/user-attachments/assets/ff094646-94f1-4390-a26c-72ee379049bc" />


## Attached Issue
Fix: #305 