### PR TITLE
Fix gravity-forms submission issue on video preview page

### DIFF
--- a/inc/templates/video-preview.php
+++ b/inc/templates/video-preview.php
@@ -69,6 +69,6 @@ $godam_page_title = empty( $godam_video_id ) ? __( 'Video Preview', 'godam' ) : 
 	}
 	?>
 
-	<?php do_action( 'wp_footer' ); ?>
+	<?php wp_footer(); ?>
 </body>
 </html>


### PR DESCRIPTION
This pull request updates the `video-preview.php` template to include a complete HTML document structure for the video preview page. The changes ensure the page outputs valid HTML, properly includes WordPress hooks, and improves markup correctness.

HTML structure and markup improvements:

* Added a full HTML document structure (`<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`) to `video-preview.php`, including meta tags and a dynamic title. Also moved `wp_head()` to the correct location inside the `<head>` section.
* Fixed a minor markup issue by correcting the closing `div` tag in the "video not found" message.
* Added closing `</body>` and `</html>` tags after the video preview content and ensured `wp_footer` is called before the body ends.

## Related issue:
- #1181 