### PR TITLE
Docs: Update changelog and version to 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog #
 
+## v1.3.2 (August 6, 2025) ##
+
+- Fix: Resolved PHP Warning on admin pages
+
 ## v1.3.1 (August 4, 2025) ##
 
 - Tweak: Added settings for CPT visibility in permalinks

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tested up to: 6.8.1
 
 Requires PHP: 7.4
 
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 1.3.1
+ * Version: 1.3.2
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '1.3.1' );
+	define( 'RTGODAM_VERSION', '1.3.2' );
 }
 
 if ( ! defined( 'RTGODAM_NO_MAIL' ) && defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {

--- a/languages/godam.pot
+++ b/languages/godam.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: GoDAM 1.3.1\n"
+"Project-Id-Version: GoDAM 1.3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/godam\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-01T11:45:15+00:00\n"
+"POT-Creation-Date: 2025-08-06T10:05:04+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: godam\n"
@@ -2517,48 +2517,48 @@ msgstr ""
 msgid "Chapter"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:540
+#: assets/src/js/godam-player/frontend.js:541
 msgid "Check out this video!"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:547
+#: assets/src/js/godam-player/frontend.js:548
 msgid "Facebook icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:553
+#: assets/src/js/godam-player/frontend.js:554
 msgid "Twitter icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:559
+#: assets/src/js/godam-player/frontend.js:560
 msgid "LinkedIn icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:565
+#: assets/src/js/godam-player/frontend.js:566
 msgid "Reddit icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:571
+#: assets/src/js/godam-player/frontend.js:572
 msgid "WhatsApp icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:577
+#: assets/src/js/godam-player/frontend.js:578
 msgid "Telegram icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:584
+#: assets/src/js/godam-player/frontend.js:585
 msgid "Share Media"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:596
+#: assets/src/js/godam-player/frontend.js:597
 msgid "Page Link"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:600
-#: assets/src/js/godam-player/frontend.js:610
+#: assets/src/js/godam-player/frontend.js:601
+#: assets/src/js/godam-player/frontend.js:611
 msgid "copy icon"
 msgstr ""
 
-#: assets/src/js/godam-player/frontend.js:606
+#: assets/src/js/godam-player/frontend.js:607
 msgid "Embed"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "1.3.1",
+			"version": "1.3.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -217,6 +217,9 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 
 == Changelog ==
 
+= v1.3.2 (August 6, 2025) =
+- Fix: Resolved PHP Warning on admin pages
+
 = v1.3.1 (August 4, 2025) =
 
 - Tweak: Added settings for CPT visibility in permalinks
@@ -251,10 +254,6 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 - Fix: Eliminated display of "0" value after removing images in Image CTA Layer
 - Fix: Updated Share Button and Share Modal visibility on GoDAM Video block
 - Fix: Added validation for empty form selection in form layers
-
-= v1.2.1 (July 11, 2025) =
-
-- Fix: Resolved thumbnail issue with rtMedia for transcoded videos
 
 [CHECK THE FULL CHANGELOG](https://github.com/rtCamp/godam/blob/main/CHANGELOG.md)
 


### PR DESCRIPTION
This pull request releases version 1.3.2 of the GoDAM WordPress plugin. The main change is a bug fix resolving a PHP warning on admin pages. All relevant files have been updated to reflect the new version number.

Bug Fix:

* Resolved a PHP warning that appeared on admin pages, improving stability for site administrators. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R220-R222)

Version and Documentation Updates:

* Updated the version number to 1.3.2 in `godam.php`, `package.json`, `languages/godam.pot`, `README.md`, and `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-11ad0cbfc6e1732b964b5298a09e2b1cd2df3efc7f60babe88d5d0e88d748916L6-R6) [[2]](diffhunk://#diff-11ad0cbfc6e1732b964b5298a09e2b1cd2df3efc7f60babe88d5d0e88d748916L46-R46) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[4]](diffhunk://#diff-fb9116805b98fd64a43f682dfe4b35f1ce478a4620fa8d77038a51997b97e38bL5-R12) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[6]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Updated translation file references and line numbers in `languages/godam.pot` for accuracy.
* Cleaned up the changelog section in `readme.txt` by removing outdated entries.