### PR TITLE
Remove 'elementor/loaded' hook check to fix widgets loading issue on 

### DIFF
--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -192,6 +192,11 @@ class Plugin {
 	 * @return void
 	 */
 	public function load_elementor_widgets() {
+
+		if ( ! is_plugin_active( 'elementor/elementor.php' ) ) {
+			return;
+		}
+
 		Elementor_Widgets::get_instance();
 	}
 


### PR DESCRIPTION
Issue: - #1308 

This pull request makes a minor update to the `load_elementor_widgets` method in the `class-plugin.php` file. The change ensures that the `Elementor_Widgets` instance is always loaded, regardless of whether the `elementor/loaded` action has fired.

* Removed the conditional check for the `elementor/loaded` action in the `load_elementor_widgets` method, so `Elementor_Widgets::get_instance()` is now called unconditionally. (`inc/classes/class-plugin.php`)

**Reference for developers:** https://developers.elementor.com/docs/widgets/simple-example/

**Before** 
| GoDAM | Elementor | Widgets Working? |
|-----------|-----------|-----------------|
| Network Activated | Network Activated | Yes |
| Network Activated | Site Activated | No |
| Site Activated | Network Activated | Yes |
| Site Activated | Site Activated | Yes |

**After**
| GoDAM | Elementor | Widgets Working? |
|-----------|-----------|-----------------|
| Network Activated | Network Activated | Yes |
| Network Activated | Site Activated | Yes |
| Site Activated | Network Activated | Yes |
| Site Activated | Site Activated | Yes |

## Testing instruction

Make sure the conditions below are met

| GoDAM | Elementor | Widgets Working? |
|-----------|-----------|-----------------|
| Network Activated | Network Activated | Yes |
| Network Activated | Site Activated | Yes |
| Site Activated | Network Activated | Yes |
| Site Activated | Site Activated | Yes |