### PR TITLE
Enhance Loading Skeleton Animation

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -38,6 +38,19 @@ $media-frame-width: calc(300px + 2 * 24px);
 	width: $media-frame-width;
 }
 
+.skeleton-wrapper {
+	display: grid;
+	grid-template-columns: 1fr 2fr;
+	min-height: 80vh;
+	gap: 2em;
+
+	.godam-skeleton-card {
+		height: 250px;
+		display: flex;
+		justify-content: space-between;
+	}
+}
+
 @media (max-width: 900px) {
 
 	.media-frame-menu {

--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -48,6 +48,7 @@ $media-frame-width: calc(300px + 2 * 24px);
 		height: 250px;
 		display: flex;
 		justify-content: space-between;
+		padding: 30px;
 	}
 }
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -278,9 +278,46 @@ class Pages {
 	 */
 	public function render_tools_page() {
 		?>
-		<div class="godam-admin-root">
-			<div id="root-godam-tools"></div>
-		</div>
+			<div class="godam-admin-root">
+				<div id="root-godam-tools">
+					<div class="wrap skeleton-wrapper">
+					
+					<!-- Sidebar Skeleton -->
+					<div class="w-full rounded-lg bg-white shadow-md border border-gray-200 max-w-72">
+						<nav class="loading-skeleton flex flex-col gap-3 p-4">
+						<!-- Sidebar Tabs -->
+						<div class="skeleton-container flex items-center gap-2">
+							<div class="skeleton-circle w-5 h-5"></div>
+						</div>
+						<div class="skeleton-container flex items-center gap-2">
+							<div class="skeleton-circle w-5 h-5"></div>
+						</div>
+						<div class="skeleton-container flex items-center gap-2">
+							<div class="skeleton-circle w-5 h-5"></div>
+						</div>
+						<div class="skeleton-container flex items-center gap-2">
+							<div class="skeleton-circle w-5 h-5"></div>
+						</div>
+						</nav>
+					</div>
+
+					<!-- Main Content Skeleton -->
+					<div id="main-content" class="w-full p-5 bg-white rounded-lg border flex flex-col gap-6">
+						
+						<!-- Card Title -->
+						<div class="skeleton-container godam-skeleton-card">
+							<div>
+								<div class="skeleton-line w-1/3 h-6"></div>
+								<div class="skeleton-line w-1/3 h-6"></div>
+							</div>
+							<div class="skeleton-button w-24 h-10"></div>
+						</div>
+
+						<!-- Save Button -->
+					</div>
+					</div>
+				</div>
+			</div>
 		<?php
 	}
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -342,49 +342,48 @@ class Pages {
 	public function render_godam_page() {
 		?>
 		<div class="godam-admin-root">
-			<div id="root-godam-settings">
-				<div class="wrap flex min-h-[80vh] gap-4 my-4">
+				<div id="root-godam-settings">
+					<div class="wrap skeleton-wrapper">
+					
 					<!-- Sidebar Skeleton -->
-					<div class="max-w-[220px] w-full rounded-lg bg-white shadow-md border border-gray-200">
-						<nav class="loading-skeleton flex flex-col gap-4 p-4">
+						<div class="w-full rounded-lg bg-white shadow-md border border-gray-200">
+							<nav class="loading-skeleton flex flex-col gap-3 p-4">
 							<!-- Sidebar Tabs -->
-							<div class="skeleton-container skeleton-container-short">
-								<div class="skeleton-header w-3/4"></div>
+							<div class="skeleton-container flex items-center gap-2">
+								<div class="skeleton-circle w-5 h-5"></div>
 							</div>
-							<div class="skeleton-container skeleton-container-short">
-								<div class="skeleton-header w-3/4"></div>
+							<div class="skeleton-container flex items-center gap-2">
+								<div class="skeleton-circle w-5 h-5"></div>
 							</div>
-							<div class="skeleton-container skeleton-container-short">
-								<div class="skeleton-header w-3/4"></div>
+							<div class="skeleton-container flex items-center gap-2">
+								<div class="skeleton-circle w-5 h-5"></div>
 							</div>
-						</nav>
-					</div>
+							<div class="skeleton-container flex items-center gap-2">
+								<div class="skeleton-circle w-5 h-5"></div>
+							</div>
+							</nav>
+						</div>
 
-					<!-- Main Content Skeleton -->
-					<div id="main-content" class="w-full p-5 bg-white rounded-lg border">
-						<!-- General Settings Form Skeleton -->
-						<div class="loading-skeleton flex flex-col gap-4">
-							<!-- Title -->
-							<div class="skeleton-container skeleton-container-short">
-								<div class="skeleton-header w-1/2"></div>
+						<!-- Main Content Skeleton -->
+						<div id="main-content" class="w-full p-5 bg-white rounded-lg border flex flex-col gap-6">
+							
+							<!-- Card Title -->
+							<div class="skeleton-container"></div>
+
+							<!-- Toggle + Label -->
+							<div class="skeleton-container flex items-center gap-3">
+								<div class="skeleton-rect w-12 h-6 rounded-full"></div>
 							</div>
 
-							<!-- Input Field Skeleton -->
-							<div class="skeleton-container">
-								<div class="skeleton-line w-3/4"></div>
-								<div class="skeleton-line short w-1/2"></div>
-							</div>
+							<!-- Description -->
+							<div class="skeleton-container flex flex-col gap-2"></div>
 
-							<!-- Buttons Skeleton -->
-							<div class="flex gap-2">
-								<div class="skeleton-button w-32 h-10"></div>
-								<div class="skeleton-button w-40 h-10"></div>
-							</div>
+							<!-- Save Button -->
+							<div class="skeleton-button w-24 h-10"></div>
 						</div>
 					</div>
 				</div>
 			</div>
-		</div>
 		<?php
 	}
 

--- a/pages/godam/components/Skeleton.jsx
+++ b/pages/godam/components/Skeleton.jsx
@@ -1,18 +1,36 @@
 const Skeleton = () => {
 	return (
-		<div id="main-content" className="w-full p-5 bg-white">
-			<div className="loading-skeleton flex flex-col gap-4">
-				<div className="skeleton-container skeleton-container-short">
-					<div className="skeleton-header w-1/2"></div>
+		<div className="wrap skeleton-wrapper">
+
+			<div className="w-full rounded-lg bg-white shadow-md border border-gray-200">
+				<nav className="loading-skeleton flex flex-col gap-3 p-4">
+
+					<div className="skeleton-container flex items-center gap-2">
+						<div className="skeleton-circle w-5 h-5"></div>
+					</div>
+					<div className="skeleton-container flex items-center gap-2">
+						<div className="skeleton-circle w-5 h-5"></div>
+					</div>
+					<div className="skeleton-container flex items-center gap-2">
+						<div className="skeleton-circle w-5 h-5"></div>
+					</div>
+					<div className="skeleton-container flex items-center gap-2">
+						<div className="skeleton-circle w-5 h-5"></div>
+					</div>
+				</nav>
+			</div>
+
+			<div id="main-content" className="w-full p-5 bg-white rounded-lg border flex flex-col gap-6">
+
+				<div className="skeleton-container"></div>
+
+				<div className="skeleton-container flex items-center gap-3">
+					<div className="skeleton-rect w-12 h-6 rounded-full"></div>
 				</div>
-				<div className="skeleton-container">
-					<div className="skeleton-line w-3/4"></div>
-					<div className="skeleton-line short w-1/2"></div>
-				</div>
-				<div className="flex gap-2">
-					<div className="skeleton-button w-32 h-10"></div>
-					<div className="skeleton-button w-40 h-10"></div>
-				</div>
+
+				<div className="skeleton-container flex flex-col gap-2"></div>
+
+				<div className="skeleton-button w-24 h-10"></div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Resolves issue #1103

1. Add skeleton for tools page:

<img width="720" height="557" alt="Image" src="https://github.com/user-attachments/assets/a1c3b66f-9b63-4406-919e-11b9419d7546" />

2. Improve skeleton on settings page and fix two different skeleton loading for settings page to depict two different loading state

<img width="970" height="741" alt="image" src="https://github.com/user-attachments/assets/4e4d1f4e-f6e5-4fa7-918f-45da75ab845a" />
