### PR TITLE
Fix: Jetpack Form Entry

### DIFF
--- a/assets/src/js/jetpack-form.js
+++ b/assets/src/js/jetpack-form.js
@@ -25,7 +25,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		const fields = {};
 		for ( const [ key, value ] of formData.entries() ) {
 			// Only include user fields, not Jetpack hidden fields
-			if ( ! [ 'action', 'contact-form-id', 'contact-form-hash', '_wpnonce', '_wp_http_referer' ].includes( key ) ) {
+			if ( ! [ 'action', 'contact-form-id', 'contact-form-hash', '_wpnonce', '_wp_http_referer', 'jetpack_contact_form_jwt' ].includes( key ) ) {
 				fields[ key ] = value;
 			}
 		}


### PR DESCRIPTION
Related Issue: https://github.com/rtCamp/godam/issues/873

### Description
Remove the `jetpack_contact_form_jwt` from the form fields when submitting the form to prevent the fields from shifting in the form entry.

#### Before
https://github.com/user-attachments/assets/4e17176e-4353-48dc-8f6d-550b59d93667

#### After

https://github.com/user-attachments/assets/e82c150b-4f78-4e6b-92ec-4c6bf26c3fea


