### PR TITLE
Enable hover-to-open behavior for captions & settings menus

### DIFF
--- a/assets/src/js/godam-player/managers/controlsManager.js
+++ b/assets/src/js/godam-player/managers/controlsManager.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import GoDAM from '../../../../../assets/src/images/GoDAM.png';
 import SettingsButton from '../masterSettings.js';
 import { PLAYER_SKINS } from '../utils/constants.js';
+import MenuButtonHoverManager from './menuButtonHover.js';
 
 /**
  * Controls Manager
@@ -32,6 +33,7 @@ export default class ControlsManager {
 	setupPlayerConfiguration() {
 		this.setupControlBarConfiguration();
 		this.setupCustomButtons();
+		new MenuButtonHoverManager( this.player );
 	}
 
 	/**

--- a/assets/src/js/godam-player/managers/menuButtonHover.js
+++ b/assets/src/js/godam-player/managers/menuButtonHover.js
@@ -1,0 +1,63 @@
+/**
+ * CaptionHoverManager
+ *
+ * Keeps the captions (CC) menu open when hovering over the captions button
+ * or the captions submenu, instead of requiring an explicit click.
+ */
+class MenuButtonHoverManager {
+	constructor( player ) {
+		this.player = player;
+
+		// Add more menu button component names as needed
+		this.menuButtons = [ 'SubsCapsButton', 'SettingsButton' ];
+
+		this.init();
+	}
+
+	init() {
+		this.menuButtons.forEach( ( buttonName ) => {
+			const button = this.player.controlBar?.getChild( buttonName );
+
+			if ( ! button ) {
+				return;
+			}
+
+			const btnEl = button.el();
+
+			// Observe for insertion of .vjs-menu
+			const observer = new MutationObserver( () => {
+				const menuEl = btnEl.querySelector( '.vjs-menu' );
+				if ( menuEl ) {
+					this.attachMenuListeners( btnEl, menuEl );
+					observer.disconnect(); // stop after found
+				}
+			} );
+
+			observer.observe( btnEl, { childList: true, subtree: true } );
+		} );
+	}
+
+	attachMenuListeners( btnEl, menuEl ) {
+		// Add your hover listeners here
+		btnEl.addEventListener( 'mouseenter', () => {
+			menuEl.classList.add( 'vjs-lock-showing' );
+		} );
+
+		menuEl.addEventListener( 'mouseenter', () => {
+			menuEl.classList.add( 'vjs-lock-showing' );
+		} );
+
+		menuEl.addEventListener( 'mouseout', ( e ) => {
+			if ( ! btnEl.contains( e.relatedTarget ) ) {
+				this.hideMenu( menuEl );
+			}
+		} );
+	}
+
+	hideMenu( menuEl ) {
+		menuEl.style.display = '';
+		menuEl.classList.remove( 'vjs-lock-showing' );
+	}
+}
+
+export default MenuButtonHoverManager;

--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -15,6 +15,7 @@ import ChaptersManager from './managers/chaptersManager.js';
 import AdsManager from './managers/adsManager.js';
 import HoverManager from './managers/hoverManager.js';
 import ShareManager from './managers/shareManager.js';
+import MenuButtonHoverManager from './managers/menuButtonHover.js';
 
 /**
  * Refactored Video Player Class
@@ -93,6 +94,7 @@ export default class GodamVideoPlayer {
 
 			// Now that managers are initialized, we can safely access them
 			this.setupEventListeners();
+			new MenuButtonHoverManager( this.player );
 		} );
 	}
 


### PR DESCRIPTION
Resolves issue #942 

1. Add a new MenuButtonHoverManager class.
2. Observe and attach listeners to both SubsCapsButton and SettingsButton.
3. Keep their menus open on mouseenter of the button or submenu.
4. Close the menu only when the mouse leaves both the button and submenu.
5. Integrate the manager into ControlsManager after control bar setup.

