### PR TITLE
Fix: Prevent duplicate media attachments when selected from GoDAM tab

### DIFF
--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1133,6 +1133,17 @@ class Media_Library extends Base {
 		// Sanitize the GoDAM ID.
 		$godam_id = sanitize_text_field( $data['id'] );
 
+		if ( is_numeric( $godam_id ) ) {
+			return new \WP_REST_Response(
+				array(
+					'success'    => true,
+					'attachment' => wp_prepare_attachment_for_js( $godam_id ),
+					'message'    => 'Attachment already exists',
+				),
+				200
+			);
+		}
+
 		// Check if a media entry already exists for this GoDAM ID.
 		$existing = new \WP_Query(
 			array(

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1133,15 +1133,19 @@ class Media_Library extends Base {
 		// Sanitize the GoDAM ID.
 		$godam_id = sanitize_text_field( $data['id'] );
 
+		// Check if godam_id is numeric; if yes, check if an attachment with this ID exists before returning.
 		if ( is_numeric( $godam_id ) ) {
-			return new \WP_REST_Response(
-				array(
-					'success'    => true,
-					'attachment' => wp_prepare_attachment_for_js( $godam_id ),
-					'message'    => 'Attachment already exists',
-				),
-				200
-			);
+			$attachment_post = get_post( $godam_id );
+			if ( $attachment_post && 'attachment' === $attachment_post->post_type ) {
+				return new \WP_REST_Response(
+					array(
+						'success'    => true,
+						'attachment' => wp_prepare_attachment_for_js( $godam_id ),
+						'message'    => 'Attachment already exists',
+					),
+					200
+				);
+			}
 		}
 
 		// Check if a media entry already exists for this GoDAM ID.

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -510,7 +510,7 @@ class Media_Library extends Base {
 		} else {
 			$custom_thumbnails = array();
 		}
-		
+
 
 		$selected_thumbnail = get_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', true );
 
@@ -555,13 +555,13 @@ class Media_Library extends Base {
 	public function upload_custom_video_thumbnail( $request ) {
 		$attachment_id = $request->get_param( 'attachment_id' );
 		$thumbnail_url = $request->get_param( 'thumbnail_url' );
-	
+
 		$mime_type = get_post_mime_type( $attachment_id );
 
 		if ( ! preg_match( '/^video\//', $mime_type ) ) {
 			return new \WP_Error( 'invalid_attachment', __( 'Attachment is not a video.', 'godam' ), array( 'status' => 400 ) );
 		}
-	
+
 		// Get current thumbnails.
 		$existing_thumbnails = get_post_meta( $attachment_id, 'rtgodam_custom_media_thumbnails', true );
 
@@ -578,18 +578,18 @@ class Media_Library extends Base {
 			);
 		}
 
-	
+
 		// Add new custom thumbnail at beginning and remove duplicates.
 		if ( ! in_array( $thumbnail_url, $existing_thumbnails, true ) ) {
 			array_unshift( $existing_thumbnails, $thumbnail_url );
 		}
-	
+
 		// Save updated thumbnails.
 		update_post_meta( $attachment_id, 'rtgodam_custom_media_thumbnails', $existing_thumbnails );
-	
+
 		// Also set as selected thumbnail.
 		update_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', $thumbnail_url );
-	
+
 		return new \WP_REST_Response(
 			array(
 				'success' => true,
@@ -1137,7 +1137,7 @@ class Media_Library extends Base {
 		$existing = new \WP_Query(
 			array(
 				'post_type'      => 'attachment',
-				'meta_key'       => '_godam_original_id',
+				'meta_key'       => 'rtgodam_transcoding_job_id',
 				'meta_value'     => $godam_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'post_status'    => 'any',
 				'fields'         => 'ids',


### PR DESCRIPTION
closes #864 

### Steps to reproduce:
1. Upload a media and wait for transcoding to finish.
2. Create a post
3. Add GoDAM Video Block
4. Add media from "Media Library" Tab
5. Add the same media again from GoDAM Tab
6. Check media library

### Acceptance Criteria:
- [x] When selecting a transcoded media from GoDAM tab it should not add the same media to the library as an attachment again.

https://github.com/user-attachments/assets/51655ae1-aa49-4cd8-b10f-08d11b7afe8b


