### PR TITLE
GH-908: Player controls remain visible on mobile when tapping onscreen

### DIFF
--- a/assets/src/js/godam-player/masterSettings.js
+++ b/assets/src/js/godam-player/masterSettings.js
@@ -97,6 +97,7 @@ class SettingsButton extends videojs.getComponent( 'MenuButton' ) {
 		// Attach a new outside click listener and store its reference
 		this._outsideClickListener = this.outsideClickListener.bind( this );
 		document.addEventListener( 'click', this._outsideClickListener, { once: true } );
+		document.addEventListener( 'touchstart', this._outsideClickListener, { once: true } );
 	}
 
 	// Method to detach the outside click listener
@@ -141,7 +142,34 @@ function closeAndResetMenu( menuButton ) {
 	menuButton.menu.hide();
 	menuButton.menu.unlockShowing();
 	menuButton.resetToDefaultMenu(); // reset to default menu
+
+	// On mobile, hide controls as well
+	if ( menuButton.player_ ) {
+		menuButton.player_.userActive( false );
+	}
 }
+
+// Add listener on video element to hide controls on mobile tap
+function attachVideoTapListener( player ) {
+	const videoEl = player.el();
+	if ( ! videoEl ) {
+		return;
+	}
+
+	const hideControls = ( e ) => {
+		if ( ! e.target.closest( '.vjs-control' ) ) {
+			player.userActive( false );
+		}
+	};
+
+	videoEl.addEventListener( 'click', hideControls );
+	videoEl.addEventListener( 'touchstart', hideControls );
+}
+
+// Attach when player is ready
+videojs.hook( 'ready', ( player ) => {
+	attachVideoTapListener( player );
+} );
 
 function openSubmenu( menuButton, items, title = '' ) {
 	// Ensure the menu is created


### PR DESCRIPTION
## Summary:
This PR fixes mobile issues where tapping the video didn’t hide controls and tapping outside the SettingsButton menu didn’t close it. Added touchstart listeners alongside click and ensured proper menu reset on outside taps. Desktop behavior is unchanged.

## Testing:
Tap the video area or outside the menu on mobile to ensure controls hide and menus close as expected.

## Screencast:

https://github.com/user-attachments/assets/a3bf2bf8-e18d-422e-8520-c8ad27d5a233

## References / Issue:

Fixes issue reported on #908