### PR TITLE
Fix/godam player script size

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import videojs from 'video.js';
 import { Analytics } from 'analytics';
 /**
  * Internal dependencies
@@ -33,7 +32,7 @@ window.analytics = analytics;
 			return el.player;
 		}
 		try {
-			return videojs.getPlayer( el );
+			return videojs.getPlayer( el ); // eslint-disable-line no-undef -- variable is defined globally
 		} catch ( e ) {
 			return null;
 		}
@@ -162,7 +161,7 @@ function playerAnalytics() {
 
 	videos.forEach( ( video ) => {
 		// read the data-setup attribute.
-		const player = videojs.getPlayer( video ) || videojs( video );
+		const player = videojs.getPlayer( video ) || videojs( video ); // eslint-disable-line no-undef -- variable is defined globally
 
 		window.addEventListener( 'beforeunload', () => {
 			const played = player.played();

--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -15,8 +15,15 @@ import 'videojs-flvjs-es6';
 /**
  * FontAwesome dependencies
  */
-import { library, dom } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
+
+async function loadHotspotIcons() {
+	const { library, dom } = await import( '@fortawesome/fontawesome-svg-core' );
+	const { fas } = await import( '@fortawesome/free-solid-svg-icons' );
+	library.add( fas );
+	dom.watch();
+}
+
+loadHotspotIcons();
 
 /**
  * Quill dependencies dependencies for the CTA text layer
@@ -27,9 +34,6 @@ import 'quill/dist/quill.snow.css';
  * Internal dependencies
  */
 import PlayerManager from './managers/playerManager.js';
-
-library.add( fas );
-dom.watch();
 
 /**
  * Initialize player on DOM content loaded

--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -12,6 +12,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * VideoJs dependencies
  */
 import videojs from 'video.js';
+window.videojs = videojs; // Make videojs globally accessible.
 
 /**
  * Internal dependencies

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -177,7 +177,10 @@ class Assets {
 			'https://imasdk.googleapis.com/js/sdkloader/ima3.js', // It is required to load the IMA SDK from the Google CDN, else it will show console error.
 			array(),
 			RTGODAM_VERSION,
-			true
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
 		);
 	}
 


### PR DESCRIPTION
This pull request introduces improvements to how dependencies are loaded and managed for the Godam Player, with a focus on optimizing icon loading, ensuring global access to the `videojs` library, and refining script loading strategies. These changes enhance performance.

**Dependency loading optimization:**

* Changed FontAwesome imports in `frontend.js` to use asynchronous dynamic imports via the new `loadHotspotIcons` function, improving load performance and avoiding possible race conditions.
* Removed redundant direct FontAwesome setup calls (`library.add(fas)` and `dom.watch()`) from the main execution flow in `frontend.js`, as these are now handled asynchronously.

**Global accessibility and code clarity:**

* Made `videojs` globally accessible by assigning it to `window.videojs` in `playerManager.js`, ensuring compatibility with scripts that expect `videojs` to be defined globally.
* Remove redundant videojs script import from analytics.js to reduce the final build file.

**Script loading strategy:**
* Changed the loading strategy for the IMA SDK in `class-assets.php` to use the `defer` attribute and ensure it loads in the footer, improving page load performance and avoiding blocking the main thread.