### PR TITLE
Add Support for close button's position in Single Product Page Story 

### DIFF
--- a/assets/src/css/godam-video-carousel.scss
+++ b/assets/src/css/godam-video-carousel.scss
@@ -469,11 +469,15 @@
         margin-bottom: 0px !important;
     }
 
-     .rtgodam-product-video-gallery-slider-modal-close {
+    .rtgodam-product-video-gallery-slider-modal-close {
         right: 7vw !important;
-        top: 10% !important;
         position: fixed !important;
     }
+
+    .rtgodam-product-video-gallery-slider-modal-close.godam-transcoded {
+        top: 10% !important;
+    }
+
     .rtgodam-product-video-gallery-slider-modal-content .godam-share-button{
         top: 2% !important;
         right: 2vw !important;

--- a/assets/src/js/woocommerce/single-product-story/wc-video-carousel.js
+++ b/assets/src/js/woocommerce/single-product-story/wc-video-carousel.js
@@ -87,9 +87,39 @@ const wcVideoCarousel = {
 					},
 					freeMode: true,
 					autoplay: false,
+					on: {
+						init() {
+							const activeSlide = this.slides[ this.activeIndex ];
+							if ( activeSlide ) {
+								const isTranscoded = activeSlide.getAttribute( 'data-is-transcoded' ) === 'true';
+								const closeBtn = document.querySelector( '.rtgodam-product-video-gallery-slider-modal-close' );
+								if ( closeBtn ) {
+									closeBtn.classList.toggle( 'godam-transcoded', isTranscoded );
+								}
+							}
+						},
+						slideChange() {
+							const activeSlide = this.slides[ this.activeIndex ];
+							if ( activeSlide ) {
+								const isTranscoded = activeSlide.getAttribute( 'data-is-transcoded' ) === 'true';
+								const closeBtn = document.querySelector( '.rtgodam-product-video-gallery-slider-modal-close' );
+								if ( closeBtn ) {
+									closeBtn.classList.toggle( 'godam-transcoded', isTranscoded );
+								}
+							}
+						},
+					},
 				} );
 				const itemIndex = parseInt( event.target.getAttribute( 'data-swiper-slide-index' ) );
 				self.swiperModal.slideTo( itemIndex );
+
+				// Run the check immediately for the first slide.
+				const firstSlide = self.swiperModal.slides[ self.swiperModal.activeIndex ];
+				const isTranscoded = firstSlide.getAttribute( 'data-is-transcoded' ) === 'true';
+				const closeBtn = document.querySelector( '.rtgodam-product-video-gallery-slider-modal-close' );
+				if ( closeBtn ) {
+					closeBtn.classList.toggle( 'godam-transcoded', isTranscoded );
+				}
 
 				const videoElmModal = document.querySelector( '.rtgodam-product-video-gallery-slider-modal' );
 				videoElmModal.classList.add( 'open' );

--- a/inc/classes/woocommerce/class-wc-product-video-gallery.php
+++ b/inc/classes/woocommerce/class-wc-product-video-gallery.php
@@ -467,9 +467,12 @@ class WC_Product_Video_Gallery {
 
 		$srcsets = array_map(
 			function ( $attachment_id ) {
+				$transcoded_url = get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true );
+
 				return array(
 					'id'  => $attachment_id,
 					'src' => wp_get_attachment_url( $attachment_id ),
+					'is_transcoded' => (bool) random_int(0,1),
 				);
 			},
 			$rtgodam_product_video_gallery_ids
@@ -506,9 +509,11 @@ class WC_Product_Video_Gallery {
 		$modal_carousel_html = array_map(
 			function ( $item ) use ( $srcsets, $single_product_modal_summary ) {
 				$src_id = $srcsets[ $item ]['id'];
+				$is_transcoded  = $srcsets[ $item ]['is_transcoded'] ? 'true' : 'false';
+
 				return sprintf(
 					'
-					<div class="swiper-slide">
+					<div class="swiper-slide" data-is-transcoded="%3$s">
 						<div class="rtgodam-product-video-gallery-slider-modal-content-left">
 							%1$s
 						</div>
@@ -518,6 +523,7 @@ class WC_Product_Video_Gallery {
 					</div>',
 					do_shortcode( "[godam_video id='{$src_id}']" ),
 					$single_product_modal_summary,
+					esc_attr( $is_transcoded )
 				);
 			},
 			$srcsets_keys


### PR DESCRIPTION
**PR Description:**
Add support for dynamically adjusting the close button position in the single product video gallery modal based on whether the active slide’s video is transcoded. This includes:

* Adding `data-is-transcoded` attribute to modal slides in PHP output.
* Updating JS to toggle a `godam-transcoded` class on the close button when slides change or modal opens.
* Adjusting SCSS to apply different positioning styles for transcoded videos.
