### PR TITLE
Modify the admanager initialization order

### DIFF
--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -65,6 +65,11 @@ export default class GodamVideoPlayer {
 	 */
 	initializePlayer() {
 		this.player = videojs( this.video, this.configManager.videoSetupControls );
+
+		// Initialize ads manager
+		this.adsManager = new AdsManager( this.player, this.configManager );
+		this.adsManager?.setupAdsIntegration();
+
 		this.setupAspectRatio();
 		this.setupPlayerReady();
 	}
@@ -135,9 +140,6 @@ export default class GodamVideoPlayer {
 		// Initialize chapters manager
 		this.chaptersManager = new ChaptersManager( this.player, this.video );
 
-		// Initialize ads manager
-		this.adsManager = new AdsManager( this.player, this.configManager );
-
 		// Initialize hover and share managers (existing)
 		this.hoverManager = new HoverManager( this.player, this.video );
 		this.shareManager = new ShareManager( this.player, this.video, this.configManager.videoSetupOptions );
@@ -191,7 +193,6 @@ export default class GodamVideoPlayer {
 	setupEventListeners() {
 		this.eventsManager?.setupEventListeners();
 		this.layersManager?.setupLayers();
-		this.adsManager?.setupAdsIntegration();
 	}
 
 	/**


### PR DESCRIPTION
This pull request refactors the initialization sequence of the ads manager within the `GodamVideoPlayer` class to ensure that ad integration is set up earlier in the player lifecycle. The changes primarily reorganize where and when the ads manager is instantiated and its integration is initialized.

Initialization sequence improvements:

* Moved the instantiation and setup of the `AdsManager` from later in the constructor to the `initializePlayer()` method, ensuring ad integration (`setupAdsIntegration()`) occurs immediately after the player is created. [[1]](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398R68-R72) [[2]](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398L138-L140)
* Removed the redundant call to `setupAdsIntegration()` from the `setupEventListeners()` method, as ad setup is now handled during player initialization.