### PR TITLE
Resolve hover issues and enable Picture-in-Picture in Firefox for Classic skin (refs #963, #993)

### DIFF
--- a/assets/src/css/classic-skin.scss
+++ b/assets/src/css/classic-skin.scss
@@ -468,7 +468,16 @@
 			display: none;
 		}
 	
+		@-moz-document url-prefix() {
+			/* CSS rules here apply only in Firefox */
+			.vjs-settings-button {
+			  right: 40px;
+			}
 
+			.vjs-subs-caps-button.vjs-control.vjs-menu-button {
+			  right: 80px;
+			}
+		  }
 	}
 
 	.video-js {


### PR DESCRIPTION
Resolves issue: 
https://github.com/rtCamp/godam/issues/963
https://github.com/rtCamp/godam/issues/993

1. Having hover issues with the video player controls in the Classic player skin

https://github.com/user-attachments/assets/a8c33580-a6b5-406a-b445-531486a7ebed



2. Picture in picture not displayed in Firefox:
<img width="687" height="397" alt="image" src="https://github.com/user-attachments/assets/b3ea7c13-a876-4328-8fd3-adee3406cee2" />

Refer: https://github.com/rtCamp/godam/issues/993#issuecomment-3248550600