### PR TITLE
Fix Video SEO Data Logic Edge Cases and Performance Issues

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -43,7 +43,7 @@ import Video from './VideoJS';
 import TracksEditor from './track-uploader';
 import { Caption } from './caption';
 import VideoSEOModal from './components/VideoSEOModal.js';
-import { appendTimezoneOffsetToUTC, secondsToISO8601 } from './utils/index.js';
+import { appendTimezoneOffsetToUTC, isSEODataEmpty, secondsToISO8601 } from './utils/index.js';
 import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
@@ -124,6 +124,7 @@ function VideoEdit( {
 	const [ defaultPoster, setDefaultPoster ] = useState( '' );
 	const [ isSEOModalOpen, setIsSEOModelOpen ] = useState( false );
 	const [ duration, setDuration ] = useState( 0 );
+	const [ isVideoSelecting, setIsVideoSelecting ] = useState( false );
 	const isInsideQueryLoop = context?.hasOwnProperty( 'queryId' );
 
 	const dispatch = useDispatch();
@@ -231,7 +232,64 @@ function VideoEdit( {
 		}
 	}, [ id, setAttributes, dispatch ] );
 
+	// Backward compatibility: Initialize SEO data for existing blocks
+	useEffect( () => {
+		// Don't run during video selection process
+		if ( isVideoSelecting ) {
+			return;
+		}
+
+		// Only run if we have a video source but no SEO data
+		if ( ( id || src ) && isSEODataEmpty( attributes.seo ) ) {
+			const defaultSEOData = {
+				contentUrl: src || '',
+				headline: '',
+				description: '',
+				uploadDate: '',
+				duration: '',
+				thumbnailUrl: '',
+				isFamilyFriendly: true,
+			};
+
+			// If we have an attachment ID, try to fetch more data
+			if ( id && ! isNaN( Number( id ) ) ) {
+				( async () => {
+					try {
+						const response = await apiFetch( { path: `/wp/v2/media/${ id }` } );
+
+						const enhancedSEOData = {
+							contentUrl: response.meta?.rtgodam_transcoded_url || response.source_url || src || '',
+							headline: response.title?.rendered || '',
+							description: response.description?.rendered || '',
+							uploadDate: appendTimezoneOffsetToUTC( response.date_gmt || '' ),
+							duration: response.video_duration_iso8601 || '',
+							thumbnailUrl: response.meta?.rtgodam_media_video_thumbnail || '',
+							isFamilyFriendly: true,
+						};
+
+						setAttributes( {
+							seo: enhancedSEOData,
+						} );
+					} catch ( error ) {
+						// Fallback to basic SEO data if API call fails
+						setAttributes( {
+							seo: defaultSEOData,
+						} );
+					}
+				} )();
+			} else {
+				// For custom URLs or when ID is not available
+				setAttributes( {
+					seo: defaultSEOData,
+				} );
+			}
+		}
+	}, [ id, src, attributes.seo, isVideoSelecting, setAttributes ] );
+
 	function onSelectVideo( media ) {
+		// Set flag to prevent backward compatibility logic during video selection
+		setIsVideoSelecting( true );
+
 		if ( ! media || ! media.url ) {
 			// In this case there was an error
 			// previous attributes should be removed
@@ -242,43 +300,34 @@ function VideoEdit( {
 				poster: undefined,
 				caption: undefined,
 				blob: undefined,
+				seo: undefined, // Clear SEO data when no media selected
 			} );
 			setTemporaryURL();
+			setIsVideoSelecting( false );
 			return;
 		}
 
 		if ( isBlobURL( media.url ) ) {
 			setTemporaryURL( media.url );
+			setIsVideoSelecting( false );
 			return;
 		}
-
-		// Sets the block's attribute and updates the edit component from the
-		// selected media.
-		setAttributes( {
-			blob: undefined,
-			src: media.url,
-			id: media.id,
-			cmmId: media.id,
-			poster: undefined,
-			caption: media.caption,
-		} );
 
 		if ( media.image?.src !== media.icon ) {
 			setDefaultPoster( media.image?.src );
 		}
 
 		if ( media?.origin === 'godam' ) {
-			setAttributes( {
-				seo: {
-					contentUrl: media?.url,
-					headline: media?.title || '',
-					description: media?.description || '',
-					uploadDate: appendTimezoneOffsetToUTC( media?.date || '' ),
-					duration: secondsToISO8601( media?.duration || '' ),
-					thumbnailUrl: media?.thumbnail_url || '',
-					isFamilyFriendly: true, // Default value
-				},
-			} );
+			// Create new SEO data from GoDAM media
+			const newSEOData = {
+				contentUrl: media?.url,
+				headline: media?.title || '',
+				description: media?.description || '',
+				uploadDate: appendTimezoneOffsetToUTC( media?.date || '' ),
+				duration: secondsToISO8601( media?.duration || '' ),
+				thumbnailUrl: media?.thumbnail_url || '',
+				isFamilyFriendly: true, // Default value
+			};
 
 			const mediaSources = [];
 
@@ -296,26 +345,47 @@ function VideoEdit( {
 				} );
 			}
 
+			// Set all attributes updates into single setAttributes call
 			setAttributes( {
+				blob: undefined,
+				src: media.url,
+				id: media.id,
+				cmmId: media.id,
+				poster: undefined,
+				caption: media.caption,
+				seo: newSEOData,
 				sources: mediaSources,
 			} );
+
+			setTemporaryURL();
+			setIsVideoSelecting( false );
 		} else {
-		// Fetch transcoded URL from media meta.
+			// Handle WordPress media - batch initial attributes and fetch additional data
+			const baseAttributes = {
+				blob: undefined,
+				src: media.url,
+				id: media.id,
+				cmmId: media.id,
+				poster: undefined,
+				caption: media.caption,
+				seo: undefined, // Will be set after API call
+			};
+
+			// Fetch transcoded URL from media meta.
 			( async () => {
 				try {
 					const response = await apiFetch( { path: `/wp/v2/media/${ media.id }` } );
 
-					setAttributes( {
-						seo: {
-							contentUrl: response.meta?.rtgodam_transcoded_url || response.source_url,
-							headline: response.title?.rendered || '',
-							description: response.description?.rendered || '',
-							uploadDate: appendTimezoneOffsetToUTC( response.date_gmt ),
-							duration: response.video_duration_iso8601 || '',
-							thumbnailUrl: response.meta?.rtgodam_media_video_thumbnail || '',
-							isFamilyFriendly: true, // Default value
-						},
-					} );
+					// Create new SEO data from WordPress media
+					const newSEOData = {
+						contentUrl: response.meta?.rtgodam_transcoded_url || response.source_url,
+						headline: response.title?.rendered || '',
+						description: response.description?.rendered || '',
+						uploadDate: appendTimezoneOffsetToUTC( response.date_gmt ),
+						duration: response.video_duration_iso8601 || '',
+						thumbnailUrl: response.meta?.rtgodam_media_video_thumbnail || '',
+						isFamilyFriendly: true, // Default value
+					};
 
 					if ( response && response.meta ) {
 						if ( response.meta.rtgodam_media_video_thumbnail !== '' ) {
@@ -345,12 +415,17 @@ function VideoEdit( {
 							type: media.url.endsWith( '.mov' ) ? 'video/mp4' : media.mime,
 						} );
 
+						// Batch all final attributes into single setAttributes call
 						setAttributes( {
+							...baseAttributes,
+							seo: newSEOData,
 							sources: mediaSources,
 						} );
 					} else {
-					// If meta not present, use media url.
+						// If meta not present, use media url.
 						setAttributes( {
+							...baseAttributes,
+							seo: newSEOData,
 							sources: [
 								{
 									src: media.url,
@@ -360,7 +435,20 @@ function VideoEdit( {
 						} );
 					}
 				} catch ( error ) {
+					// Create basic SEO data on error
+					const fallbackSEOData = {
+						contentUrl: media.url,
+						headline: '',
+						description: '',
+						uploadDate: '',
+						duration: '',
+						thumbnailUrl: '',
+						isFamilyFriendly: true,
+					};
+
 					setAttributes( {
+						...baseAttributes,
+						seo: fallbackSEOData,
 						sources: [
 							{
 								src: media.url,
@@ -369,21 +457,31 @@ function VideoEdit( {
 						],
 					} );
 				}
+
+				setTemporaryURL();
+				setIsVideoSelecting( false );
 			} )();
 		}
-
-		setTemporaryURL();
 	}
 
 	function onSelectURL( newSrc ) {
 		if ( newSrc !== src ) {
+			// Set flag to prevent backward compatibility logic during URL selection
+			setIsVideoSelecting( true );
+
 			setAttributes( {
 				blob: undefined,
 				src: newSrc,
 				id: undefined,
 				poster: undefined,
+				seo: undefined, // Clear SEO data when new URL is selected
 			} );
 			setTemporaryURL();
+
+			// Reset flag after a brief delay to allow attribute changes to settle
+			setTimeout( () => {
+				setIsVideoSelecting( false );
+			}, 100 );
 		}
 	}
 
@@ -594,6 +692,7 @@ function VideoEdit( {
 								<BaseControl
 									id={ `video-block__video-seo-${ instanceId }` }
 									label={ __( 'SEO Settings', 'godam' ) }
+									help={ __( 'Configure SEO metadata for this video. Note: SEO data will be cleared when replacing the video.', 'godam' ) }
 									__nextHasNoMarginBottom
 								>
 									<Button

--- a/assets/src/blocks/godam-player/utils/index.js
+++ b/assets/src/blocks/godam-player/utils/index.js
@@ -85,4 +85,11 @@ function secondsToISO8601( seconds ) {
 	return isoString;
 }
 
-export { getFirstNonEmpty, appendTimezoneOffsetToUTC, isObjectEmpty, secondsToISO8601 };
+function isSEODataEmpty( seoData ) {
+	return ! seoData ||
+		typeof seoData !== 'object' ||
+		Object.keys( seoData ).length === 0 ||
+		( Object.keys( seoData ).length === 1 && seoData.hasOwnProperty( 'isFamilyFriendly' ) );
+}
+
+export { getFirstNonEmpty, appendTimezoneOffsetToUTC, isObjectEmpty, secondsToISO8601, isSEODataEmpty };


### PR DESCRIPTION
## ✨ Overview

**ISSUE**: https://github.com/rtCamp/godam/issues/975

- Fixed Video SEO modal not showing existing data for older videos
- Resolved multiple API calls during video replacement
- Improved backward compatibility for blocks created before SEO feature
- Enhanced user experience when replacing videos

## 🐞 Bug Fixes

- Empty Data Detection: Improved detection of empty SEO data objects vs undefined values
- Multiple API Calls: Reduced 3-4 API requests to single request during video replacement
- State Interference: Prevented backward compatibility logic from running during video selection process

## 🚀 Enhancements

- Batched Updates: Combined multiple calls into single operations for better performance
- User Customization: SEO data is properly cleared and refreshed when videos are replaced
- Error Handling: Added fallback logic for API failures during SEO data fetching
- State Management: flag to prevent unwanted useEffect triggers

## 📝 Notes

- I simulated the backward incompatibility by manually removing the SEO data from the block.
- The user would need to save the post once before they can see the SEO data autofilled.
- This also means that now user can not diable the SEO feature, if we need to provide this customization we have to add another attribute for that.