### PR TITLE
fix: Avoid re-initializing the video

### DIFF
--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -70,6 +70,12 @@ export default class PlayerManager {
 	 * @param {HTMLElement} video - Video element to initialize
 	 */
 	initializeVideo( video ) {
+		// Skip if already initialized (prevents re-init by external observers)
+		if ( video.dataset.godamInitialized === '1' ) {
+			return;
+		}
+		video.dataset.godamInitialized = '1';
+
 		const playerInstance = new VideoPlayer( video, this.isDisplayingLayers );
 		playerInstance.initialize();
 	}


### PR DESCRIPTION
Issue: https://github.com/rtCamp/godam/issues/1140

## Overview
This pull request adds a safeguard to prevent the video player from being initialized multiple times on the same video element. This helps avoid potential bugs caused by duplicate initialization.

- Video Initialization Improvement:
  * In `playerManager.js`, the `initializeVideo` method now checks for a `godamInitialized` data attribute on the video element and skips initialization if it has already been set. This prevents re-initialization by external observers.


## Recording


https://github.com/user-attachments/assets/0df815d7-b50b-47d9-a5e8-70b588ff89f3

