### PR TITLE
fix: HTML CTA button styles

### DIFF
--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -174,9 +174,10 @@
 	border-radius: 4px;
 }
 
-.easydam-layer--cta-html button,
-.video-js .easydam-layer--cta-html button {
-	all: unset;
+// Only apply default styles to plain buttons without any classes
+.easydam-layer--cta-html button:not([class]),
+.video-js .easydam-layer--cta-html button:not([class]) {
+	appearance: none;
 	display: inline-block;
 	padding: 10px 20px;
 	border-radius: 4px;
@@ -190,7 +191,8 @@
 	cursor: pointer;
 }
 
-.easydam-layer--cta-html button:hover {
+.easydam-layer--cta-html button:not([class]):hover,
+.video-js .easydam-layer--cta-html button:not([class]):hover {
 	background-color: #1a5d99;
 }
 

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -195,9 +195,10 @@
 	border-radius: 4px;
 }
 
-.easydam-layer--cta-html button,
-.video-js .easydam-layer--cta-html button {
-	all: unset;
+// Only apply default styles to plain buttons without any classes
+.easydam-layer--cta-html button:not([class]),
+.video-js .easydam-layer--cta-html button:not([class]) {
+	appearance: none;
 	display: inline-block;
 	padding: 10px 20px;
 	border-radius: 4px;
@@ -211,7 +212,8 @@
 	cursor: pointer;
 }
 
-.easydam-layer--cta-html button:hover {
+.easydam-layer--cta-html button:not([class]):hover,
+.video-js .easydam-layer--cta-html button:not([class]):hover {
 	background-color: #1a5d99;
 }
 


### PR DESCRIPTION
# Fix: Button styles in .easydam-layer--cta-html overriding global style guide buttons
Issue - #1267

## Problem
The CSS rule `.easydam-layer--cta-html button` was applying styles to **all buttons** in CTA layers, overriding GoDAM design system classes (`.godam-button`) and custom CSS classes.

## Solution
Changed the CSS selector to only target buttons without classes using `:not([class])`:

**Before:**
```scss
.easydam-layer--cta-html button {
    all: unset;
    background-color: #2271b1;
    /* ... */
}
```

**After:**
```scss
.easydam-layer--cta-html button:not([class]) {
    appearance: none;
    background-color: #2271b1;
    /* ... */
}
```

## Changes
- **Files**: `godam-player.scss` and `style.scss`
- **Replaced**: `all: unset` with `appearance: none`
- **Added**: `:not([class])` selector to target only default buttons that do not have customizations
- **Result**: Plain buttons get blue styling, buttons with classes use their intended styles

## Testing Code
```html
<div>
    <h2>Mixed Button Styles</h2>
    <button type="button">Plain Button</button>
    <button type="button" class="godam-button is-primary">GoDAM Primary</button>
    <button type="button" class="godam-button is-secondary">GoDAM Secondary</button>
    <button type="button" class="custom-btn">Custom Button (add custom styles)</button>
</div>
```

## Screenshot
<img width="1166" height="751" alt="Screenshot 2025-10-21 at 6 07 38 PM" src="https://github.com/user-attachments/assets/2ebb908a-df1c-4a2f-a0a7-ed630d79d9a0" />
