### PR TITLE
QA Fix: Like, comments & views feature 

### DIFF
--- a/assets/src/js/godam-player/engagement.js
+++ b/assets/src/js/godam-player/engagement.js
@@ -572,13 +572,17 @@ function CommentForm( props ) {
 	const textareaRef = useRef( null );
 
 	async function handleSubmit() {
+		const text = commentText.trim();
+		if ( 0 === text.length ) {
+			return;
+		}
 		setIsSending( true );
 		const parentId = comment.id ? comment.id : '';
 		const queryParams = {
 			site_url: siteUrl,
 			video_id: videoAttachmentId,
 			comment_parent_id: parentId,
-			comment_text: commentText,
+			comment_text: text,
 			comment_type: commentType,
 		};
 		apiFetch.use( apiFetch.createNonceMiddleware( nonceData.nonce ) );
@@ -648,7 +652,7 @@ function CommentForm( props ) {
 				<button
 					className={ 'rtgodam-video-engagement--comment-button' +
 					( isSending ? ' is-comment-progressing' : '' ) }
-					disabled={ isSending || ! commentText }
+					disabled={ isSending || 0 === commentText.trim().length }
 					onClick={ handleSubmit }
 				>
 					{ 'thread-reply' === type ? __( 'Reply', 'godam' ) : __( 'Comment', 'godam' ) }

--- a/inc/classes/rest-api/class-engagement.php
+++ b/inc/classes/rest-api/class-engagement.php
@@ -567,7 +567,7 @@ class Engagement extends Base {
 			$response_data = array(
 				'id'              => $comment['name'],
 				'parent_id'       => isset( $comment['custom_reply_to'] ) ? $comment['custom_reply_to'] : null,
-				'text'            => $comment['content'],
+				'text'            => html_entity_decode( $comment['content'], ENT_QUOTES, 'UTF-8' ),
 				'author_name'     => $comment['comment_by'],
 				'author_email'    => $comment['comment_email'],
 				'created_at_date' => $created_date['date'],
@@ -735,7 +735,7 @@ class Engagement extends Base {
 			$comment_index[ $comment['name'] ] = array(
 				'id'              => $comment['name'],
 				'parent_id'       => $comment['custom_reply_to'],
-				'text'            => $text,
+				'text'            => html_entity_decode( $text, ENT_QUOTES, 'UTF-8' ),
 				'author_name'     => $comment['comment_by'],
 				'author_email'    => $comment['comment_email'],
 				'created_at_date' => $created_date['date'],


### PR DESCRIPTION
This pull request improves the handling and display of comment text in the video engagement feature, focusing on input validation and proper decoding of special characters. The main changes ensure that empty or whitespace-only comments cannot be submitted and that comment text is correctly decoded before display.

**Frontend validation improvements:**

* Prevents submission of empty or whitespace-only comments by trimming input and disabling the submit button accordingly in `CommentForm` (`assets/src/js/godam-player/engagement.js`). [[1]](diffhunk://#diff-2179ea92e3683b1c7aa26095806b008d73cc061b5885bb8939982e1ef27cddf0R575-R585) [[2]](diffhunk://#diff-2179ea92e3683b1c7aa26095806b008d73cc061b5885bb8939982e1ef27cddf0L651-R655)

**Backend comment text handling:**

* Ensures that comment text is decoded from HTML entities before being returned in API responses in both `user_comment` and `get_comments` methods (`inc/classes/rest-api/class-engagement.php`). [[1]](diffhunk://#diff-33305b3f35254b30a7a847f98588a4c2de593a5c614293213a7f4c754b070686L570-R570) [[2]](diffhunk://#diff-33305b3f35254b30a7a847f98588a4c2de593a5c614293213a7f4c754b070686L738-R738)

Ref: 
https://github.com/rtCamp/godam/issues/582
https://github.com/rtCamp/godam/issues/583
https://github.com/rtCamp/godam/issues/584