### PR TITLE
Fix: Overflow of Vertical Video from Player #1144

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1521,6 +1521,7 @@ body.godam-share-modal-open {
 .easydam-player.video-js {
 	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9 );
 	cursor: pointer;
+	overflow: hidden;
 }
 
 .video-js .vjs-time-tooltip,


### PR DESCRIPTION
When embedding vertical (portrait) videos (e.g. 9:16 aspect ratio), the video overflows beyond the visible container, causing layout breakage and parts of the video being clipped.

The expected behavior is that vertical videos should scale to fit within the player container without breaking layouts or having parts outside the container boundaries.

Current changes should resolve the fix by preserving aspect ratio and not affecting existing behavior for horizontal videos.

closes: https://github.com/rtCamp/godam/issues/1144