### PR TITLE
Fix null check for VM analytics, and convert VM job_id into original attachment ID

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -141,7 +141,7 @@ if ( ! window.pageLoadEventTracked ) {
 		// Collect all video IDs
 		const videoIds = Array.from( videos )
 			.map( ( video ) => video.getAttribute( 'data-id' ) )
-			.filter( ( id ) => id !== null && id !== '' ) // Null and empty string check
+			.filter( ( id ) => id !== null && id !== '' && ! isNaN( id ) ) // Null and empty string check
 			.map( ( id ) => parseInt( id, 10 ) ); // Convert to integer
 
 		// Send a single page_load request with all video IDs

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -398,7 +398,7 @@ if ( empty( $attachment_title ) ) {
 					class="easydam-player video-js vjs-big-play-centered vjs-hidden"
 					data-options="<?php echo esc_attr( $video_config ); ?>"
 					data-ad_tag_url="<?php echo esc_url( $ad_tag_url ); ?>"
-					data-id="<?php echo esc_attr( $attachment_id ); ?>"
+					data-id="<?php echo esc_attr( is_numeric( $attachment_id ) ? $attachment_id : $original_id ); ?>"
 					data-instance-id="<?php echo esc_attr( $instance_id ); ?>"
 					data-controls="<?php echo esc_attr( $video_setup ); ?>"
 					data-job_id="<?php echo esc_attr( $job_id ); ?>"


### PR DESCRIPTION
Fix NULL check for video analytics, and convert Virtual Media job_id into original attachment ID

**Data validation improvements:**

* In `inc/templates/godam-player.php`, the `data-id` attribute for video elements is now set to use `$attachment_id` only if it is numeric; otherwise, it falls back to `$original_id`. This ensures that only valid numeric IDs are assigned to the `data-id` attribute.
* In `assets/src/js/godam-player/analytics.js`, the code that collects video IDs now filters out any values that are not numeric, in addition to checking for null and empty strings. This prevents non-numeric IDs from being processed or sent in analytics events.

## Related issue:
- #747 