### PR TITLE
fix: Z-index issue between GoDAM Video and GoDAM Gallery

### DIFF
--- a/assets/src/css/bubble-skin.scss
+++ b/assets/src/css/bubble-skin.scss
@@ -124,7 +124,7 @@
 				position: absolute;
 				bottom: 25px;
 				right: 90px;
-				z-index: 99;
+				z-index: 19;
 			}
 		}
 
@@ -137,7 +137,7 @@
 				position: absolute;
 				left: 40px;
 				bottom: 25px;
-				z-index: 99;
+				z-index: 19;
 			}
 		}
 
@@ -270,14 +270,14 @@
 			
 			.vjs-settings-button{
 				right: 55px;
-				z-index: 99;
+				z-index: 19;
 			}
 
 			div.vjs-subs-caps-button {
 				right: 100px !important;
 				left: unset;
 				bottom: 3px !important;
-				z-index: 99;
+				z-index: 19;
 			}
 
 			.vjs-control.vjs-custom-play-button {
@@ -337,7 +337,7 @@
 				bottom: 0;
 				left: unset;
 				right: 152px;
-				z-index: 99;
+				z-index: 19;
 			}
 
 			&:has(.vjs-subs-caps-button.vjs-hidden) .vjs-volume-panel {
@@ -350,8 +350,8 @@
 				left: 20px;
 				position: absolute;
 				transform: translateY(-120%);
-				z-index: 99;
-	
+				z-index: 19;
+
 				.vjs-current-time-display {
 					position: unset;
 				}
@@ -363,8 +363,8 @@
 				position: absolute;
 				right: 20px;
 				transform: translateY(-120%);
-				z-index: 99;
-	
+				z-index: 19;
+
 				.vjs-duration-display {
 					position: unset;
 				}

--- a/assets/src/css/classic-skin.scss
+++ b/assets/src/css/classic-skin.scss
@@ -278,7 +278,7 @@
 			bottom: 0;
 			right: 80px;
 			height: 3em !important;
-			z-index: 99;
+			z-index: 19;
 
 			.vjs-menu-item:hover {
 				background-color: initial !important;
@@ -398,7 +398,7 @@
 			bottom: 0;
 			left: calc(3 * 40px);
 			height: 3em !important;
-			z-index: 99;
+			z-index: 19;
 		}
 
 		.vjs-quality-menu-wrapper {
@@ -522,7 +522,7 @@
 		bottom: 0;
 		right: calc(3 * 40px);
 		height: 3em !important;
-		z-index: 99;
+		z-index: 19;
 	}
 
 	.video-js .vjs-subs-caps-button.vjs-menu-button.vjs-menu-button-popup.vjs-control.vjs-button {
@@ -566,7 +566,7 @@
 			}
 
 			.vjs-settings-button, div.vjs-subs-caps-button {
-				z-index: 99;
+				z-index: 19;
 			}
 
 			.vjs-volume-panel {

--- a/assets/src/css/godam-gallery.scss
+++ b/assets/src/css/godam-gallery.scss
@@ -259,7 +259,7 @@
 		max-width: none;
 		max-height: 95vh;
 		box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
-		z-index: 10;
+		z-index: 200;
 
 		@media (min-width: 1728px) {
 			width: 65vw;
@@ -338,7 +338,7 @@
 		justify-content: center;
 		cursor: pointer;
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-		z-index: 11;
+		z-index: 201;
 
 		@media (max-width: 1099px) {
 			top: -40px;
@@ -346,7 +346,7 @@
 			color: #fff;
 			background-color: rgba(0, 0, 0, 0.7);
 			box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-			z-index: 12;
+			z-index: 201;
 			border: 1px solid rgba(255, 255, 255, 0.2);
 			transition: background-color 0.2s ease;
 

--- a/assets/src/css/pills-skin.scss
+++ b/assets/src/css/pills-skin.scss
@@ -6,9 +6,9 @@
 		width: 95% !important;
 		border-radius: 80px;
 		margin: -50px auto 0 auto;
-		z-index: 999;
 		background-color: var(--rtgodam-control-bar-color, #000) !important;
 		bottom: 0.5rem !important;
+		z-index: 19;
 	}
 
 	.video-js .vjs-big-play-button {
@@ -106,7 +106,7 @@
 
 	@container godam-player-pills-skin (max-width: 480px) {
 
-		.video-js .godam-central-controls {
+		.video-js 		.godam-central-controls {
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -114,9 +114,9 @@
 			background-color: var(--rtgodam-control-bar-color, #000000AD) !important;
 			border-radius: 999px;
 			padding: 6px 12px;
-			z-index: 20;
 			width: 164px;
 			height: 30px;
+			z-index: 19;
 		}
 	
 		.video-js .vjs-control-bar {
@@ -132,7 +132,7 @@
 			}
 
 			.vjs-settings-button, div.vjs-subs-caps-button {
-				z-index: 99;
+				z-index: 19;
 			}
 
 			.vjs-fullscreen-control, .vjs-settings-button, div.vjs-subs-caps-button {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam.io/issues/371

This pull request adjusts the stacking order of various UI components by modifying their `z-index` values across several CSS skin files. The main goal is to ensure correct layering and visibility of elements, particularly for video player controls and gallery overlays.

**Z-index adjustments for UI layering:**

* Lowered the `z-index` from 99 (or higher values) to 19 for multiple video player control elements in `bubble-skin.scss`, `classic-skin.scss`, and `pills-skin.scss` to standardize stacking and prevent overlap issues with other UI components. [[1]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138L127-R127) [[2]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138L140-R140) [[3]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138L273-R280) [[4]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138L340-R340) [[5]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138L353-R353) [[6]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138L366-R366) [[7]](diffhunk://#diff-6ea9c238097ae9dd06a55af25dbb37e17c164489853c0a88ec952aca709ebeb2L281-R281) [[8]](diffhunk://#diff-6ea9c238097ae9dd06a55af25dbb37e17c164489853c0a88ec952aca709ebeb2L401-R401) [[9]](diffhunk://#diff-6ea9c238097ae9dd06a55af25dbb37e17c164489853c0a88ec952aca709ebeb2L525-R525) [[10]](diffhunk://#diff-6ea9c238097ae9dd06a55af25dbb37e17c164489853c0a88ec952aca709ebeb2L569-R569) [[11]](diffhunk://#diff-f678c6b3cdf1601812afd91da5d6850d8edc3640dd563c91bfbc5a4a10683300L9-R11) [[12]](diffhunk://#diff-f678c6b3cdf1601812afd91da5d6850d8edc3640dd563c91bfbc5a4a10683300L117-R119) [[13]](diffhunk://#diff-f678c6b3cdf1601812afd91da5d6850d8edc3640dd563c91bfbc5a4a10683300L135-R135)

* Increased the `z-index` for the Godam gallery overlay and its controls in `godam-gallery.scss` to 200+ to ensure it appears above other interface elements. [[1]](diffhunk://#diff-886f5e2d9d16ce1332754960568cffa9d0481ae1d89ab385dcdb9d58ff2dfd77L262-R262) [[2]](diffhunk://#diff-886f5e2d9d16ce1332754960568cffa9d0481ae1d89ab385dcdb9d58ff2dfd77L341-R349)

These changes help maintain a consistent and predictable UI layering, reducing visual bugs where controls or overlays could appear behind unintended elements.


## Before:
<img width="1190" height="551" alt="Bubble Skin" src="https://github.com/user-attachments/assets/d2af0b4d-d8d6-4330-ade5-f4c583003a8c" />
<img width="1275" height="652" alt="Classic Skin" src="https://github.com/user-attachments/assets/427913ac-84da-4cb2-868d-2d2d7393ed2a" />
<img width="1304" height="673" alt="Pills Skin" src="https://github.com/user-attachments/assets/5f871e24-338d-4748-9e7f-62565406c07b" />

## After: No Overlap

<img width="1365" height="735" alt="Screenshot 2025-11-11 at 12 20 56 AM" src="https://github.com/user-attachments/assets/8eda7725-6a30-4e31-84e8-9b4fb5e3081e" />

### Tested overlapping of modal with:
1. All skins
2. Share button
3. Engagements bar
4. Overlay Blocks in block editor
