### PR TITLE
fix: Add SEO content description to video schema data

### DIFF
--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -271,6 +271,7 @@ class Seo {
 					) {
 						$_seo_data['contentUrl']       = isset( $element['settings']['seo_content_url'] ) ? $element['settings']['seo_content_url'] : '';
 						$_seo_data['headline']         = isset( $element['settings']['seo_content_headline'] ) ? $element['settings']['seo_content_headline'] : '';
+						$_seo_data['description']      = isset( $element['settings']['seo_content_description'] ) ? $element['settings']['seo_content_description'] : '';
 						$_seo_data['uploadDate']       = isset( $element['settings']['seo_content_upload_date'] ) ? $element['settings']['seo_content_upload_date'] : '';
 						$_seo_data['thumbnailUrl']     = isset( $element['settings']['seo_content_video_thumbnail_url'] ) ? $element['settings']['seo_content_video_thumbnail_url'] : '';
 						$_seo_data['isFamilyFriendly'] = isset( $element['settings']['seo_content_family_friendly'] ) ? 'yes' === $element['settings']['seo_content_family_friendly'] : true;


### PR DESCRIPTION
Fixes : [Description provided for a video in SEO settings using elementor is not being reflected in the page Source #1067](https://github.com/rtCamp/godam/issues/1067)

This PR adds an SEO description to the video schema when using Elementor.