### PR TITLE
Fix Localhost API Key verification requests

### DIFF
--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -362,6 +362,24 @@ function rtgodam_get_server_var( $server_key, $filter_type = FILTER_SANITIZE_FUL
 }
 
 /**
+ * Check if API request should be blocked due to HTTP or localhost environment.
+ *
+ * @since n.e.x.t
+ *
+ * @return bool True if request should be blocked, false otherwise.
+ */
+function rtgodam_should_block_api_request() {
+	// Check if current request is over HTTP (not HTTPS).
+	$is_http = ! is_ssl();
+
+	// Check if request is from localhost using existing helper function.
+	$is_localhost = rtgodam_is_local_environment();
+
+	// Block if either condition is met (HTTP OR localhost).
+	return $is_http || $is_localhost;
+}
+
+/**
  * Helper function to verify the api key.
  *
  * @param string $api_key The api key to verify.
@@ -372,6 +390,27 @@ function rtgodam_get_server_var( $server_key, $filter_type = FILTER_SANITIZE_FUL
 function rtgodam_verify_api_key( $api_key, $save = false ) {
 	if ( empty( $api_key ) ) {
 		return new \WP_Error( 'missing_api_key', __( 'API key is required.', 'godam' ), array( 'status' => 400 ) );
+	}
+
+	// Check if request should be blocked due to HTTP or localhost environment.
+	if ( rtgodam_should_block_api_request() ) {
+		// Check if RTGODAM_API_KEY constant is defined in wp-config.php.
+		if ( ! defined( 'RTGODAM_API_KEY' ) ) {
+			return new \WP_Error(
+				'localhost_blocked',
+				__( 'API key verification is blocked for HTTP connections or localhost environments. To use production API keys on localhost, please add the following constant to your wp-config.php file: define(\'RTGODAM_API_KEY\', \'your-api-key-here\');', 'godam' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Match the provided API key with the RTGODAM_API_KEY constant.
+		if ( RTGODAM_API_KEY !== $api_key ) {
+			return new \WP_Error(
+				'api_key_mismatch',
+				__( 'The provided API key does not match the RTGODAM_API_KEY constant defined in wp-config.php.', 'godam' ),
+				array( 'status' => 403 )
+			);
+		}
 	}
 
 	$api_url = RTGODAM_API_BASE . '/api/method/godam_core.api.verification.verify_api_key';


### PR DESCRIPTION
Issue: https://github.com/rtCamp/godam-core/issues/489

This pull request introduces logic to enhance the security of API key verification by blocking requests made over HTTP or from localhost environments, unless a specific override is present. The main change is to prevent accidental use of production API keys in insecure or development environments, unless explicitly allowed via a constant in `wp-config.php`.

Security improvements for API key verification:

* Added a new function `rtgodam_should_block_api_request()` to determine if an API request should be blocked due to being over HTTP or from a localhost environment.
* Updated `rtgodam_verify_api_key()` to block API key verification on HTTP or localhost unless the `RTGODAM_API_KEY` constant is defined in `wp-config.php`, providing clear error messages for these cases.

## Screenshots
<img width="1452" height="748" alt="Screenshot 2025-11-01 at 5 51 42 PM" src="https://github.com/user-attachments/assets/4b313b2d-ea1c-4a2c-a95c-bcd14f1541ba" />
<img width="1470" height="792" alt="Screenshot 2025-11-01 at 5 57 57 PM" src="https://github.com/user-attachments/assets/3940bc27-0ee0-497f-9306-f53e1e11c3ff" />

