### PR TITLE
Vimeo Migration Hotfixes

### DIFF
--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -100,7 +100,7 @@
 		},
 		"showShareButton": {
 			"type": "boolean",
-			"default": true
+			"default": false
 		},
 		"layout": {
 			"type": "object",

--- a/inc/classes/rest-api/class-video-migration.php
+++ b/inc/classes/rest-api/class-video-migration.php
@@ -189,6 +189,7 @@ class Video_Migration extends Base {
 		if ( ! in_array( $migration_type, array( 'core', 'vimeo' ), true ) ) {
 			return new \WP_Error( 'invalid_migration_type', __( 'Invalid migration type specified.', 'godam' ), array( 'status' => 400 ) );
 		}
+		$wp_option_key = 'godam_' . $migration_type . '_video_migration_status';
 
 		if ( 'vimeo' === $migration_type ) {
 			// Check if Vimeo migration is enabled.
@@ -200,15 +201,16 @@ class Video_Migration extends Base {
 			if ( isset( $godam_migration_status['message']['migration_status'] ) ) {
 				$status = $godam_migration_status['message']['migration_status'];
 				if ( 'Completed' !== $status ) {
+					// Reset migration status since Central migration is not completed.
+					delete_option( $wp_option_key );
+					
 					return new \WP_REST_Response(
 						$godam_migration_status,
-						400,
+						200,
 					);
 				}
 			}
 		}
-
-		$wp_option_key = 'godam_' . $migration_type . '_video_migration_status';
 
 		$migration_status = get_option( $wp_option_key, array() );
 

--- a/pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx
+++ b/pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx
@@ -50,7 +50,14 @@ const VimeoVideoMigration = ( { migrationStatus, setMigrationStatus, showNotice 
 			},
 		} )
 			.then( ( response ) => {
-				setMigrationStatus( response.data );
+				// Check the status in the response data
+				if ( response.data?.message?.migration_status && response.data.message.migration_status !== 'Completed' ) {
+					setGodamMigrationCompleted( false );
+					setMigrationStatus( { total: 0, done: 0, started: null, completed: null, status: 'pending', message: '' } );
+				} else {
+					// Proceed with migration
+					setMigrationStatus( response.data );
+				}
 			} )
 			.catch( ( err ) => {
 				// Check if status is 400, set godamMigrationStatus
@@ -59,7 +66,7 @@ const VimeoVideoMigration = ( { migrationStatus, setMigrationStatus, showNotice 
 				}
 				// Reset UI as request failed; show an error notice for clarity.
 				setMigrationStatus( { total: 0, done: 0, started: null, completed: null, status: 'pending', message: '' } );
-				const apiMessage = err?.response?.data?.message || err?.message || __( 'Something went wrong while starting migration.', 'godam' );
+				const apiMessage = __( 'Something went wrong while starting migration.', 'godam' );
 				showNotice( apiMessage, 'error' );
 			} );
 	};


### PR DESCRIPTION
## Fixes
### 1. GoDAM Central (Virtual Media) Logo now appears for Vimeo Migrated Videos:

<img width="910" height="420" alt="Screenshot 2025-09-05 at 9 56 26 PM" src="https://github.com/user-attachments/assets/b25ae4ac-b6be-495d-84dd-0fe235c07f96" />

### 2. Same videos migrated from Vimeo in subsequent migrations will not create duplicate attachments in Media Library.

### 3. Fixed fatal error when Vimeo Migration is in progress on Central
Before:
<img width="1461" height="786" alt="Screenshot 2025-09-07 at 5 17 00 PM" src="https://github.com/user-attachments/assets/d4e078ed-3ebd-4c85-a8df-05160c13a7b2" />

After:

https://github.com/user-attachments/assets/e67eb949-f0d3-4014-aad1-407096bd0546

