### PR TITLE
Fix: Jetpack Form console error

### DIFF
--- a/assets/src/js/jetpack-form.js
+++ b/assets/src/js/jetpack-form.js
@@ -123,7 +123,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		let newForm = form;
 
-		// If the form doesn't have `is-ajax-form` class, skip form replacement.
+		// If the form doesn't have the is-ajax-form class, skip form replacement.
 		if ( form.classList.contains( 'is-ajax-form' ) ) {
 			// Completely disable Jetpack's original form handling
 			// Remove any existing event listeners by cloning the form

--- a/assets/src/js/jetpack-form.js
+++ b/assets/src/js/jetpack-form.js
@@ -121,10 +121,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			return;
 		}
 
-		// Completely disable Jetpack's original form handling
-		// Remove any existing event listeners by cloning the form
-		const newForm = form.cloneNode( true );
-		form.parentNode.replaceChild( newForm, form );
+		let newForm = form;
+
+		// If the form doesn't have `is-ajax-form` class, skip form replacement.
+		if ( form.classList.contains( 'is-ajax-form' ) ) {
+			// Completely disable Jetpack's original form handling
+			// Remove any existing event listeners by cloning the form
+			newForm = form.cloneNode( true );
+			form.parentNode.replaceChild( newForm, form );
+		}
 
 		// Prevent default form submission with highest priority
 		newForm.addEventListener( 'submit', function( e ) {


### PR DESCRIPTION
Related issue: https://github.com/rtCamp/godam/issues/1174

### Summary
In Jetpack v14.9 and above, the Interactivity API is used to manage forms. When a Jetpack form is used inside a GoDAM video block, console errors related to field registration are thrown. This happens because the entire form is being replaced on the frontend, causing the Interactivity API scripts to initialize twice.

### Changes made
Added a check to replace the from only if the form is using it is using ajax form submission.

### Screenshots
**Before**

<img width="1468" height="814" alt="Screenshot 2025-09-26 at 12 36 37 PM" src="https://github.com/user-attachments/assets/6e031916-486f-430e-8342-0bc54aa82790" />


**After**
<img width="1465" height="728" alt="Screenshot 2025-09-26 at 12 35 06 PM" src="https://github.com/user-attachments/assets/8b5cf4bc-89db-4595-933a-2e3c902bee3d" />
