### PR TITLE
Fix: Watermark media selector to show GoDAM Tab

### DIFF
--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -190,12 +190,8 @@ class Assets {
 		$screen           = get_current_screen();
 		$is_upload_screen = ( $screen && 'upload' === $screen->id );
 
-		$pages                 = Pages::get_instance();
-		$is_godam_settings     = ( $screen && $pages->settings_page_id === $screen->id ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not using user-submitted data, only checking query param for page context.
-		$is_godam_video_editor = ( $screen && $pages->video_editor_page_id === $screen->id ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not using user-submitted data, only checking query param for page context.
-
 		// Ensure WordPress media modal assets are available on admin pages where we open wp.media.
-		if ( ( $is_upload_screen || $is_godam_settings || $is_godam_video_editor ) && function_exists( 'wp_enqueue_media' ) ) {
+		if ( function_exists( 'wp_enqueue_media' ) ) {
 			wp_enqueue_media();
 		}
 
@@ -307,7 +303,7 @@ class Assets {
 			)
 		);
 
-		if ( $is_upload_screen || $is_godam_settings || $is_godam_video_editor ) {
+		if ( $is_upload_screen ) {
 			wp_enqueue_style( 'easydam-media-library' );
 		}
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -72,7 +72,7 @@ class Pages {
 	 *
 	 * @var string
 	 */
-	public $video_editor_page_id = 'godam_page_rtgodam_video_editor';
+	private $video_editor_page_id = 'godam_page_rtgodam_video_editor';
 
 	/**
 	 * Analytics page ID.
@@ -93,7 +93,7 @@ class Pages {
 	 *
 	 * @var string
 	 */
-	public $settings_page_id = 'godam_page_rtgodam_settings';
+	private $settings_page_id = 'godam_page_rtgodam_settings';
 
 	/**
 	 * Tools page ID.
@@ -386,6 +386,16 @@ class Pages {
 
 			wp_enqueue_script( 'rtgodam-page-style' );
 			wp_enqueue_media();
+
+			wp_register_style(
+				'easydam-media-library',
+				RTGODAM_URL . 'assets/build/css/media-library.css',
+				array(),
+				filemtime( RTGODAM_PATH . 'assets/build/css/media-library.css' )
+			);
+
+			wp_enqueue_style( 'easydam-media-library' );
+
 		}
 		// Check if this is your custom admin page.
 		if ( $screen && $this->video_editor_page_id === $screen->id ) {
@@ -479,31 +489,6 @@ class Pages {
 
 			if ( is_plugin_active( 'gravityforms/gravityforms.php' ) ) {
 				$this->enqueue_gravity_forms_styles();
-			}
-
-			$poll_ajax_style = get_option( 'poll_ajax_style' );
-
-			if ( is_plugin_active( 'wp-polls/wp-polls.php' ) && isset( $poll_ajax_style['loading'] ) && $poll_ajax_style['loading'] ) {
-
-				if ( ! defined( 'WP_POLLS_VERSION' ) ) {
-					define( 'WP_POLLS_VERSION', '2.77.3' );
-				}
-
-				wp_enqueue_script( 'wp-polls', plugins_url( 'wp-polls/polls-js.js' ), array( 'jquery' ), WP_POLLS_VERSION, true );
-				wp_enqueue_style( 'wp-polls', plugins_url( 'wp-polls/polls-css.css' ), false, WP_POLLS_VERSION, 'all' );
-
-				wp_localize_script(
-					'wp-polls',
-					'pollsL10n',
-					array(
-						'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
-						'textWait'     => __( 'Your last request is still being processed. Please wait a while ...', 'godam' ),
-						'textValid'    => __( 'Please choose a valid poll answer.', 'godam' ),
-						'textMultiple' => __( 'Maximum number of choices allowed: ', 'godam' ),
-						'showLoading'  => (int) $poll_ajax_style['loading'],
-						'showFading'   => (int) $poll_ajax_style['fading'],
-					)
-				);
 			}
 
 			$poll_ajax_style = get_option( 'poll_ajax_style' );


### PR DESCRIPTION
closes #928 

Enqueue Media library script on  GoDAM settings page

https://github.com/user-attachments/assets/8cff9620-2697-4bb7-91aa-cdb132771e8c


- [x] GoDAM tab should be visible when selecting a watermark
- [x] Folder organization sidebar should be visible when selecting a watermark