### PR TITLE
Fix volume button visibility for mobile devices

### DIFF
--- a/assets/src/css/bubble-skin.scss
+++ b/assets/src/css/bubble-skin.scss
@@ -329,6 +329,13 @@
 				}
 			}
 
+			.vjs-volume-panel {
+				bottom: 0;
+				left: unset;
+				right: 152px;
+				z-index: 99;
+			}
+
 			.vjs-time-control.vjs-current-time {
 				bottom: 0;
 				display: block !important;
@@ -359,7 +366,7 @@
 				margin: 0 30px !important;
 			}
 	
-		   .vjs-duration, .vjs-current-time, .vjs-time-divider, .vjs-picture-in-picture-control, .vjs-volume-panel {
+		   .vjs-duration, .vjs-current-time, .vjs-time-divider, .vjs-picture-in-picture-control {
 				display: none !important;
 			}
 		}

--- a/assets/src/css/minimal-skin.scss
+++ b/assets/src/css/minimal-skin.scss
@@ -61,10 +61,6 @@
 		}
 	}
 
-	.video-js .vjs-fullscreen-control {
-		order: 3;
-	}
-
 	.video-js .vjs-settings-button {
 		order: 2;
 	}
@@ -136,6 +132,12 @@
 				z-index: 99;
 			}
 
+			.vjs-volume-panel {
+				bottom: 0;
+				position: absolute;
+				right: 120px;
+			}
+
 			.vjs-subs-caps-button {
 				right: 80px !important;
 			}
@@ -168,7 +170,7 @@
 			height: 3em !important;
 		}
 
-	   .vjs-duration, .vjs-current-time, .vjs-time-divider, .vjs-picture-in-picture-control, .vjs-volume-panel, .vjs-remaining-time, .vjs-custom-play-button {
+	   .vjs-duration, .vjs-current-time, .vjs-time-divider, .vjs-picture-in-picture-control, .vjs-remaining-time, .vjs-custom-play-button {
 			display: none !important;
 		}
 

--- a/assets/src/css/pills-skin.scss
+++ b/assets/src/css/pills-skin.scss
@@ -34,7 +34,7 @@
 	}
 
 	.video-js .vjs-fullscreen-control {
-		order: 4;
+		order: 8;
 	}
 
 	.video-js .vjs-subs-caps-button {
@@ -123,7 +123,7 @@
 			height: initial !important;
 			margin: -40px auto 0;
 
-			.vjs-duration, .vjs-current-time, .vjs-time-divider, .vjs-picture-in-picture-control, .vjs-volume-panel, .vjs-remaining-time {
+			.vjs-duration, .vjs-current-time, .vjs-time-divider, .vjs-picture-in-picture-control, .vjs-remaining-time, .vjs-control.vjs-custom-play-button {
 				display: none !important;
 			}
 
@@ -185,10 +185,6 @@
 
 			.vjs-time-control.vjs-current-time {
 				left: 30px;
-			}
-			
-			.vjs-time-divider, .vjs-picture-in-picture-control, .vjs-volume-panel, .vjs-control.vjs-custom-play-button {
-				display: none !important;
 			}
 
 			.right-80 {


### PR DESCRIPTION
Add volume button for mobile devices for:
1. Bubble skin
<img width="404" height="250" alt="image" src="https://github.com/user-attachments/assets/9a66ca55-7e7f-4bfd-be44-989a2d9ac901" />

2. Pills skin
<img width="382" height="229" alt="image" src="https://github.com/user-attachments/assets/46724769-fd87-44c8-a242-f9bcd7e7d17a" />


3. Minimal skin
<img width="315" height="192" alt="image" src="https://github.com/user-attachments/assets/ccc706ed-adc8-4839-b6fb-937d7c9f0e4a" />


Move full screen to thr right of pip button for:
1. Pills skin
<img width="732" height="409" alt="image" src="https://github.com/user-attachments/assets/43fb387f-6451-4b8b-ac9a-413e8b13895e" />


2. Minimal skin
<img width="733" height="421" alt="image" src="https://github.com/user-attachments/assets/88308915-42e8-4627-b44b-305b21ec15d2" />

