### PR TITLE
Enhancement: merge CPT settings into a single option

### DIFF
--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -27,6 +27,14 @@ class Video_Permalinks {
 	const OPTION_SLUG = 'rtgodam_video_post_settings';
 
 	/**
+	 * Default video slug.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	const DEFAULT_VIDEO_SLUG = 'videos';
+
+	/**
 	 * Construct method.
 	 * 
 	 * @return void
@@ -66,7 +74,7 @@ class Video_Permalinks {
 				'description'       => __( 'GoDAM Video post settings', 'godam' ),
 				'sanitize_callback' => array( $this, 'sanitize_video_post_settings' ),
 				'default'           => array(
-					'video_slug'    => 'videos',
+					'video_slug'    => self::DEFAULT_VIDEO_SLUG,
 					'allow_archive' => false,
 					'allow_single'  => false,
 				),
@@ -128,11 +136,11 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_slug_field() {
-		$settings = get_option( self::OPTION_SLUG, array( 'video_slug' => 'videos' ) );
+		$settings = get_option( self::OPTION_SLUG, array( 'video_slug' => self::DEFAULT_VIDEO_SLUG ) );
 
 		// If video_slug key doesn't exist in currently stored settings, check old option for display.
 		if ( ! isset( $settings['video_slug'] ) ) {
-			$value = get_option( 'rtgodam_video_slug', 'videos' );
+			$value = get_option( 'rtgodam_video_slug', self::DEFAULT_VIDEO_SLUG );
 		} else {
 			$value = $settings['video_slug'];
 		}
@@ -221,7 +229,7 @@ class Video_Permalinks {
 			// Get current settings with migration fallback for video_slug.
 			$current_settings = get_option( self::OPTION_SLUG, false );
 			if ( false === $current_settings || ! isset( $current_settings['video_slug'] ) ) {
-				$old_video_slug = get_option( 'rtgodam_video_slug', 'videos' );
+				$old_video_slug = get_option( 'rtgodam_video_slug', self::DEFAULT_VIDEO_SLUG );
 				
 				// If settings don't exist, create new array, otherwise preserve existing settings.
 				if ( false === $current_settings ) {
@@ -245,7 +253,7 @@ class Video_Permalinks {
 			if ( isset( $_POST[ self::OPTION_SLUG ]['video_slug'] ) ) {
 				$new_settings['video_slug'] = sanitize_title( wp_unslash( $_POST[ self::OPTION_SLUG ]['video_slug'] ) );
 			} else {
-				$new_settings['video_slug'] = isset( $current_settings['video_slug'] ) ? $current_settings['video_slug'] : 'videos';
+				$new_settings['video_slug'] = isset( $current_settings['video_slug'] ) ? $current_settings['video_slug'] : self::DEFAULT_VIDEO_SLUG;
 			}
 			
 			// Handle archive visibility.
@@ -283,7 +291,7 @@ class Video_Permalinks {
 		if ( isset( $input['video_slug'] ) ) {
 			$sanitized['video_slug'] = sanitize_title( $input['video_slug'] );
 		} else {
-			$sanitized['video_slug'] = 'videos';
+			$sanitized['video_slug'] = self::DEFAULT_VIDEO_SLUG;
 		}
 		
 		// Sanitize allow_archive setting.

--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -19,6 +19,14 @@ class Video_Permalinks {
 	use Singleton;
 
 	/**
+	 * Option slug for video post settings.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	const OPTION_SLUG = 'rtgodam_video_post_settings';
+
+	/**
 	 * Construct method.
 	 * 
 	 * @return void
@@ -52,7 +60,7 @@ class Video_Permalinks {
 		// Combined settings for video slug and visibility options.
 		register_setting(
 			'permalink',
-			'rtgodam_video_post_settings',
+			self::OPTION_SLUG,
 			array(
 				'type'              => 'object',
 				'description'       => __( 'GoDAM Video post settings', 'godam' ),
@@ -120,8 +128,8 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_slug_field() {
-		$settings = get_option( 'rtgodam_video_post_settings', array( 'video_slug' => 'videos' ) );
-		
+		$settings = get_option( self::OPTION_SLUG, array( 'video_slug' => 'videos' ) );
+
 		// If video_slug key doesn't exist in currently stored settings, check old option for display.
 		if ( ! isset( $settings['video_slug'] ) ) {
 			$value = get_option( 'rtgodam_video_slug', 'videos' );
@@ -151,7 +159,7 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_archive_visibility_field() {
-		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_archive' => false ) );
+		$settings = get_option( self::OPTION_SLUG, array( 'allow_archive' => false ) );
 		$value    = isset( $settings['allow_archive'] ) ? $settings['allow_archive'] : false;
 		?>
 		<input 
@@ -175,7 +183,7 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_single_visibility_field() {
-		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_single' => false ) );
+		$settings = get_option( self::OPTION_SLUG, array( 'allow_single' => false ) );
 		$value    = isset( $settings['allow_single'] ) ? $settings['allow_single'] : false;
 		?>
 		<input 
@@ -211,7 +219,7 @@ class Video_Permalinks {
 		if ( isset( $_POST['permalink_structure'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-permalink' ) ) {
 			
 			// Get current settings with migration fallback for video_slug.
-			$current_settings = get_option( 'rtgodam_video_post_settings', false );
+			$current_settings = get_option( self::OPTION_SLUG, false );
 			if ( false === $current_settings || ! isset( $current_settings['video_slug'] ) ) {
 				$old_video_slug = get_option( 'rtgodam_video_slug', 'videos' );
 				
@@ -234,21 +242,21 @@ class Video_Permalinks {
 			$new_settings = array();
 			
 			// Handle video slug.
-			if ( isset( $_POST['rtgodam_video_post_settings']['video_slug'] ) ) {
-				$new_settings['video_slug'] = sanitize_title( wp_unslash( $_POST['rtgodam_video_post_settings']['video_slug'] ) );
+			if ( isset( $_POST[ self::OPTION_SLUG ]['video_slug'] ) ) {
+				$new_settings['video_slug'] = sanitize_title( wp_unslash( $_POST[ self::OPTION_SLUG ]['video_slug'] ) );
 			} else {
 				$new_settings['video_slug'] = isset( $current_settings['video_slug'] ) ? $current_settings['video_slug'] : 'videos';
 			}
 			
 			// Handle archive visibility.
-			$new_settings['allow_archive'] = isset( $_POST['rtgodam_video_post_settings']['allow_archive'] ) ? true : false;
+			$new_settings['allow_archive'] = isset( $_POST[ self::OPTION_SLUG ]['allow_archive'] ) ? true : false;
 			
 			// Handle single page visibility.
-			$new_settings['allow_single'] = isset( $_POST['rtgodam_video_post_settings']['allow_single'] ) ? true : false;
+			$new_settings['allow_single'] = isset( $_POST[ self::OPTION_SLUG ]['allow_single'] ) ? true : false;
 			
 			// Check if any settings changed.
 			if ( $current_settings !== $new_settings ) {
-				update_option( 'rtgodam_video_post_settings', $new_settings );
+				update_option( self::OPTION_SLUG, $new_settings );
 				$should_flush = true;
 			}
 			

--- a/inc/classes/class-video-permalinks.php
+++ b/inc/classes/class-video-permalinks.php
@@ -49,26 +49,16 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function register_permalink_settings() {
-		register_setting(
-			'permalink',
-			'rtgodam_video_slug',
-			array(
-				'type'              => 'string',
-				'description'       => __( 'GoDAM Video slug', 'godam' ),
-				'sanitize_callback' => 'sanitize_title',
-				'default'           => 'videos',
-			)
-		);
-		
-		// Settings for archive and single visibility.
+		// Combined settings for video slug and visibility options.
 		register_setting(
 			'permalink',
 			'rtgodam_video_post_settings',
 			array(
 				'type'              => 'object',
-				'description'       => __( 'GoDAM Video post visibility settings', 'godam' ),
+				'description'       => __( 'GoDAM Video post settings', 'godam' ),
 				'sanitize_callback' => array( $this, 'sanitize_video_post_settings' ),
 				'default'           => array(
+					'video_slug'    => 'videos',
 					'allow_archive' => false,
 					'allow_single'  => false,
 				),
@@ -126,15 +116,23 @@ class Video_Permalinks {
 
 	/**
 	 * Video slug field.
-	 *
+	 * 
 	 * @return void
 	 */
 	public function video_slug_field() {
-		$value = get_option( 'rtgodam_video_slug', 'videos' );
+		$settings = get_option( 'rtgodam_video_post_settings', array( 'video_slug' => 'videos' ) );
+		
+		// If video_slug key doesn't exist in currently stored settings, check old option for display.
+		if ( ! isset( $settings['video_slug'] ) ) {
+			$value = get_option( 'rtgodam_video_slug', 'videos' );
+		} else {
+			$value = $settings['video_slug'];
+		}
+
 		?>
 		<input 
 			type='text' 
-			name='rtgodam_video_slug' 
+			name='rtgodam_video_post_settings[video_slug]' 
 			id='rtgodam_video_slug' 
 			value='<?php echo esc_attr( $value ); ?>' 
 			class='regular-text code'
@@ -153,13 +151,7 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_archive_visibility_field() {
-		$settings = get_option(
-			'rtgodam_video_post_settings',
-			array(
-				'allow_archive' => false,
-				'allow_single'  => false,
-			) 
-		);
+		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_archive' => false ) );
 		$value    = isset( $settings['allow_archive'] ) ? $settings['allow_archive'] : false;
 		?>
 		<input 
@@ -183,13 +175,7 @@ class Video_Permalinks {
 	 * @return void
 	 */
 	public function video_single_visibility_field() {
-		$settings = get_option(
-			'rtgodam_video_post_settings',
-			array(
-				'allow_archive' => false,
-				'allow_single'  => false,
-			) 
-		);
+		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_single' => false ) );
 		$value    = isset( $settings['allow_single'] ) ? $settings['allow_single'] : false;
 		?>
 		<input 
@@ -224,31 +210,35 @@ class Video_Permalinks {
 		// Nonce verification.
 		if ( isset( $_POST['permalink_structure'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-permalink' ) ) {
 			
-			// Save video slug if it exists in the POST data.
-			if ( isset( $_POST['rtgodam_video_slug'] ) ) {
-				$video_slug = sanitize_title( wp_unslash( $_POST['rtgodam_video_slug'] ) );
+			// Get current settings with migration fallback for video_slug.
+			$current_settings = get_option( 'rtgodam_video_post_settings', false );
+			if ( false === $current_settings || ! isset( $current_settings['video_slug'] ) ) {
+				$old_video_slug = get_option( 'rtgodam_video_slug', 'videos' );
 				
-				// Get the old value to compare.
-				$old_value = get_option( 'rtgodam_video_slug', 'videos' );
-				
-				// Only update if changed.
-				if ( $old_value !== $video_slug ) {
-					update_option( 'rtgodam_video_slug', $video_slug );
-					
-					// Flush rewrite rules to apply new video slug.
-					$should_flush = true;
+				// If settings don't exist, create new array, otherwise preserve existing settings.
+				if ( false === $current_settings ) {
+					$current_settings = array(
+						'video_slug'    => $old_video_slug,
+						'allow_archive' => false,
+						'allow_single'  => false,
+					);
+				} else {
+					// Settings exist but missing video_slug, add it.
+					$current_settings['video_slug'] = $old_video_slug;
 				}
+				
+				// Delete old option since we've migrated its value.
+				delete_option( 'rtgodam_video_slug' );
 			}
 			
-			// Save archive and single visibility options.
-			$current_settings = get_option(
-				'rtgodam_video_post_settings',
-				array(
-					'allow_archive' => false,
-					'allow_single'  => false,
-				) 
-			);
-			$new_settings     = array();
+			$new_settings = array();
+			
+			// Handle video slug.
+			if ( isset( $_POST['rtgodam_video_post_settings']['video_slug'] ) ) {
+				$new_settings['video_slug'] = sanitize_title( wp_unslash( $_POST['rtgodam_video_post_settings']['video_slug'] ) );
+			} else {
+				$new_settings['video_slug'] = isset( $current_settings['video_slug'] ) ? $current_settings['video_slug'] : 'videos';
+			}
 			
 			// Handle archive visibility.
 			$new_settings['allow_archive'] = isset( $_POST['rtgodam_video_post_settings']['allow_archive'] ) ? true : false;
@@ -256,7 +246,7 @@ class Video_Permalinks {
 			// Handle single page visibility.
 			$new_settings['allow_single'] = isset( $_POST['rtgodam_video_post_settings']['allow_single'] ) ? true : false;
 			
-			// Check if settings changed.
+			// Check if any settings changed.
 			if ( $current_settings !== $new_settings ) {
 				update_option( 'rtgodam_video_post_settings', $new_settings );
 				$should_flush = true;
@@ -280,6 +270,13 @@ class Video_Permalinks {
 	 */
 	public function sanitize_video_post_settings( $input ) {
 		$sanitized = array();
+		
+		// Sanitize video slug.
+		if ( isset( $input['video_slug'] ) ) {
+			$sanitized['video_slug'] = sanitize_title( $input['video_slug'] );
+		} else {
+			$sanitized['video_slug'] = 'videos';
+		}
 		
 		// Sanitize allow_archive setting.
 		if ( isset( $input['allow_archive'] ) ) {

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -100,7 +100,7 @@ class GoDAM_Video extends Base {
 		
 		// Fallback to old option if new settings don't exist.
 		if ( false === $settings || ! isset( $settings['video_slug'] ) ) {
-			return get_option( 'rtgodam_video_slug', 'videos' );
+			return get_option( 'rtgodam_video_slug', Video_Permalinks::DEFAULT_VIDEO_SLUG );
 		}
 		
 		return $settings['video_slug'];

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -95,7 +95,14 @@ class GoDAM_Video extends Base {
 	 * @return string
 	 */
 	private function get_rewrite_slug() {
-		return get_option( 'rtgodam_video_slug', 'videos' );
+		$settings = get_option( 'rtgodam_video_post_settings', false );
+		
+		// Fallback to old option if new settings don't exist.
+		if ( false === $settings || ! isset( $settings['video_slug'] ) ) {
+			return get_option( 'rtgodam_video_slug', 'videos' );
+		}
+		
+		return $settings['video_slug'];
 	}
 	
 	/**
@@ -106,7 +113,7 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_archive() {
-		$settings = get_option( 'rtgodam_video_post_settings' );
+		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_archive' => false ) );
 		return (bool) ( isset( $settings['allow_archive'] ) ? $settings['allow_archive'] : false );
 	}
 	
@@ -118,7 +125,7 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_single() {
-		$settings = get_option( 'rtgodam_video_post_settings' );
+		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_single' => false ) );
 		return (bool) ( isset( $settings['allow_single'] ) ? $settings['allow_single'] : false );
 	}
 

--- a/inc/classes/post-types/class-godam-video.php
+++ b/inc/classes/post-types/class-godam-video.php
@@ -10,6 +10,7 @@ namespace RTGODAM\Inc\Post_Types;
 defined( 'ABSPATH' ) || exit;
 
 use WP_Query;
+use RTGODAM\Inc\Video_Permalinks;
 
 /**
  * Class GoDAM_Video.
@@ -95,7 +96,7 @@ class GoDAM_Video extends Base {
 	 * @return string
 	 */
 	private function get_rewrite_slug() {
-		$settings = get_option( 'rtgodam_video_post_settings', false );
+		$settings = get_option( Video_Permalinks::OPTION_SLUG, false );
 		
 		// Fallback to old option if new settings don't exist.
 		if ( false === $settings || ! isset( $settings['video_slug'] ) ) {
@@ -113,7 +114,7 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_archive() {
-		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_archive' => false ) );
+		$settings = get_option( Video_Permalinks::OPTION_SLUG, array( 'allow_archive' => false ) );
 		return (bool) ( isset( $settings['allow_archive'] ) ? $settings['allow_archive'] : false );
 	}
 	
@@ -125,7 +126,7 @@ class GoDAM_Video extends Base {
 	 * @return bool
 	 */
 	private function get_allow_single() {
-		$settings = get_option( 'rtgodam_video_post_settings', array( 'allow_single' => false ) );
+		$settings = get_option( Video_Permalinks::OPTION_SLUG, array( 'allow_single' => false ) );
 		return (bool) ( isset( $settings['allow_single'] ) ? $settings['allow_single'] : false );
 	}
 


### PR DESCRIPTION
Closes #718 

## What
This PR merges CPT related settings to a single option

Currently in the plugin, there are 2 CPT related options

1. `rtgodam_video_slug` - Stores the slug for video pages
2. `rtgodam_video_post_settings` - Stores CPT page visiblility settings (array)

It will be better to combine these two into a single option

https://github.com/rtCamp/godam/pull/696#issuecomment-3089400484

## How
- This PR adds another key `video_slug` to the array of `rtgodam_video_post_settings` that stores the value of CPT rewrite slug
- For existing users, the behavior is as follows:
  - If `rtgodam_video_slug` is set in DB, it'll  continue to be used
  - When the user updates permalink settings, value from `rtgodam_video_slug` will be merged into `rtgodam_video_post_settings` & the old option will be deleted

## Screenshot

<img width="1222" height="425" alt="image" src="https://github.com/user-attachments/assets/83bd7c6b-9bab-4ce9-8e93-ef4f702c30c2" />
