### PR TITLE
fix: Allow new user creation using username

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -261,6 +261,20 @@ class RTGODAM_Transcoder_Handler {
 			$attachment_author    = get_user_by( 'id', $attachment_author_id );
 			$site_url             = get_site_url();
 
+			// Get author name with fallback to username.
+			$author_first_name = '';
+			$author_last_name  = '';
+			
+			if ( $attachment_author ) {
+				$author_first_name = $attachment_author->first_name;
+				$author_last_name  = $attachment_author->last_name;
+				
+				// If first and last names are empty, use username as fallback.
+				if ( empty( $author_first_name ) && empty( $author_last_name ) ) {
+					$author_first_name = $attachment_author->user_login;
+				}
+			}
+
 			$args = array(
 				'method'    => 'POST',
 				'sslverify' => false,
@@ -282,8 +296,8 @@ class RTGODAM_Transcoder_Handler {
 						'video_quality'        => $rtgodam_video_compress_quality,
 						'wp_author_email'      => $attachment_author ? $attachment_author->user_email : '',
 						'wp_site'              => $site_url,
-						'wp_author_first_name' => $attachment_author ? $attachment_author->first_name : '',
-						'wp_author_last_name'  => $attachment_author ? $attachment_author->last_name : '',
+						'wp_author_first_name' => $author_first_name,
+						'wp_author_last_name'  => $author_last_name,
 						'public'               => 1,
 					),
 					$watermark_to_use

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -432,6 +432,15 @@ function rtgodam_send_video_to_godam_for_transcoding( $form_type = '', $form_tit
 	$current_user = wp_get_current_user();
 	$site_url     = get_site_url();
 
+	// Get author name with fallback to username.
+	$author_first_name = $current_user->first_name;
+	$author_last_name  = $current_user->last_name;
+	
+	// If first and last names are empty, use username as fallback.
+	if ( empty( $author_first_name ) && empty( $author_last_name ) ) {
+		$author_first_name = $current_user->user_login;
+	}
+
 	$body = array_merge(
 		array(
 			'api_token'            => $api_key,
@@ -449,8 +458,8 @@ function rtgodam_send_video_to_godam_for_transcoding( $form_type = '', $form_tit
 			'folder_name'          => ! empty( $form_title ) ? $form_title : __( 'Gravity forms', 'godam' ),
 			'wp_author_email'      => $current_user->user_email,
 			'wp_site'              => $site_url,
-			'wp_author_first_name' => $current_user->first_name,
-			'wp_author_last_name'  => $current_user->last_name,
+			'wp_author_first_name' => $author_first_name,
+			'wp_author_last_name'  => $author_last_name,
 			'public'               => 1,
 		),
 		$watermark_to_use


### PR DESCRIPTION
Related issue: https://github.com/rtCamp/godam/issues/302

This pull request introduces improvements to how author information is handled when sending video transcoding requests. The main change is ensuring that if an author's first and last names are missing, their username is used as a fallback, which increases reliability and consistency of metadata sent to the transcoding service.

**Author information handling improvements:**

* In `admin/class-rtgodam-transcoder-handler.php`, updated the logic to set `author_first_name` and `author_last_name` with a fallback to `user_login` if both names are empty, ensuring a valid value is always sent.
* Updated the transcoding request payload in `admin/class-rtgodam-transcoder-handler.php` to use the new fallback logic for author names.
* In `inc/helpers/custom-functions.php`, added similar fallback logic for the current user when preparing transcoding requests, using `user_login` if both names are missing.
* Updated the transcoding request payload in `inc/helpers/custom-functions.php` to use the new fallback logic for author names.