### PR TITLE
Add folder name in folder info attachment details

### DIFF
--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -132,6 +132,23 @@ export default AttachmentDetailsTwoColumn?.extend( {
 	},
 
 	/**
+	 * Render media folder item name when image is selected in media library.
+	 */
+	renderFolderName() {
+		if ( ! this.model.get( 'id' ) ) {
+			return;
+		}
+
+		const data = this.model.get( 'media_folder' );
+
+		if ( ! data || ! data.name ) {
+			return;
+		}
+
+		this.$el.find( '.details' ).append( DOMPurify.sanitize( `<div class="media-folder-name"><strong>${ __( 'Media Folder:', 'godam' ) }</strong> ${ data.name }</div>` ) );
+	},
+
+	/**
 	 * Sets up click handlers for removing custom video thumbnails.
 	 */
 	setupThumbnailActions() {
@@ -666,6 +683,7 @@ export default AttachmentDetailsTwoColumn?.extend( {
 				this.getExifDetails( attachmentId ),
 				this.renderExifDetails,
 			);
+			this.renderFolderName();
 		}
 
 		// Return this view.

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -250,6 +250,20 @@ class Media_Library_Ajax {
 			$response['image']['src'] = $response['icon'];
 		}
 
+		// Get and show the media folder term.
+		$terms = get_the_terms( $attachment->ID, 'media-folder' );
+
+		if ( ! is_wp_error( $terms ) && ! empty( $terms ) && is_array( $terms ) ) {
+			$term                     = array_shift( $terms );
+			$response['media_folder'] = array(
+				'id'   => $term->term_id,
+				'name' => $term->name,
+				'slug' => $term->slug,
+			);
+		} else {
+			$response['media_folder'] = null;
+		}
+
 		return $response;
 	}
 
@@ -603,7 +617,7 @@ class Media_Library_Ajax {
 	/**
 	 * Replace an existing WordPress media attachment with a file from an external URL,
 	 * using the WordPress Filesystem API.
-	 * 
+	 *
 	 * @since 1.4.2
 	 *
 	 * @param int    $attachment_id The ID of the existing media attachment.


### PR DESCRIPTION
## 🗂️ Add Media Folder Name Display in Attachment Details

ISSUE: https://github.com/rtCamp/godam/issues/1109

### Summary
Displays the folder name in the media library attachment details panel when a media item is selected.

### Changes

- Retrieves folder data from Backbone model using `this.model.get('media_folder')`
- Renders folder name with proper sanitization and internationalization
- Gracefully handles media items without assigned folders
- Integrated into existing video attachment rendering flow