### PR TITLE
Update workflow to include develop branch for dry-run zip

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -3,44 +3,52 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - develop
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
-    - name: Install dependencies & build assets
-      shell: bash
-      run: |
-        npm install
-        npm run build:prod
-    - name: WordPress Plugin Deploy
-      id: deploy
-      uses: 10up/action-wordpress-plugin-deploy@2.3.0
-      with:
-        generate-zip: 'true'
-        dry-run: ${{ startsWith(github.ref, 'refs/tags/dry') }}
-      env:
-        SLUG: 'godam'
-        ASSETS_DIR: 'wp-assets'
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        VERSION: '${{ github.ref_name }}'
-    - name: Upload Test Artifact
-      if: startsWith(github.ref, 'refs/tags/dry')
-      uses: actions/upload-artifact@v4.6.1
-      with:
-        name: godam
-        path: '${{ steps.deploy.outputs.zip-path }}'
-    - name: Upload Release Artifact
-      if: startsWith(github.ref, 'refs/tags/dry') == false
-      uses: softprops/action-gh-release@v2.2.1
-      with:
-        files: |
-          ${{ steps.deploy.outputs.zip-path }}
-        token: '${{ github.token }}'
-        tag_name: ${{ github.ref_name }}
-        draft: true
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies & build assets
+        shell: bash
+        run: |
+          npm install
+          npm run build:prod
+
+      - name: WordPress Plugin Deploy
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@2.3.0
+        with:
+          generate-zip: 'true'
+          dry-run: ${{ startsWith(github.ref, 'refs/tags/dry') || github.ref == 'refs/heads/develop' }}
+        env:
+          SLUG: 'godam'
+          ASSETS_DIR: 'wp-assets'
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          VERSION: '${{ github.ref_name }}'
+
+      - name: Upload Test Artifact
+        if: startsWith(github.ref, 'refs/tags/dry') || github.ref == 'refs/heads/develop'
+        uses: actions/upload-artifact@v4.6.1
+        with:
+          name: godam
+          path: '${{ steps.deploy.outputs.zip-path }}'
+
+      - name: Upload Release Artifact
+        if: startsWith(github.ref, 'refs/tags/dry') == false && github.ref != 'refs/heads/develop'
+        uses: softprops/action-gh-release@v2.2.1
+        with:
+          files: |
+            ${{ steps.deploy.outputs.zip-path }}
+          token: '${{ github.token }}'
+          tag_name: ${{ github.ref_name }}
+          draft: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/release_on_tag.yml` to include support for the `develop` branch in addition to tags. It also adjusts the conditions for deploying and uploading artifacts based on the branch or tag being processed.

### Workflow updates for `develop` branch support:
* Added the `develop` branch to the `on.push.branches` configuration, enabling the workflow to trigger on pushes to the `develop` branch.
* Modified the `dry-run` condition for the WordPress Plugin Deploy step to include the `develop` branch (`github.ref == 'refs/heads/develop'`).
* Updated the conditions for the "Upload Test Artifact" and "Upload Release Artifact" steps to account for the `develop` branch:
  - Test artifacts are uploaded when the branch is `develop` or a dry-run tag is used.
  - Release artifacts are only uploaded when the branch is not `develop` and the tag is not a dry-run tag.