### PR TITLE
fix: Update hook to fix transcoding callback issue

### DIFF
--- a/admin/class-rtgodam-retranscodemedia.php
+++ b/admin/class-rtgodam-retranscodemedia.php
@@ -687,7 +687,7 @@ class RTGODAM_RetranscodeMedia {
 }
 
 // Start up this plugin.
-add_action( 'admin_init', 'rtgodam_retranscode_media' );
+add_action( 'init', 'rtgodam_retranscode_media' );
 
 /**
  * Execute RetranscodeMedia constructor.


### PR DESCRIPTION
This pull request makes a minor update to the plugin initialization process, ensuring that the `rtgodam_retranscode_media` function is hooked to the broader `init` action instead of the more limited `admin_init` action.

* Changed the action hook from `admin_init` to `init` for starting up the plugin, which allows the plugin to initialize in both admin and non-admin contexts.
* REST Endpoints were dependent on the class to be initialized.