### PR TITLE
Refactor the GoDAM pages permission for core users roles

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -46,6 +46,7 @@ import VideoSEOModal from './components/VideoSEOModal.js';
 import { appendTimezoneOffsetToUTC, isSEODataEmpty, secondsToISO8601 } from './utils/index.js';
 import './editor.scss';
 import { ReactComponent as icon } from '../../images/godam-video-filled.svg';
+import { canManageAttachment } from '../../js/media-library/utility';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -126,6 +127,7 @@ function VideoEdit( {
 	const [ isSEOModalOpen, setIsSEOModelOpen ] = useState( false );
 	const [ duration, setDuration ] = useState( 0 );
 	const [ isVideoSelecting, setIsVideoSelecting ] = useState( false );
+	const [ attachmentAuthorId, setattachmentAuthorId ] = useState( null );
 	const isInsideQueryLoop = context?.hasOwnProperty( 'queryId' );
 
 	const dispatch = useDispatch();
@@ -194,6 +196,10 @@ function VideoEdit( {
 			( async () => {
 				try {
 					const response = await apiFetch( { path: `/wp/v2/media/${ id }` } );
+
+					if ( response.author ) {
+						setattachmentAuthorId( response.author );
+					}
 
 					if ( response.meta.rtgodam_media_video_thumbnail !== '' ) {
 						setDefaultPoster( response.meta.rtgodam_media_video_thumbnail );
@@ -675,20 +681,22 @@ function VideoEdit( {
 									</MediaUploadCheck>
 								</BaseControl>
 
-								<BaseControl
-									id={ `video-block__video-editor-${ instanceId }` }
-									label={ __( 'Customise Video', 'godam' ) }
-									__nextHasNoMarginBottom
-								>
-									<Button
-										__next40pxDefaultSize
-										href={ `${ window?.pluginInfo?.adminUrl }admin.php?page=rtgodam_video_editor&id=${ undefined !== id ? id : cmmId }` }
-										target="_blank"
-										variant="primary"
+								{ canManageAttachment( attachmentAuthorId ) && (
+									<BaseControl
+										id={ `video-block__video-editor-${ instanceId }` }
+										label={ __( 'Customise Video', 'godam' ) }
+										__nextHasNoMarginBottom
 									>
-										{ __( 'Customise', 'godam' ) }
-									</Button>
-								</BaseControl>
+										<Button
+											__next40pxDefaultSize
+											href={ `${ window?.pluginInfo?.adminUrl }admin.php?page=rtgodam_video_editor&id=${ undefined !== id ? id : cmmId }` }
+											target="_blank"
+											variant="primary"
+										>
+											{ __( 'Customise', 'godam' ) }
+										</Button>
+									</BaseControl>
+								) }
 
 								<BaseControl
 									id={ `video-block__video-seo-${ instanceId }` }

--- a/assets/src/js/media-library/utility.js
+++ b/assets/src/js/media-library/utility.js
@@ -135,4 +135,15 @@ function canManageOptions() {
 	return _canManageOptions;
 }
 
-export { isAPIKeyValid, checkMediaLibraryView, isUploadPage, isFolderOrgDisabled, addManageMediaButton, getQuery, getGodamSettings, canManageAttachment, canManageOptions };
+/**
+ * Checks if the current user is allowed to edit pages.
+ *
+ * @return {boolean} Returns true if the user can edit pages, false otherwise.
+ */
+function canEditPages() {
+	const _canEditPages = window?.easydamMediaLibrary?.canEditPages;
+
+	return _canEditPages;
+}
+
+export { isAPIKeyValid, checkMediaLibraryView, isUploadPage, isFolderOrgDisabled, addManageMediaButton, getQuery, getGodamSettings, canManageAttachment, canManageOptions, canEditPages };

--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -541,10 +541,6 @@ export default AttachmentDetailsTwoColumn?.extend( {
 	 * Renders the Edit Video and Analytics buttons in the attachment details view.
 	 */
 	renderVideoActions() {
-		//		if ( ! canManageAttachment( this.model.get( 'author' ) ) ) {
-		//			return;
-		//		}
-
 		const buttonsHTML = this.getButtonsHTML();
 		this.$el.find( '.attachment-actions' ).append( DOMPurify.sanitize( `<div class="attachment-video-actions">${ buttonsHTML }</div>` ) );
 	},

--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -541,9 +541,9 @@ export default AttachmentDetailsTwoColumn?.extend( {
 	 * Renders the Edit Video and Analytics buttons in the attachment details view.
 	 */
 	renderVideoActions() {
-		if ( ! canManageAttachment( this.model.get( 'author' ) ) ) {
-			return;
-		}
+		//		if ( ! canManageAttachment( this.model.get( 'author' ) ) ) {
+		//			return;
+		//		}
 
 		const buttonsHTML = this.getButtonsHTML();
 		this.$el.find( '.attachment-actions' ).append( DOMPurify.sanitize( `<div class="attachment-video-actions">${ buttonsHTML }</div>` ) );
@@ -570,10 +570,19 @@ export default AttachmentDetailsTwoColumn?.extend( {
 			`;
 		}
 
-		return `
-		<a href="${ editVideoURL }" class="button button-primary" target="_blank">Edit Video</a>
-		<a href="${ analyticsURL }" class="button button-secondary" target="_blank">Analytics</a>
-		`;
+		const editVideoButtonHTML = `<a href="${ editVideoURL }" class="button button-primary" target="_blank">Edit Video</a>`;
+		const analyticsButtonHTML = `<a href="${ analyticsURL }" class="button button-secondary" target="_blank">Analytics</a>`;
+
+		const buttons = [];
+
+		// If the user can manage the attachment, show the Edit Video button, else show only Analytics.
+		if ( canManageAttachment( this.model.get( 'author' ) ) ) {
+			buttons.push( editVideoButtonHTML );
+		}
+
+		buttons.push( analyticsButtonHTML );
+
+		return buttons.join( '' );
 	},
 
 	/**

--- a/assets/src/js/media-library/views/filters/media-retranscode.js
+++ b/assets/src/js/media-library/views/filters/media-retranscode.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { canManageOptions } from '../../utility';
+import { canEditPages } from '../../utility';
 
 let MediaRetranscode = wp?.media?.view?.Button;
 const homeUrl = window.godamRestRoute.homeUrl || window.location.origin; // eslint-disable-line no-unused-vars
@@ -14,7 +14,7 @@ MediaRetranscode = MediaRetranscode?.extend( {
 
 	initialize() {
 		// If user cannot manage options we don't render the button.
-		if ( ! canManageOptions() ) {
+		if ( ! canEditPages() ) {
 			return;
 		}
 

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -297,6 +297,7 @@ class Assets {
 				'userId'                   => $current_user_id,
 				'canEditOthersMedia'       => current_user_can( 'edit_others_posts' ),
 				'canManageOptions'         => current_user_can( 'manage_options' ),
+				'canEditPages'             => current_user_can( 'edit_pages' ),
 			)
 		);
 

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -165,7 +165,7 @@ class Pages {
 		add_menu_page(
 			__( 'GoDAM', 'godam' ),
 			__( 'GoDAM', 'godam' ),
-			'manage_options',
+			'edit_pages',
 			$this->menu_slug,
 			array( $this, 'render_dashboard_page' ),
 			'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTI1LjU1NzggMjAuMDkxMUw4LjA1NTg3IDM3LjU5M0wzLjQ2Mzk3IDMzLjAwMTFDMC44MTg1MjEgMzAuMzU1NiAyLjA4MjEgMjUuODMzNiA1LjcyMjI4IDI0Ljk0NjRMMjUuNTYzMiAyMC4wOTY0TDI1LjU1NzggMjAuMDkxMVoiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik00Ny4zNzczIDIxLjg4NjdMNDUuNTQzOCAyOS4zODc1TDIyLjY5NzIgNTIuMjM0MUwxMS4yNjA1IDQwLjc5NzRMMzQuMTY2MiAxNy44OTE2TDQxLjU3MDMgMTYuMDc5NkM0NS4wNzA2IDE1LjIyNDcgNDguMjMyMyAxOC4zODYzIDQ3LjM3MiAyMS44ODEzTDQ3LjM3NzMgMjEuODg2N1oiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik00My41MDU5IDM4LjEwMzZMMzguNjY2NyA1Ny44OTA3QzM3Ljc3NDEgNjEuNTI1NSAzMy4yNTIxIDYyLjc4OTEgMzAuNjA2NiA2MC4xNDM2TDI2LjAzNjMgNTUuNTczMkw0My41MDU5IDM4LjEwMzZaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K',
@@ -180,7 +180,7 @@ class Pages {
 			$this->menu_slug,
 			__( 'Dashboard', 'godam' ),
 			__( 'Dashboard', 'godam' ),
-			'manage_options',
+			'edit_pages', // Dashboard is accessible to editors and above.
 			$this->menu_slug,
 			array( $this, 'render_dashboard_page' ),
 			1
@@ -190,7 +190,7 @@ class Pages {
 			$this->menu_slug,
 			__( 'Video Editor', 'godam' ),
 			__( 'Video Editor', 'godam' ),
-			'publish_posts',
+			'upload_files', // Video Editor is accessible to authors and above.
 			$this->video_editor_slug,
 			array( $this, 'render_video_editor_page' ),
 			3
@@ -200,7 +200,7 @@ class Pages {
 			$this->menu_slug,
 			__( 'Analytics', 'godam' ),
 			__( 'Analytics', 'godam' ),
-			'edit_posts',
+			'upload_files', // Analytics is accessible to authors and above.
 			$this->analytics_slug,
 			array( $this, 'render_analytics_page' ),
 			2
@@ -212,7 +212,7 @@ class Pages {
 				$this->menu_slug,
 				__( 'Tools', 'godam' ),
 				__( 'Tools', 'godam' ),
-				'manage_options',
+				'manage_options', // Tools is accessible to admins and above.
 				$this->tools_slug,
 				array( $this, 'render_tools_page' ),
 				5
@@ -223,7 +223,7 @@ class Pages {
 			$this->menu_slug,
 			__( 'Settings', 'godam' ),
 			__( 'Settings', 'godam' ),
-			'edit_pages',
+			'manage_options', // Settings is accessible to admins and above.
 			$this->settings_slug,
 			array( $this, 'render_godam_page' ),
 			6

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -212,7 +212,7 @@ class Pages {
 				$this->menu_slug,
 				__( 'Tools', 'godam' ),
 				__( 'Tools', 'godam' ),
-				'manage_options', // Tools is accessible to admins and above.
+				'edit_pages', // Tools is accessible to editors and above.
 				$this->tools_slug,
 				array( $this, 'render_tools_page' ),
 				5

--- a/inc/classes/rest-api/class-video-migration.php
+++ b/inc/classes/rest-api/class-video-migration.php
@@ -166,7 +166,7 @@ class Video_Migration extends Base {
 	 */
 	public function check_video_migration_permission() {
 		// Check if the user has the capability to manage options.
-		return current_user_can( 'manage_options' );
+		return current_user_can( 'edit_pages' );
 	}
 
 	/**

--- a/pages/video-editor/attachment-picker.scss
+++ b/pages/video-editor/attachment-picker.scss
@@ -1,4 +1,5 @@
 #root-video-editor {
+	height: 100%;
 	background-color: #f3f4f6;
 
 	.godam-video-list {


### PR DESCRIPTION
## Summary
- FIX: `Retranscode Media` button was made hidden from editor role, now visible.
- FEAT: Author user can only see analytics of his added media only
- FEAT: User who don't have access to the manage attachment will not see the `Customise Video` button on the block editor
- FIX: Tools page is now visible to editor

| Issue                                | Before   | After        |
|--------------------------------------|----------|--------------|
| Retranscode button visible to editor |  | <img width="548" height="230" alt="Screenshot 2025-10-07 at 9 00 09 PM" src="https://github.com/user-attachments/assets/bba7f5bc-7aca-48fb-a924-60506e3eacb3" /> |
| Author can see own media analytics only (User can see edit video button for own media, and analytics button for all media) |  <img width="478" height="290" alt="Screenshot 2025-10-07 at 9 01 52 PM" src="https://github.com/user-attachments/assets/77b92077-4517-4d0e-a2ae-f70cec801f86" /> | <img width="407" height="258" alt="Screenshot 2025-10-07 at 9 02 01 PM" src="https://github.com/user-attachments/assets/e0d1c5f2-7ba6-404b-a865-5c3ef94b7d48" /> |
| Customise Video button not visible to user with no access to media | <img width="475" height="440" alt="Screenshot 2025-10-07 at 8 56 47 PM" src="https://github.com/user-attachments/assets/7fdf8c6f-cc75-47cd-b52a-6f17249eaa45" />  | <img width="408" height="398" alt="Screenshot 2025-10-07 at 8 56 55 PM" src="https://github.com/user-attachments/assets/4ccb7f56-c812-480f-a6fe-d3aacab0aee9" /> |
| Tools page available for Editor  |  <img width="229" height="201" alt="Screenshot 2025-10-07 at 9 01 14 PM" src="https://github.com/user-attachments/assets/9503023d-984c-4be3-90d1-8879cb7f6a88" /> | <img width="215" height="172" alt="Screenshot 2025-10-07 at 9 00 25 PM" src="https://github.com/user-attachments/assets/ca202d8b-8099-4483-9d56-11e816d74887" /> |





### Issue
- #1027 