### PR TITLE
Fix the audio mute issue on mac safari browser for GoDAM video block

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -198,13 +198,6 @@ function VideoEdit( {
 					}
 
 					if ( response ) {
-						const newSources = [
-							{
-								src: response.source_url,
-								type: response.source_url.endsWith( '.mov' ) ? 'video/mp4' : response.mime_type,
-							},
-						];
-
 						if ( response?.meta && response?.meta?.rtgodam_hls_transcoded_url ) {
 							const hlsTranscodedUrl = response.meta.rtgodam_hls_transcoded_url;
 
@@ -223,8 +216,14 @@ function VideoEdit( {
 							} );
 						}
 
-						// Reverse the sources to ensure the preferred format is first. MPD -> HLS -> Origin
-						setAttributes( { sources: newSources.reverse() } );
+						const newSources = [
+							{
+								src: response.source_url,
+								type: response.source_url.endsWith( '.mov' ) ? 'video/mp4' : response.mime_type,
+							},
+						];
+
+						setAttributes( { sources: newSources } );
 					}
 				} catch ( error ) {
 					// Show error notice if fetching media fails.
@@ -291,13 +290,6 @@ function VideoEdit( {
 
 			const mediaSources = [];
 
-			if ( media.url ) {
-				mediaSources.push( {
-					src: media.url,
-					type: media.url.endsWith( '.mov' ) ? 'video/mp4' : media.mime,
-				} );
-			}
-
 			if ( media.hls_url ) {
 				mediaSources.push( {
 					src: media.hls_url,
@@ -305,11 +297,18 @@ function VideoEdit( {
 				} );
 			}
 
+			if ( media.url ) {
+				mediaSources.push( {
+					src: media.url,
+					type: media.url.endsWith( '.mov' ) ? 'video/mp4' : media.mime,
+				} );
+			}
+
 			setAttributes( {
 				sources: mediaSources,
 			} );
 		} else {
-		// Fetch transcoded URL from media meta.
+			// Fetch transcoded URL from media meta.
 			( async () => {
 				try {
 					const response = await apiFetch( { path: `/wp/v2/media/${ media.id }` } );
@@ -333,19 +332,19 @@ function VideoEdit( {
 
 						const mediaSources = [];
 
-						const transcodedUrl = response.meta.rtgodam_transcoded_url;
-						if ( transcodedUrl ) {
-							mediaSources.push( {
-								src: transcodedUrl,
-								type: transcodedUrl.endsWith( '.mpd' ) ? 'application/dash+xml' : media.mime,
-							} );
-						}
-
 						const hlsTranscodedUrl = response.meta.rtgodam_hls_transcoded_url;
 						if ( hlsTranscodedUrl ) {
 							mediaSources.push( {
 								src: hlsTranscodedUrl,
 								type: hlsTranscodedUrl.endsWith( '.m3u8' ) ? 'application/x-mpegURL' : media.mime,
+							} );
+						}
+
+						const transcodedUrl = response.meta.rtgodam_transcoded_url;
+						if ( transcodedUrl ) {
+							mediaSources.push( {
+								src: transcodedUrl,
+								type: transcodedUrl.endsWith( '.mpd' ) ? 'application/dash+xml' : media.mime,
 							} );
 						}
 

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -97,8 +97,9 @@ $aspect_ratio       = ! empty( $attributes['aspectRatio'] ) && 'responsive' === 
 	)
 	: '16:9';
 
-$src            = ! empty( $attributes['src'] ) ? esc_url( $attributes['src'] ) : '';
-$transcoded_url = ! empty( $attributes['transcoded_url'] ) ? esc_url( $attributes['transcoded_url'] ) : '';
+$src                = ! empty( $attributes['src'] ) ? esc_url( $attributes['src'] ) : '';
+$transcoded_url     = ! empty( $attributes['transcoded_url'] ) ? esc_url( $attributes['transcoded_url'] ) : '';
+$hls_transcoded_url = ! empty( $attributes['hls_transcoded_url'] ) ? esc_url( $attributes['hls_transcoded_url'] ) : '';
 
 // Retrieve 'rtgodam_meta' for the given attachment ID, defaulting to an empty array if not found.
 $easydam_meta_data = $attachment_id ? get_post_meta( $attachment_id, 'rtgodam_meta', true ) : array();
@@ -121,13 +122,23 @@ if ( empty( $attachment_id ) ) {
 	$job_id = ! empty( $attributes['cmmId'] ) ? sanitize_text_field( $attributes['cmmId'] ) : '';
 }
 
-if (
-	( empty( $attachment_id ) || ( $is_virtual && ! empty( $original_id ) ) ) &&
+if ( ( empty( $attachment_id ) || ( $is_virtual && ! empty( $original_id ) ) ) &&
 	! empty( $attributes['sources'] ) 
-) { // If media is virtual media.
+) {
+	// If media is virtual media.
 	$sources = $attributes['sources'];
-} elseif ( empty( $attachment_id ) && ! ( empty( $src ) && empty( $transcoded_url ) ) ) {   // in case of shortcode with src or transcoded_url attribute.
+} elseif ( empty( $attachment_id ) &&
+	! ( empty( $src ) && empty( $transcoded_url ) && empty( $hls_transcoded_url ) )
+) {
+	// in case of shortcode with src or transcoded_url or hls_transcoded_url attribute.
 	$sources = array();
+
+	if ( ! empty( $hls_transcoded_url ) ) {
+		$sources[] = array(
+			'src'  => $hls_transcoded_url,
+			'type' => 'application/x-mpegURL',
+		);
+	}
 	if ( ! empty( $transcoded_url ) ) {
 		$sources[] = array(
 			'src'  => $transcoded_url,
@@ -141,6 +152,7 @@ if (
 		);
 	}
 } else {
+
 	if ( $is_virtual ) {
 		// For virtual media, we need to get the actual attachment ID first.
 		$attachment_id = $original_id;


### PR DESCRIPTION
Update the video sources sequence for the GoDAM video player to fix the Audio mute issue on the Safari browser.

**Old sequence**
- MPD source
- HLS source
- Original File source

**New sequence**
- HLS source
- MPD source
- Original File source

`MPD` format isn’t fully supported on Safari for Mac, which causes the audio to mute after a few seconds. To resolve this, we should prioritize the `HLS` format, as it is well supported across Mac browsers and devices.

## Changes
- Update the source sequence in the GoDAM Video block edit page
- Update the frontend video source sequence in the GoDAM Video block and shortcode
- Fix the edge case of virtual media source sequence to avoid future bus and take care for the existing virtual media audio issue.
- Provide `hls_transcoded_url` attribute support for `[godam_video src="" transcoded_url="" hls_transcoded_url="" ]` shortcode 

## Related issue
- #1119 