### PR TITLE
Fix: migration percentage decimal

### DIFF
--- a/inc/classes/rest-api/class-video-migration.php
+++ b/inc/classes/rest-api/class-video-migration.php
@@ -426,8 +426,8 @@ class Video_Migration extends Base {
 			}
 
 			$migration_status['message'] = sprintf(
-			/* translators: %1$d is the number of posts processed, %2$d is the total number of posts, %3$f is the progress percentage */
-				__( 'Processed %1$d/%2$d posts (%3$f%% complete)', 'godam' ),
+			/* translators: %1$d is the number of posts processed, %2$d is the total number of posts, %3$d is the progress percentage */
+				__( 'Processed %1$d/%2$d posts (%3$d%% complete)', 'godam' ),
 				$migration_status['done'],
 				$migration_status['total'],
 				$progress

--- a/inc/classes/rest-api/class-video-migration.php
+++ b/inc/classes/rest-api/class-video-migration.php
@@ -422,7 +422,7 @@ class Video_Migration extends Base {
 			// Calculate progress percentage.
 			$progress = 0;
 			if ( $migration_status['total'] > 0 ) {
-				$progress = round( ( $migration_status['done'] / $migration_status['total'] ) * 100, 2 );
+				$progress = round( ( $migration_status['done'] / $migration_status['total'] ) * 100 );
 			}
 
 			$migration_status['message'] = sprintf(


### PR DESCRIPTION
This PR removes this decimal precision from migration % text:
<img width="1416" height="310" alt="image" src="https://github.com/user-attachments/assets/ccbc001b-af92-4fb2-8310-1a6e0a0c0b4b" />

Only whole numbers will now be visible.

cc: @subodhr258 