### PR TITLE
Add repackaging step for WordPress plugin ZIP

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -41,15 +41,15 @@ jobs:
         shell: bash
         run: |
           # Extract the plugin ZIP to a temporary directory
-          mkdir -p /tmp/plugin-extract
-          unzip -q "${{ steps.deploy.outputs.zip-path }}" -d /tmp/plugin-extract
+          mkdir -p "${{ runner.temp }}/plugin-extract"
+          unzip -q "${{ steps.deploy.outputs.zip-path }}" -d "${{ runner.temp }}/plugin-extract"
           
           # Create a properly structured ZIP for WordPress installation
-          cd /tmp/plugin-extract
-          zip -r -q ../godam.zip .
+          cd "${{ runner.temp }}/plugin-extract"
+          zip -r -q "${{ runner.temp }}/godam.zip" .
           
           # Move the new ZIP to a location where upload-artifact can find it
-          mv /tmp/godam.zip ./godam.zip
+          mv "${{ runner.temp }}/godam.zip" ./godam.zip
 
       - name: Upload Test Artifact
         if: startsWith(github.ref, 'refs/tags/dry') || github.ref == 'refs/heads/develop'

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -37,12 +37,26 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           VERSION: '${{ github.ref_name }}'
 
+      - name: Repack Artifact
+        shell: bash
+        run: |
+          # Extract the plugin ZIP to a temporary directory
+          mkdir -p /tmp/plugin-extract
+          unzip -q "${{ steps.deploy.outputs.zip-path }}" -d /tmp/plugin-extract
+          
+          # Create a properly structured ZIP for WordPress installation
+          cd /tmp/plugin-extract
+          zip -r -q ../godam.zip .
+          
+          # Move the new ZIP to a location where upload-artifact can find it
+          mv /tmp/godam.zip ./godam.zip
+
       - name: Upload Test Artifact
         if: startsWith(github.ref, 'refs/tags/dry') || github.ref == 'refs/heads/develop'
         uses: actions/upload-artifact@v4.6.1
         with:
           name: godam
-          path: '${{ steps.deploy.outputs.zip-path }}'
+          path: './godam.zip'
           compression-level: 0
 
       - name: Upload Release Artifact
@@ -50,7 +64,7 @@ jobs:
         uses: softprops/action-gh-release@v2.2.1
         with:
           files: |
-            ${{ steps.deploy.outputs.zip-path }}
+            './godam.zip'
           token: '${{ github.token }}'
           tag_name: ${{ github.ref_name }}
           draft: true

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -56,8 +56,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.1
         with:
           name: godam
-          path: './godam.zip'
-          compression-level: 0
+          path: '${{ runner.temp }}/plugin-extract/'
 
       - name: Upload Release Artifact
         if: startsWith(github.ref, 'refs/tags/dry') == false && github.ref != 'refs/heads/develop'


### PR DESCRIPTION
This pull request updates the release workflow to ensure the plugin ZIP artifact is properly structured for WordPress installation before being uploaded or released. The main change is the introduction of a repacking step to re-zip the plugin files, and updating the upload steps to use the new ZIP file.

**Artifact packaging improvements:**

* Added a "Repack Artifact" step to extract the original plugin ZIP, repackage its contents into a new ZIP (`godam.zip`), and make it available for subsequent upload steps.

**Artifact upload adjustments:**

* Updated both the "Upload Test Artifact" and "Upload Release Artifact" steps to use the new `godam.zip` file instead of the original ZIP path, ensuring the uploaded artifact is correctly structured for WordPress installation.