### PR TITLE
fix: Allow 0 values in bandwidth and storage

### DIFF
--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -270,19 +270,20 @@ function rtgodam_get_user_data( $use_for_localize_array = false, $timeout = 300 
 			$localized_array_data['storageBandwidthError'] = $rtgodam_user_data['storageBandwidthError'];
 		}
 
-		if ( isset( $rtgodam_user_data['storage_used'] ) && ! empty( $rtgodam_user_data['storage_used'] ) ) {
+		// Use isset() instead of !empty() to allow 0 values.
+		if ( isset( $rtgodam_user_data['storage_used'] ) ) {
 			$localized_array_data['storageUsed'] = $rtgodam_user_data['storage_used'];
 		}
 
-		if ( isset( $rtgodam_user_data['total_storage'] ) && ! empty( $rtgodam_user_data['total_storage'] ) ) {
+		if ( isset( $rtgodam_user_data['total_storage'] ) ) {
 			$localized_array_data['totalStorage'] = $rtgodam_user_data['total_storage'];
 		}
 
-		if ( isset( $rtgodam_user_data['bandwidth_used'] ) && ! empty( $rtgodam_user_data['bandwidth_used'] ) ) {
+		if ( isset( $rtgodam_user_data['bandwidth_used'] ) ) {
 			$localized_array_data['bandwidthUsed'] = $rtgodam_user_data['bandwidth_used'];
 		}
 
-		if ( isset( $rtgodam_user_data['total_bandwidth'] ) && ! empty( $rtgodam_user_data['total_bandwidth'] ) ) {
+		if ( isset( $rtgodam_user_data['total_bandwidth'] ) ) {
 			$localized_array_data['totalBandwidth'] = $rtgodam_user_data['total_bandwidth'];
 		}
 


### PR DESCRIPTION
## Screenshots
Update `!empty` to `isset`, to allow for 0 values in used bandwidth and storage.
1. Before:

<img width="1942" height="629" alt="Screenshot 2025-07-23 at 1 00 19 PM" src="https://github.com/user-attachments/assets/33cc69b7-3372-458a-a611-8fdc3b5e3d53" />

3. After:

<img width="1567" height="453" alt="Screenshot 2025-07-23 at 1 00 42 PM" src="https://github.com/user-attachments/assets/83a2adf4-1df4-4a2d-9b13-f5d4ca607e54" />
