### PR TITLE
Fix: Ensure CMM image insertion uses the transcoded URL instead of the original file URL.

### DIFF
--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1187,6 +1187,10 @@ class Media_Library extends Base {
 					$all_items[ $key ]['meta']['artist'] = isset( $all_items[ $key ]['meta']['artist'] ) ? $all_items[ $key ]['meta']['artist'] : '';
 					$all_items[ $key ]['meta']['album']  = isset( $all_items[ $key ]['meta']['album'] ) ? $all_items[ $key ]['meta']['album'] : '';
 				}
+
+				if ( 'image' === $type && isset( $item->transcoded_file_path ) ) {
+					$all_items[ $key ]['url'] = $item->transcoded_file_path;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Previously, when adding an image via CMM, the selected media returned the original site file URL rather than the transcoded URL.
This caused the inserted images to bypass the optimized or CDN-served versions, affecting performance and media consistency.

## What’s Changed
1. Updated the CMM image selection handler to use the transcoded URL (if available).
2. Added a fallback to the original URL for cases where the transcoded version doesn’t exist.

## Expected Result
All images now use the transcoded URL whenever available.

## Related Issue

Fixes https://github.com/rtCamp/godam/issues/1272