### PR TITLE
Fix: Prevent sending transcoding requests for virtual media

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -203,6 +203,15 @@ class RTGODAM_Transcoder_Handler {
 
 		$transcoding_job_id = get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true );
 
+		// Log virtual media status for transcoding requests.
+		$godam_original_id = get_post_meta( $attachment_id, '_godam_original_id', true );
+		$is_virtual_media  = ! empty( $godam_original_id );
+
+		// Skip transcoding for virtual media.
+		if ( $is_virtual_media ) {
+			return $wp_metadata;
+		}
+
 		$path = get_attached_file( $attachment_id );
 		$url  = wp_get_attachment_url( $attachment_id );
 

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1276,8 +1276,19 @@ class Media_Library extends Base {
 			'guid'           => esc_url_raw( $data['url'] ),
 		);
 
+		// Pre-set virtual media marker before insertion so transcoding handler can detect it.
+		$pre_setter = function ( $new_id ) use ( $godam_id ) {
+			// Ensure virtual marker is available for any listeners on add_attachment.
+			update_post_meta( $new_id, '_godam_original_id', $godam_id );
+		};
+		// Set at early priority so it runs before the handler's priority 21.
+		add_action( 'add_attachment', $pre_setter, 1, 1 );
+
 		// Insert the attachment into WordPress.
 		$attach_id = wp_insert_attachment( $attachment, $data['title'] );
+
+		// Remove the temporary setter.
+		remove_action( 'add_attachment', $pre_setter, 1 );
 
 		// If creation fails, return an error response.
 		if ( is_wp_error( $attach_id ) ) {


### PR DESCRIPTION
This pull request introduces logic to properly handle "virtual media" attachments by ensuring they are not sent through the transcoding process. The changes focus on marking virtual media early in the attachment lifecycle and updating the transcoding handler to skip these files.

**Virtual media handling improvements:**

* In `class-media-library.php`, a pre-setter is added to mark attachments as virtual media (`_godam_original_id`) before insertion, ensuring that any listeners (including the transcoding handler) can detect this status. The pre-setter is attached at an early priority and then removed after use.

**Transcoding logic updates:**

* In `class-rtgodam-transcoder-handler.php`, the transcoding handler now checks for the virtual media marker and skips transcoding for such attachments, preventing unnecessary processing.