### PR TITLE
fix: Copy Block issue on Safari

### DIFF
--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -36,7 +36,7 @@ import './video-editor.scss';
 import { useGetAttachmentMetaQuery, useSaveAttachmentMetaMutation } from './redux/api/attachment';
 import { useFetchForms } from './components/forms/fetchForms';
 import Chapters from './components/chapters/Chapters';
-import { copyGoDAMVideoBlock } from './utils/index';
+import { copyGoDAMVideoBlock, prefetchMediaDataForCopy } from './utils/index';
 import { getFormIdFromLayer } from './utils/formUtils';
 import { canManageAttachment } from '../../assets/src/js/media-library/utility.js';
 
@@ -47,6 +47,11 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 	const [ duration, setDuration ] = useState( 0 );
 	const [ snackbarMessage, setSnackbarMessage ] = useState( '' );
 	const [ showSnackbar, setShowSnackbar ] = useState( false );
+
+	// Pre-fetch data on mount to ensure copy always works
+	useEffect( () => {
+		prefetchMediaDataForCopy( attachmentID );
+	}, [ attachmentID ] );
 
 	const playerRef = useRef( null );
 
@@ -257,6 +262,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 
 	const handleCopyGoDAMVideoBlock = async () => {
 		const result = await copyGoDAMVideoBlock( attachmentID );
+
 		if ( result ) {
 			setSnackbarMessage( __( 'GoDAM Video Block copied to clipboard', 'godam' ) );
 			setShowSnackbar( true );

--- a/pages/video-editor/components/media-grid/MediaItem.jsx
+++ b/pages/video-editor/components/media-grid/MediaItem.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useEffect } from 'react';
 
 /**
  * WordPress dependencies
@@ -15,7 +15,7 @@ import { createPortal } from '@wordpress/element';
  * Internal dependencies
  */
 import NoThumbnailImage from '../../assets/no-thumbnail.jpg';
-import { copyGoDAMVideoBlock } from '../../utils';
+import { copyGoDAMVideoBlock, prefetchMediaDataForCopy } from '../../utils';
 import { canManageAttachment } from '../../../../assets/src/js/media-library/utility.js';
 
 const MediaItem = forwardRef( ( { item, handleAttachmentClick }, ref ) => {
@@ -49,6 +49,11 @@ const MediaItem = forwardRef( ( { item, handleAttachmentClick }, ref ) => {
 	const handleOnSnackbarRemove = () => {
 		setShowSnackbar( false );
 	};
+
+	// Pre-fetch data on mount to ensure copy always works
+	useEffect( () => {
+		prefetchMediaDataForCopy( item.id );
+	}, [ item.id ] );
 
 	return (
 		<div


### PR DESCRIPTION
Issue: rtCamp/godam-core#534

This pull request introduces a caching and prefetching mechanism to optimize the process of copying GoDAM video blocks. The main goal is to ensure that the necessary media data is loaded ahead of time, improving the responsiveness and reliability of the copy-to-clipboard feature in both the video editor and media grid components.

**Caching and Prefetching Enhancements:**

* Added a `mediaDataCache` and a new `prefetchMediaDataForCopy` function in `utils/index.js` to pre-load and cache video block markup for each attachment, minimizing repeated network requests and speeding up copy operations.
* Updated the `copyGoDAMVideoBlock` function to use cached data when available, falling back to fetching and caching if not already present. [[1]](diffhunk://#diff-05a90d66aa127d72dc031b452ef95c01080591fe5f34bb6cca4b94d506f01916R68-R94) [[2]](diffhunk://#diff-05a90d66aa127d72dc031b452ef95c01080591fe5f34bb6cca4b94d506f01916R103)

**Integration in Components:**

* In `VideoEditor.js`, added a `useEffect` hook to prefetch media data for the current `attachmentID` when the editor mounts or the attachment changes. [[1]](diffhunk://#diff-0559daddab966567cf8d9f589b35d6c35f4a44b62c60586606523dd0cbcb3494L39-R39) [[2]](diffhunk://#diff-0559daddab966567cf8d9f589b35d6c35f4a44b62c60586606523dd0cbcb3494R51-R55)
* In `MediaItem.jsx`, added a similar `useEffect` to prefetch media data for each media item as it renders, ensuring copy operations are always fast and reliable. [[1]](diffhunk://#diff-e0707fd3a3d522de315bb85f1996b834c394e991ebd638b5308772352cea03e5L4-R4) [[2]](diffhunk://#diff-e0707fd3a3d522de315bb85f1996b834c394e991ebd638b5308772352cea03e5L18-R18) [[3]](diffhunk://#diff-e0707fd3a3d522de315bb85f1996b834c394e991ebd638b5308772352cea03e5R53-R57)

These changes collectively improve user experience by making the copy-to-clipboard functionality more robust and responsive, especially in scenarios with multiple video attachments.