### PR TITLE
Fix: retranscode_failed_media interval value

### DIFF
--- a/inc/classes/cron-jobs/class-retranscode-failed-media.php
+++ b/inc/classes/cron-jobs/class-retranscode-failed-media.php
@@ -49,7 +49,7 @@ class Retranscode_Failed_Media {
 	public function add_re_transcoding_schedule( $schedules ) {
 		if ( ! isset( $schedules['retranscode_failed_media'] ) ) {
 			$schedules['retranscode_failed_media'] = array(
-				'interval' => 10, // 10 minutes
+				'interval' => 10 * MINUTE_IN_SECONDS,
 				'display'  => __( 'Retranscode Failed Media', 'godam' ),
 			);
 		}


### PR DESCRIPTION
This PR fixes the cron schedule interval added for retrying failed media transcoding. It was intended to be 10 minutes but values passed to `cron_schedules` was 10 seconds.