### PR TITLE
Fix: Remove unused wp_register_script for JS file that is not present in build - #862

### DIFF
--- a/inc/classes/wpforms/class-wpforms-integration.php
+++ b/inc/classes/wpforms/class-wpforms-integration.php
@@ -62,14 +62,6 @@ class WPForms_Integration {
 		);
 
 		wp_register_script(
-			'wpforms-godam-recorder',
-			RTGODAM_URL . 'assets/build/js/wpforms-godam-recorder.min.js',
-			array( 'jquery' ),
-			filemtime( RTGODAM_PATH . 'assets/build/js/wpforms-godam-recorder.min.js' ),
-			true
-		);
-
-		wp_register_script(
 			'wpforms-godam-recorder-editor',
 			RTGODAM_URL . 'assets/build/js/wpforms-godam-recorder-editor.min.js',
 			array( 'godam-player-frontend-script' ),


### PR DESCRIPTION
- Issue - #862 
- Fixes the issue related to the JS file being enqueue which is removed, but forget to remove register_script for the same, hence unable to fetch the filemtime for that JS file because build process does not include to add that script.