### PR TITLE
Fix the godam admin page theme style

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -8,11 +8,6 @@ $GREEN: #4CAF50;
 $RED: #F44336;
 $LIGHT_BLUE: #2196F3;
 
-#root-easydam,
-#root-video-editor {
-	--wp-components-color-accent: variables.$godam-primary-text-color;
-}
-
 #wpbody-content {
 	container: wpBodyContent / inline-size;
 }


### PR DESCRIPTION
**Partially Closes:**
#884 

## Before
<img width="1470" height="714" alt="Screenshot 2025-08-13 at 12 24 05 PM" src="https://github.com/user-attachments/assets/525f80a0-932f-4bdb-b520-ae68bd434b21" />


## After
<img width="1470" height="714" alt="Screenshot 2025-08-13 at 12 40 42 PM" src="https://github.com/user-attachments/assets/0c04fb50-ef5a-479e-9039-8cf6bee8d950" />
