### PR TITLE
feat: Add media replacement for MP4 URLs

### DIFF
--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -232,6 +232,12 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 								update_post_meta( $attachment_id, 'rtgodam_hls_transcoded_url', sanitize_url( $post_array['hls_path'] ) );
 							}
 
+							// Save mp4 url as well for runtime URL replacement if present.
+							$mp4_url = $request->get_param( 'mp4_url' );
+							if ( ! empty( $mp4_url ) ) {
+								update_post_meta( $attachment_id, 'rtgodam_transcoded_mp4_url', esc_url_raw( $mp4_url ) );
+							}
+
 							if ( ! empty( $latest_attachment ) && $latest_attachment['attachment_id'] === $attachment_id ) {
 								$latest_attachment['transcoding_status'] = 'success';
 								update_option( 'rtgodam_new_attachment', $latest_attachment, '', true );

--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -729,3 +729,35 @@ function rtgodam_get_transcoded_error_message_from_attachment( $attachment ) {
 
 	return strval( get_post_meta( $attachment_id, 'rtgodam_transcoding_error_msg', true ) );
 }
+
+/**
+ * Return MP4 CDN URL for transcoded media at runtime when available.
+ *
+ * @since 1.4.5
+ */
+add_filter(
+	'wp_get_attachment_url',
+	function ( $url, $post_id ) {
+		// Validate attachment.
+		$attachment = get_post( $post_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return $url;
+		}
+
+		// Only apply for video/audio attachments.
+		$mime = get_post_mime_type( $post_id );
+		if ( empty( $mime ) || ( 0 !== strpos( $mime, 'video/' ) && 0 !== strpos( $mime, 'audio/' ) ) ) {
+			return $url;
+		}
+
+		// Use persisted MP4 CDN URL when present.
+		$mp4_cdn_url = get_post_meta( $post_id, 'rtgodam_transcoded_mp4_url', true );
+		if ( ! empty( $mp4_cdn_url ) ) {
+			return esc_url( $mp4_cdn_url );
+		}
+
+		return $url;
+	},
+	10,
+	2 
+);

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -709,6 +709,9 @@ class Media_Library_Ajax {
 			return;
 		}
 
+		// Persist MP4 CDN URL for runtime URL replacement.
+		update_post_meta( $attachment_id, 'rtgodam_transcoded_mp4_url', $transcoded_mp4_url );
+
 		// Replace the existing attachment file with the transcoded MP4.
 		$attachment_id = $this->godam_replace_attachment_with_external_file( $attachment_id, $transcoded_mp4_url );
 


### PR DESCRIPTION
Issue: #1277

This pull request introduces runtime support for replacing video and audio attachment URLs with their transcoded MP4 CDN URLs when available. The main changes ensure that the transcoded MP4 URL is saved to the attachment metadata during processing and that WordPress uses this URL for relevant media types. This improves media delivery performance and reliability by serving optimized content.

**Runtime URL replacement for media attachments:**

* Added a filter to `wp_get_attachment_url` to return the persisted MP4 CDN URL for video and audio attachments when available, falling back to the default URL otherwise.

**Persistence and metadata updates:**

* Updated the transcoder REST callback (`class-rtgodam-transcoder-rest-routes.php`) to save the transcoded MP4 URL to the `rtgodam_transcoded_mp4_url` post meta if provided in the callback request.
* Modified the media library AJAX handler (`class-media-library-ajax.php`) to persist the MP4 CDN URL in the attachment metadata after a successful download of the transcoded MP4 source.