### PR TITLE
Fix: GH - #732 - Only generate source maps in development mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,8 @@ const sharedConfig = {
 		},
 		minimizer: defaultConfig.optimization.minimizer.concat( [ new CssMinimizerPlugin() ] ),
 	},
-	devtool: 'source-map',
+	// Only generate source maps in development mode
+	devtool: isProduction ? false : 'source-map',
 };
 
 // Generate a webpack config which includes setup for CSS extraction.
@@ -80,7 +81,8 @@ const styles = {
 			( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
 		),
 	],
-	devtool: 'source-map',
+	// Only generate source maps in development mode
+	devtool: isProduction ? false : 'source-map',
 };
 
 // Example of how to add a new entry point for JS file.
@@ -252,7 +254,8 @@ const pages = {
 	resolve: {
 		extensions: [ '.js', '.jsx' ], // Automatically resolve these extensions
 	},
-	devtool: 'source-map',
+	// Only generate source maps in development mode
+	devtool: isProduction ? false : 'source-map',
 };
 
 module.exports = [


### PR DESCRIPTION
Closes #732  
Added this in webpack.config.js for build folder:
```js
	// Only generate source maps in development mode
	devtool: isProduction ? false : 'source-map',
```

So that `.min.js.map` files are not created in production.
Previously they were leading to this error:
```
Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 10485760 bytes) in phar:///opt/homebrew/Cellar/wp-cli/2.12.0/bin/wp/vendor/mck89/peast/lib/Peast/Syntax/CommentsRegistry.php on line 170
```