### PR TITLE
Fix: Render the iframe only when the MetForm ID is present

### DIFF
--- a/pages/video-editor/components/forms/MetForm.js
+++ b/pages/video-editor/components/forms/MetForm.js
@@ -76,21 +76,19 @@ const MetForm = ( { layerID } ) => {
 					>
 
 						{
-							<div className={ clsx( 'form-container', 'metform', { loading: isFetching } ) }>
-								{ <iframe
-									src={ window.godamRestRoute.homeUrl + '?rtgodam-render-layer=metform&rtgodam-layer-id=' + layer?.metform_id }
-									title="Met Form"
-									scrolling="auto"
-									width="100%"
-									className={ isFetching ? 'hidden' : '' }
-									onLoad={ () => setIsFetching( false ) }
-								></iframe> }
-
-								{
-									isFetching &&
-									<p>{ __( 'Loading form…', 'godam' ) }</p>
-								}
-							</div>
+							layer?.metform_id && (
+								<div className={ clsx( 'form-container', 'metform', { loading: isFetching } ) }>
+									<iframe
+										src={ window.godamRestRoute.homeUrl + '?rtgodam-render-layer=metform&rtgodam-layer-id=' + layer?.metform_id }
+										title="Met Form"
+										scrolling="auto"
+										width="100%"
+										className={ isFetching ? 'hidden' : '' }
+										onLoad={ () => setIsFetching( false ) }
+									></iframe>
+									{ isFetching && <p>{ __( 'Loading form…', 'godam' ) }</p> }
+								</div>
+							)
 						}
 
 						{


### PR DESCRIPTION
### What is in the PR?
Fix rendering the iframe in the editor only when the MetForm ID is present
### Before
<img width="1924" height="991" alt="Screenshot 2025-08-13 at 3 02 23 PM" src="https://github.com/user-attachments/assets/c734c68b-1c1d-4cd0-b094-50a37bb08f34" />

### After
<img width="1914" height="993" alt="Screenshot 2025-08-13 at 3 03 52 PM" src="https://github.com/user-attachments/assets/0a4efb29-cf7d-48ce-9b4d-6eb9dac04de4" />
Issue: #566 
