### PR TITLE
Add rtgodam_is_local_environment function and restrict the media transcoding for local environment

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -172,7 +172,7 @@ class RTGODAM_Transcoder_Handler {
 	 */
 	public function send_transcoding_request( $attachment_id ) {
 
-		// // Check if local development environment.
+		// Check if local development environment.
 		if ( rtgodam_is_local_environment() ) {
 			return;
 		}

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -171,6 +171,12 @@ class RTGODAM_Transcoder_Handler {
 	 * @param int $attachment_id    ID of attachment.
 	 */
 	public function send_transcoding_request( $attachment_id ) {
+
+		// // Check if local development environment.
+		if ( rtgodam_is_local_environment() ) {
+			return;
+		}
+
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		$mime_type = get_post_mime_type( $attachment_id );

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -172,11 +172,6 @@ class RTGODAM_Transcoder_Handler {
 	 */
 	public function send_transcoding_request( $attachment_id ) {
 
-		// Check if local development environment.
-		if ( rtgodam_is_local_environment() ) {
-			return;
-		}
-
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
 		$mime_type = get_post_mime_type( $attachment_id );
@@ -202,6 +197,10 @@ class RTGODAM_Transcoder_Handler {
 	 * @param bool   $retranscode       If its retranscoding request or not.
 	 */
 	public function wp_media_transcoding( $wp_metadata, $attachment_id, $autoformat = true, $retranscode = false ) {
+		// Check if local development environment.
+		if ( rtgodam_is_local_environment() ) {
+			return;
+		}
 
 		if ( empty( $wp_metadata['mime_type'] ) ) {
 			return $wp_metadata;

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -332,13 +332,6 @@ class RTGODAM_Transcoder_Handler {
 
 			$transcoding_url = $this->transcoding_api_url . 'resource/Transcoder Job' . ( empty( $transcoding_job_id ) ? '' : '/' . $transcoding_job_id );
 
-			// Block if blacklisted ip address.
-			$remote_address_key = 'REMOTE_ADDR';
-			$client_ip          = isset( $_SERVER[ $remote_address_key ] ) ? filter_var( $_SERVER[ $remote_address_key ], FILTER_VALIDATE_IP ) : '';
-			if ( ! empty( $client_ip ) && in_array( $client_ip, rtgodam_get_blacklist_ip_addresses(), true ) ) {
-				return $metadata;
-			}
-
 			$upload_page = wp_remote_request( $transcoding_url, $args );
 
 			if ( ! is_wp_error( $upload_page ) &&

--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -362,20 +362,6 @@ function rtgodam_get_server_var( $server_key, $filter_type = FILTER_SANITIZE_FUL
 }
 
 /**
- * Get local ip addresses for block.
- *
- * @return array
- */
-function rtgodam_get_blacklist_ip_addresses() {
-	// If custom API URL added then don't block local ips.
-	if ( defined( 'RTGODAM_TRANSCODER_API_URL' ) ) {
-		return array();
-	}
-
-	return array( '127.0.0.1', '::1' );
-}
-
-/**
  * Helper function to verify the api key.
  *
  * @param string $api_key The api key to verify.

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -98,6 +98,11 @@ class Media_Library_Ajax {
 	 * @return void
 	 */
 	public function upload_media_to_frappe_backend( $attachment_id ) {
+		// Check if local development environment.
+		if ( rtgodam_is_local_environment() ) {
+			return;
+		}
+
 		// Only if attachment type if image.
 		if ( 'image' !== substr( get_post_mime_type( $attachment_id ), 0, 5 ) ) {
 			return;

--- a/inc/classes/rest-api/class-transcoding.php
+++ b/inc/classes/rest-api/class-transcoding.php
@@ -379,6 +379,25 @@ class Transcoding extends Base {
 
 		$title = get_the_title( $attachment_id );
 
+		// Check if local development environment.
+		if ( rtgodam_is_local_environment() ) {
+			$message = sprintf(
+				// translators: 1: Attachment title, 2: Attachment ID.
+				__( '%1$s (ID %2$d) transcoding request failed. Transcoding requests are not allowed in the localhost environment.', 'godam' ),
+				esc_html( $title ),
+				absint( $attachment_id )
+			);
+
+			return new \WP_REST_Response(
+				array( 
+					'message' => $message,
+					'skipped' => true,
+					'reason'  => 'local_environment',
+				),
+				200
+			);
+		}
+
 		// Check if this is virtual media (fetched from Central).
 		$godam_original_id = get_post_meta( $attachment_id, '_godam_original_id', true );
 		if ( ! empty( $godam_original_id ) ) {

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -712,10 +712,11 @@ function godam_get_transcript_path( $job_id ) {
  * @return bool True if the environment is localhost, false otherwise.
  */
 function rtgodam_is_local_environment() {
+
 	$whitelist = array( '127.0.0.1', '::1', 'localhost' );
 
 	// phpcs:disable -- Disabling phpcs as its not manipulating any data, just reading server variables, and function is used for local environment check only.
-	$server_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$server_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( $_SERVER[ 'REMOTE_ADDR' ], FILTER_VALIDATE_IP ) : '';
 	$host        = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 	// phpcs:enable
 

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -717,7 +717,7 @@ function rtgodam_is_local_environment() {
 	// phpcs:disable -- Disabling phpcs as its not manipulating any data, just reading server variables, and function is used for local environment check only.
 	$server_addr = $_SERVER['REMOTE_ADDR'] ?? '';
 	$host        = $_SERVER['HTTP_HOST'] ?? '';
-	// phpcs:phpcs:enable
+	// phpcs:enable
 
 	$is_localhost = (
 		in_array( $server_addr, $whitelist, true ) ||

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -715,8 +715,8 @@ function rtgodam_is_local_environment() {
 	$whitelist = array( '127.0.0.1', '::1', 'localhost' );
 
 	// phpcs:disable -- Disabling phpcs as its not manipulating any data, just reading server variables, and function is used for local environment check only.
-	$server_addr = $_SERVER['REMOTE_ADDR'] ?? '';
-	$host        = $_SERVER['HTTP_HOST'] ?? '';
+	$server_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$host        = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 	// phpcs:enable
 
 	$is_localhost = (

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -699,3 +699,31 @@ function godam_get_transcript_path( $job_id ) {
 
 	return ! empty( $transcript_path ) ? $transcript_path : false;
 }
+
+/**
+ * Check if the current environment is localhost.
+ * 
+ * This function checks the server's remote address and host to determine if the site is running in a local development environment.
+ * It checks against a whitelist of common localhost IPs and also looks for '.local' or '.test' in the host name.
+ * Additionally, it respects the RTGODAM_IS_LOCAL constant if defined.
+ * 
+ * @since n.e.x.t
+ * 
+ * @return bool True if the environment is localhost, false otherwise.
+ */
+function rtgodam_is_local_environment() {
+	$whitelist = array( '127.0.0.1', '::1', 'localhost' );
+
+	// phpcs:disable -- Disabling phpcs as its not manipulating any data, just reading server variables, and function is used for local environment check only.
+	$server_addr = $_SERVER['REMOTE_ADDR'] ?? '';
+	$host        = $_SERVER['HTTP_HOST'] ?? '';
+	// phpcs:phpcs:enable
+
+	$is_localhost = (
+		in_array( $server_addr, $whitelist, true ) ||
+		strpos( $host, '.local' ) !== false ||
+		strpos( $host, '.test' ) !== false
+	);
+
+	return ( $is_localhost || ( defined( 'RTGODAM_IS_LOCAL' ) && RTGODAM_IS_LOCAL ) );
+}

--- a/pages/tools/components/tabs/RetranscodeTab.jsx
+++ b/pages/tools/components/tabs/RetranscodeTab.jsx
@@ -390,7 +390,7 @@ const RetranscodeTab = () => {
 						( retranscoding || aborted || done ) &&
 						<div className="mb-4">
 							<ProgressBar total={ attachments?.length } done={ mediaCount } />
-							<pre className="w-full h-[120px] max-h-[120px] overflow-y-auto bg-gray-100 p-3 rounded">
+							<pre className="w-full h-[120px] max-h-[120px] overflow-y-auto bg-gray-100 p-3 rounded whitespace-break-spaces">
 								{ logs.map( ( log, index ) => (
 									<div key={ index } className="text-sm text-gray-700">
 										• { log }


### PR DESCRIPTION
The primary change is the introduction of a new helper function to identify local environments, which is then utilized to bypass media upload and transcoding requests when developing locally.

**Local environment detection and conditional logic:**

* Added the new helper function `rtgodam_is_local_environment()` in `inc/helpers/custom-functions.php` to check if the site is running in a local development environment based on IP, host, or a constant.
* Updated `send_transcoding_request()` in `admin/class-rtgodam-transcoder-handler.php` to return early if running locally, preventing unnecessary transcoding requests during development.
* Updated `upload_media_to_frappe_backend()` in `inc/classes/class-media-library-ajax.php` to return early if running locally, preventing media uploads to the backend during development.

Ref: https://rtcamp.slack.com/archives/C09AKDEL47J/p1759401808279099

## Related issue:
- #1216 