### PR TITLE
Fix QA issues 

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -117,6 +117,10 @@
 		}
 	}
 
+	.vjs-text-track-display {
+		bottom: 4em !important;
+	}
+
 	&:hover {
 
 		.vjs-big-play-button {

--- a/pages/analytics/index.scss
+++ b/pages/analytics/index.scss
@@ -13,6 +13,7 @@
 }
 
 #root-video-analytics {
+
 	.godam-settings-header-content {
 		padding: 0 2.5rem;
 	}
@@ -401,7 +402,7 @@
 	justify-content: space-between;
 	position: relative;
 	border-bottom: 1px solid #ddd;
-	margin: 0 0 0 40px;
+	margin: 0 40px;
 	padding-bottom: 8px;
 }
 

--- a/pages/dashboard/components/ChartsDashboard.js
+++ b/pages/dashboard/components/ChartsDashboard.js
@@ -116,7 +116,7 @@ export function generateUsageDonutChart( selector, usedRaw, totalRaw, type = 'ba
 			.attr( 'dy', '-0.25em' )
 			.style( 'font-size', '14px' )
 			.style( 'font-weight', 'bold' )
-			.text( total === 0 ? '0%' : `${ percent.toFixed( 1 ) }%` );
+			.text( total === 0 ? '0%' : `${ percent?.toFixed( 1 ) }%` );
 
 		svg
 			.append( 'text' )
@@ -187,7 +187,7 @@ function main() {
 
 	const watchTimeEl = document.getElementById( 'watch-time' );
 	if ( watchTimeEl ) {
-		watchTimeEl.innerText = `${ formatWatchTime( playTime.toFixed( 2 ) ) }`;
+		watchTimeEl.innerText = `${ formatWatchTime( playTime?.toFixed( 2 ) ) }`;
 	}
 
 	const analyticsContainer = document.getElementById( 'video-analytics-container' );


### PR DESCRIPTION
1. Remove error from console when Dashboard is accessed without API key
<img width="617" height="322" alt="image" src="https://github.com/user-attachments/assets/82ee65be-f51d-4f40-84f8-967bbbff0a5e" />

2.  In Safari, the caption is overlapping with the timeline (On iOS mobile devices, both Safari and Chrome browsers exhibit the same issue.) 
FIx:
<img width="715" height="391" alt="Screenshot 2025-09-03 at 7 12 11 PM" src="https://github.com/user-attachments/assets/9e9d0691-84a1-4482-8e31-ff97275b11ec" />

3. On the video analytics page, the "Back to video Editor" button extends beyond the content width.
<img width="1298" height="759" alt="image" src="https://github.com/user-attachments/assets/ed965f43-7bb8-42af-a40b-6971a4fd3e2f" />
