### PR TITLE
Add API hide and show toggle with eye icon

### DIFF
--- a/pages/godam/components/tabs/VideoSettings/APISettings.jsx
+++ b/pages/godam/components/tabs/VideoSettings/APISettings.jsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 /**
  * WordPress dependencies
  */
-import { Button, Panel, PanelBody, TextControl, Spinner } from '@wordpress/components';
+import { Button, Panel, PanelBody, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -15,26 +15,12 @@ import { __ } from '@wordpress/i18n';
 import { useDeactivateAPIKeyMutation, useVerifyAPIKeyMutation } from '../../../redux/api/media-settings.js';
 import { hasValidAPIKey, maskedAPIKey, scrollToTop } from '../../../utils/index.js';
 import UsageData from './UsageData.jsx';
+import PasswordFieldWithToggle from './components/PasswordFieldWIthToggle/index.jsx';
 
 const APISettings = ( { setNotice } ) => {
 	const [ apiKey, setAPIKey ] = useState( hasValidAPIKey ? maskedAPIKey : '' );
 	const [ verifyAPIKey, { isLoading: isAPIKeyLoading } ] = useVerifyAPIKeyMutation();
 	const [ deactivateAPIKey, { isLoading: isDeactivateLoading } ] = useDeactivateAPIKeyMutation();
-
-	// Function to render help text based on API key validity
-	const renderHelpText = () => {
-		if ( ! hasValidAPIKey ) {
-			return (
-				<>
-					{ __( 'Your API key is required to access the features. You can get your active API key from your ', 'godam' ) }
-					<a href={ ( window.godamRestRoute?.apiBase ?? 'https://app.godam.io' ) + '/web/my-account?accTab=API' } target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
-						{ __( 'Account', 'godam' ) }
-					</a>.
-				</>
-			);
-		}
-		return null;
-	};
 
 	// Function to handle saving the API key
 	const handleSaveAPIKey = async () => {
@@ -95,14 +81,11 @@ const APISettings = ( { setNotice } ) => {
 		<Panel header={ __( 'API Settings', 'godam' ) } className="godam-panel">
 			<PanelBody initialOpen className="flex gap-8 flex-col sm:flex-row">
 				<div className="flex flex-col gap-2 b-4m">
-					<TextControl
-						label={ __( 'API Key', 'godam' ) }
-						value={ apiKey }
-						onChange={ setAPIKey }
-						help={ renderHelpText() }
-						placeholder={ __( 'Enter your API key here', 'godam' ) }
-						className={ `godam-input ${ ! hasValidAPIKey && maskedAPIKey ? 'invalid-api-key' : '' }` }
-						disabled={ hasValidAPIKey }
+					<PasswordFieldWithToggle
+						hasValidAPIKey={ hasValidAPIKey }
+						maskedAPIKey={ maskedAPIKey }
+						apiKey={ apiKey }
+						setAPIKey={ setAPIKey }
 					/>
 					<div className="flex gap-2">
 						<Button

--- a/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx
+++ b/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx
@@ -11,10 +11,25 @@ import { seen, unseen } from '@wordpress/icons';
  */
 import './style.scss';
 
+/**
+ * PasswordFieldWithToggle component
+ *
+ * @param {Object}   param0                - Props passed to the PasswordFieldWithToggle component.
+ * @param {boolean}  param0.hasValidAPIKey - Indicates if the API key is valid.
+ * @param {string}   param0.maskedAPIKey   - The masked version of the API key.
+ * @param {string}   param0.apiKey         - The current API key value.
+ * @param {Function} param0.setAPIKey      - Function to update the API key value.
+ *
+ * @return {JSX.Element} the rendered component.
+ */
 const PasswordFieldWithToggle = ( { hasValidAPIKey, maskedAPIKey, apiKey, setAPIKey } ) => {
 	const [ showPassword, setShowPassword ] = useState( false );
 
-	// Function to render help text based on API key validity
+	/**
+	 * Function to render help text based on the API key validity.
+	 *
+	 * @return {JSX.Element|null} Returns help text if API key is not valid, otherwise null.
+	 */
 	const renderHelpText = () => {
 		if ( ! hasValidAPIKey ) {
 			return (
@@ -29,53 +44,38 @@ const PasswordFieldWithToggle = ( { hasValidAPIKey, maskedAPIKey, apiKey, setAPI
 		return null;
 	};
 
-	const togglePasswordVisibility = () => {
-		setShowPassword( ! showPassword );
-	};
+	/**
+	 * Renders the TextControl component with shared props
+	 *
+	 * @param {string} inputType - The input type ('text' or 'password')
+	 * @return {JSX.Element} The TextControl component
+	 */
+	const renderTextControl = ( inputType = 'text' ) => (
+		<TextControl
+			label={ __( 'API Key', 'godam' ) }
+			value={ apiKey }
+			onChange={ setAPIKey }
+			help={ renderHelpText() }
+			placeholder={ __( 'Enter your API key here', 'godam' ) }
+			className={ `godam-input ${ ! hasValidAPIKey && maskedAPIKey ? 'invalid-api-key' : '' }` }
+			disabled={ hasValidAPIKey }
+			type={ inputType }
+		/>
+	);
 
 	// If API key is valid, render simple TextControl without toggle
 	if ( hasValidAPIKey ) {
-		return (
-			<TextControl
-				label={ __( 'API Key', 'godam' ) }
-				value={ apiKey }
-				onChange={ setAPIKey }
-				help={ renderHelpText() }
-				placeholder={ __( 'Enter your API key here', 'godam' ) }
-				className={ `godam-input ${ ! hasValidAPIKey && maskedAPIKey ? 'invalid-api-key' : '' }` }
-				disabled={ hasValidAPIKey }
-				type="text"
-			/>
-		);
+		return renderTextControl();
 	}
 
 	// If API key is not valid, render with password toggle
 	return (
-		<div className="godam-password-field-wrapper" style={ { position: 'relative' } }>
-			<TextControl
-				label={ __( 'API Key', 'godam' ) }
-				value={ apiKey }
-				onChange={ setAPIKey }
-				help={ renderHelpText() }
-				placeholder={ __( 'Enter your API key here', 'godam' ) }
-				className={ `godam-input ${ ! hasValidAPIKey && maskedAPIKey ? 'invalid-api-key' : '' }` }
-				disabled={ hasValidAPIKey }
-				type={ showPassword ? 'text' : 'password' }
-			/>
+		<div className="godam-password-field-wrapper">
+			{ renderTextControl( showPassword ? 'text' : 'password' ) }
 			<Button
 				icon={ showPassword ? seen : unseen }
-				onClick={ togglePasswordVisibility }
+				onClick={ () => setShowPassword( ! showPassword ) }
 				className="godam-password-toggle"
-				style={ {
-					position: 'absolute',
-					right: '8px',
-					top: '32px',
-					background: 'none',
-					border: 'none',
-					padding: '4px',
-					minWidth: 'auto',
-					height: 'auto',
-				} }
 				aria-label={ showPassword ? __( 'Hide password', 'godam' ) : __( 'Show password', 'godam' ) }
 			/>
 		</div>

--- a/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx
+++ b/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { TextControl, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { seen, unseen } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const PasswordFieldWithToggle = ( { hasValidAPIKey, maskedAPIKey, apiKey, setAPIKey } ) => {
+	const [ showPassword, setShowPassword ] = useState( false );
+
+	// Function to render help text based on API key validity
+	const renderHelpText = () => {
+		if ( ! hasValidAPIKey ) {
+			return (
+				<>
+					{ __( 'Your API key is required to access the features. You can get your active API key from your ', 'godam' ) }
+					<a href={ ( window.godamRestRoute?.apiBase ?? 'https://app.godam.io' ) + '/web/my-account?accTab=API' } target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
+						{ __( 'Account', 'godam' ) }
+					</a>.
+				</>
+			);
+		}
+		return null;
+	};
+
+	const togglePasswordVisibility = () => {
+		setShowPassword( ! showPassword );
+	};
+
+	// If API key is valid, render simple TextControl without toggle
+	if ( hasValidAPIKey ) {
+		return (
+			<TextControl
+				label={ __( 'API Key', 'godam' ) }
+				value={ apiKey }
+				onChange={ setAPIKey }
+				help={ renderHelpText() }
+				placeholder={ __( 'Enter your API key here', 'godam' ) }
+				className={ `godam-input ${ ! hasValidAPIKey && maskedAPIKey ? 'invalid-api-key' : '' }` }
+				disabled={ hasValidAPIKey }
+				type="text"
+			/>
+		);
+	}
+
+	// If API key is not valid, render with password toggle
+	return (
+		<div className="godam-password-field-wrapper" style={ { position: 'relative' } }>
+			<TextControl
+				label={ __( 'API Key', 'godam' ) }
+				value={ apiKey }
+				onChange={ setAPIKey }
+				help={ renderHelpText() }
+				placeholder={ __( 'Enter your API key here', 'godam' ) }
+				className={ `godam-input ${ ! hasValidAPIKey && maskedAPIKey ? 'invalid-api-key' : '' }` }
+				disabled={ hasValidAPIKey }
+				type={ showPassword ? 'text' : 'password' }
+			/>
+			<Button
+				icon={ showPassword ? seen : unseen }
+				onClick={ togglePasswordVisibility }
+				className="godam-password-toggle"
+				style={ {
+					position: 'absolute',
+					right: '8px',
+					top: '32px',
+					background: 'none',
+					border: 'none',
+					padding: '4px',
+					minWidth: 'auto',
+					height: 'auto',
+				} }
+				aria-label={ showPassword ? __( 'Hide password', 'godam' ) : __( 'Show password', 'godam' ) }
+			/>
+		</div>
+	);
+};
+
+export default PasswordFieldWithToggle;

--- a/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/style.scss
+++ b/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/style.scss
@@ -1,0 +1,38 @@
+.godam-password-field-wrapper {
+	position: relative;
+}
+
+.godam-password-field-wrapper .components-text-control__input {
+	padding-right: 40px;
+}
+
+.godam-password-toggle {
+	position: absolute;
+	right: 8px;
+	top: 32px;
+	background: none !important;
+	border: none !important;
+	padding: 4px !important;
+	min-width: auto !important;
+	height: auto !important;
+	color: #757575;
+	cursor: pointer;
+	z-index: 1;
+}
+
+.godam-password-toggle:hover {
+	color: #1e1e1e;
+}
+
+.godam-password-toggle:focus {
+	box-shadow: 0 0 0 1.5px #007cba;
+	outline: none;
+}
+
+.godam-password-field-wrapper .components-base-control__label {
+	margin-bottom: 8px;
+}
+
+.godam-password-field-wrapper.no-label .godam-password-toggle {
+	top: 8px;
+}


### PR DESCRIPTION
## ✨ Overview

Issue - https://github.com/rtCamp/godam/issues/766

This PR implements a secure password field component with toggle visibility functionality for API key input, enhancing user experience while maintaining security best practices.

## 🚀 What's New?

### New Component: PasswordFieldWithToggle
**Enhanced API Key Input Field**
 
- Added eye icon toggle to show/hide API key during input
- Conditional rendering based on API key validation state
- Uses WordPress native seen/unseen icons for consistency
- Includes proper accessibility labels for screen readers

## 🤔 Why These Changes
User Experience: API keys are typically long, complex strings that are difficult to verify when masked. The toggle allows users to:

- Verify they've entered the correct API key
- Copy-paste keys without guesswork

## 🎥 Screen Recording

https://github.com/user-attachments/assets/2b82f095-f398-4afe-9c8e-0540a56dc707



