### PR TITLE
fix: Ensure the media library preview error overlay doesn't cover any elements

### DIFF
--- a/assets/src/css/media-library.scss
+++ b/assets/src/css/media-library.scss
@@ -612,3 +612,10 @@ $media-library-active-folder: #f5f5f5;
 .edit-attachment-frame .attachment-info {
 	height: auto;
 }
+
+/**
+ * Ensure the media library preview error overlay doesn't cover any elements.
+ */
+.mejs-overlay.mejs-layer {
+	overflow: auto;
+}


### PR DESCRIPTION
Fix:

<img width="1459" height="869" alt="Screenshot 2025-09-05 at 4 18 20 PM" src="https://github.com/user-attachments/assets/13bfb26f-0413-425a-b7cb-9dad9564ecda" />
