### PR TITLE
fix: Added dependencies of wp-media for the media-library js.

### DIFF
--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -229,7 +229,7 @@ class Assets {
 		wp_register_script(
 			'easydam-media-library',
 			RTGODAM_URL . 'assets/build/js/media-library.min.js',
-			array(),
+			array( 'media-editor', 'media-views', 'media-models', 'media-grid' ),
 			filemtime( RTGODAM_PATH . 'assets/build/js/media-library.min.js' ),
 			true
 		);


### PR DESCRIPTION
This PR fixes the following point:

- When we activate the plugin, it is throwing the console error for the setupAttachmentBrowser method -- saying that the wp-media is undefined.
- Attaching video for the brief explanation.

https://github.com/user-attachments/assets/c648ae02-8b02-499d-8f0c-6f51f31cde09

