### PR TITLE
Fix: Ensure video speed and quality settings are player-specific

### DIFF
--- a/assets/src/js/godam-player/masterSettings.js
+++ b/assets/src/js/godam-player/masterSettings.js
@@ -38,6 +38,8 @@ class SettingsButton extends videojs.getComponent( 'MenuButton' ) {
 	constructor( player, options ) {
 		super( player, options );
 		this.player_ = player;
+		this.player_.selectedSpeed = this.player_.selectedSpeed || '1x';
+		this.player_.selectedQuality = this.player_.selectedQuality || 'Auto';
 		this.addClass( 'vjs-settings-button' );
 		this.controlText( 'Settings' );
 		this.hasQualityItem = false;
@@ -101,8 +103,6 @@ class SettingsButton extends videojs.getComponent( 'MenuButton' ) {
 	}
 }
 
-let selectedSpeed = '1x';
-let selectedQuality = 'Auto'; // initiated globally so it can be share between multiple instances of the function.
 function openSubmenu( menuButton, items, title = '' ) {
 	// Ensure the menu is created
 	if ( ! menuButton.menu ) {
@@ -163,9 +163,11 @@ function openSubmenu( menuButton, items, title = '' ) {
 
 				let isSelected = false;
 				if ( title === 'Speed' ) {
-					isSelected = selectedSpeed === itemData.label;
+					const currentSpeed = this.player().selectedSpeed || '1x';
+					isSelected = currentSpeed === itemData.label;
 				} else if ( title === 'Quality' ) {
-					isSelected = selectedQuality === itemData.label;
+					const currentQuality = this.player().selectedQuality || 'Auto';
+					isSelected = currentQuality === itemData.label;
 				}
 
 				let html = '';
@@ -213,7 +215,7 @@ function openSubmenu( menuButton, items, title = '' ) {
 					for ( let i = 0; i < qualityLevels.length; i++ ) {
 						qualityLevels[ i ].enabled = true;
 					}
-					selectedQuality = 'Auto';
+					this.player().selectedQuality = 'Auto';
 				} else {
 					// Parse height from label like '720p'
 					const selectedHeight = parseInt( qualityLabel.replace( 'p', '' ), 10 );
@@ -222,7 +224,7 @@ function openSubmenu( menuButton, items, title = '' ) {
 						const level = qualityLevels[ i ];
 						level.enabled = level.height === selectedHeight;
 					}
-					selectedQuality = selectedHeight + 'p';
+					this.player().selectedQuality = selectedHeight + 'p';
 				}
 
 				menuButton.el_.focus(); // keep menu focused
@@ -233,20 +235,7 @@ function openSubmenu( menuButton, items, title = '' ) {
 				// Implement playback speed change
 				const rate = parseFloat( speed.replace( 'x', '' ) );
 				this.player().playbackRate( rate );
-				selectedSpeed = speed;
-
-				document
-					.querySelectorAll( '.easydam-player.video-js' )
-					.forEach( ( videoElement ) => {
-						try {
-							const player = videojs.getPlayer( videoElement );
-							if ( player ) {
-								player.playbackRate( rate );
-							}
-						} catch ( error ) {
-							// silently fail.
-						}
-					} );
+				this.player().selectedSpeed = speed;
 
 				menuButton.el_.focus();
 				openSubmenu( menuButton, items, title ); // refresh menu to show new tick

--- a/assets/src/js/godam-player/masterSettings.js
+++ b/assets/src/js/godam-player/masterSettings.js
@@ -38,8 +38,8 @@ class SettingsButton extends videojs.getComponent( 'MenuButton' ) {
 	constructor( player, options ) {
 		super( player, options );
 		this.player_ = player;
-		this.player_.selectedSpeed = this.player_.selectedSpeed || '1x';
-		this.player_.selectedQuality = this.player_.selectedQuality || 'Auto';
+		this.player_.selectedSpeed ??= '1x';
+		this.player_.selectedQuality ??= 'Auto';
 		this.addClass( 'vjs-settings-button' );
 		this.controlText( 'Settings' );
 		this.hasQualityItem = false;


### PR DESCRIPTION
## Closes
- Issue #855 

## Details
- Removed global variables and assigned `selectedSpeed` and `selectedQuality` as properties on the player instance.
- Removed DOM loop that applied playback rate across all video instances


https://github.com/user-attachments/assets/b28a932e-b6bf-4737-9e91-b6220cebad96

