### PR TITLE
Fix: Topbar add media counts support

### DIFF
--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1081,7 +1081,7 @@ class Media_Library extends Base {
 			);
 		}
 
-		$folder_id = (int) sanitize_text_field( $request['folder_id'] );
+		$folder_id = absint( sanitize_text_field( $request['folder_id'] ) );
 		$args      = array();
 		if ( 0 === $folder_id ) {
 			$args = array(

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -147,7 +147,7 @@ const App = () => {
 					onClick={ () => handleClick( -1 ) }
 				>
 					<p className="folder-list__text">{ __( 'All Media', 'godam' ) }
-						<span className="folder-list__count">{ allMediaCount || 0 }</span>
+						<span className="folder-list__count">{ allMediaCount ?? 0 }</span>
 					</p>
 				</button>
 
@@ -159,7 +159,7 @@ const App = () => {
 					data-id={ 0 }
 				>
 					<p className="folder-list__text">{ __( 'Uncategorized', 'godam' ) }
-						<span className="folder-list__count">{ uncategorizedCount?.count || 0 }</span>
+						<span className="folder-list__count">{ uncategorizedCount?.count ?? 0 }</span>
 					</p>
 				</button>
 			</div>

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -26,7 +26,7 @@ import { FolderCreationModal, RenameModal, DeleteModal } from './components/moda
 import { triggerFilterChange } from './data/media-grid.js';
 import BookmarkTab from './components/folder-tree/BookmarkTab.jsx';
 import LockedTab from './components/folder-tree/LockedTab.jsx';
-import { useGetAllMediaCountQuery } from './redux/api/folders.js';
+import { useGetAllMediaCountQuery, useGetCategoryMediaCountQuery } from './redux/api/folders.js';
 
 const App = () => {
 	const dispatch = useDispatch();
@@ -34,6 +34,7 @@ const App = () => {
 	const isMultiSelecting = useSelector( ( state ) => state.FolderReducer.isMultiSelecting );
 	const currentSortOrder = useSelector( ( state ) => state.FolderReducer.sortOrder );
 	const { data: allMediaCount } = useGetAllMediaCountQuery();
+	const { data: uncategorizedCount } = useGetCategoryMediaCountQuery( { folderId: 0 } );
 
 	const [ contextMenu, setContextMenu ] = useState( {
 		visible: false,
@@ -157,6 +158,7 @@ const App = () => {
 					data-id={ 0 }
 				>
 					<p className="folder-list__text">{ __( 'Uncategorized', 'godam' ) }</p>
+					{ uncategorizedCount?.count && <p>{ uncategorizedCount?.count }</p> }
 				</button>
 			</div>
 

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -26,12 +26,14 @@ import { FolderCreationModal, RenameModal, DeleteModal } from './components/moda
 import { triggerFilterChange } from './data/media-grid.js';
 import BookmarkTab from './components/folder-tree/BookmarkTab.jsx';
 import LockedTab from './components/folder-tree/LockedTab.jsx';
+import { useGetAllMediaCountQuery } from './redux/api/folders.js';
 
 const App = () => {
 	const dispatch = useDispatch();
 	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
 	const isMultiSelecting = useSelector( ( state ) => state.FolderReducer.isMultiSelecting );
 	const currentSortOrder = useSelector( ( state ) => state.FolderReducer.sortOrder );
+	const { data: allMediaCount } = useGetAllMediaCountQuery();
 
 	const [ contextMenu, setContextMenu ] = useState( {
 		visible: false,
@@ -144,6 +146,7 @@ const App = () => {
 					onClick={ () => handleClick( -1 ) }
 				>
 					<p className="folder-list__text">{ __( 'All Media', 'godam' ) }</p>
+					{ allMediaCount && <p>{ allMediaCount }</p> }
 				</button>
 
 				<button

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -146,8 +146,9 @@ const App = () => {
 					}` }
 					onClick={ () => handleClick( -1 ) }
 				>
-					<p className="folder-list__text">{ __( 'All Media', 'godam' ) }</p>
-					{ allMediaCount && <p>{ allMediaCount }</p> }
+					<p className="folder-list__text">{ __( 'All Media', 'godam' ) }
+						<span className="folder-list__count">{ allMediaCount || 0 }</span>
+					</p>
 				</button>
 
 				<button
@@ -157,8 +158,9 @@ const App = () => {
 					onClick={ () => handleClick( 0 ) }
 					data-id={ 0 }
 				>
-					<p className="folder-list__text">{ __( 'Uncategorized', 'godam' ) }</p>
-					{ uncategorizedCount?.count && <p>{ uncategorizedCount?.count }</p> }
+					<p className="folder-list__text">{ __( 'Uncategorized', 'godam' ) }
+						<span className="folder-list__count">{ uncategorizedCount?.count || 0 }</span>
+					</p>
 				</button>
 			</div>
 

--- a/pages/media-library/index.scss
+++ b/pages/media-library/index.scss
@@ -87,6 +87,21 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+
+		&__count {
+			font-size: 0.75rem;
+			font-weight: 600;
+			color: #1c1c1c;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.5rem;
+			height: 1.5rem;
+			min-width: 1.5rem;
+			border-radius: 0.5rem;
+			background-color: #F5F5F5;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+		}
 	}
 
 	.folder-list__item {
@@ -115,6 +130,9 @@
 		font-size: 0.875rem;
 		color: #000;
 		margin: 0;
+		width: 100%;
+		display: flex;
+		justify-content: space-between;
 	}
 
 	.tree-item:hover {

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -19,7 +19,7 @@ export const folderApi = createApi( {
 					return { error: result.error };
 				}
 
-				const totalMediaCount = result.meta?.response?.headers.get( 'X-WP-Total' );
+				const totalMediaCount = parseInt( result.meta?.response?.headers.get( 'X-WP-Total' ) || '0', 10 );
 
 				return { data: totalMediaCount };
 			},

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -9,6 +9,21 @@ export const folderApi = createApi( {
 	reducerPath: 'folderApi',
 	baseQuery: fetchBaseQuery( { baseUrl: restURL } ),
 	endpoints: ( builder ) => ( {
+		getAllMediaCount: builder.query( {
+			async queryFn( arg, api, extraOptions, baseQuery ) {
+				const result = await baseQuery( {
+					url: 'wp/v2/media',
+					params: { _fields: 'id', per_page: 1 },
+				} );
+				if ( result.error ) {
+					return { error: result.error };
+				}
+
+				const totalMediaCount = result.meta?.response?.headers.get( 'X-WP-Total' );
+
+				return { data: totalMediaCount };
+			},
+		} ),
 		getFolders: builder.query( {
 			query: () => ( {
 				url: 'wp/v2/media-folder',
@@ -115,6 +130,7 @@ export const folderApi = createApi( {
 } );
 
 export const {
+	useGetAllMediaCountQuery,
 	useGetFoldersQuery,
 	useCreateFolderMutation,
 	useUpdateFolderMutation,

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -24,6 +24,14 @@ export const folderApi = createApi( {
 				return { data: totalMediaCount };
 			},
 		} ),
+		getCategoryMediaCount: builder.query( {
+			query: ( { folderId } ) => ( {
+				url: `godam/v1/media-library/category-count/${ folderId }`,
+				headers: {
+					'X-WP-Nonce': window.MediaLibrary.nonce,
+				},
+			} ),
+		} ),
 		getFolders: builder.query( {
 			query: () => ( {
 				url: 'wp/v2/media-folder',
@@ -131,6 +139,7 @@ export const folderApi = createApi( {
 
 export const {
 	useGetAllMediaCountQuery,
+	useGetCategoryMediaCountQuery,
 	useGetFoldersQuery,
 	useCreateFolderMutation,
 	useUpdateFolderMutation,


### PR DESCRIPTION
This PR adds support for media counts to the All media and Uncategorized button in the media library topbar

<img width="330" height="271" alt="image" src="https://github.com/user-attachments/assets/67ebf1d0-86ac-4c3d-a3ed-b4f479d84675" />
