### PR TITLE
Provide thumbnail support for Vimeo video migration

### DIFF
--- a/inc/classes/rest-api/class-video-migration.php
+++ b/inc/classes/rest-api/class-video-migration.php
@@ -1034,8 +1034,25 @@ class Video_Migration extends Base {
 		}
 
 		// Set the attachment thumbnail.
-		if ( ! empty( $video_info['thumbnail_url'] ) ) {
-			update_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', $video_info['thumbnail_url'] );
+		if ( isset( $video_info['thumbnails'] ) && ! empty( $video_info['thumbnails'] ) ) {
+
+			$thumbnails     = $video_info['thumbnails'];
+			$thumbnail_urls = array();
+
+			foreach ( $thumbnails as $thumb ) {
+				if ( empty( $thumb['thumbnail_url'] ) ) {
+					continue;
+				}
+
+				$thumbnail_urls[] = $thumb['thumbnail_url'];
+
+				// Set as primary thumbnail if set to active.
+				if ( isset( $thumb['is_active'] ) && $thumb['is_active'] ) {
+					update_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', $thumb['thumbnail_url'] );
+				}
+			}
+
+			update_post_meta( $attachment_id, 'rtgodam_media_thumbnails', $thumbnail_urls );
 		}
 
 		// Set the attachment file size.


### PR DESCRIPTION
This pull request updates how video thumbnails are handled when creating attachments from Vimeo videos. Instead of saving just a single thumbnail URL, the code now supports multiple thumbnails and marks the active one as primary.

**Improvements to thumbnail handling:**

* Modified the logic in `create_attachment_from_vimeo_video` (in `class-video-migration.php`) to support multiple thumbnails: now saves all available thumbnail URLs in the `rtgodam_media_thumbnails` post meta and sets the primary thumbnail based on the `is_active` flag in the thumbnail data.