### PR TITLE
Add HLS, and MPD source in selfhosted Ads mediafiles list

### DIFF
--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -699,3 +699,49 @@ function godam_get_transcript_path( $job_id ) {
 
 	return ! empty( $transcript_path ) ? $transcript_path : false;
 }
+
+/**
+ * Get attachment sources for a given attachment ID.
+ *
+ * This function retrieves the various source URLs for a media attachment,
+ * including the original file URL and any transcoded versions (DASH, HLS).
+ *
+ * @param int $attachment_id The ID of the media attachment.
+ *
+ * @return array An array of source arrays, each containing 'src' and 'type' keys.
+ */
+function rtgodam_get_attachment_sources( $attachment_id ) {
+	$sources = array();
+
+	if ( empty( $attachment_id ) || 0 === intval( $attachment_id ) ) {
+		return $sources;
+	}
+
+	$transcoded_url     = get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true );
+	$hls_transcoded_url = get_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', true );
+	$video_src          = $attachment_id ? wp_get_attachment_url( $attachment_id ) : '';
+	$video_src_type     = $attachment_id ? get_post_mime_type( $attachment_id ) : '';
+
+	if ( ! empty( $hls_transcoded_url ) ) {
+		$sources[] = array(
+			'src'  => $hls_transcoded_url,
+			'type' => 'application/x-mpegURL',
+		);
+	}
+
+	if ( ! empty( $transcoded_url ) ) {
+		$sources[] = array(
+			'src'  => $transcoded_url,
+			'type' => 'application/dash+xml',
+		);
+	}
+
+	if ( ! empty( $video_src ) ) {
+		$sources[] = array(
+			'src'  => $video_src,
+			'type' => 'video/quicktime' === $video_src_type ? 'video/mp4' : $video_src_type,
+		);
+	}
+
+	return $sources;
+}

--- a/pages/video-editor/components/ads/CustomAdSettings.js
+++ b/pages/video-editor/components/ads/CustomAdSettings.js
@@ -46,6 +46,13 @@ const CustomAdSettings = ( { layerID } ) => {
 					value: attachment.url,
 				} ),
 			);
+			dispatch(
+				updateLayerField( {
+					id: layerID,
+					field: 'attachment_id',
+					value: attachment.id,
+				} ),
+			);
 		} );
 
 		fileFrame.open();


### PR DESCRIPTION
This pull request introduces support for attaching media files to ads and improves how ad media sources are handled and rendered. The main changes include adding a helper function to retrieve all relevant media sources for an attachment, updating the REST API to accept and process an `attachment_id`, and enhancing the ad tag XML output to support multiple media types (such as HLS and DASH). Additionally, the video editor UI now correctly updates the ad layer with the selected attachment's ID.

**Backend improvements for ad media sources:**

* Added the `rtgodam_get_attachment_sources` helper function in `custom-functions.php` to retrieve all available media sources (original, HLS, DASH) for a given attachment ID.
* Updated `get_ad_tag_url` in `class-ads.php` to accept an `attachment_id` parameter, use the helper to fetch sources, and render multiple `<MediaFile>` entries in the VAST XML output, supporting progressive and streaming delivery types. [[1]](diffhunk://#diff-1d33d4cc16f7397da6af04ea45164fd91f47b396996cb15d0458f2704d26043bR105-R116) [[2]](diffhunk://#diff-1d33d4cc16f7397da6af04ea45164fd91f47b396996cb15d0458f2704d26043bL127-R150)

**REST API and data flow enhancements:**

* Modified ad layer processing in `class-ads.php` to handle and pass `attachment_id` through REST API requests and ad tag URL generation. [[1]](diffhunk://#diff-1d33d4cc16f7397da6af04ea45164fd91f47b396996cb15d0458f2704d26043bR261) [[2]](diffhunk://#diff-1d33d4cc16f7397da6af04ea45164fd91f47b396996cb15d0458f2704d26043bR272)

**Frontend integration:**

* Updated the video editor UI in `CustomAdSettings.js` to dispatch an update for the ad layer's `attachment_id` when a media file is selected, ensuring the backend receives the correct attachment reference.