### PR TITLE
Add hierarchical folder dropdown with proper escaping in media upload UI

### DIFF
--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -1,3 +1,5 @@
+/* global jQuery */
+
 /**
  * WordPress dependencies
  */
@@ -18,6 +20,7 @@ import MediaDateRangeFilter from './views/filters/media-date-range-filter-list-v
 import MediaListViewTableDragHandler from './views/attachment-list.js';
 
 import { isFolderOrgDisabled, isUploadPage, addManageMediaButton } from './utility.js';
+import MediaUploaderHandler from './media-uploader-handler.js';
 
 /**
  * MediaLibrary class.
@@ -30,6 +33,14 @@ class MediaLibrary {
 	initialize() {
 		this.setupAttachmentBrowser();
 		document.addEventListener( 'DOMContentLoaded', () => this.onDOMContentLoaded() );
+
+		jQuery( () => {
+			this.jQueryReadyFunction();
+		} );
+	}
+
+	jQueryReadyFunction() {
+		new MediaUploaderHandler();
 	}
 
 	onDOMContentLoaded() {

--- a/assets/src/js/media-library/media-uploader-handler.js
+++ b/assets/src/js/media-library/media-uploader-handler.js
@@ -1,0 +1,57 @@
+/**
+ * MediaUploaderHandler - Handles media upload folder parameter injection
+ *
+ * @class MediaUploaderHandler
+ */
+class MediaUploaderHandler {
+	/**
+	 * Initialize the media uploader handler
+	 *
+	 * @param {string} folderSelector - CSS selector for folder input (default: '#media-folder')
+	 */
+	constructor( folderSelector = '#media-folder' ) {
+		this.uploader = window.uploader;
+		this.folderSelector = folderSelector;
+
+		if ( this.isValidUploader() ) {
+			this.bindEvents();
+		}
+	}
+
+	/**
+	 * Check if uploader instance is valid
+	 *
+	 * @return {boolean} boolean value if uploader is valid
+	 */
+	isValidUploader() {
+		return this.uploader &&
+				typeof this.uploader.bind === 'function' &&
+				this.uploader.hasOwnProperty( 'settings' );
+	}
+
+	/**
+	 * Bind the BeforeUpload event
+	 */
+	bindEvents() {
+		this.uploader.bind( 'BeforeUpload', ( up, file ) => {
+			this.handleBeforeUpload( up, file );
+		} );
+	}
+
+	/**
+	 * Handle before upload - inject folder parameter
+	 *
+	 * @param {Object} up   - Uploader instance
+	 * @param {Object} file - File object
+	 */
+	handleBeforeUpload( up, file ) {
+		void file; // Not being used anywhere but file Object might still be important in future.
+		const folderElement = document.querySelector( this.folderSelector );
+
+		if ( folderElement && folderElement.value ) {
+			up.settings.multipart_params[ 'media-folder' ] = folderElement.value;
+		}
+	}
+}
+
+export default MediaUploaderHandler;


### PR DESCRIPTION
## ✨ Overview
**Issue**: https://github.com/rtCamp/godam/issues/914

- Updated the “Select Media Folder” dropdown to show parent–child hierarchy with - indentation.
- Added proper escaping (esc_attr, esc_html) for security.
- Improved readability by using printf formatting.

## 🎥 Recording

Uploading Screen Recording 2025-08-14 at 12.28.34 PM.mov…

