### PR TITLE
Add transcoding job ID metadata to attachments on Virtual Media

### DIFF
--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1012,7 +1012,6 @@ class Media_Library extends Base {
 
 		// Set custom metadata to track GoDAM-related properties.
 		update_post_meta( $attach_id, '_godam_original_id', $godam_id );
-		update_post_meta( $attach_id, 'rtgodam_transcoding_job_id', $godam_id ?? '' );
 		update_post_meta( $attach_id, '_godam_icon', esc_url_raw( $data['icon'] ?? '' ) );
 		update_post_meta( $attach_id, '_filesize_human', sanitize_text_field( $data['filesizeHumanReadable'] ?? '' ) );
 		update_post_meta( $attach_id, '_godam_label', sanitize_text_field( $data['label'] ?? '' ) );

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -119,8 +119,15 @@ if ( empty( $attachment_id ) && ! empty( $attributes['sources'] ) ) {
 	$hls_transcoded_url = $attachment_id ? rtgodam_get_hls_transcoded_url_from_attachment( $attachment_id ) : '';
 	$video_src          = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
 	$video_src_type     = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
-	$job_id             = $attachment_id && ! empty( $transcoded_url ) ? get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true ) : '';
+	$job_id             = '';
 
+	if ( $attachment_id && ! empty( $transcoded_url ) ) {
+		$job_id = get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true );
+
+		if ( empty( $job_id ) ) {
+			$job_id = get_post_meta( $attachment_id, '_godam_original_id', true );
+		}
+	}
 	$sources = array();
 
 	if ( ! empty( $transcoded_url ) ) {


### PR DESCRIPTION
## ✨ Overview
Issue – https://github.com/rtCamp/godam/issues/820
This PR updates the create_media_entry method in class-media-library.php to store the transcoding job ID in a new post meta field: rtgodam_transcoding_job_id.


