### PR TITLE
Fix: Mobile sidebar toggle doesnt open

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -1,6 +1,5 @@
 
 @use './variables';
-
 @import url(https://vjs.zencdn.net/8.3.0/video-js.css);
 @import "_common"; // stylelint-disable-line scss/load-no-partial-leading-underscore
 
@@ -14,6 +13,7 @@ $LIGHT_BLUE: #2196F3;
 }
 
 #wpbody-content {
+	/* stylelint-disable-next-line value-keyword-case */
 	container: wpBodyContent / inline-size;
 }
 
@@ -115,6 +115,29 @@ $media-frame-width: calc(300px + 2 * 24px);
 	.media-frame-content {
 		left: 0;
 	}
+}
+
+/**
+* CSS for custom filtering options for the media library.
+*/
+#media-date-range-filter {
+	display: inline-block;
+	margin: 0 10px 0 0;
+	margin-right: auto;
+	font-size: 14px;
+	line-height: 2;
+	color: #2c3338;
+	box-shadow: none;
+	padding: 0 24px 0 8px;
+	min-height: 30px;
+	max-width: 8rem;
+	border: 1px solid #A3A3A3;
+	vertical-align: middle;
+}
+
+.media-modal-content #media-date-range-filter {
+	vertical-align: bottom;
+	margin: 12px 0;
 }
 
 /**
@@ -262,6 +285,17 @@ $media-frame-width: calc(300px + 2 * 24px);
 				top: 240px;
 			}
 		}
+
+		@media (max-width: 640px) {
+
+			.media-toolbar {
+				width: calc(100% - 64px);
+			}
+
+			.attachments-wrapper {
+				width: calc(100% - 48px);
+			}
+		}
 	}
 
 	.edit-attachment-frame {
@@ -322,29 +356,6 @@ $media-frame-width: calc(300px + 2 * 24px);
 	label {
 		white-space: nowrap;
 	}
-}
-
-/**
-* CSS for custom filtering options for the media library.
-*/
-#media-date-range-filter {
-	display: inline-block;
-	margin: 0 10px 0 0;
-	margin-right: auto;
-	font-size: 14px;
-	line-height: 2;
-	color: #2c3338;
-	box-shadow: none;
-	padding: 0 24px 0 8px;
-	min-height: 30px;
-	max-width: 8rem;
-	border: 1px solid #A3A3A3;
-	vertical-align: middle;
-}
-
-.media-modal-content #media-date-range-filter {
-	vertical-align: bottom;
-	margin: 12px 0;
 }
 
 #media-attachment-date-filters,

--- a/assets/src/js/media-library/views/attachment-browser.js
+++ b/assets/src/js/media-library/views/attachment-browser.js
@@ -126,7 +126,7 @@ export default AttachmentsBrowser?.extend( {
 					const menu = $( '.media-frame' ).find( '.media-frame-menu' );
 
 					if ( menu.length ) {
-						menu.append( '<div id="rt-transcoder-media-library-root"></div>' );
+						menu.append( '<div id="rt-transcoder-media-library-root" class="media-menu"></div>' );
 					}
 				}
 

--- a/assets/src/js/media-library/views/filters/toggle-folders-button.js
+++ b/assets/src/js/media-library/views/filters/toggle-folders-button.js
@@ -11,19 +11,38 @@ ToggleFoldersButton = ToggleFoldersButton?.extend( {
 	initialize() {
 		wp.media.View.prototype.initialize.apply( this, arguments );
 		this.updateButtonText();
+
+		this._boundToggleFolders = this.toggleFolders.bind( this );
+
+		// Attach listener to the `.media-frame-menu-toggle` button
+		const onReady = () => {
+			const externalToggle = document.querySelector( '.media-frame-menu-toggle' );
+			if ( externalToggle ) {
+				externalToggle.addEventListener( 'click', this._boundToggleFolders );
+			}
+		};
+
+		if ( document.readyState === 'loading' ) {
+			document.addEventListener( 'DOMContentLoaded', onReady, { once: true } );
+		} else {
+			onReady();
+		}
 	},
 
 	onButtonClick() {
+		this.toggleFolders();
+	},
+
+	toggleFolders() {
 		const sidebar = document.getElementById( 'rt-transcoder-media-library-root' );
 		if ( sidebar ) {
 			sidebar.classList.toggle( 'hide-sidebar' );
-			this.updateButtonText();
 		}
 		const mediaModal = document.querySelector( '.media-modal-content' );
 		if ( mediaModal ) {
 			mediaModal.classList.toggle( 'hide-sidebar' );
-			this.updateButtonText();
 		}
+		this.updateButtonText();
 	},
 
 	updateButtonText() {

--- a/assets/src/js/media-library/views/filters/toggle-folders-button.js
+++ b/assets/src/js/media-library/views/filters/toggle-folders-button.js
@@ -19,6 +19,7 @@ ToggleFoldersButton = ToggleFoldersButton?.extend( {
 			const externalToggle = document.querySelector( '.media-frame-menu-toggle' );
 			if ( externalToggle ) {
 				externalToggle.addEventListener( 'click', this._boundToggleFolders );
+				externalToggle.setAttribute( 'aria-expanded', 'false' );
 			}
 		};
 
@@ -47,10 +48,14 @@ ToggleFoldersButton = ToggleFoldersButton?.extend( {
 
 	updateButtonText() {
 		const sidebar = document.getElementById( 'rt-transcoder-media-library-root' );
-		if ( sidebar && sidebar.classList.contains( 'hide-sidebar' ) ) {
-			this.el.innerHTML = `${ folderIconSvg } Show Folders`;
-		} else {
-			this.el.innerHTML = `${ folderIconSvg } Hide Folders`;
+		const isHidden = !! ( sidebar && sidebar.classList.contains( 'hide-sidebar' ) );
+
+		this.el.innerHTML = `${ folderIconSvg } ${ isHidden ? 'Show Folders' : 'Hide Folders' }`;
+		this.el.setAttribute( 'aria-expanded', String( ! isHidden ) );
+
+		const externalToggle = document.querySelector( '.media-frame-menu-toggle' );
+		if ( externalToggle ) {
+			externalToggle.setAttribute( 'aria-expanded', String( ! isHidden ) );
 		}
 	},
 

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -74,6 +74,12 @@ const App = () => {
 		if ( mediaToggleButton ) {
 			mediaToggleButton.innerHTML = mediaToggleButton.innerHTML.replace( /Hide/g, 'Show' );
 		}
+
+		const sidebarToggle = document.querySelector( '#media-folder-toggle-button' );
+		const externalToggle = document.querySelector( '.media-frame-menu-toggle' );
+
+		externalToggle?.setAttribute( 'aria-expanded', 'false' );
+		sidebarToggle?.setAttribute( 'aria-expanded', 'false' );
 	};
 
 	const handleContextMenu = ( e, folderId, folder ) => {

--- a/pages/media-library/index.scss
+++ b/pages/media-library/index.scss
@@ -208,5 +208,8 @@
 	.media-menu {
 		background: #FFF;
 		z-index: -1;
+		top: 0;
+		max-width: 100%;
+		width: 100%;
 	}
 }


### PR DESCRIPTION
closes #794 

This PR fixes the issue where the built in WordPress sidebar menu toggle was not being used to toggle sidebar.

### Testing Instructions
1. On mobile view, create a new post.
2. Add a GoDAM video block and open media library.
3. Sidebar can be toggled using the "Menu" button.



https://github.com/user-attachments/assets/9dd0011e-e215-4517-b4df-5bb1df7721b0

