### PR TITLE
fix: Correct path for moving and uploading the plugin ZIP artifact

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -48,8 +48,8 @@ jobs:
           cd "${{ runner.temp }}/plugin-extract"
           zip -r -q "${{ runner.temp }}/godam.zip" .
           
-          # Move the new ZIP to a location where upload-artifact can find it
-          mv "${{ runner.temp }}/godam.zip" ./godam.zip
+          # Move the new ZIP to the workspace root for release upload
+          mv "${{ runner.temp }}/godam.zip" "${{ github.workspace }}/godam.zip"
 
       - name: Upload Test Artifact
         if: startsWith(github.ref, 'refs/tags/dry') || github.ref == 'refs/heads/develop'
@@ -63,7 +63,7 @@ jobs:
         uses: softprops/action-gh-release@v2.2.1
         with:
           files: |
-            './godam.zip'
+            '${{ github.workspace }}/godam.zip'
           token: '${{ github.token }}'
           tag_name: ${{ github.ref_name }}
           draft: true


### PR DESCRIPTION
This pull request updates the release workflow configuration to ensure that the ZIP artifact is correctly moved and referenced for release uploads. The changes improve compatibility with GitHub Actions by using the workspace root for artifact storage and referencing.

**Release workflow improvements:**

* Changed the destination of the ZIP file in the release workflow from the current directory to the workspace root (`${{ github.workspace }}`) to ensure proper access for release upload steps.
* Updated the file path in the release step to reference the ZIP file in the workspace root instead of the current directory.