### PR TITLE
Fix/video editor capabilities

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -38,6 +38,18 @@ $media-frame-width: calc(300px + 2 * 24px);
 	width: $media-frame-width;
 }
 
+.godam-page-error {
+	background: #fff;
+    border: 1px solid #ccd0d4;
+    color: #444;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 2em auto;
+    padding: 2em 3em;
+    max-width: 700px;
+    -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+}
+
 @media (max-width: 900px) {
 
 	.media-frame-menu {

--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -40,14 +40,14 @@ $media-frame-width: calc(300px + 2 * 24px);
 
 .godam-page-error {
 	background: #fff;
-    border: 1px solid #ccd0d4;
-    color: #444;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-    margin: 2em auto;
-    padding: 2em 3em;
-    max-width: 700px;
-    -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
-    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+	border: 1px solid #ccd0d4;
+	color: #444;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	margin: 2em auto;
+	padding: 2em 3em;
+	max-width: 700px;
+	-webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
 }
 
 @media (max-width: 900px) {

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -357,14 +357,6 @@ class Pages {
 	 * @return void
 	 */
 	public function render_video_editor_page() {
-		// Check if current user can edit posts.
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			?>
-			<p class="godam-page-error"><?php echo esc_html( __( 'You do not have sufficient permissions to access this page.', 'godam' ) ); ?></p>
-			<?php
-			return;
-		}
-
 		// Check if user can media with given id.
 		$attachment_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -357,7 +357,7 @@ class Pages {
 	 * @return void
 	 */
 	public function render_video_editor_page() {
-		// Check if user can media with given id.
+		// Check if user can edit media with given id.
 		$attachment_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( $attachment_id && ! current_user_can( 'edit_post', $attachment_id ) ) {

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -357,6 +357,24 @@ class Pages {
 	 * @return void
 	 */
 	public function render_video_editor_page() {
+		// Check if current user can edit posts.
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			?>
+			<p class="godam-page-error"><?php echo esc_html( __( 'You do not have sufficient permissions to access this page.', 'godam' ) ); ?></p>
+			<?php
+			return;
+		}
+
+		// Check if user can media with given id.
+		$attachment_id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( $attachment_id && ! current_user_can( 'edit_post', $attachment_id ) ) {
+			?>
+			<p class="godam-page-error"><?php echo esc_html( __( 'Sorry, you are not allowed to edit this item.', 'godam' ) ); ?></p>
+			<?php
+			return;
+		}
+
 		?>
 		<div class="godam-admin-root">
 			<div id="root-video-editor">


### PR DESCRIPTION
This pull request introduces an access control check to the video editor page and improves user feedback for unauthorized access. The main focus is to ensure that only users with the correct permissions can edit media items, and to provide a clear error message when access is denied. Additionally, new styles are added for consistent error message presentation.

Access control and user feedback:

* Added a permission check in the `render_video_editor_page` method of `class-pages.php` to ensure only users with the `edit_post` capability for the given media item can access the editor. If the user lacks permission, an error message is displayed.

## Related issue
- #1210 