### PR TITLE
Set compression level 0 for already zipped file

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           name: godam
           path: '${{ steps.deploy.outputs.zip-path }}'
+          compression-level: 0
 
       - name: Upload Release Artifact
         if: startsWith(github.ref, 'refs/tags/dry') == false && github.ref != 'refs/heads/develop'


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/release_on_tag.yml` file. The change sets the compression level for the release artifact to `0` to adjust the packaging process.