### PR TITLE
feat: Add GTM Tracking feature for analytics

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -7,6 +7,7 @@ import { Analytics } from 'analytics';
  * Internal dependencies
  */
 import videoAnalyticsPlugin from './video-analytics-plugin';
+import GTMVideoTracker from './gtm-video-tracker';
 
 const analytics = Analytics( {
 	app: 'analytics-cdp-plugin',
@@ -163,6 +164,13 @@ function playerAnalytics() {
 	videos.forEach( ( video ) => {
 		// read the data-setup attribute.
 		const player = videojs.getPlayer( video ) || videojs( video );
+
+		// Initialize GTM tracker for this video
+		if ( typeof window.dataLayer !== 'undefined' && window.godamSettings?.enableGTMTracking ) {
+			const gtmTracker = new GTMVideoTracker( player, video );
+			// Store tracker reference for potential cleanup
+			video.gtmTracker = gtmTracker;
+		}
 
 		window.addEventListener( 'beforeunload', () => {
 			const played = player.played();

--- a/assets/src/js/godam-player/gtm-video-tracker.js
+++ b/assets/src/js/godam-player/gtm-video-tracker.js
@@ -1,0 +1,237 @@
+/**
+ * GTM Video Analytics Tracker
+ * Tracks video progress and sends dataLayer events for GTM
+ *
+ * @package
+ * @since 1.0.0
+ */
+
+/**
+ * GTM Video Tracker Class
+ * Handles video progress tracking and GTM dataLayer events
+ */
+class GTMVideoTracker {
+	constructor( player, videoElement ) {
+		this.player = player;
+		this.videoElement = videoElement;
+		this.videoId = videoElement.getAttribute( 'data-id' );
+		this.trackingInterval = null;
+		this.trackedProgress = new Set(); // Track which progress milestones have been sent
+		this.isTracking = false;
+		this.lastPlayedDuration = 0;
+
+		// Initialize tracking
+		this.init();
+	}
+
+	/**
+	 * Initialize the tracker
+	 */
+	init() {
+		// Wait for player to be ready
+		this.player.ready( () => {
+			this.setupEventListeners();
+		} );
+	}
+
+	/**
+	 * Setup VideoJS event listeners
+	 */
+	setupEventListeners() {
+		// Start tracking when video starts playing
+		this.player.on( 'play', () => {
+			if ( ! this.trackedProgress.has( 0 ) ) {
+				this.sendGTMEvent( 'video_start', 0 );
+				this.trackedProgress.add( 0 );
+			}
+			this.startTracking();
+		} );
+
+		// Stop tracking when video pauses
+		this.player.on( 'pause', () => {
+			this.stopTracking();
+		} );
+
+		// Stop tracking when video ends
+		this.player.on( 'ended', () => {
+			const progressPercentage = this.calculatePlayedPercentage();
+			if ( progressPercentage >= 99 && ! this.trackedProgress.has( 100 ) ) {
+				this.sendGTMEvent( 'video_complete', 100 );
+				this.trackedProgress.add( 100 );
+			}
+			this.stopTracking();
+		} );
+
+		// Stop tracking when video is seeking
+		this.player.on( 'seeking', () => {
+			this.stopTracking();
+		} );
+
+		// Resume tracking after seeking
+		this.player.on( 'seeked', () => {
+			if ( ! this.player.paused() ) {
+				this.startTracking();
+			}
+		} );
+
+		// Clean up on disposal
+		this.player.on( 'dispose', () => {
+			this.stopTracking();
+		} );
+	}
+
+	/**
+	 * Start progress tracking
+	 */
+	startTracking() {
+		if ( this.isTracking ) {
+			return;
+		}
+
+		this.isTracking = true;
+
+		// Check progress every 2.5 seconds
+		this.trackingInterval = setInterval( () => {
+			this.checkProgress();
+		}, 2500 );
+	}
+
+	/**
+	 * Stop progress tracking
+	 */
+	stopTracking() {
+		if ( this.trackingInterval ) {
+			clearInterval( this.trackingInterval );
+			this.trackingInterval = null;
+		}
+		this.isTracking = false;
+	}
+
+	/**
+	 * Check video progress and send milestone events
+	 */
+	checkProgress() {
+		const progressPercentage = this.calculatePlayedPercentage();
+
+		// Check for progress milestones
+		if ( progressPercentage >= 25 && ! this.trackedProgress.has( 25 ) ) {
+			this.trackedProgress.add( 25 );
+			this.sendGTMEvent( 'video_progress', 25 );
+		}
+
+		if ( progressPercentage >= 50 && ! this.trackedProgress.has( 50 ) ) {
+			this.trackedProgress.add( 50 );
+			this.sendGTMEvent( 'video_progress', 50 );
+		}
+
+		if ( progressPercentage >= 75 && ! this.trackedProgress.has( 75 ) ) {
+			this.trackedProgress.add( 75 );
+			this.sendGTMEvent( 'video_progress', 75 );
+		}
+
+		if ( progressPercentage >= 99 && ! this.trackedProgress.has( 100 ) ) {
+			this.trackedProgress.add( 100 );
+			this.sendGTMEvent( 'video_complete', 100 );
+		}
+	}
+
+	/**
+	 * Calculate the percentage of video that has been played
+	 * Uses player.played() ranges to get accurate played duration
+	 *
+	 * @return {number} Percentage of video played (0-100)
+	 */
+	calculatePlayedPercentage() {
+		try {
+			const played = this.player.played();
+			const totalDuration = this.player.duration();
+
+			if ( ! played || ! totalDuration || totalDuration === 0 ) {
+				return 0;
+			}
+
+			let totalPlayedDuration = 0;
+
+			// Sum up all played ranges
+			for ( let i = 0; i < played.length; i++ ) {
+				const startTime = played.start( i );
+				const endTime = played.end( i );
+				totalPlayedDuration += ( endTime - startTime );
+			}
+
+			// Calculate percentage
+			const percentage = ( totalPlayedDuration / totalDuration ) * 100;
+			return Math.min( Math.round( percentage ), 100 ); // Cap at 100%
+		} catch ( error ) {
+			return 0;
+		}
+	}
+
+	/**
+	 * Send GTM dataLayer event
+	 *
+	 * @param {string} eventName          - Name of the event
+	 * @param {number} progressPercentage - Progress percentage
+	 */
+	sendGTMEvent( eventName, progressPercentage ) {
+		try {
+			// Ensure dataLayer exists
+			if ( typeof window.dataLayer === 'undefined' ) {
+				window.dataLayer = [];
+			}
+
+			const eventData = {
+				event: eventName,
+				video_id: this.videoId ? parseInt( this.videoId, 10 ) : null,
+				video_url: this.player.currentSrc() || '',
+				video_title: this.videoElement.getAttribute( 'data-video-title' ) || '',
+				video_duration: this.player.duration() || 0,
+				video_progress_percentage: progressPercentage,
+				video_current_time: this.player.currentTime() || 0,
+				page_url: window.location.href,
+				page_title: document.title,
+				timestamp: new Date().toISOString(),
+			};
+
+			// Push to dataLayer
+			window.dataLayer.push( eventData );
+		} catch {
+			// Error is silently ignored, not console logged.
+		}
+	}
+
+	/**
+	 * Reset tracking state (useful for video restarts)
+	 */
+	reset() {
+		this.trackedProgress.clear();
+		this.lastPlayedDuration = 0;
+		this.stopTracking();
+	}
+
+	/**
+	 * Get current tracking status
+	 *
+	 * @return {boolean} Whether tracking is currently active
+	 */
+	isCurrentlyTracking() {
+		return this.isTracking;
+	}
+
+	/**
+	 * Get tracked progress milestones
+	 *
+	 * @return {Set} Set of tracked progress percentages
+	 */
+	getTrackedProgress() {
+		return new Set( this.trackedProgress );
+	}
+}
+
+// Export for use in other modules
+export default GTMVideoTracker;
+
+// Also make available globally for backward compatibility
+if ( typeof window !== 'undefined' ) {
+	window.GTMVideoTracker = GTMVideoTracker;
+}

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -320,13 +320,15 @@ class Assets {
 	private function enqueue_godam_settings() {
 		$godam_settings = get_option( 'rtgodam-settings' );
 
-		$brand_image = $godam_settings['video_player']['brand_image'] ?? '';
-		$brand_color = $godam_settings['video_player']['brand_color'] ?? '';
+		$brand_image         = $godam_settings['video_player']['brand_image'] ?? '';
+		$brand_color         = $godam_settings['video_player']['brand_color'] ?? '';
+		$enable_gtm_tracking = $godam_settings['general']['enable_gtm_tracking'] ?? false;
 
 		$godam_settings_obj = array(
-			'brandImage' => $brand_image,
-			'brandColor' => $brand_color,
-			'apiBase'    => RTGODAM_API_BASE,
+			'brandImage'        => $brand_image,
+			'brandColor'        => $brand_color,
+			'apiBase'           => RTGODAM_API_BASE,
+			'enableGTMTracking' => $enable_gtm_tracking,
 		);
 
 		if ( ! rtgodam_is_api_key_valid() ) {

--- a/inc/classes/rest-api/class-settings.php
+++ b/inc/classes/rest-api/class-settings.php
@@ -46,6 +46,7 @@ class Settings extends Base {
 			),
 			'general'      => array(
 				'enable_folder_organization' => true,
+				'enable_gtm_tracking'        => false,
 			),
 			'video_player' => array(
 				'brand_image'    => '',
@@ -302,6 +303,7 @@ class Settings extends Base {
 			),
 			'general'      => array(
 				'enable_folder_organization' => rest_sanitize_boolean( $settings['general']['enable_folder_organization'] ?? $default['general']['enable_folder_organization'] ),
+				'enable_gtm_tracking'        => rest_sanitize_boolean( $settings['general']['enable_gtm_tracking'] ?? $default['general']['enable_gtm_tracking'] ),
 			),
 			'video_player' => array(
 				'brand_image'    => sanitize_text_field( $settings['video_player']['brand_image'] ?? $default['video_player']['brand_image'] ),

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -353,6 +353,17 @@ if ( ! empty( $transcript_path ) ) {
 	);
 }
 
+$attachment_title = '';
+
+if ( ! empty( $attachment_id ) && is_numeric( $attachment_id ) ) {
+	$attachment_title = get_the_title( $attachment_id );
+} elseif ( ! empty( $original_id ) && is_numeric( $original_id ) ) {
+	$attachment_title = get_the_title( $original_id );
+}
+// Use the filename as the title.
+if ( empty( $attachment_title ) ) {
+	$attachment_title = basename( get_attached_file( $attachment_id ) );
+}
 
 ?>
 
@@ -393,6 +404,7 @@ if ( ! empty( $transcript_path ) ) {
 					data-job_id="<?php echo esc_attr( $job_id ); ?>"
 					data-global_ads_settings="<?php echo esc_attr( $ads_settings ); ?>"
 					data-hover-select="<?php echo esc_attr( $hover_select ); ?>"
+					data-video-title="<?php echo esc_attr( $attachment_title ); ?>"
 				>
 					<?php
 

--- a/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
@@ -100,6 +100,15 @@ const GeneralSettings = () => {
 						onChange={ ( value ) => handleSettingChange( 'enable_folder_organization', value ) }
 					/>
 
+					<ToggleControl
+						__nextHasNoMarginBottom
+						className="godam-toggle godam-margin-bottom"
+						label={ __( 'Enable GTM Tracking', 'godam' ) }
+						help={ __( 'Enable Google Tag Manager video tracking for analytics and conversion tracking.', 'godam' ) }
+						checked={ mediaSettings?.general?.enable_gtm_tracking }
+						onChange={ ( value ) => handleSettingChange( 'enable_gtm_tracking', value ) }
+					/>
+
 				</PanelBody>
 			</Panel>
 

--- a/pages/godam/redux/slice/media-settings.js
+++ b/pages/godam/redux/slice/media-settings.js
@@ -27,6 +27,7 @@ const initialState = {
 	},
 	general: {
 		enable_folder_organization: true,
+		enable_gtm_tracking: false,
 	},
 	video_player: {
 		brand_image: '',


### PR DESCRIPTION
This pull request adds support for Google Tag Manager (GTM) video tracking to the Godam video player. It introduces a new `GTMVideoTracker` class that tracks video progress and sends analytics events to GTM via the `dataLayer`. The feature is configurable via a new setting in both the backend and frontend, and video titles are now passed to the player for improved event data.

**GTM Video Tracking Integration**

* Added a new `GTMVideoTracker` class (`gtm-video-tracker.js`) that listens to video player events, tracks progress milestones (start, 25%, 50%, 75%, complete), and pushes structured events to the GTM `dataLayer`.
* Updated `analytics.js` to initialize `GTMVideoTracker` for each video when GTM tracking is enabled in settings and `dataLayer` is available. [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR10) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR168-R174)

**Settings and Configuration**

* Introduced a new `enable_gtm_tracking` setting in backend defaults and sanitization logic, and exposed it to the frontend via the `godamSettings` object. [[1]](diffhunk://#diff-53b2ebd47ae78063d191af5a38b72dcee08982e0803759099aedbe794c85c3fcR49) [[2]](diffhunk://#diff-53b2ebd47ae78063d191af5a38b72dcee08982e0803759099aedbe794c85c3fcR306) [[3]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dR325-R331)
* Added a toggle control for "Enable GTM Tracking" in the general settings panel of the media settings UI.
* Updated Redux initial state to include the new `enable_gtm_tracking` flag.

**Player Data Improvements**

* Ensured that the video player's DOM element includes a `data-video-title` attribute with the attachment's title or filename, allowing GTM events to include descriptive video titles. [[1]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aR356-R366) [[2]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aR407)