### PR TITLE
Add user settings for CPT visibility in links

### DIFF
--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -148,6 +148,8 @@ class Video_Permalinks {
 	/**
 	 * Video archive visibility field.
 	 *
+	 * @since n.e.x.t
+	 * 
 	 * @return void
 	 */
 	public function video_archive_visibility_field() {
@@ -175,6 +177,8 @@ class Video_Permalinks {
 	
 	/**
 	 * Video single page visibility field.
+	 * 
+	 * @since n.e.x.t
 	 *
 	 * @return void
 	 */
@@ -267,6 +271,8 @@ class Video_Permalinks {
 
 	/**
 	 * Sanitize video post settings.
+	 * 
+	 * @since n.e.x.t
 	 *
 	 * @param array $input The input array to sanitize.
 	 * 

--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -148,7 +148,7 @@ class Video_Permalinks {
 			class='regular-text code'
 		/>
 		<p class='description'>
-			<?php echo esc_html__( 'This slug will be used in the URL for video archive and single video pages (e.g., yoursite.com/videos/). Only lowercase letters, numbers, hyphens, and underscores are allowed.', 'godam' ); ?>
+			<?php esc_html_e( 'This slug will be used in the URL for video archive and single video pages (e.g., yoursite.com/videos/). Only lowercase letters, numbers, hyphens, and underscores are allowed.', 'godam' ); ?>
 		</p>
 		<?php
 	}
@@ -169,7 +169,7 @@ class Video_Permalinks {
 			<?php checked( $value ); ?> 
 		/>
 		<p class='description'>
-			<?php echo esc_html__( 'Enable this to allow public access to the video archive page. When disabled, the video archive page will return 404.', 'godam' ); ?>
+			<?php esc_html_e( 'Enable this to allow public access to the video archive page. When disabled, the video archive page will return 404.', 'godam' ); ?>
 		</p>
 		<?php
 	}
@@ -190,7 +190,7 @@ class Video_Permalinks {
 			<?php checked( $value ); ?> 
 		/>
 		<p class='description'>
-			<?php echo esc_html__( 'Enable this to allow public access to individual video pages. When disabled, single video pages will return 404 but videos will still be available in Query Loop blocks.', 'godam' ); ?>
+			<?php esc_html_e( 'Enable this to allow public access to individual video pages. When disabled, single video pages will return 404 but videos will still be available in Query Loop blocks.', 'godam' ); ?>
 		</p>
 		<?php
 	}

--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -240,11 +240,11 @@ class Video_Permalinks {
 			}
 			
 			// Save single page visibility option.
-			$publicly_queryable     = isset( $_POST['rtgodam_video_post_allow_single'] ) ? true : false;
-			$old_publicly_queryable = get_option( 'rtgodam_video_post_allow_single', false );
+			$allow_single     = isset( $_POST['rtgodam_video_post_allow_single'] ) ? true : false;
+			$old_allow_single = get_option( 'rtgodam_video_post_allow_single', false );
 			
-			if ( $old_publicly_queryable !== $publicly_queryable ) {
-				update_option( 'rtgodam_video_post_allow_single', $publicly_queryable );
+			if ( $old_allow_single !== $allow_single ) {
+				update_option( 'rtgodam_video_post_allow_single', $allow_single );
 				$should_flush = true;
 			}
 			

--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -63,23 +63,23 @@ class Video_Permalinks {
 		// Settings for archive and single visibility.
 		register_setting(
 			'permalink',
-			'rtgodam_video_has_archive',
+			'rtgodam_video_post_allow_archive',
 			array(
 				'type'              => 'boolean',
 				'description'       => __( 'GoDAM Video archive visibility', 'godam' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
-				'default'           => true,
+				'default'           => false,
 			)
 		);
 		
 		register_setting(
 			'permalink',
-			'rtgodam_video_publicly_queryable',
+			'rtgodam_video_post_allow_single',
 			array(
 				'type'              => 'boolean',
 				'description'       => __( 'GoDAM Video single page visibility', 'godam' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
-				'default'           => true,
+				'default'           => false,
 			)
 		);
 	}
@@ -107,7 +107,7 @@ class Video_Permalinks {
 		
 		// Add new settings fields for visibility.
 		add_settings_field(
-			'rtgodam_video_has_archive',
+			'rtgodam_video_post_allow_archive',
 			__( 'Video archive page visibility', 'godam' ),
 			array( $this, 'video_archive_visibility_field' ),
 			'permalink',
@@ -115,7 +115,7 @@ class Video_Permalinks {
 		);
 		
 		add_settings_field(
-			'rtgodam_video_publicly_queryable',
+			'rtgodam_video_post_allow_single',
 			__( 'Video single page visibility', 'godam' ),
 			array( $this, 'video_single_visibility_field' ),
 			'permalink',
@@ -159,12 +159,12 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_archive_visibility_field() {
-		$value = get_option( 'rtgodam_video_has_archive', true );
+		$value = get_option( 'rtgodam_video_post_allow_archive', false );
 		?>
 		<input 
 			type='checkbox' 
-			name='rtgodam_video_has_archive' 
-			id='rtgodam_video_has_archive' 
+			name='rtgodam_video_post_allow_archive' 
+			id='rtgodam_video_post_allow_archive' 
 			value='1' 
 			<?php checked( $value ); ?> 
 		/>
@@ -180,12 +180,12 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_single_visibility_field() {
-		$value = get_option( 'rtgodam_video_publicly_queryable', true );
+		$value = get_option( 'rtgodam_video_post_allow_single', false );
 		?>
 		<input 
 			type='checkbox' 
-			name='rtgodam_video_publicly_queryable' 
-			id='rtgodam_video_publicly_queryable' 
+			name='rtgodam_video_post_allow_single' 
+			id='rtgodam_video_post_allow_single' 
 			value='1' 
 			<?php checked( $value ); ?> 
 		/>
@@ -231,20 +231,20 @@ class Video_Permalinks {
 			}
 			
 			// Save archive visibility option.
-			$has_archive     = isset( $_POST['rtgodam_video_has_archive'] ) ? true : false;
-			$old_has_archive = get_option( 'rtgodam_video_has_archive', true );
+			$has_archive     = isset( $_POST['rtgodam_video_post_allow_archive'] ) ? true : false;
+			$old_has_archive = get_option( 'rtgodam_video_post_allow_archive', false );
 			
 			if ( $old_has_archive !== $has_archive ) {
-				update_option( 'rtgodam_video_has_archive', $has_archive );
+				update_option( 'rtgodam_video_post_allow_archive', $has_archive );
 				$should_flush = true;
 			}
 			
 			// Save single page visibility option.
-			$publicly_queryable     = isset( $_POST['rtgodam_video_publicly_queryable'] ) ? true : false;
-			$old_publicly_queryable = get_option( 'rtgodam_video_publicly_queryable', true );
+			$publicly_queryable     = isset( $_POST['rtgodam_video_post_allow_single'] ) ? true : false;
+			$old_publicly_queryable = get_option( 'rtgodam_video_post_allow_single', false );
 			
 			if ( $old_publicly_queryable !== $publicly_queryable ) {
-				update_option( 'rtgodam_video_publicly_queryable', $publicly_queryable );
+				update_option( 'rtgodam_video_post_allow_single', $publicly_queryable );
 				$should_flush = true;
 			}
 			

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -433,7 +433,7 @@ class GoDAM_Video extends Base {
 		if ( is_singular( self::SLUG ) && ! $this->get_allow_single() ) {
 			$wp_query->set_404();
 			status_header( 404 );
-			include get_query_template( '404' );
+			require get_query_template( '404' );
 			exit;
 		}
 		
@@ -441,7 +441,7 @@ class GoDAM_Video extends Base {
 		if ( is_post_type_archive( self::SLUG ) && ! $this->get_allow_archive() ) {
 			$wp_query->set_404();
 			status_header( 404 );
-			include get_query_template( '404' );
+			require get_query_template( '404' );
 			exit;
 		}
 	}

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -100,6 +100,8 @@ class GoDAM_Video extends Base {
 	
 	/**
 	 * Get allow_archive setting from plugin options.
+	 * 
+	 * @since n.e.x.t
 	 *
 	 * @return bool
 	 */
@@ -110,6 +112,8 @@ class GoDAM_Video extends Base {
 	
 	/**
 	 * Get allow_single setting from plugin options.
+	 * 
+	 * @since n.e.x.t
 	 *
 	 * @return bool
 	 */
@@ -425,6 +429,8 @@ class GoDAM_Video extends Base {
 	/**
 	 * Handle URL access for both single and archive pages based on user settings.
 	 * This ensures videos appear in Query Loop but respect visibility settings for direct URLs.
+	 * 
+	 * @since n.e.x.t
 	 *
 	 * @return void
 	 */

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -104,7 +104,8 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_archive() {
-		return (bool) get_option( 'rtgodam_video_post_allow_archive', false );
+		$settings = get_option( 'rtgodam_video_post_settings' );
+		return (bool) ( isset( $settings['allow_archive'] ) ? $settings['allow_archive'] : false );
 	}
 	
 	/**
@@ -113,7 +114,8 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_single() {
-		return (bool) get_option( 'rtgodam_video_post_allow_single', false );
+		$settings = get_option( 'rtgodam_video_post_settings' );
+		return (bool) ( isset( $settings['allow_single'] ) ? $settings['allow_single'] : false );
 	}
 
 	/**

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -104,7 +104,7 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_archive() {
-		return (bool) get_option( 'rtgodam_video_post_allow_archive', true );
+		return (bool) get_option( 'rtgodam_video_post_allow_archive', false );
 	}
 	
 	/**
@@ -113,7 +113,7 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_single() {
-		return (bool) get_option( 'rtgodam_video_post_allow_single', true );
+		return (bool) get_option( 'rtgodam_video_post_allow_single', false );
 	}
 
 	/**


### PR DESCRIPTION
Follows up on #630 

## What
This PR adds user settings for controlling CPT pages visibility
New settings are added under Permalinks for controlling whether archive/single pages for videos are visible to public

## Why
After introduction of CPTs, the archive & single pages were visible by default
While this may work for websites like YouTube / Netflix, this behavior might not be ideal for other websites which use GoDAM just for hosting & serving their video content in their post

## How
- Two new options: `rtgodam_video_post_allow_archive` & `rtgodam_video_post_allow_single` are added to store user preferences
- Based on these settings, `exclude_from_search` & `has_archive` options are controlled during CPT registration
- `public` & `publicly_queryable` are always set to `true` to allow compatibility with Query Loop block regardless of user preferences
- Instead, to control visibility, `template_redirect` hook is utilized to check the value of options & redirect to 404 template accordingly

## Screenshot

<img width="1024" height="432" alt="image" src="https://github.com/user-attachments/assets/4ab87229-afea-46ed-ac3f-c0dfa1d311c4" />
