### PR TITLE
Fix: Redirect to What's New Page after reinstalling GoDAM plugin

### DIFF
--- a/godam.php
+++ b/godam.php
@@ -142,3 +142,15 @@ function rtgodam_plugin_deactivate() {
 }
 
 register_deactivation_hook( __FILE__, 'rtgodam_plugin_deactivate' );
+
+/**
+ * Runs when the plugin is deleted.
+ */
+function rtgodam_plugin_delete() {
+	// Delete options related to What's New page.
+	// This is to ensure redirection on a fresh install.
+	delete_option( 'rtgodam_plugin_version' );
+	delete_option( '_transient_rtgodam_release_data' );
+}
+
+register_uninstall_hook( __FILE__, 'rtgodam_plugin_delete' );


### PR DESCRIPTION
Issue - #409 

This PR fixes an issue where the What’s New page was not redirected after deleting and reinstalling the GoDAM plugin.

Changes made:
- Removed What's New page related options on plugin deletion.
- Ensures that a new installation is treated as a fresh install, triggering the redirect.