### PR TITLE
GH-947 Make all transcoded videos public

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -275,6 +275,7 @@ class RTGODAM_Transcoder_Handler {
 						'watermark'       => boolval( $rtgodam_watermark ),
 						'resolutions'     => array( 'auto' ),
 						'video_quality'   => $rtgodam_video_compress_quality,
+						'public'          => 1,
 					),
 					$watermark_to_use
 				),

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -443,6 +443,7 @@ function rtgodam_send_video_to_godam_for_transcoding( $form_type = '', $form_tit
 			'watermark'       => boolval( $rtgodam_watermark ),
 			'resolutions'     => array( 'auto' ),
 			'folder_name'     => ! empty( $form_title ) ? $form_title : __( 'Gravity forms', 'godam' ),
+			'public'          => 1,
 		),
 		$watermark_to_use
 	);


### PR DESCRIPTION
Closes #947

This pull request introduces a small but important update to the transcoding configuration for video uploads. The main change is the addition of a `public` flag to the transcoding options, ensuring that videos are explicitly marked as public during processing.

Transcoding configuration update:

* Added the `'public' => 1` option to the transcoding settings in both the `wp_media_transcoding` method in `admin/class-rtgodam-transcoder-handler.php` [[1]](diffhunk://#diff-4f7d5e41b95ad49276b75df0eccbc9295818361e0ad9f8949e6d7f5d7e079868R278) and the `rtgodam_send_video_to_godam_for_transcoding` function in `inc/helpers/custom-functions.php` [[2]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R446).