### PR TITLE
Add pagination count proper instead of normal optimistic pagination for media library

### DIFF
--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1347,7 +1347,7 @@ class Media_Library extends Base {
 			'hide_empty' => false,
 			'orderby'    => 'name',
 			'order'      => 'ASC',
-			'per_page'   => 100, // Default to 100 items per page.
+			'number'     => 100, // Default to 100 items per page.
 		);
 
 		// Initialize meta_query as empty array.
@@ -1371,6 +1371,9 @@ class Media_Library extends Base {
 			$args['meta_query'] = $meta_queries; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Meta query is needed to filter by bookmark and locked.
 		}
 
+		$total_pages = 0;
+		$total_items = 0;
+
 		if ( ! $locked && ! $bookmark ) {
 			$page = (int) $request->get_param( 'page' );
 
@@ -1388,6 +1391,9 @@ class Media_Library extends Base {
 			$args['offset'] = ( $page - 1 ) * $per_page;
 
 			$args['parent'] = (int) ( $request->get_param( 'parent' ) ?? 0 );
+
+			$total_items = $this->get_total_media_folders_count();
+			$total_pages = ceil( $total_items / $per_page );
 		}
 
 		$terms = get_terms( $args );
@@ -1396,7 +1402,26 @@ class Media_Library extends Base {
 			$terms = $this->get_all_children_terms( $terms, $taxonomy );
 		}
 
-		return rest_ensure_response( $this->prepare_term_responses( $terms ) );
+		// Prepare the response data.
+		$prepared_terms = $this->prepare_term_responses( $terms );
+
+		// Ensure we always have an array, never null.
+		if ( is_null( $prepared_terms ) || ! is_array( $prepared_terms ) ) {
+			$prepared_terms = array();
+		}
+
+		// Create the response.
+		$response = rest_ensure_response( $prepared_terms );
+
+		// Add headers only for paginated requests.
+		if ( ! $locked && ! $bookmark ) {
+			$response->header( 'X-WP-Total', $total_items );
+			$response->header( 'X-WP-TotalPages', $total_pages );
+			$response->header( 'X-WP-Current-Page', $page );
+			$response->header( 'X-WP-Per-Page', $per_page );
+		}
+
+		return $response;
 	}
 
 	/**
@@ -1432,6 +1457,28 @@ class Media_Library extends Base {
 		}
 
 		return $all_terms;
+	}
+
+	/**
+	 * Get the total count of media folders.
+	 *
+	 * @return int Total media folders count.
+	 */
+	private function get_total_media_folders_count() {
+		$taxonomy = Media_Folders::SLUG;
+		$args     = array(
+			'taxonomy'   => $taxonomy,
+			'hide_empty' => false,
+			'fields'     => 'ids',
+			'parent'     => 0,
+		);
+		$term_ids = get_terms( $args );
+
+		if ( is_wp_error( $term_ids ) ) {
+			return 0;
+		}
+
+		return count( $term_ids );
 	}
 
 	/**

--- a/pages/media-library/components/folder-tree/BookmarkTab.jsx
+++ b/pages/media-library/components/folder-tree/BookmarkTab.jsx
@@ -26,14 +26,14 @@ const BookmarkTab = ( { handleContextMenu } ) => {
 
 	useEffect( () => {
 		if ( ! isBookmarkLoading && bookmarkData && initializedRef.current === false ) {
-			dispatch( initializeBookmarks( bookmarkData || [] ) );
+			dispatch( initializeBookmarks( bookmarkData?.data || [] ) );
 			initializedRef.current = true;
 		}
 	}, [ isBookmarkLoading, bookmarkData, dispatch ] );
 
 	const bookmarks = useSelector( ( state ) => state.FolderReducer?.bookmarks || [] );
 
-	const bookmarkCount = bookmarks?.length || 0;
+	const bookmarkCount = bookmarkData?.total || bookmarks?.length;
 
 	if ( bookmarkCount === 0 ) {
 		return (

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -59,13 +59,6 @@ const FolderTree = ( { handleContextMenu } ) => {
 		},
 	);
 
-	useEffect( () => {
-		// Refetch folders when the current page changes
-		if ( page.current > 1 ) {
-			refetchFolders();
-		}
-	}, [ refetchFolders, page ] );
-
 	const dispatch = useDispatch();
 	const data = useSelector( ( state ) => state.FolderReducer.folders );
 	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
@@ -75,11 +68,11 @@ const FolderTree = ( { handleContextMenu } ) => {
 
 	useEffect( () => {
 		if ( folders ) {
-			dispatch( setTree( openLocalStorageItem( folders ) ) );
+			dispatch( setTree( openLocalStorageItem( folders?.data ) ) );
 
-			if ( Array.isArray( folders ) && ( folders.length === 0 || folders.length < page.perPage ) && ! isFetching ) {
+			if ( Array.isArray( folders?.data ) && ! isFetching ) {
 				// If no folders are returned, reset to the first page
-				dispatch( updatePage( { hasNext: false } ) );
+				dispatch( updatePage( { totalPages: folders.totalPages } ) );
 			}
 		}
 	}, [ dispatch, folders, currentPage, isFetching, page.perPage ] );
@@ -196,6 +189,7 @@ const FolderTree = ( { handleContextMenu } ) => {
 
 	function handleLoadMore() {
 		dispatch( updatePage( { current: page.current + 1 } ) );
+		refetchFolders();
 	}
 
 	/**
@@ -412,11 +406,12 @@ const FolderTree = ( { handleContextMenu } ) => {
 						} ) }
 					</SortableContext>
 				</div>
-				{ page.hasNext && ( <button
+				{ ( ( currentPage < page.totalPages ) || ( isFetching && currentPage === page.totalPages ) ) && ( <button
 					className="tree-load-more"
 					onClick={ () => {
 						handleLoadMore();
 					} }
+					disabled={ isFetching }
 				>
 					{ isFetching ? __( 'Loading…', 'godam' ) : __( 'Load More', 'godam' ) }
 				</button> ) }

--- a/pages/media-library/components/folder-tree/LockedTab.jsx
+++ b/pages/media-library/components/folder-tree/LockedTab.jsx
@@ -27,7 +27,7 @@ const LockedTab = ( { handleContextMenu } ) => {
 	useEffect( () => {
 		if ( ! initializedRef.current && lockedData && ! isLockedLoading ) {
 			// Dispatch an action to set the locked folders in the Redux store
-			dispatch( initializeLockedFolders( lockedData ) );
+			dispatch( initializeLockedFolders( lockedData?.data || [] ) );
 			initializedRef.current = true;
 		}
 	}, [ lockedData, dispatch, isLockedLoading ] );
@@ -42,7 +42,7 @@ const LockedTab = ( { handleContextMenu } ) => {
 		window.dispatchEvent( event );
 	}, [ locked ] );
 
-	const lockedCount = locked?.length || 0;
+	const lockedCount = lockedData?.total || locked?.length;
 
 	if ( lockedCount === 0 ) {
 		return (

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -52,6 +52,18 @@ export const folderApi = createApi( {
 					},
 				};
 			},
+			transformResponse: ( responseData, meta ) => {
+				// Extract headers from meta.response.headers
+				const headers = meta.response.headers;
+				const totalItems = headers.get( 'X-WP-Total' ) || headers.get( 'x-wp-total' );
+				const totalPages = headers.get( 'X-WP-TotalPages' ) || headers.get( 'x-wp-totalpages' );
+
+				return {
+					data: responseData, // Your original response data
+					total: totalItems ? parseInt( totalItems, 10 ) : 0,
+					totalPages: totalPages ? parseInt( totalPages, 10 ) : 0,
+				};
+			},
 		} ),
 		createFolder: builder.mutation( {
 			query: ( data ) => ( {

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -35,7 +35,7 @@ const slice = createSlice( {
 		page: {
 			current: 1,
 			perPage: 10,
-			hasNext: true,
+			totalPages: 2, // So initially show the loadMore button.
 		},
 
 		modals: {
@@ -314,11 +314,11 @@ const slice = createSlice( {
 			state.lockedFolders = lockedFolders;
 		},
 		updatePage: ( state, action ) => {
-			const { current, hasNext, perPage } = action.payload;
+			const { current, totalPages, perPage } = action.payload;
 			state.page = {
 				current: current ?? state.page.current,
-				hasNext: hasNext ?? state.page.hasNext,
 				perPage: perPage ?? state.page.perPage,
+				totalPages: totalPages ?? state.page.totalPages,
 			};
 		},
 		setCurrentContextMenuFolder: ( state, action ) => {


### PR DESCRIPTION
## ✨ Updates

**ISSUE**: https://github.com/rtCamp/godam/issues/819#issuecomment-3210346854

- Backend now returns pagination headers (X-WP-Total, X-WP-TotalPages) 
- New helper get_total_media_folders_count for total count 
- Frontend parses headers → adds total & totalPages 
- Redux slice: hasNext ➝ totalPages
- React components (FolderTree, BookmarkTab, LockedTab) updated for new response
- Removed unused useEffect cleanup 🧹