### PR TITLE
Implement custom fullscreen feature for iOS devices

### DIFF
--- a/assets/src/css/classic-skin.scss
+++ b/assets/src/css/classic-skin.scss
@@ -466,6 +466,24 @@
 
 	}
 
+	.video-js {
+
+		&.vjs-fullscreen {
+
+			.vjs-fullscreen-control {
+
+				span::before {
+					background: url(../images/classic-exit-full-screen.svg);
+					background-repeat: no-repeat;
+					background-size: contain !important;
+					display: inline-block;
+					height: 20px;
+					width: 20px;
+				}
+			}
+		}
+	}
+
 	.godam-submenu-open {
 
 		.vjs-settings-button {

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -130,6 +130,17 @@
 			opacity: 0.7;
 		}
 	}
+
+	&.godam-video-fullscreen {
+		position: fixed;
+		inset: 0;
+		width: 100vw;
+		height: 100vh;
+		background: #000;
+		z-index: 99999999;
+		display: flex;
+		align-items: center;
+	}
 }
 
 .easydam-video-container .video-js .vjs-big-play-button {
@@ -204,11 +215,6 @@
 
 .vjs-picture-in-picture-control {
 	order: 7;
-}
-
-.easydam-player.video-js {
-	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9 );
-	cursor: pointer;
 }
 
 .form-container {
@@ -1361,40 +1367,37 @@ body.godam-share-modal-open {
 	}
 }
 
-// Style for video player fullscreen button
+/* Style for video player fullscreen buttons */
 .video-js {
 
-	.vjs-custom-fullscreen-control {
+	.vjs-custom-fullscreen-exit-control {
+		position: fixed !important;
+		top: 0.75rem !important;
+		left: 0.5rem !important;
+		display: none !important;
+		height: 20px;
+		width: 20px;
 
-		.vjs-icon-placeholder {
+		span::before {
+			content: ''; /* Hide default icon */
+			background: url(../images/close.svg);
+			background-position: center;
+			background-repeat: no-repeat;
+			background-size: contain;
+			display: inline-block;
+		}
 
-			&.fullscreen-icon {
-				display: block;
-			}
-
-			&.exitscreen-icon {
-				display: none;
-			}
+		&.vjs-icon-placeholder {
+			color: var(--rtgodam-control-hover-color) !important;
 		}
 	}
 
 	&.vjs-fullscreen {
 
-		.vjs-custom-fullscreen-control {
-
-			.vjs-icon-placeholder {
-
-				&.fullscreen-icon {
-					display: none;
-				}
-
-				&.exitscreen-icon {
-					display: block;
-				}
-			}
+		.vjs-custom-fullscreen-exit-control {
+			display: block !important;
 		}
 	}
-
 
 	@container godam-player-default-skin (max-width: 480px) {
 
@@ -1585,6 +1588,11 @@ body.godam-share-modal-open {
 			}
 		}
 	}
+}
+
+.easydam-player.video-js {
+	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9 );
+	cursor: pointer;
 }
 
 .video-js .vjs-time-tooltip,

--- a/assets/src/css/pills-skin.scss
+++ b/assets/src/css/pills-skin.scss
@@ -4,12 +4,11 @@
 
 	.video-js .vjs-control-bar {
 		width: 95% !important;
-		position: relative;
 		border-radius: 80px;
 		margin: -50px auto 0 auto;
 		z-index: 999;
 		background-color: var(--rtgodam-control-bar-color, #000) !important;
-		bottom: unset !important;
+		bottom: 0.5rem !important;
 	}
 
 	.video-js .vjs-big-play-button {

--- a/assets/src/images/classic-exit-full-screen.svg
+++ b/assets/src/images/classic-exit-full-screen.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-minimize-icon lucide-minimize"><path d="M8 3v3a2 2 0 0 1-2 2H3"/><path d="M21 8h-3a2 2 0 0 1-2-2V3"/><path d="M3 16h3a2 2 0 0 1 2 2v3"/><path d="M16 21v-3a2 2 0 0 1 2-2h3"/></svg>

--- a/assets/src/images/close.svg
+++ b/assets/src/images/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x-icon lucide-x"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>

--- a/assets/src/js/godam-player/managers/controlsManager.js
+++ b/assets/src/js/godam-player/managers/controlsManager.js
@@ -112,7 +112,9 @@ export default class ControlsManager {
 				}
 			}
 		}
-		videojs.registerComponent( 'CustomFullscreenButton', CustomFullscreenButton );
+		if ( ! videojs.getComponent( 'CustomFullscreenButton' ) ) {
+			videojs.registerComponent( 'CustomFullscreenButton', CustomFullscreenButton );
+		}
 		return new CustomFullscreenButton( this.player );
 	}
 
@@ -145,7 +147,9 @@ export default class ControlsManager {
 				}
 			}
 		}
-		videojs.registerComponent( 'CustomFullscreenExitButton', CustomFullscreenExitButton );
+		if ( ! videojs.getComponent( 'CustomFullscreenExitButton' ) ) {
+			videojs.registerComponent( 'CustomFullscreenExitButton', CustomFullscreenExitButton );
+		}
 		return new CustomFullscreenExitButton( this.player );
 	}
 

--- a/assets/src/js/godam-player/managers/controlsManager.js
+++ b/assets/src/js/godam-player/managers/controlsManager.js
@@ -44,7 +44,7 @@ export default class ControlsManager {
 		this.setupControlBarComponents( controlBarSettings );
 		this.setupCustomPlayButton( controlBarSettings );
 
-		this.setupFullscreenButton();
+		this.setupCustomFullscreenButton();
 	}
 
 	/**
@@ -149,15 +149,21 @@ export default class ControlsManager {
 		return new CustomFullscreenExitButton( this.player );
 	}
 
+	/**
+	 * Check if the device is iOS
+	 *
+	 * @return {boolean} - True if iOS device, false otherwise
+	 */
 	checkIOSDevice() {
 		const userAgent = window.navigator.userAgent.toLowerCase();
 		return /iphone|ipad|ipod/.test( userAgent );
 	}
 
 	/**
-	 * Setup fullscreen button for iOS devices
+	 * Setup custom fullscreen button
+	 * This is for iOS devices that does not support videojs on fullscreen mode
 	 */
-	setupFullscreenButton() {
+	setupCustomFullscreenButton() {
 		// Add custom fullscreen button to control bar
 		const controlBar = this.player.controlBar;
 		const controlBarEl = controlBar.el();

--- a/assets/src/js/godam-player/managers/controlsManager.js
+++ b/assets/src/js/godam-player/managers/controlsManager.js
@@ -43,6 +43,8 @@ export default class ControlsManager {
 		this.setupPlayButtonPosition( controlBarSettings );
 		this.setupControlBarComponents( controlBarSettings );
 		this.setupCustomPlayButton( controlBarSettings );
+
+		this.setupFullscreenButton();
 	}
 
 	/**
@@ -65,6 +67,108 @@ export default class ControlsManager {
 		const position = controlBarSettings?.playButtonPosition;
 		if ( position && alignments.includes( `${ position }-align` ) ) {
 			playButton.addClass( `${ position }-align` );
+		}
+	}
+
+	/**
+	 * Create a custom fullscreen button
+	 *
+	 * @return {Object} - The custom fullscreen button instance
+	 */
+	createCustomFullscreenButton() {
+		class CustomFullscreenButton extends videojs.getComponent( 'Button' ) {
+			constructor( player, options ) {
+				super( player, options );
+				this.controlText( __( 'Custom Fullscreen', 'godam' ) );
+			}
+
+			createEl() {
+				const el = super.createEl();
+				el.classList.add( 'vjs-fullscreen-control', 'vjs-control', 'vjs-button' );
+
+				return el;
+			}
+
+			handleClick( e ) {
+				const videoContainer = e.target.closest( '.video-js' );
+				const godamVideoContainer = e.target.closest( '.easydam-video-container' );
+
+				const isFullscreen = videoContainer && videoContainer.classList.contains( 'vjs-fullscreen' );
+
+				if ( isFullscreen ) {
+					if ( videoContainer ) {
+						videoContainer.classList.remove( 'vjs-fullscreen' );
+					}
+					if ( godamVideoContainer ) {
+						godamVideoContainer.classList.remove( 'godam-video-fullscreen' );
+					}
+				} else {
+					if ( videoContainer ) {
+						videoContainer.classList.add( 'vjs-fullscreen' );
+					}
+					if ( godamVideoContainer ) {
+						godamVideoContainer.classList.add( 'godam-video-fullscreen' );
+					}
+				}
+			}
+		}
+		videojs.registerComponent( 'CustomFullscreenButton', CustomFullscreenButton );
+		return new CustomFullscreenButton( this.player );
+	}
+
+	/**
+	 * Exit fullscreen button
+	 */
+	createCustomFullscreenExitButton() {
+		class CustomFullscreenExitButton extends videojs.getComponent( 'Button' ) {
+			constructor( player, options ) {
+				super( player, options );
+				this.controlText( __( 'Exit Fullscreen', 'godam' ) );
+			}
+
+			createEl() {
+				const el = super.createEl();
+				el.classList.add( 'vjs-custom-fullscreen-exit-control', 'vjs-control', 'vjs-button' );
+
+				return el;
+			}
+
+			handleClick( e ) {
+				const videoContainer = e.target.closest( '.video-js' );
+				const godamVideoContainer = e.target.closest( '.easydam-video-container' );
+
+				if ( videoContainer ) {
+					videoContainer.classList.remove( 'vjs-fullscreen' );
+				}
+				if ( godamVideoContainer ) {
+					godamVideoContainer.classList.remove( 'godam-video-fullscreen' );
+				}
+			}
+		}
+		videojs.registerComponent( 'CustomFullscreenExitButton', CustomFullscreenExitButton );
+		return new CustomFullscreenExitButton( this.player );
+	}
+
+	checkIOSDevice() {
+		const userAgent = window.navigator.userAgent.toLowerCase();
+		return /iphone|ipad|ipod/.test( userAgent );
+	}
+
+	/**
+	 * Setup fullscreen button for iOS devices
+	 */
+	setupFullscreenButton() {
+		// Add custom fullscreen button to control bar
+		const controlBar = this.player.controlBar;
+		const controlBarEl = controlBar.el();
+		const _fullscreenButton = controlBarEl.querySelector( '.vjs-fullscreen-control.vjs-control.vjs-button' );
+		if ( _fullscreenButton && this.checkIOSDevice() ) { // Also check if is iOS device.
+			// Replace fullscreen button with custom implementation
+			const customFullscreenButton = this.createCustomFullscreenButton();
+			_fullscreenButton.parentNode.replaceChild( customFullscreenButton.el(), _fullscreenButton );
+			// Add exit button
+			const customFullscreenExitButton = this.createCustomFullscreenExitButton();
+			controlBar.addChild( customFullscreenExitButton );
 		}
 	}
 


### PR DESCRIPTION
On iOS devices, the GoDAM video player cannot enter fullscreen mode using the default Video.js option. This causes the video to appear blank without layers, ads, or the GoDAM player skin.

Ref: https://github.com/rtCamp/godam-core/issues/124

**Solution:**
Detect if the user is on iOS, then replace the default Video.js fullscreen button with a custom one. The custom button will handle full-screen behavior manually, allowing us to simulate fullscreen mode on iOS without triggering the native video player.

- [x] Add custom fullscreen button.
- [x] Make sure that the custom fullscreen UI does not change compared to the default fullscreen button on all available skins.
- [x] Add a check to detect if an iOS device, then replace the default full-screen button with a custom full-screen button.
- [x] Fix the pill skin fullscreen breaking UI

**Before**
iOS default video player
![Image](https://github.com/user-attachments/assets/e4ba4d10-a602-4ebe-820f-cf1c9cbb01d1)

**After**
| Mimic fullscreen | with layers | Classic skin |
|----------|----------|----------|
| ![WhatsApp Image 2025-08-27 at 18 06 32](https://github.com/user-attachments/assets/9964dc48-e436-4a59-b2cf-0f197071eb16) | ![WhatsApp Image 2025-08-27 at 18 06 33](https://github.com/user-attachments/assets/315597e4-417e-4867-9667-b060d280e4a9) | ![WhatsApp Image 2025-08-27 at 18 08 07](https://github.com/user-attachments/assets/725b7148-042a-429f-975f-690fa67ff929)


