### PR TITLE
enhance: save and use hsl url along with mpd url for transcoded videos.

### DIFF
--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -228,6 +228,11 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 
 							$latest_attachment = get_option( 'rtgodam_new_attachment', false );
 
+							// Save hls url as well.
+							if ( isset( $post_array['hls_path'] ) && ! empty( trim ( $post_array['hls_path'] ) ) ) {
+								update_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', sanitize_url( $post_array['hls_path'] ) );
+							}
+
 							if ( ! empty( $latest_attachment ) && $latest_attachment['attachment_id'] === $attachment_id ) {
 								$latest_attachment['transcoding_status'] = 'success';
 								update_option( 'rtgodam_new_attachment', $latest_attachment, '', true );

--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -229,7 +229,7 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 							$latest_attachment = get_option( 'rtgodam_new_attachment', false );
 
 							// Save hls url as well.
-							if ( isset( $post_array['hls_path'] ) && ! empty( trim ( $post_array['hls_path'] ) ) ) {
+							if ( isset( $post_array['hls_path'] ) && ! empty( trim( $post_array['hls_path'] ) ) ) {
 								update_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', sanitize_url( $post_array['hls_path'] ) );
 							}
 

--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -617,6 +617,37 @@ function rtgodam_get_transcoded_url_from_attachment( $attachment ) {
 }
 
 /**
+ * Return hls transcoded url from attachment.
+ *
+ * @since n.e.x.t
+ *
+ * @param int|\WP_Post $attachment Attachment.
+ *
+ * @return string|false
+ */
+function rtgodam_get_hls_transcoded_url_from_attachment( $attachment ) {
+	$attachment_id = 0;
+
+	if ( $attachment instanceof \WP_Post ) {
+		$attachment_id = $attachment->ID;
+	} elseif ( is_numeric( $attachment ) ) {
+		$attachment_id = $attachment;
+	}
+
+	if ( $attachment_id <= 0 ) {
+		return '';
+	}
+
+	$attachment_obj = get_post( $attachment_id );
+
+	if ( 'attachment' !== $attachment_obj->post_type ) {
+		return '';
+	}
+
+	return get_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', true );
+}
+
+/**
  * Return transcoded status from attachment.
  *
  * @since 1.3.0

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -204,7 +204,7 @@ function VideoEdit( {
 							} );
 						}
 
-						// Reverse the sources to ensure the preferred format is first. MPD -> HLD -> Origin
+						// Reverse the sources to ensure the preferred format is first. MPD -> HLS -> Origin
 						setAttributes( { sources: newSources.reverse() } );
 					}
 				} catch ( error ) {

--- a/inc/classes/rest-api/class-dynamic-shortcode.php
+++ b/inc/classes/rest-api/class-dynamic-shortcode.php
@@ -60,7 +60,9 @@ class Dynamic_Shortcode extends Base {
 	public function render_shortcode( WP_REST_Request $request ) {
 		$id = $request->get_param( 'id' );
 
-		if ( ! get_post( $id ) ) {
+		$attachment = get_post( $id );
+
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
 			return new WP_REST_Response(
 				array(
 					'status'  => 'error',
@@ -69,6 +71,33 @@ class Dynamic_Shortcode extends Base {
 				404
 			);
 		}
+
+		$transcoded_url     = $id ? rtgodam_get_transcoded_url_from_attachment( $id ) : '';
+		$hls_transcoded_url = $id ? rtgodam_get_hls_transcoded_url_from_attachment( $id ) : '';
+		$video_src          = $id ? wp_get_attachment_url( $id ) : '';
+		$video_src_type     = $id ? get_post_mime_type( $id ) : '';
+		$sources            = array();
+
+		if ( ! empty( $transcoded_url ) ) {
+			$sources[] = array(
+				'src'  => $transcoded_url,
+				'type' => 'application/dash+xml',
+			);
+		}
+
+		if ( ! empty( $hls_transcoded_url ) ) {
+			$sources[] = array(
+				'src'  => $hls_transcoded_url,
+				'type' => 'application/x-mpegURL',
+			);
+		}
+
+		$sources[] = array(
+			'src'  => $video_src,
+			'type' => 'video/quicktime' === $video_src_type ? 'video/mp4' : $video_src_type,
+		);
+
+		$sources_json = wp_json_encode( $sources );
 
 		// Add action before shortcode rendering.
 		do_action( 'rtgodam_shortcode_before_render', $id );
@@ -82,11 +111,11 @@ class Dynamic_Shortcode extends Base {
 		$video_date  = apply_filters( 'rtgodam_shortcode_video_date', $video_date, $id );
 
 		ob_start();
-		$shortcode = '[godam_video id="' . $id . '"]';
-		
+		$shortcode = "[godam_video id='{$id}' sources='{$sources_json}']";
+
 		// Add filter for shortcode.
 		$shortcode = apply_filters( 'rtgodam_shortcode_output', $shortcode, $id );
-		
+
 		echo do_shortcode( $shortcode );
 		$html = ob_get_clean();
 

--- a/inc/classes/rest-api/class-dynamic-shortcode.php
+++ b/inc/classes/rest-api/class-dynamic-shortcode.php
@@ -72,10 +72,10 @@ class Dynamic_Shortcode extends Base {
 			);
 		}
 
-		$transcoded_url     = $id ? rtgodam_get_transcoded_url_from_attachment( $id ) : '';
-		$hls_transcoded_url = $id ? rtgodam_get_hls_transcoded_url_from_attachment( $id ) : '';
-		$video_src          = $id ? wp_get_attachment_url( $id ) : '';
-		$video_src_type     = $id ? get_post_mime_type( $id ) : '';
+		$transcoded_url     = strval( rtgodam_get_transcoded_url_from_attachment( $id ) );
+		$hls_transcoded_url = strval( rtgodam_get_hls_transcoded_url_from_attachment( $id ) );
+		$video_src          = strval( wp_get_attachment_url( $id ) );
+		$video_src_type     = strval( get_post_mime_type( $id ) );
 		$sources            = array();
 
 		if ( ! empty( $transcoded_url ) ) {

--- a/inc/classes/rest-api/class-meta-rest-fields.php
+++ b/inc/classes/rest-api/class-meta-rest-fields.php
@@ -83,5 +83,21 @@ class Meta_Rest_Fields {
 				},
 			)
 		);
+
+		register_post_meta(
+			'attachment',
+			'rtgodam_hls_transcoded_url',
+			array(
+				'type'          => 'string',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'get_callback'  => function ( $post ) {
+					return rtgodam_get_hls_transcoded_url_from_attachment( $post->ID );
+				},
+			)
+		);
 	}
 }

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -112,8 +112,8 @@ if ( empty( $attachment_id ) && ! empty( $attributes['sources'] ) ) {
 		);
 	}
 } else {
-	$transcoded_url     = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true ) : '';
-	$hls_transcoded_url = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', true ) : '';
+	$transcoded_url     = $attachment_id ? rtgodam_get_transcoded_url_from_attachment( $attachment_id ) : '';
+	$hls_transcoded_url = $attachment_id ? rtgodam_get_hls_transcoded_url_from_attachment( $attachment_id ) : '';
 	$video_src          = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
 	$video_src_type     = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
 	$job_id             = $attachment_id && ! empty( $transcoded_url ) ? get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true ) : '';

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -113,7 +113,7 @@ if ( empty( $attachment_id ) && ! empty( $attributes['sources'] ) ) {
 	}
 } else {
 	$transcoded_url     = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true ) : '';
-	$hls_transcoded_url = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', true ): '';
+	$hls_transcoded_url = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', true ) : '';
 	$video_src          = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
 	$video_src_type     = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
 	$job_id             = $attachment_id && ! empty( $transcoded_url ) ? get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true ) : '';

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -112,30 +112,32 @@ if ( empty( $attachment_id ) && ! empty( $attributes['sources'] ) ) {
 		);
 	}
 } else {
-	$transcoded_url = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true ) : '';
-	$video_src      = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
-	$video_src_type = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
-	$job_id         = $attachment_id && ! empty( $transcoded_url ) ? get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true ) : '';
+	$transcoded_url     = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true ) : '';
+	$hls_transcoded_url = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', true ): '';
+	$video_src          = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
+	$video_src_type     = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
+	$job_id             = $attachment_id && ! empty( $transcoded_url ) ? get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true ) : '';
+
+	$sources = array();
 
 	if ( ! empty( $transcoded_url ) ) {
-		$sources = array(
-			array(
-				'src'  => $transcoded_url,
-				'type' => 'application/dash+xml',
-			),
-			array(
-				'src'  => $video_src,
-				'type' => 'video/quicktime' === $video_src_type ? 'video/mp4' : $video_src_type,
-			),
-		);
-	} else {
-		$sources = array(
-			array(
-				'src'  => $video_src,
-				'type' => 'video/quicktime' === $video_src_type ? 'video/mp4' : $video_src_type,
-			),
+		$sources[] = array(
+			'src'  => $transcoded_url,
+			'type' => 'application/dash+xml',
 		);
 	}
+
+	if ( ! empty( $hls_transcoded_url ) ) {
+		$sources[] = array(
+			'src'  => $hls_transcoded_url,
+			'type' => 'application/x-mpegURL',
+		);
+	}
+
+	$sources[] = array(
+		'src'  => $video_src,
+		'type' => 'video/quicktime' === $video_src_type ? 'video/mp4' : $video_src_type,
+	);
 }
 $easydam_control_bar_color = 'initial'; // Default color.
 


### PR DESCRIPTION
## Describe
This PR saves HLS transcodes URL along with the MPD URL. The Video and Gallery block has been updated to construct a video tag with three URLs in the following order

1. MPD
2. HLS
3. Original URL

## How to test

1. Upload a new video through `WP Media Library`.
2. Once the video is transcoded, verify the HLS URL is saved along with the MPD.
<img width="2394" height="750" alt="2025-07-24_18-11" src="https://github.com/user-attachments/assets/7e39d71f-cc71-4b99-ba64-93079f8cdee0" />

3. Include the video in both the `GoDAM Video` and `GoDAM Gallery` block.
4. Inspect element and verify it has both the three URLS MPD -> HLS -> Origin.
5. Verify on the iPhone, that the HLS URL is being used rather then origin URL

## Screenshot
<img width="1526" height="646" alt="2025-07-24_18-09" src="https://github.com/user-attachments/assets/bd6c5ef2-81f0-4819-8712-e88efa1ecb22" />


Closes - #618 