### PR TITLE
Fix: Media library locked drag drop

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -300,7 +300,7 @@ $media-frame-width: calc(300px + 2 * 24px);
     }
 }
 
-#menu-item-library {
+#menu-item-library, #menu-item-featured-image {
 	display: none;
 }
 

--- a/assets/src/js/media-library/views/attachment-list.js
+++ b/assets/src/js/media-library/views/attachment-list.js
@@ -40,7 +40,8 @@ class MediaListViewTableDragHandler {
 	 * Sets up drag functionality for all media table rows if folder organization is enabled.
 	 */
 	init() {
-		if ( isFolderOrgDisabled() ) {
+		const currentSelectedFolder = window.godam?.selectedFolder;
+		if ( isFolderOrgDisabled() || currentSelectedFolder?.meta?.locked ) {
 			return;
 		}
 
@@ -225,4 +226,3 @@ class MediaListViewTableDragHandler {
 }
 
 export default MediaListViewTableDragHandler;
-

--- a/assets/src/js/media-library/views/attachment-list.js
+++ b/assets/src/js/media-library/views/attachment-list.js
@@ -45,7 +45,22 @@ class MediaListViewTableDragHandler {
 		}
 
 		this.tableRows = document.querySelectorAll( '.wp-list-table.media tbody tr' );
-		this.setupDragHandlers();
+		window.addEventListener( 'godam:lockedFolderLoaded', ( e ) => {
+			const { ids } = e.detail;
+			const params = new URLSearchParams( window.location.search );
+			const mediaFolderId = parseInt( params.get( 'media-folder' ) );
+
+			if ( ids && ids.length > 0 && mediaFolderId && ! ids.includes( mediaFolderId ) ) {
+				this.setupDragHandlers();
+			}
+		} );
+
+		// This check is done here to ensure drag handlers are set up on initial load if applicable.
+		const params = new URLSearchParams( window.location.search );
+		const mediaFolderId = parseInt( params.get( 'media-folder' ) );
+		if ( ! mediaFolderId ) { // Only set up if no media folder is currently selected in the URL (for all media and uncategorized pages)
+			this.setupDragHandlers();
+		}
 	}
 
 	/**

--- a/assets/src/js/media-library/views/attachment-list.js
+++ b/assets/src/js/media-library/views/attachment-list.js
@@ -40,8 +40,7 @@ class MediaListViewTableDragHandler {
 	 * Sets up drag functionality for all media table rows if folder organization is enabled.
 	 */
 	init() {
-		const currentSelectedFolder = window.godam?.selectedFolder;
-		if ( isFolderOrgDisabled() || currentSelectedFolder?.meta?.locked ) {
+		if ( isFolderOrgDisabled() ) {
 			return;
 		}
 

--- a/assets/src/js/media-library/views/attachment-list.js
+++ b/assets/src/js/media-library/views/attachment-list.js
@@ -52,6 +52,12 @@ class MediaListViewTableDragHandler {
 
 			if ( ids && ids.length > 0 && mediaFolderId && ! ids.includes( mediaFolderId ) ) {
 				this.setupDragHandlers();
+			} else if ( ids.includes( mediaFolderId ) ) {
+				jQuery( '#wpbody-content .page-title-action' ).prop( 'disabled', true )
+					.css( {
+						'pointer-events': 'none',
+						opacity: '0.5',
+					} );
 			}
 		} );
 

--- a/assets/src/js/media-library/views/attachment.js
+++ b/assets/src/js/media-library/views/attachment.js
@@ -22,57 +22,59 @@ const Attachment = wp?.media?.view?.Attachment?.extend( {
 	initialize() {
 		wp.media.view.Attachment.prototype.initialize.call( this );
 
-		if ( ! isFolderOrgDisabled() ) {
-			/**
-			 * Attach drag event to the attachment element, this will allow the user to drag the attachment.
-			 * It's more useful to do this here, because on re-render, the draggable event will be lost.
-			 */
-			this.$el.draggable( {
-				cursor: 'move',
-
-				/**
-				 * Using arrow function here is necessary to bind the context of `this` to the parent view.
-				 * Otherwise, `this` will refer to the draggable instance.
-				 *
-				 * not using it here would result in you having to use timeout function to wait for the initialization of the view.
-				 */
-				helper: () => {
-					// Get the current selection from Backbone's state
-					const selection = wp.media.frame.state().get( 'selection' );
-
-					// Map through the selection to extract IDs
-					let draggedItemIds = selection?.map( ( model ) => model.get( 'id' ) );
-
-					// If no items are selected, use the current item's ID
-					if ( ! draggedItemIds || draggedItemIds.length === 0 ) {
-						const currentItemId = this.model.get( 'id' ); // Get the ID of the current attachment
-						draggedItemIds = [ currentItemId ];
-					}
-
-					this.$el.data( 'draggedItems', draggedItemIds );
-
-					return $( '<div>', {
-						text: `Moving ${ draggedItemIds.length } item${ draggedItemIds.length > 1 ? 's' : '' }`,
-						css: {
-							background: '#333',
-							color: '#fff',
-							padding: '8px 12px',
-							borderRadius: '4px',
-							fontSize: '14px',
-							fontWeight: 'bold',
-							boxShadow: '0 2px 5px rgba(0,0,0,0.3)',
-							zIndex: 160001, // Ensure that the helper is above media library popup
-							PointerEvent: 'none',
-							position: 'relative',
-						},
-					} );
-				},
-				opacity: 0.7,
-				appendTo: 'body',
-				cursorAt: { top: 5, left: 5 },
-
-			} );
+		const currentSelectedFolder = window.godam?.selectedFolder;
+		if ( isFolderOrgDisabled() || currentSelectedFolder?.meta?.locked ) {
+			return;
 		}
+		/**
+		 * Attach drag event to the attachment element, this will allow the user to drag the attachment.
+		 * It's more useful to do this here, because on re-render, the draggable event will be lost.
+		 */
+		this.$el.draggable( {
+			cursor: 'move',
+
+			/**
+			 * Using arrow function here is necessary to bind the context of `this` to the parent view.
+			 * Otherwise, `this` will refer to the draggable instance.
+			 *
+			 * not using it here would result in you having to use timeout function to wait for the initialization of the view.
+			 */
+			helper: () => {
+				// Get the current selection from Backbone's state
+				const selection = wp.media.frame.state().get( 'selection' );
+
+				// Map through the selection to extract IDs
+				let draggedItemIds = selection?.map( ( model ) => model.get( 'id' ) );
+
+				// If no items are selected, use the current item's ID
+				if ( ! draggedItemIds || draggedItemIds.length === 0 ) {
+					const currentItemId = this.model.get( 'id' ); // Get the ID of the current attachment
+					draggedItemIds = [ currentItemId ];
+				}
+
+				this.$el.data( 'draggedItems', draggedItemIds );
+
+				return $( '<div>', {
+					text: `Moving ${ draggedItemIds.length } item${ draggedItemIds.length > 1 ? 's' : '' }`,
+					css: {
+						background: '#333',
+						color: '#fff',
+						padding: '8px 12px',
+						borderRadius: '4px',
+						fontSize: '14px',
+						fontWeight: 'bold',
+						boxShadow: '0 2px 5px rgba(0,0,0,0.3)',
+						zIndex: 160001, // Ensure that the helper is above media library popup
+						PointerEvent: 'none',
+						position: 'relative',
+					},
+				} );
+			},
+			opacity: 0.7,
+			appendTo: 'body',
+			cursorAt: { top: 5, left: 5 },
+
+		} );
 	},
 
 	render() {

--- a/assets/src/js/media-library/views/attachment.js
+++ b/assets/src/js/media-library/views/attachment.js
@@ -73,7 +73,14 @@ const Attachment = wp?.media?.view?.Attachment?.extend( {
 			opacity: 0.7,
 			appendTo: 'body',
 			cursorAt: { top: 5, left: 5 },
-
+			// eslint-disable-next-line no-unused-vars
+			start: ( event, ui ) => {
+				// Cancel drag if folder is locked
+				if ( window.godam?.selectedFolder?.meta?.locked ) {
+					event.preventDefault();
+					$( event.target ).draggable( 'cancel' );
+				}
+			},
 		} );
 	},
 

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -109,6 +109,7 @@ const App = () => {
 					text={ __( 'New Folder', 'godam' ) }
 					className="button--full mb-spacing new-folder-button"
 					onClick={ () => dispatch( openModal( 'folderCreation' ) ) }
+					disabled={ selectedFolder?.meta?.locked }
 				/>
 
 				<Button

--- a/pages/media-library/components/context-menu/ContextMenu.jsx
+++ b/pages/media-library/components/context-menu/ContextMenu.jsx
@@ -364,7 +364,7 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 				icon={ NewFolderIcon }
 				onClick={ () => handleMenuItemClick( 'newSubFolder' ) }
 				className="folder-context-menu__item"
-				disabled={ ( isMultiSelecting && multiSelectedFolderIds.length > 1 ) || isSpecialFolder }
+				disabled={ ( isMultiSelecting && multiSelectedFolderIds.length > 1 ) || isSpecialFolder || currentFolder?.meta?.locked }
 			>
 				{ __( 'New Sub-folder', 'godam' ) }
 			</Button>

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -90,6 +90,20 @@ const FolderTree = ( { handleContextMenu } ) => {
 	const projected = activeId && overId ? utilities.getProjection( filteredData, activeId, overId, offsetLeft ) : null;
 
 	function handleDragStart( { active: { id: draggedItemId } } ) {
+		const draggedFolder = data.find( ( folder ) => folder.id === draggedItemId );
+
+		// If the dragged folder has a parent and that parent is locked, prevent dragging.
+		if ( draggedFolder?.parent && draggedFolder.parent !== 0 ) {
+			const parentFolder = data.find( ( folder ) => folder.id === draggedFolder.parent );
+			if ( parentFolder?.meta?.locked ) {
+				dispatch( updateSnackbar( {
+					message: __( 'The parent folder is locked, so this folder cannot be moved.', 'godam' ),
+					type: 'fail',
+				} ) );
+				return;
+			}
+		}
+
 		setActiveId( draggedItemId );
 		setOverId( draggedItemId );
 	}
@@ -106,6 +120,18 @@ const FolderTree = ( { handleContextMenu } ) => {
 
 			if ( ! parent ) {
 				parent = 0;
+			}
+
+			// Do not allow reordering/move if the destination folder (new parent) is locked.
+			if ( parent !== 0 ) {
+				const destinationFolder = data.find( ( folder ) => folder.id === parent );
+				if ( destinationFolder?.meta?.locked ) {
+					dispatch( updateSnackbar( {
+						message: __( 'The destination folder is locked and cannot be modified', 'godam' ),
+						type: 'fail',
+					} ) );
+					return;
+				}
 			}
 
 			const clonedItems = JSON.parse(

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -226,7 +226,7 @@ const FolderTree = ( { handleContextMenu } ) => {
 						// do not allow assigning item to other folder from the locked folder.
 						if ( selectedFolder?.meta?.locked ) {
 							dispatch( updateSnackbar( {
-								message: __( 'This folder is locked and cannot be modified', 'godam' ),
+								message: __( 'Currently opened folder is locked and cannot be modified', 'godam' ),
 								type: 'fail',
 							} ) );
 							return;

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -283,6 +283,62 @@ const FolderTree = ( { handleContextMenu } ) => {
 
 		setupDroppable();
 
+		// Disable the Add Media Button and the Upload button for locked folders
+		if ( selectedFolder?.meta?.locked ) {
+		// Media Library Add media button
+			jQuery( '#wp-media-grid .page-title-action' ).prop( 'disabled', true )
+				.css( {
+					'pointer-events': 'none',
+					opacity: '0.5',
+				} );
+
+			// Edit Post add media button
+			jQuery( '#__wp-uploader-id-1' ).prop( 'disabled', true )
+				.css( 'pointer-events', 'none' );
+
+			// Media Library Drag and Drop
+			jQuery( '#wpwrap' ).on( 'dragover.lock drop.lock', function( e ) {
+				e.preventDefault();
+				e.stopPropagation();
+			} );
+
+			// Edit post Drag and Drop
+			jQuery( '.media-modal-content' ).on( 'dragover.lock drop.lock', function( e ) {
+				e.preventDefault();
+				e.stopPropagation();
+			} );
+
+			// Tell WordPress uploader to ignore drop
+			if ( wp?.media?.frames?.frame?.uploader?.dropzone ) {
+				wp.media.frames.frame.uploader.dropzone.off( 'drop' );
+			}
+		} else {
+			// Media Library Add media button
+			jQuery( '#wp-media-grid .page-title-action' ).prop( 'disabled', false )
+				.css( {
+					'pointer-events': 'auto',
+					opacity: '1',
+				} );
+
+			// Edit Post add media button
+			jQuery( '#__wp-uploader-id-1' ).prop( 'disabled', false )
+				.css( 'pointer-events', 'auto' );
+
+			// Media Library Drag and Drop
+			jQuery( '#wpwrap' ).off( 'dragover.lock drop.lock' );
+
+			// Edit post Drag and Drop
+			jQuery( '.media-modal-content' ).off( 'dragover.lock drop.lock' );
+
+			// Restore default dropzone
+			if ( wp?.media?.frames?.frame?.uploader?.dropzone ) {
+				// eslint-disable-next-line no-unused-vars
+				wp.media.frames.frame.uploader.dropzone.on( 'drop', function( e ) {
+					// Normally handled by WP
+				} );
+			}
+		}
+
 		// Cleanup to avoid multiple event bindings
 		return () => {
 			if ( jQuery.fn.droppable ) {

--- a/pages/media-library/components/folder-tree/LockedTab.jsx
+++ b/pages/media-library/components/folder-tree/LockedTab.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelector } from 'react-redux';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 
 /**
  * WordPress dependencies
@@ -26,6 +26,14 @@ const LockedTab = ( { handleContextMenu } ) => {
 		return folders
 			?.filter( ( folder ) => folder?.meta?.locked ) || [];
 	}, [ folders ] );
+
+	useEffect( () => {
+		const event = new CustomEvent( 'godam:lockedFolderLoaded', {
+			detail: { ids: locked.map( ( folder ) => folder.id ) },
+		} );
+
+		window.dispatchEvent( event );
+	}, [ locked ] );
 
 	const lockedCount = locked?.length || 0;
 

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -192,6 +192,8 @@ const slice = createSlice( {
 						window.godam = window.godam || {};
 						window.godam.selectedFolder = { ...state.selectedFolder, meta: { ...state.selectedFolder.meta, locked: folder.meta.locked } };
 					}
+
+					state.selectedFolder.meta.locked = folder.meta.locked;
 				}
 			} else {
 				ids.forEach( ( id ) => {

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -48,6 +48,8 @@ const slice = createSlice( {
 	reducers: {
 		changeSelectedFolder: ( state, action ) => {
 			state.selectedFolder = action.payload.item;
+			window.godam = window.godam || {};
+			window.godam.selectedFolder = action.payload.item;
 		},
 		openModal: ( state, action ) => {
 			const modalName = action.payload;
@@ -185,6 +187,11 @@ const slice = createSlice( {
 					}
 
 					folder.meta.locked = ! Boolean( folder.meta?.locked );
+
+					if ( state.selectedFolder && state.selectedFolder.id === folder.id ) {
+						window.godam = window.godam || {};
+						window.godam.selectedFolder = { ...state.selectedFolder, meta: { ...state.selectedFolder.meta, locked: folder.meta.locked } };
+					}
 				}
 			} else {
 				ids.forEach( ( id ) => {
@@ -194,6 +201,11 @@ const slice = createSlice( {
 							folder.meta = {};
 						}
 						folder.meta.locked = status;
+
+						if ( state.selectedFolder && state.selectedFolder.id === folder.id ) {
+							window.godam = window.godam || {};
+							window.godam.selectedFolder = { ...state.selectedFolder, meta: { ...state.selectedFolder.meta, locked: folder.meta.locked } };
+						}
 					}
 				} );
 			}

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -193,7 +193,9 @@ const slice = createSlice( {
 						window.godam.selectedFolder = { ...state.selectedFolder, meta: { ...state.selectedFolder.meta, locked: folder.meta.locked } };
 					}
 
-					state.selectedFolder.meta.locked = folder.meta.locked;
+					if ( state?.selectedFolder?.meta ) {
+						state.selectedFolder.meta.locked = folder.meta.locked;
+					}
 				}
 			} else {
 				ids.forEach( ( id ) => {


### PR DESCRIPTION
This PR fixes the following UI bugs

- [x] Disable the "New Folder" button when the selected folder is locked
- [x] Fix header layout in the featured image modal
- [x] Prevent dropping files outside of locked folders
- [x] Prevent dragging folders in or out of locked folders
- [x] Disable media drag-and-drop when the current folder is locked
- [x] Handle media drag-and-drop correctly in list view
- [x] Disable upload buttons and drop zones for locked folders
- [x] Ensure upload button is disabled in list view for locked folders
