### PR TITLE
fix: Video Editor Accent Color

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -10,7 +10,7 @@ $LIGHT_BLUE: #2196F3;
 
 #root-easydam,
 #root-video-editor {
-	--wp-components-color-accent: variables.$godam-primary-text-color;
+	--wp-components-color-accent: #ab3a6c;
 }
 
 #wpbody-content {


### PR DESCRIPTION
This pull request makes a small visual update to the admin interface by changing the accent color used for WordPress components in the `#root-easydam` and `#root-video-editor` sections. The accent color is now set to `#ab3a6c` instead of using the `$godam-primary-text-color` variable.