### PR TITLE
fix: Save button broken UI

### DIFF
--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -363,7 +363,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 					</div>
 
 					<Button
-						className="godam-button absolute right-4 bottom-8"
+						className="godam-button absolute right-4 bottom-8 video-editor-save-button"
 						variant="primary"
 						icon={ isSavingMeta && <Spinner /> }
 						onClick={ handleSaveAttachmentMeta }

--- a/pages/video-editor/video-editor.scss
+++ b/pages/video-editor/video-editor.scss
@@ -31,3 +31,12 @@
 		}
 	}
 }
+
+// Override media library styles for video editor save button
+.video-editor-container .aside .video-editor-save-button {
+	position: absolute !important;
+	top: auto !important;
+	bottom: 2rem;
+	right: 1rem;
+	margin: 0 !important;
+}


### PR DESCRIPTION
This pull request introduces a minor UI improvement for the video editor save button, ensuring its positioning is consistent and overrides conflicting styles from the media library.

Styling and UI consistency:

* Added the `video-editor-save-button` class to the save button in `VideoEditor.js` to allow for targeted styling.
* Added CSS rules in `video-editor.scss` to override media library styles, ensuring the save button remains correctly positioned within the video editor interface.