### PR TITLE
Fix: Prevent hotspot layers from blocking interaction by overlapping

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -449,6 +449,10 @@
 .easydam-layer.hotspot-layer {
 	pointer-events: none;
 	background: transparent;
+
+	&.overlapped {
+		z-index: 0;
+	}
 }
 
 .godam-menu-item-container {

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -11,10 +11,12 @@ export default class HotspotLayerManager {
 	static BASE_WIDTH = 800;
 	static BASE_HEIGHT = 600;
 
-	constructor( player ) {
+	constructor( player, isDisplayingLayers, currentPlayerVideoInstanceId ) {
 		this.player = player;
 		this.hotspotLayers = [];
 		this.wasPlayingBeforeHover = false;
+		this.isDisplayingLayers = isDisplayingLayers;
+		this.currentPlayerVideoInstanceId = currentPlayerVideoInstanceId;
 	}
 
 	/**
@@ -42,6 +44,8 @@ export default class HotspotLayerManager {
 	 * @param {number} currentTime - Current video time in seconds
 	 */
 	handleHotspotLayersTimeUpdate( currentTime ) {
+		const blockedByLayer = this.isDisplayingLayers?.[ this.currentPlayerVideoInstanceId ] === true;
+
 		this.hotspotLayers.forEach( ( layerObj ) => {
 			if ( ! layerObj.show ) {
 				return;
@@ -49,6 +53,14 @@ export default class HotspotLayerManager {
 
 			const endTime = layerObj.displayTime + layerObj.duration;
 			const isActive = currentTime >= layerObj.displayTime && currentTime < endTime;
+
+			if ( blockedByLayer ) {
+				if ( ! layerObj.layerElement.classList.contains( 'overlapped' ) ) {
+					layerObj.layerElement.classList.add( 'overlapped' );
+				}
+			} else if ( layerObj.layerElement.classList.contains( 'overlapped' ) ) {
+				layerObj.layerElement.classList.remove( 'overlapped' );
+			}
 
 			if ( isActive ) {
 				if ( layerObj.layerElement.classList.contains( 'hidden' ) ) {

--- a/assets/src/js/godam-player/managers/layersManager.js
+++ b/assets/src/js/godam-player/managers/layersManager.js
@@ -20,7 +20,7 @@ export default class LayersManager {
 
 		// Initialize sub-managers
 		this.formLayerManager = new FormLayerManager( player, isDisplayingLayers, currentPlayerVideoInstanceId );
-		this.hotspotLayerManager = new HotspotLayerManager( player );
+		this.hotspotLayerManager = new HotspotLayerManager( player, isDisplayingLayers, currentPlayerVideoInstanceId );
 	}
 
 	/**


### PR DESCRIPTION
Closes #901 

This PR fixes an issue where seeking to a hotspot layer could block interactions by overlapping pending form layers.

Changes made:
- Added a check for any pending layers visible during a hotspot’s display duration.
- If found, set the hotspot layer’s `z-index` to `0` to disable interactions while keeping it visible.

https://github.com/user-attachments/assets/feb1b948-1cb6-45b4-8871-dfcff353aca3
