### PR TITLE
Fixes to share button and share modal

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -622,6 +622,7 @@
 			padding: 10px;
 			font-size: 14px;
 			color: #000;
+			width: 80%;
 		}
 
 		button {
@@ -733,7 +734,15 @@
 	font-size: 15px !important;
 	border-radius: 50%;
 	display: flex;
-	transition: all 0.3s ease
+	transition: all 0.3s ease;
+
+	@media screen and (max-width: 768px) {
+
+		&  {
+			opacity: 1;
+			visibility: visible;
+		}
+	}
 }
 
 .easydam-video-container:hover .godam-share-button {

--- a/assets/src/css/pills-skin.scss
+++ b/assets/src/css/pills-skin.scss
@@ -48,6 +48,13 @@
         order: 3;
     }
 
+    .vjs-custom-play-button img {
+        height: 100%;
+        width: auto;
+        object-fit: fill;
+        margin-right: 20px;
+    }
+
     .vjs-menu-content {
         background-color: #fff !important;
         color: #000;

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -214,6 +214,23 @@ const Analytics = ( { attachmentID } ) => {
 		}
 	}, [ analyticsData, abTestComparisonAnalyticsData ] );
 
+	useEffect( () => {
+		const analyticsVideoEl = document.getElementById( 'analytics-video' );
+
+		if ( ! analyticsVideoEl ) {
+			return;
+		}
+
+		const existingPlayer = videojs.getPlayer( 'analytics-video' );
+		if ( existingPlayer ) {
+			existingPlayer.dispose();
+		}
+
+		videojs( 'analytics-video', {
+			aspectRatio: '16:9',
+		} );
+	}, [ analyticsData ] );
+
 	const openVideoUploader = () => {
 		const fileFrame = wp.media( {
 			title: __( 'Select Video to Perform Performance Comparison Testing', 'godam' ),


### PR DESCRIPTION
1. Always show share button on <768px devices

<img width="326" height="178" alt="image" src="https://github.com/user-attachments/assets/a91a7362-312d-4cb3-890f-b6ffdf64c464" />

2. Fix input width in share modal
Issue:
<img width="437" height="386" alt="image" src="https://github.com/user-attachments/assets/a4ee8d7e-fe1b-4a8f-99d4-8a3f4b4a8168" />

Fix:
<img width="1002" height="519" alt="image" src="https://github.com/user-attachments/assets/a0c0223f-0cb0-4916-b0a8-587a78f31588" />

3. Fix branding logo style In pills skin so it doesn't overlay on the control bar border radius
Issue:
<img width="775" height="166" alt="image" src="https://github.com/user-attachments/assets/16d2e22e-b74b-40f4-9534-3cbd9b0e6a0e" />

Fixed:
<img width="700" height="410" alt="image" src="https://github.com/user-attachments/assets/8b5cbec6-e2bb-4884-b924-44a81a6b4fb8" />

4. Fix portrait videos overflow in analytics page
Issue: https://godam-develop.rt.gw/wp-admin/admin.php?page=rtgodam_analytics&id=1305
Fixed:
<img width="1305" height="762" alt="image" src="https://github.com/user-attachments/assets/ccd98d2e-41cb-43b5-9966-82c0fcf22027" />

