### PR TITLE
Fix - Null Video IDs being sent for Analytics

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -25,7 +25,7 @@ if ( ! window.pageLoadEventTracked ) {
 		// Collect all video IDs
 		const videoIds = Array.from( videos )
 			.map( ( video ) => video.getAttribute( 'data-id' ) )
-			.filter( ( id ) => id !== null ) // Remove null values
+			.filter( ( id ) => id !== null && id !== '' ) // Null and empty string check
 			.map( ( id ) => parseInt( id, 10 ) ); // Convert to integer
 
 		// Send a single page_load request with all video IDs


### PR DESCRIPTION
Part of #747 
## Overview
Before:
```
video_ids: [null, 199]
```
This led to 422 error:
```
Input should be a valid integer
```
After:
```
video_ids: [199]
```