### PR TITLE
Fix: Improve thumbnail fetching behavior for attachment details.

### DIFF
--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -36,7 +36,7 @@ export default AttachmentDetailsTwoColumn?.extend( {
 	 *
 	 * @param {Function} renderMethod - The method to render the fetched data.
 	 *
-	 * @param {string}   type         - The type of data being fetched.
+	 * @param {string}   type         - The type of data being fetched. Defaults to empty string.
 	 */
 	async fetchAndRender( fetchPromise, renderMethod, type = '' ) {
 		const data = await fetchPromise;


### PR DESCRIPTION
closes #1094 

This PR fixes the issue where "No Thumbnails Found" message is flashed before thumbnails load.

This issue was caused when fetching EXIF data failed as both used the same method. 