### PR TITLE
fix: _load_textdomain_just_in_time called incorrectly warning when Fluent Forms or WPForms is active.

### DIFF
--- a/inc/classes/fluentforms/class-init.php
+++ b/inc/classes/fluentforms/class-init.php
@@ -67,9 +67,13 @@ class Init {
 	public function load_fluentforms_classes() {
 
 		/**
-		 * Load the new field on `fluentform/loaded`.
+		 * Load the new field on `init`.
+		 *
+		 * Previously, the field was loaded on `fluentform/loaded`, which triggered the `_load_textdomain_just_in_time was called incorrectly` warning.
+		 * The `fluentform/loaded` hook is executed after `plugins_loaded`, meaning the field was effectively initialized during `plugins_loaded`.
+		 * Since the translation function is invoked within the field constructor, it caused the warning because translations had not yet been loaded.
 		 */
-		add_action( 'fluentform/loaded', array( $this, 'on_fluentforms_loaded' ) );
+		add_action( 'init', array( $this, 'on_fluentforms_loaded' ) );
 
 		/**
 		 * Filter to exclude godam scripts on fluent forms pages.

--- a/inc/classes/fluentforms/class-init.php
+++ b/inc/classes/fluentforms/class-init.php
@@ -69,6 +69,8 @@ class Init {
 		/**
 		 * Load the new field on `init`.
 		 *
+		 * @see https://github.com/rtCamp/godam/issues/465
+		 *
 		 * Previously, the field was loaded on `fluentform/loaded`, which triggered the `_load_textdomain_just_in_time was called incorrectly` warning.
 		 * The `fluentform/loaded` hook is executed after `plugins_loaded`, meaning the field was effectively initialized during `plugins_loaded`.
 		 * Since the translation function is invoked within the field constructor, it caused the warning because translations had not yet been loaded.

--- a/inc/classes/wpforms/class-wpforms-integration.php
+++ b/inc/classes/wpforms/class-wpforms-integration.php
@@ -38,7 +38,7 @@ class WPForms_Integration {
 
 			add_action( 'wpforms_frontend_confirmation_message_before', array( $this, 'load_godam_recorder_script_on_success' ), 10, 4 );
 
-			add_action( 'wpforms_loaded', array( $this, 'init_godam_video_field' ) );
+			add_action( 'init', array( $this, 'init_godam_video_field' ) );
 
 			add_action( 'wpforms_process_entry_saved', array( $this, 'send_saved_files_for_transcoding' ), 10, 4 );
 

--- a/inc/classes/wpforms/class-wpforms-integration.php
+++ b/inc/classes/wpforms/class-wpforms-integration.php
@@ -38,6 +38,15 @@ class WPForms_Integration {
 
 			add_action( 'wpforms_frontend_confirmation_message_before', array( $this, 'load_godam_recorder_script_on_success' ), 10, 4 );
 
+			/**
+			 * Initialize the GoDAM video field.
+			 *
+			 * @see https://github.com/rtCamp/godam/issues/465
+			 *
+			 * Previously, the field was loaded on `wpforms_loaded`, which triggered the `_load_textdomain_just_in_time was called incorrectly` warning.
+			 * Since the translation function is invoked within the field constructor, it caused the warning because translations had not yet been loaded.
+			 * All the WPForms fields are initialized in the `init` hook. See, WPForms\Loader->populate_fields().
+			 */
 			add_action( 'init', array( $this, 'init_godam_video_field' ) );
 
 			add_action( 'wpforms_process_entry_saved', array( $this, 'send_saved_files_for_transcoding' ), 10, 4 );


### PR DESCRIPTION
## What?

This PR resolves the `_load_textdomain_just_in_time called incorrectly` warning, which occurs when either Fluent Forms or WPForms is active. The issue was caused by initializing the respective fields well before the `init` hook, during which translation functions were being called.


## Testing Instructions

Since both `Fluent Forms` and `WPForms` integrations were affected by the fix, please verify that the fields are functioning correctly for both form types.


Closes - #465 