### PR TITLE
Fix: Quality Menu Missing for Some Transcoded Videos in VideoJS Player

### DIFF
--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -106,7 +106,16 @@ const VideoEditor = ( { attachmentID } ) => {
 			videoSources.push( { src: sourceURL, type: adjustedMimeType } );
 		}
 
-		// Add transcoded video source if valid
+		// Add HLS transcoded video source if valid (for quality menu support)
+		const hlsTranscodedUrl = meta?.rtgodam_hls_transcoded_url;
+		if ( hlsTranscodedUrl && typeof hlsTranscodedUrl === 'string' && hlsTranscodedUrl.trim() !== '' ) {
+			videoSources.push( { 
+				src: hlsTranscodedUrl, 
+				type: 'application/x-mpegURL' 
+			} );
+		}
+
+		// Add DASH transcoded video source if valid (for quality menu support)
 		const transcodedUrl = meta?.rtgodam_transcoded_url;
 		if ( transcodedUrl && typeof transcodedUrl === 'string' && transcodedUrl.trim() !== '' ) {
 			const transcodedType = transcodedUrl.endsWith( '.mpd' )
@@ -115,6 +124,10 @@ const VideoEditor = ( { attachmentID } ) => {
 
 			videoSources.push( { src: transcodedUrl, type: transcodedType } );
 		}
+
+		// Reverse the sources to ensure the preferred format is first (DASH -> HLS -> Original)
+		// This matches the order used in the Gutenberg block editor and main player template
+		videoSources.reverse();
 
 		setSources( videoSources );
 	}, [ attachmentConfig, dispatch ] );


### PR DESCRIPTION
Issue Resolved: Quality selection menu not appearing for transcoded videos with single source formats

Problem:
The VideoJS player's quality menu was inconsistently appearing for some transcoded videos. The quality selection dropdown would only show when multiple quality sources were available, but some videos were only getting a single source format (either DASH or HLS), preventing users from accessing quality options.

Root Cause:
The video source construction logic in VideoEditor.js was not consistently including both DASH (MPD) and HLS transcoded URLs when available. This resulted in videos having only one source format, which prevented the VideoJS quality menu from appearing.