### PR TITLE
Player skin not applying for videos added through Elementor

### DIFF
--- a/inc/classes/elementor-widgets/class-godam-video.php
+++ b/inc/classes/elementor-widgets/class-godam-video.php
@@ -27,7 +27,7 @@ class GoDAM_Video extends Base {
 			'categories'      => array( 'godam' ),
 			'keywords'        => array( 'godam', 'video' ),
 			'depended_script' => array( 'godam-player-frontend-script', 'godam-player-analytics-script', 'godam-player-frontend-script', 'godam-elementor-frontend' ),
-			'depended_styles' => array( 'godam-player-style', 'godam-player-frontend-style' ),
+			'depended_styles' => array( 'godam-player-style', 'godam-player-frontend-style', 'godam-player-minimal-skin', 'godam-player-pills-skin', 'godam-player-bubble-skin', 'godam-player-classic-skin' ),
 		);
 	}
 


### PR DESCRIPTION
## ✨ Overview

**Issue**: https://github.com/rtCamp/godam/issues/821

Added a bunch of new player skins (`godam-player-minimal-skin`, `godam-player-pills-skin`, `godam-player-bubble-skin`, `godam-player-classic-skin`) to the `depended_styles` list in `class-godam-video.php`.

This makes sure the Elementor widget has these extra skin options ready to use out of the box.

Note: This follows the same approach we already use for enqueuing assets in the Gutenberg block.
