### PR TITLE
Fix mov video copy issue

### DIFF
--- a/pages/video-editor/utils/index.js
+++ b/pages/video-editor/utils/index.js
@@ -40,12 +40,15 @@ function createVideoAttributes( attachmentId, mediaData ) {
 	const { source_url: sourceUrl, mime_type: mimeType } = mediaData;
 
 	if ( sourceUrl ) {
+		// Convert .mov files to video/mp4 type to match editor behavior
+		const adjustedMimeType = mimeType === 'video/quicktime' ? 'video/mp4' : mimeType;
+
 		return {
 			...baseAttrs,
 			src: sourceUrl,
 			sources: [ {
 				src: sourceUrl,
-				type: mimeType,
+				type: adjustedMimeType,
 			} ],
 		};
 	}


### PR DESCRIPTION
## Description

This fixes the issue by converting the quicktime mimetype to `mp4` mimetype. It is needed because this line of code in the [edit.js](https://github.com/rtCamp/godam/blob/46958563311056f10b8addeb0bdfd5ed8fb2ae6d/assets/src/blocks/godam-player/edit.js#L360) requires that.

If this piece of code is no longer needed then we can remove the logic but my guess is that it was added along with this fix: https://github.com/rtCamp/godam/pull/1142/files

to avoid side effect we can use this method to fix the issue for the `mov` files.