### PR TITLE
fix: Virtual Media Attachment Creation

### DIFF
--- a/assets/src/js/media-library/views/media-frame-select.js
+++ b/assets/src/js/media-library/views/media-frame-select.js
@@ -75,9 +75,10 @@ export default MediaFrameSelect?.extend( {
 	},
 
 	onGoDAMSelect() {
-		const tab = this.state().get( 'content' );
+		// Use the actual content mode instead of stale state
+		const isGodamTab = this.content.mode() === 'godam';
 
-		if ( 'godam' !== tab ) {
+		if ( ! isGodamTab ) {
 			return;
 		}
 


### PR DESCRIPTION
Issue: #1180 

## Overview of changes

This pull request makes a targeted fix to the logic for handling the GoDAM tab selection in the media library. The change ensures that the code checks the current content mode directly, rather than relying on potentially outdated state.

* Media library view update:
  * In `media-frame-select.js`, updated the `onGoDAMSelect` method to use `this.content.mode()` for determining the active tab, ensuring the check is based on the actual current mode rather than stale state data.

## Main issue
When we switch tabs in the Media Library Uploader Modal, the stale state was being used to detect GoDAM Tab.
**So the virtual media creation failed when the modal opened in Media Library tab, and it succeeded when the modal opened directly in GoDAM Tab.**

## Recording

### Before
1. Virtual media is created if directly on GoDAM Tab
2. Virtual media is not created if switched from other tab to GoDAM Tab

https://github.com/user-attachments/assets/93701c4c-5078-489c-8570-0ecb4e11bbc4

### After
Virtual media is created even when switching from another tab.

https://github.com/user-attachments/assets/89d82c2c-9e39-4e24-aa40-01e5d5b5df0a
