### PR TITLE
Fix videojs console errors

### DIFF
--- a/assets/src/js/godam-player/managers/configurationManager.js
+++ b/assets/src/js/godam-player/managers/configurationManager.js
@@ -19,6 +19,43 @@ export default class ConfigurationManager {
 		this.initialize();
 	}
 
+	rearrangeVideoSources( sources ) {
+		// Check if safari browser or iOS device
+		const isIOS = /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream;
+		const isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent );
+
+		// Check if .mpd source exists
+		const mpdUrl = sources.find( ( source ) => source.type === 'application/dash+xml' );
+		const m3u8Url = sources.find( ( source ) => source.type === 'application/x-mpegURL' );
+		const normalUrl = sources.find( ( source ) => source.type !== 'application/x-mpegURL' && source.type !== 'application/dash+xml' );
+
+		const newSources = [];
+
+		if ( isIOS || isSafari ) {
+			if ( m3u8Url ) {
+				newSources.push( m3u8Url );
+			}
+			if ( mpdUrl ) {
+				newSources.push( mpdUrl );
+			}
+			if ( normalUrl ) {
+				newSources.push( normalUrl );
+			}
+		} else {
+			if ( mpdUrl ) {
+				newSources.push( mpdUrl );
+			}
+			if ( m3u8Url ) {
+				newSources.push( m3u8Url );
+			}
+			if ( normalUrl ) {
+				newSources.push( normalUrl );
+			}
+		}
+
+		return newSources;
+	}
+
 	/**
 	 * Initialize configuration
 	 */
@@ -27,8 +64,13 @@ export default class ConfigurationManager {
 		this.adTagUrl = this.video.dataset.ad_tag_url;
 		this.videoSetupOptions = parseDataAttribute( this.video, 'options', {} );
 		const videoSetupControls = parseDataAttribute( this.video, 'controls', this.getDefaultControls() );
+
+		// Get mpd, m3
+		const sources = this.rearrangeVideoSources( videoSetupControls.sources || [] );
+
 		this.videoSetupControls = {
 			...videoSetupControls,
+			sources,
 			html5: {
 				vhs: {
 					bandwidth: 14_000_000, // Pretend network can do ~14 Mbps at startup

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -395,16 +395,6 @@ if ( ! empty( $transcript_path ) ) {
 					data-hover-select="<?php echo esc_attr( $hover_select ); ?>"
 				>
 					<?php
-					foreach ( $sources as $source ) :
-						if ( ! empty( $source['src'] ) && ! empty( $source['type'] ) ) :
-							?>
-							<source
-								src="<?php echo esc_url( $source['src'] ); ?>"
-								type="<?php echo esc_attr( $source['type'] ); ?>"
-							/>
-							<?php
-						endif;
-					endforeach;
 
 					$display_caption = ( ! isset( $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) ) ||
 						( isset( $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) && $easydam_meta_data['videoConfig']['controlBar']['subsCapsButton'] );


### PR DESCRIPTION
This pull request introduces a new method for prioritizing video sources based on the user's browser and device, specifically optimizing playback for Safari and iOS users. The main change is the addition of logic to rearrange the order of video sources so that the most compatible format is selected first, enhancing the user experience and reducing playback issues.

**Video source prioritization improvements:**

* Added a new method `rearrangeVideoSources` to `ConfigurationManager` that detects Safari and iOS browsers and orders video sources (`.m3u8`, `.mpd`, and normal formats) to prioritize compatibility for those platforms.
* Updated the initialization logic in `ConfigurationManager` to use the rearranged video sources when setting up video controls, ensuring the preferred formats are used during playback setup.

**Template cleanup:**

* Removed redundant video source rendering logic from `godam-player.php`, likely because source selection is now handled by the new client-side logic.


## Related issue:
https://github.com/rtCamp/godam/issues/1119#issuecomment-3327474834