### PR TITLE
Fix: Media modal column width

### DIFF
--- a/assets/src/js/media-library/views/attachments.js
+++ b/assets/src/js/media-library/views/attachments.js
@@ -13,7 +13,7 @@ export default Attachments?.extend( {
 		Attachments.prototype.initialize.apply( this, arguments );
 
 		// Increase the column width for media attachments.
-		this.options.idealColumnWidth = window.innerWidth < 640 ? 135 : 250;
+		this.options.idealColumnWidth = window.innerWidth < 640 ? 135 : 200;
 
 		if ( Attachment ) {
 			/**

--- a/assets/src/js/media-library/views/attachments.js
+++ b/assets/src/js/media-library/views/attachments.js
@@ -12,6 +12,9 @@ export default Attachments?.extend( {
 		// Call the parent initialize method
 		Attachments.prototype.initialize.apply( this, arguments );
 
+		// Increase the column width for media attachments.
+		this.options.idealColumnWidth = window.innerWidth < 640 ? 135 : 250;
+
 		if ( Attachment ) {
 			/**
 			 * Override the default AttachmentView with our custom view.


### PR DESCRIPTION
closes #913 

This PR increases the attachment width making it easier to navigate and find media items.

### Before
<img width="1024" height="880" alt="image" src="https://github.com/user-attachments/assets/405d35d4-e017-4c64-bd0b-fd92b8d9fecc" />


### After
<img width="1024" height="879" alt="image" src="https://github.com/user-attachments/assets/f04419a1-a005-4efe-b7f0-063835426d72" />

<img width="1024" height="878" alt="image" src="https://github.com/user-attachments/assets/79cdb9ce-4f77-4d69-8b08-ade7278de739" />

