### PR TITLE
FIX: Make quality selector work consistently

### DIFF
--- a/assets/src/js/godam-player/managers/eventsManager.js
+++ b/assets/src/js/godam-player/managers/eventsManager.js
@@ -208,4 +208,24 @@ export default class EventsManager {
 			this.player.one( 'play', hideOnFirstPlay );
 		}
 	}
+
+	/**
+	 * Initialize quality button on metadata load
+	 *
+	 * @param {Function} callback The callback to execute when quality levels are available.
+	 */
+	onQualityLevelsAvailable( callback ) {
+		// Run callback when metadata is loaded.
+		this.player.one( 'loadedmetadata', callback );
+
+		// Listen for HLS playlist load, run callback when that happens.
+		if ( this.player.tech_ && this.player.tech_.hls ) {
+			this.player.tech_.hls.one( 'loadedplaylist', callback );
+		}
+
+		// Listen for quality levels being added, run callback when that happens.
+		if ( this.player.qualityLevels ) {
+			this.player.qualityLevels().one( 'addqualitylevel', callback );
+		}
+	}
 }

--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -96,6 +96,7 @@ export default class GodamVideoPlayer {
 			this.setupCaptionsButton();
 			this.player.jobId = this.video.dataset.job_id;
 			this.initializeChapters();
+			this.setupQualitySelector();
 
 			// Now that managers are initialized, we can safely access them
 			this.setupEventListeners();
@@ -206,5 +207,53 @@ export default class GodamVideoPlayer {
 
 		// Handle hotspot layers
 		this.layersManager.handleHotspotLayersTimeUpdate( currentTime );
+	}
+
+	/**
+	 * If quality selector button is not present, render it.
+	 */
+	renderQualitySelectorButton() {
+		if ( this.player.qualityLevels && this.player.qualityLevels().length > 0 ) {
+			// Avoid adding the button multiple times.
+			if ( typeof this.player.hlsQualitySelector === 'function' ) {
+				this.player.hlsQualitySelector();
+			} else if ( typeof this.player.qualityMenuButton === 'function' ) {
+				this.player.qualityMenuButton();
+			}
+
+			// Refresh control bar.
+			this.player.controlBar.show();
+			if ( this.player.qualityLevels ) {
+				this.player.qualityLevels().trigger( 'change' );
+			}
+		}
+	}
+
+	/**
+	 * Setup quality selector button in control bar.
+	 */
+	setupQualitySelector() {
+		// Force load. Required.
+		if ( this.player.readyState() === 0 ) {
+			this.player.load();
+		}
+
+		// Try to render immediately.
+		this.renderQualitySelectorButton();
+
+		/**
+		 * Check if quality button is already present.
+		 * If not, wait for quality levels to be available and then render it.
+		 */
+		if ( ! this.hasQualitySelectorButton() ) {
+			this.eventsManager.onQualityLevelsAvailable( () => this.renderQualitySelectorButton() );
+		}
+	}
+
+	/**
+	 * Check if quality button has been created
+	 */
+	hasQualitySelectorButton() {
+		return !! ( this.player.controlBar.getChild( 'QualityMenuButton' ) || this.player.controlBar.getChild( 'SettingsButton' ) );
 	}
 }


### PR DESCRIPTION
## Summary
Quality selector on transcoded video was not working consistently, it would not always show up. Sometimes visible upon hard refresh `Ctrl/Cmd + Shift + R`
It would work with preload set to `none`

### Changes Made
- Upon player loading adding force check to load quality controls.
- If data preloads before player, player will load again to check if quality levels are available and show the selector.

### Screencaptures
Before:

https://github.com/user-attachments/assets/d6cdf393-28ad-4ebb-a3be-0857ca45ada3

After: 


https://github.com/user-attachments/assets/c3d14d26-dac0-49d4-b9ac-041bda6e0eb3


### Issue
- #1141  