### PR TITLE
Add CSP(Content Security Policy)  violation guide on browser console for blob workers

### DIFF
--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -43,6 +43,38 @@ import './api/godam-api.js';
 document.addEventListener( 'DOMContentLoaded', () => new PlayerManager() );
 
 /**
+ * Handle Content Security Policy (CSP) violations related to blob workers
+ *
+ * @see https://github.com/rtCamp/godam/issues/1227
+ */
+let isCSPWarningLogged = false;
+window.addEventListener( 'securitypolicyviolation', ( e ) => {
+	if ( e.blockedURI === 'blob' && e.violatedDirective === 'worker-src' ) {
+		// Handle the violation
+		if ( isCSPWarningLogged ) {
+			return;
+		}
+		isCSPWarningLogged = true;
+		// eslint-disable-next-line no-console
+		console.error(
+			'⚠️ Video playback is blocked due to Content Security Policy (CSP) restrictions.',
+			{
+				error: "Refused to create a worker from 'blob:<URL>' because it violates the CSP.",
+				guidance: [
+					"1️⃣ First, try adding 'blob:' to the 'worker-src' directive in your CSP header.",
+					"   Example: Content-Security-Policy: worker-src 'self' blob:;",
+					"2️⃣ If the issue persists, you may also need to add 'blob:' to 'script-src'.",
+					"   Example: Content-Security-Policy: script-src 'self' https: blob:;",
+				],
+				resources: [
+					'MDN CSP docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP',
+				],
+			},
+		);
+	}
+} );
+
+/**
  * Legacy function for backward compatibility
  *
  * @param {HTMLElement} videoRef - Video element reference


### PR DESCRIPTION
This pull request adds a new event handler to improve error reporting and developer guidance when video playback is blocked due to Content Security Policy (CSP) restrictions related to blob workers. This change helps developers quickly identify and resolve CSP issues that prevent worker creation from blob URLs.

CSP violation handling and developer guidance:

* Added a `securitypolicyviolation` event listener in `frontend.js` to detect when blob workers are blocked by CSP, logging a clear error message and actionable guidance for resolving the issue.

<img width="1470" height="523" alt="Screenshot 2025-10-23 at 9 07 52 AM" src="https://github.com/user-attachments/assets/ccf190d1-2e93-4644-819d-3fc481549292" />


## Related Issue:
- #1227 