### PR TITLE
Fix disable inline volume panel for Minimal and Pills player skins

### DIFF
--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -184,6 +184,17 @@ $video_setup = array(
 );
 if ( ! empty( $control_bar_settings ) ) {
 	$video_setup['controlBar'] = $control_bar_settings; // contains settings specific to control bar.
+
+	if ( isset( $control_bar_settings['volumePanel'] ) && empty( $control_bar_settings['volumePanel'] ) ) {
+		$volume_panel_setting = $control_bar_settings['volumePanel'];
+	} else {
+		// Define your default volumePanel setting.
+		$volume_panel_setting = array(
+			'inline' => ! in_array( $player_skin, array( 'Minimal', 'Pills' ), true ),
+		);
+	}
+
+	$video_setup['controlBar']['volumePanel'] = $volume_panel_setting;
 }
 
 $video_setup = wp_json_encode( $video_setup );

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -184,13 +184,6 @@ $video_setup = array(
 );
 if ( ! empty( $control_bar_settings ) ) {
 	$video_setup['controlBar'] = $control_bar_settings; // contains settings specific to control bar.
-
-	// Define your default volumePanel setting.
-	$volume_panel_setting = array(
-		'inline' => ! in_array( $player_skin, array( 'Minimal', 'Pills' ), true ),
-	);
-
-	$video_setup['controlBar']['volumePanel'] = $volume_panel_setting;
 }
 
 $video_setup = wp_json_encode( $video_setup );


### PR DESCRIPTION
## ✨ Overview

Issue – https://github.com/rtCamp/godam/issues/812

This PR resolves the issue for the Volume Panel Slider not being respected for the GoDAM player.