### PR TITLE
Fix overlap Issue for media library

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -96,7 +96,8 @@ $media-frame-width: calc(300px + 2 * 24px);
 
 .hide-sidebar {
 
-	.media-frame-menu {
+	.media-frame-menu,
+	.media-frame-menu-heading {
 		display: none;
 	}
 

--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -81,7 +81,7 @@ class MediaLibrary {
 			wp.media.view.Attachments = Attachments;
 		}
 
-		if ( wp.media.view.Attachment.Details && AttachmentDetails ) {
+		if ( wp?.media?.view?.Attachment?.Details && AttachmentDetails ) {
 			wp.media.view.Attachment.Details = AttachmentDetails;
 		}
 


### PR DESCRIPTION
## 🎨 CSS Update

ISSUE: https://github.com/rtCamp/godam/issues/826#issuecomment-3200209874

When .hide-sidebar is applied → hide .media-frame-menu & .media-frame-menu-heading 