### PR TITLE
Fix: Video block aspect ratio in forms

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1522,6 +1522,17 @@ body.godam-share-modal-open {
 	position: relative;
 }
 
+.gf-godam-video-preview {
+
+	.easydam-video-container {
+		height: 100%;
+
+		.easydam-player.video-js {
+			margin-top: -2.125rem;
+		}
+	}
+}
+
 .godam-video-overlay-container {
 	display: block;
 	pointer-events: none;


### PR DESCRIPTION
part of #657 
Fix Video Block container in Form Entry view to show correct aspect ratio for the video.

| Before | After |
| --- | --- |
| <img width="661" height="759" alt="image" src="https://github.com/user-attachments/assets/d5ec242c-9d27-45ef-bbd3-13a13abf6e88" /> | <img width="690" height="715" alt="image" src="https://github.com/user-attachments/assets/44e5f0a6-8a05-47bd-a2c8-9b8816dbe633" /> |
