### PR TITLE
Bug: Adds WPForms hidden fields

### DIFF
--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -251,6 +251,13 @@ document.addEventListener( 'click', async function( e ) {
 
 					if ( data.status === 'success' && data.html ) {
 						dispatch( engagementStore ).addVideoMarkUp( newVideoId, data.html );
+
+						/* global wpforms */
+						// This ensures that any dynamically added forms or fields are properly bound
+						// to validation, AJAX submission, and other WPForms frontend features.
+						if ( wpforms && wpforms.init ) {
+							wpforms.init();
+						}
 					}
 				}
 


### PR DESCRIPTION
## PR Description

- Currently, WPForms relies on `is_user_logged_in()` and global post context to generate nonce and post ID fields.  
- When forms are rendered via a REST API request (i.e., inside a our custom shortcode), these values are missing, causing security errors and broken AJAX submissions.

This PR adds a function `wpforms_hidden_fields` that:

- Generates a hidden nonce field (`wpforms[nonce]`) for frontend validation.
- Sets `wpforms[post_id]` based on the current post or fallback to the referring page.
- Adds the `action` hidden field for proper AJAX handling.
- Safely initializes WPForms frontend scripts for dynamic forms.

### Steps to QA
- Add a layer of WPForms in a video from GoDam Video Editor.
- Require this video inside the GoDam Video Gallery.
- Enable `Load Assets Globally` option in settings of WPForms ( As javascript and CSS for layers in Gallery Block are not Enqueued, [REF)](https://github.com/rtCamp/godam/issues/1017)
- Add Godam Video Gallery block in a page and submit the form. 
<img width="1088" height="109" alt="Screenshot 2025-09-30 at 3 28 54 PM" src="https://github.com/user-attachments/assets/144455d5-a9be-4c8c-b79f-350c24b60d3e" />

## Screenshot

https://github.com/user-attachments/assets/1babc721-7012-4411-ae78-4e312e2#1155 


Resolves Issue #1155
