### PR TITLE
Fix multisite handling and script localization warning

### DIFF
--- a/godam.php
+++ b/godam.php
@@ -147,10 +147,27 @@ register_deactivation_hook( __FILE__, 'rtgodam_plugin_deactivate' );
  * Runs when the plugin is deleted.
  */
 function rtgodam_plugin_delete() {
-	// Delete options related to What's New page.
+	// Delete options and transients related to Whats New page.
 	// This is to ensure redirection on a fresh install.
-	delete_option( 'rtgodam_plugin_version' );
-	delete_option( '_transient_rtgodam_release_data' );
+	if ( is_multisite() ) {
+		// Get all blogs in the network and delete options from each blog.
+		$blogs = get_sites( array( 'fields' => 'ids' ) );
+
+		foreach ( $blogs as $blog_id ) {
+			switch_to_blog( $blog_id );
+
+			delete_option( 'rtgodam_plugin_version' );
+			delete_transient( 'rtgodam_show_whats_new' );
+			delete_transient( 'rtgodam_release_data' );
+
+			restore_current_blog();
+		}
+	} else {
+		// For single site, delete options directly.
+		delete_option( 'rtgodam_plugin_version' );
+		delete_transient( 'rtgodam_show_whats_new' );
+		delete_transient( 'rtgodam_release_data' );
+	}
 }
 
 register_uninstall_hook( __FILE__, 'rtgodam_plugin_delete' );

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -774,8 +774,10 @@ class Pages {
 
 			wp_localize_script(
 				'godam-page-script-whats-new',
-				'version',
-				RTGODAM_VERSION
+				'headerData',
+				array(
+					'version' => RTGODAM_VERSION,
+				)
 			);
 
 			wp_enqueue_script( 'godam-page-script-whats-new' );

--- a/pages/whats-new/components/Features.js
+++ b/pages/whats-new/components/Features.js
@@ -13,7 +13,7 @@ const Features = ( { releaseData } ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ activeFeatureId, setActiveFeatureId ] = useState( null );
 
-	const version = releaseData.version ? releaseData.version : window.version;
+	const version = releaseData.version ? releaseData.version : window.headerData.version;
 	const primaryUpdates = releaseData.features ? releaseData.features.slice( 0, 3 ) : [];
 	const otherUpdates = releaseData.features ? releaseData.features.slice( 3 ) : [];
 

--- a/pages/whats-new/components/Features.js
+++ b/pages/whats-new/components/Features.js
@@ -13,7 +13,7 @@ const Features = ( { releaseData } ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ activeFeatureId, setActiveFeatureId ] = useState( null );
 
-	const version = releaseData.version ? releaseData.version : window.headerData.version;
+	const version = releaseData.version ? releaseData.version : window.headerData?.version;
 	const primaryUpdates = releaseData.features ? releaseData.features.slice( 0, 3 ) : [];
 	const otherUpdates = releaseData.features ? releaseData.features.slice( 3 ) : [];
 


### PR DESCRIPTION
This PR fixes the following:

- Multisite Handling ([ref](https://github.com/rtCamp/godam/pull/956#discussion_r2292999097)):
  - Ensured plugin options and transients are correctly handled for both network-activated and site-specific activations.
  - For network-activated plugins, data is cleared across all sites and for site-specific, only on the current site.

- WP Script PHP notice ([ref](https://github.com/rtCamp/godam/issues/409#issuecomment-3223154144)):
  - Fixed warning by passing an array to `wp_localize_script()` instead of a direct variable.