### PR TITLE
GH 759: Fix Console error when we try to compare the video performance on single analytics page

### DIFF
--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -78,7 +78,6 @@ const Analytics = ( { attachmentID } ) => {
 	const siteUrl = window.location.origin;
 	const {
 		data: analyticsDataFetched,
-		refetch,
 	} = useFetchAnalyticsDataQuery(
 		{ videoId: attachmentID, siteUrl },
 		{ skip: ! attachmentID },
@@ -98,7 +97,6 @@ const Analytics = ( { attachmentID } ) => {
 
 	const {
 		data: abTestComparisonAnalyticsDataFetched,
-		refetch: refetchAB,
 	} = useFetchAnalyticsDataQuery(
 		{
 			videoId: abTestComparisonAttachmentData?.id,
@@ -168,11 +166,7 @@ const Analytics = ( { attachmentID } ) => {
 	async function startABTesting() {
 		setIsABResultsLoading( true );
 		setIsABTestCompleted( false );
-		await refetch();
 		setAbTestComparisonAttachmentData( mediaLibraryAttachment );
-		if ( mediaLibraryAttachment ) {
-			await refetchAB();
-		}
 	}
 
 	useEffect( () => {


### PR DESCRIPTION
- Fixes - #759 

## Before
https://github.com/user-attachments/assets/3c414f2e-0b20-442d-bd8d-14b831e6f65f

## After

https://github.com/user-attachments/assets/4bf24ed7-8413-4285-a6d5-ec4451bcf313

**Note**: Notice no error related to redux toolkit is visible and still we can compare the video performances.