### PR TITLE
Fix: GH728 - Localization leading to page crashing

### DIFF
--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -134,6 +134,8 @@ class Pages {
 	 * @return void
 	 */
 	public function add_admin_pages() {
+		global $admin_page_hooks;
+
 		add_menu_page(
 			__( 'GoDAM', 'godam' ),
 			__( 'GoDAM', 'godam' ),
@@ -143,6 +145,10 @@ class Pages {
 			'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTI1LjU1NzggMjAuMDkxMUw4LjA1NTg3IDM3LjU5M0wzLjQ2Mzk3IDMzLjAwMTFDMC44MTg1MjEgMzAuMzU1NiAyLjA4MjEgMjUuODMzNiA1LjcyMjI4IDI0Ljk0NjRMMjUuNTYzMiAyMC4wOTY0TDI1LjU1NzggMjAuMDkxMVoiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik00Ny4zNzczIDIxLjg4NjdMNDUuNTQzOCAyOS4zODc1TDIyLjY5NzIgNTIuMjM0MUwxMS4yNjA1IDQwLjc5NzRMMzQuMTY2MiAxNy44OTE2TDQxLjU3MDMgMTYuMDc5NkM0NS4wNzA2IDE1LjIyNDcgNDguMjMyMyAxOC4zODYzIDQ3LjM3MiAyMS44ODEzTDQ3LjM3NzMgMjEuODg2N1oiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik00My41MDU5IDM4LjEwMzZMMzguNjY2NyA1Ny44OTA3QzM3Ljc3NDEgNjEuNTI1NSAzMy4yNTIxIDYyLjc4OTEgMzAuNjA2NiA2MC4xNDM2TDI2LjAzNjMgNTUuNTczMkw0My41MDU5IDM4LjEwMzZaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K',
 			30
 		);
+
+		// FIX: Force the admin page hook to use the untranslated slug.
+		// This prevents screen ID changes when menu title is translated.
+		$admin_page_hooks[ $this->menu_slug ] = 'godam'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		add_submenu_page(
 			$this->menu_slug,


### PR DESCRIPTION
## Overview
Part of #728 
Localization of "GoDAM" string led to different Screen ID, leading to pages crashing and showing empty screens without any console errors.
The same solution from WooCommerce plugin is applied here: https://github.com/woocommerce/woocommerce/issues/35677

### Screen ID Before:

<img width="957" height="828" alt="Screenshot 2025-07-31 at 9 28 04 PM" src="https://github.com/user-attachments/assets/eda1b828-547d-4fc2-8d36-3fbd552fbce9" />

### Screen ID After:

<img width="973" height="822" alt="Screenshot 2025-07-31 at 9 27 34 PM" src="https://github.com/user-attachments/assets/e7a275f3-c077-4ef2-8c40-633f7d180afa" />
