### PR TITLE
Enqueue the player skin styles conditionally

### DIFF
--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -165,7 +165,7 @@
 	},
 	"usesContext": [ "queryId" ],
 	"editorStyle": [ "file:./index.css", "godam-player-frontend-style" ],
-	"style": [ "godam-player-style", "godam-player-frontend-style", "godam-player-minimal-skin", "godam-player-pills-skin", "godam-player-bubble-skin", "godam-player-classic-skin" ],
+	"style": [ "godam-player-style", "godam-player-frontend-style" ],
 	"editorScript": [ "file:./index.js" ],
 	"viewScript": [ "godam-player-frontend-script", "godam-player-analytics-script" ],
 	"render": "file:./render.php"

--- a/assets/src/blocks/godam-player/render.php
+++ b/assets/src/blocks/godam-player/render.php
@@ -28,6 +28,20 @@ if ( $post && $post instanceof WP_Post ) {
 	}
 }
 
+// Conditionally enqueue skin styles based on settings (same as shortcode).
+$godam_settings = get_option( 'rtgodam-settings', array() );
+$selected_skin  = $godam_settings['video_player']['player_skin'] ?? '';
+
+if ( 'Minimal' === $selected_skin ) {
+	wp_enqueue_style( 'godam-player-minimal-skin' );
+} elseif ( 'Pills' === $selected_skin ) {
+	wp_enqueue_style( 'godam-player-pills-skin' );
+} elseif ( 'Bubble' === $selected_skin ) {
+	wp_enqueue_style( 'godam-player-bubble-skin' );
+} elseif ( 'Classic' === $selected_skin ) {
+	wp_enqueue_style( 'godam-player-classic-skin' );
+}
+
 // Get the inner blocks content.
 $inner_blocks_content = '';
 if ( ! empty( $block->inner_blocks ) ) {


### PR DESCRIPTION
This pull request updates how player skin styles are loaded for the `godam-player` block. Instead of including all skin styles by default, styles are now conditionally enqueued based on the selected skin in the plugin settings, improving efficiency and customization.

**Theme: Block configuration and style loading**

* Removed all skin styles from the default `style` array in `block.json`, so only the base styles are loaded by default.
* Added logic in `render.php` to enqueue the correct skin style based on the `player_skin` setting, matching the behavior of the shortcode implementation.