### PR TITLE
Fix: Upload page hide folder button

### DIFF
--- a/assets/src/js/media-library/views/attachment-browser.js
+++ b/assets/src/js/media-library/views/attachment-browser.js
@@ -40,7 +40,7 @@ export default AttachmentsBrowser?.extend( {
 		// Make sure to load the original toolbar
 		AttachmentsBrowser.prototype.createToolbar.call( this );
 
-		if ( ToggleFoldersButton ) {
+		if ( ToggleFoldersButton && ! isUploadPage() ) {
 			this.toolbar.set(
 				'ToggleFoldersButton',
 				new ToggleFoldersButton( {


### PR DESCRIPTION
closes #669 
This PR removes the Toggle folder sidebar button from rendering for the uploads page.

Before:
<img width="389" height="189" alt="image" src="https://github.com/user-attachments/assets/4cde03d1-5042-46eb-81fb-65655033e22f" />


After:
<img width="394" height="185" alt="image" src="https://github.com/user-attachments/assets/69c1d615-585e-4128-b3ff-315aab90f161" />
