### PR TITLE
Replace mp4 transcoded source with original uploaded video file.

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -157,10 +157,32 @@ class RTGODAM_Transcoder_Handler {
 					// Enable re-transcoding.
 					include_once RTGODAM_PATH . 'admin/class-rtgodam-retranscodemedia.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 
-					add_filter( 'wp_generate_attachment_metadata', array( $this, 'wp_media_transcoding' ), 21, 2 );
+					add_action( 'add_attachment', array( $this, 'send_transcoding_request' ), 21, 1 );
 				}
 			}
 		}
+	}
+
+	/**
+	 * Send transcoding request for uploaded media in WordPress media library.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int $attachment_id    ID of attachment.
+	 */
+	public function send_transcoding_request( $attachment_id ) {
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		$mime_type = get_post_mime_type( $attachment_id );
+
+		if ( empty( $metadata ) ) {
+			$metadata = array( 'mime_type' => $mime_type );
+		} elseif ( empty( $metadata['mime_type'] ) ) {
+			$metadata['mime_type'] = $mime_type;
+		}
+
+		// Send the transcoding request.
+		$this->wp_media_transcoding( $metadata, $attachment_id );
 	}
 
 	/**

--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -248,8 +248,6 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 
 				if ( $flag ) {
 					return new WP_Error( 'rtgodam_transcoding_error', $flag, array( 'status' => 500 ) );
-				} else {
-					return new WP_REST_Response( esc_html_e( 'Media transcoded successfully.', 'godam' ), 200 );
 				}
 			}
 		}

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -44,6 +44,8 @@ class Media_Library_Ajax {
 
 		add_action( 'admin_notices', array( $this, 'media_library_offer_banner' ) );
 		add_action( 'wp_ajax_godam_dismiss_offer_banner', array( $this, 'dismiss_offer_banner' ) );
+
+		add_action( 'rtgodam_handle_callback_finished', array( $this, 'download_transcoded_mp4_source' ), 10, 4 );
 	}
 
 	/**
@@ -595,6 +597,126 @@ class Media_Library_Ajax {
 					),
 				)
 			);
+		}
+	}
+
+	/**
+	 * Replace an existing WordPress media attachment with a file from an external URL,
+	 * using the WordPress Filesystem API.
+	 * 
+	 * @since n.e.x.t
+	 *
+	 * @param int    $attachment_id The ID of the existing media attachment.
+	 * @param string $file_url      The external file URL.
+	 *
+	 * @return int|WP_Error Attachment ID on success, WP_Error on failure.
+	 */
+	private function godam_replace_attachment_with_external_file( $attachment_id, $file_url = '' ) {
+		if ( ! $attachment_id || ! filter_var( $file_url, FILTER_VALIDATE_URL ) || ! wp_http_validate_url( $file_url ) ) {
+			return new \WP_Error( 'invalid_input', __( 'Invalid attachment ID or URL.', 'godam' ) );
+		}
+
+		// Validate the attachment.
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return new \WP_Error( 'invalid_attachment', __( 'Invalid attachment ID.', 'godam' ) );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		global $wp_filesystem;
+
+		// Initialize the WP Filesystem API.
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		WP_Filesystem();
+
+		if ( ! $wp_filesystem ) {
+			return new \WP_Error( 'fs_unavailable', __( 'Could not initialize WordPress filesystem.', 'godam' ) );
+		}
+
+		// Download file to temporary location.
+		$temp_file = download_url( $file_url );
+
+		if ( is_wp_error( $temp_file ) ) {
+			return $temp_file;
+		}
+
+		// Prepare new file path in uploads.
+		$upload_dir   = wp_upload_dir();
+		$new_filename = wp_basename( wp_parse_url( $file_url, PHP_URL_PATH ) );
+		$new_filepath = trailingslashit( $upload_dir['path'] ) . $new_filename;
+
+		// Move temp file into uploads with WP_Filesystem.
+		$moved = $wp_filesystem->move( $temp_file, $new_filepath, true );
+
+		if ( ! $moved ) {
+			$wp_filesystem->delete( $temp_file );
+			return new \WP_Error( 'file_move_failed', __( 'Could not move file into uploads directory.', 'godam' ) );
+		}
+
+		// Update attachment file info.
+		update_attached_file( $attachment_id, $new_filepath );
+
+		// update mime type.
+		$filetype = wp_check_filetype( $new_filename, null );
+		if ( $filetype['type'] ) {
+			wp_update_post(
+				array(
+					'ID'             => $attachment_id,
+					'post_mime_type' => $filetype['type'],
+				)
+			);
+		}
+
+		// Regenerate metadata.
+		$metadata = wp_generate_attachment_metadata( $attachment_id, $new_filepath );
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Download the transcoded MP4 source and replace the existing attachment file.
+	 *
+	 * @param int             $attachment_id Attachment ID.
+	 * @param string          $job_id        Job ID.
+	 * @param string          $job_for       Job for (e.g., 'wp-media').
+	 * @param WP_REST_Request $request    Request data containing transcoded file info..
+	 *
+	 * @return void
+	 */
+	public function download_transcoded_mp4_source( $attachment_id, $job_id, $job_for, $request ) {
+		if ( isset( $job_for ) && ( 'wp-media' !== $job_for ) ) {
+			return;
+		}
+
+		// Check if video attachment.
+		$attachment_mime_type = get_post_mime_type( $attachment_id );
+
+		if ( 'video' !== substr( $attachment_mime_type, 0, 5 ) ) {
+			return;
+		}
+
+		// Check if mp4_url is provided in the request.
+		$transcoded_mp4_url = esc_url( $request->get_param( 'mp4_url' ) );
+
+		if ( empty( $transcoded_mp4_url ) ) {
+			return;
+		}
+
+		// Replace the existing attachment file with the transcoded MP4.
+		$attachment_id = $this->godam_replace_attachment_with_external_file( $attachment_id, $transcoded_mp4_url );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			// Log the error for debugging purposes.
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( 'MP4 video replacement failed: ' . $attachment_id->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging for debugging.
+			}
 		}
 	}
 }


### PR DESCRIPTION
Replace the transcoded MP4 video in WordPress with the original uploaded video file.

## How to test ?
1. Upload a video to the media library of any mime_type like `.mov`, `.webm`, etc.
2. Now wait for the video to complete the transcoding, once the transcoding is completed reload the page and check if its replaced with `mp4` source or not?

## Related Issue:
- #1153 