### PR TITLE
Fix/recorder x rtmedia conflict

### DIFF
--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -64,7 +64,12 @@ export default class GodamVideoPlayer {
 	 * Initialize VideoJS player
 	 */
 	initializePlayer() {
-		this.player = videojs( this.video, this.configManager.videoSetupControls );
+		const _player = videojs.getPlayer( this.video );
+		if ( ! _player ) {
+			this.player = videojs( this.video, this.configManager.videoSetupControls );
+		} else {
+			this.player = _player;
+		}
 
 		// Initialize ads manager
 		this.adsManager = new AdsManager( this.player, this.configManager );


### PR DESCRIPTION
This pull request updates the player initialization logic in the `GodamVideoPlayer` class to prevent redundant potential side effects of calling videojs(). Now, it first checks if a player already exists for the video element and reuses it if available.

VideoJS player initialization improvement:

* [`assets/src/js/godam-player/videoPlayer.js`](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398R67-R72): Modified the `initializePlayer` method to use `videojs.getPlayer(this.video)` to check for an existing player before creating a new one, ensuring that only one player instance is associated with each video element.