### PR TITLE
Fix: breaking deployment

### DIFF
--- a/assets/src/css/wpforms-uppy-video.scss
+++ b/assets/src/css/wpforms-uppy-video.scss
@@ -1,7 +1,7 @@
-@import "@uppy/core/dist/style.min.css";
-@import "@uppy/dashboard/dist/style.min.css";
-@import "@uppy/webcam/dist/style.min.css";
-@import "@uppy/screen-capture/dist/style.min.css";
+@import "@uppy/core/css/style.min.css";
+@import "@uppy/dashboard/css/style.min.css";
+@import "@uppy/webcam/css/style.min.css";
+@import "@uppy/screen-capture/css/style.min.css";
 
 /** Style the field in the field preview **/
 .wpforms_page_wpforms-builder {


### PR DESCRIPTION
Update the uppy latest version's plugins styles path for WPForms

Partially closes: https://github.com/rtCamp/godam/issues/1106