### PR TITLE
fix: FullScreen Scroll on iPhone

### DIFF
--- a/assets/src/js/godam-player/managers/controlsManager.js
+++ b/assets/src/js/godam-player/managers/controlsManager.js
@@ -104,6 +104,8 @@ export default class ControlsManager {
 					if ( godamVideoContainer ) {
 						godamVideoContainer.classList.remove( 'godam-video-fullscreen' );
 					}
+					// Restore scrolling
+					document.body.style.overflow = '';
 				} else {
 					if ( videoContainer ) {
 						videoContainer.classList.add( 'vjs-fullscreen' );
@@ -111,6 +113,8 @@ export default class ControlsManager {
 					if ( godamVideoContainer ) {
 						godamVideoContainer.classList.add( 'godam-video-fullscreen' );
 					}
+					// Prevent scrolling on iOS
+					document.body.style.overflow = 'hidden';
 				}
 			}
 		}
@@ -147,6 +151,9 @@ export default class ControlsManager {
 				if ( godamVideoContainer ) {
 					godamVideoContainer.classList.remove( 'godam-video-fullscreen' );
 				}
+
+				// Restore scrolling
+				document.body.style.overflow = '';
 			}
 		}
 		if ( ! videojs.getComponent( 'CustomFullscreenExitButton' ) ) {


### PR DESCRIPTION
Issue - #1269
This pull request updates the fullscreen handling logic in the `ControlsManager` class to improve the user experience on iOS devices. The main change is to prevent background scrolling when the video player enters fullscreen mode and restore scrolling when exiting fullscreen.

Fullscreen and scrolling behavior improvements:

* When entering fullscreen, the code now sets `document.body.style.overflow` to `'hidden'` to prevent scrolling on iOS devices.
* When exiting fullscreen, the code restores scrolling by resetting `document.body.style.overflow` to an empty string. This is done in both fullscreen exit paths to ensure consistent behavior. [[1]](diffhunk://#diff-b43145871d9e65106d5e84ff45c8dbc1f1aa2336cd8626ab1fb0b3a066cf0217R107-R117) [[2]](diffhunk://#diff-b43145871d9e65106d5e84ff45c8dbc1f1aa2336cd8626ab1fb0b3a066cf0217R154-R156)