### PR TITLE
Hotfix 1.4.6 fixes

### DIFF
--- a/assets/src/js/media-library/views/attachment-browser.js
+++ b/assets/src/js/media-library/views/attachment-browser.js
@@ -88,7 +88,7 @@ export default AttachmentsBrowser?.extend( {
 						( container ) => getComputedStyle( container ).display !== 'none',
 					);
 
-					const activeContainer = visibleContainers.at( -1 ); // most recently opened visible one
+					const activeContainer = visibleContainers[ visibleContainers.length - 1 ]; // most recently opened visible one
 
 					if ( activeContainer ) {
 						const menu = activeContainer.querySelector( '.media-frame-menu' );
@@ -109,7 +109,7 @@ export default AttachmentsBrowser?.extend( {
 						( frame ) => getComputedStyle( frame ).display !== 'none',
 					);
 
-					const activeFrame = visibleFrames.at( -1 ); // most recently opened visible one
+					const activeFrame = visibleFrames[ visibleFrames.length - 1 ]; // most recently opened visible one
 
 					if ( activeFrame ) {
 						const menu = activeFrame.querySelector( '.media-frame-menu .media-menu' );

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -240,7 +240,6 @@ class Assets {
 
 		wp_enqueue_script( 'rtgodam-script' );
 		wp_enqueue_style( 'rtgodam-style' );
-		wp_enqueue_media();
 
 		wp_register_script(
 			'easydam-media-library',

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -192,6 +192,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function load_elementor_widgets() {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		if ( ! is_plugin_active( 'elementor/elementor.php' ) ) {
 			return;

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -170,7 +170,7 @@ function rtgodam_fetch_overlay_media_url( $media_id ) {
  */
 function rtgodam_image_cta_html( $layer ) {
 	// Determine if the image is a GoDAM hosted media.
-	$is_godam_media = is_string( $layer['image'] ) && str_starts_with( $layer['image'], 'godam_' );
+	$is_godam_media = is_string( $layer['image'] ) && strpos( $layer['image'], 'godam_' ) === 0;
 
 	if ( $is_godam_media && ! empty( $layer['imageUrlExt'] ) ) {
 		$image_url = $layer['imageUrlExt'];

--- a/pages/media-library/data/media-grid.js
+++ b/pages/media-library/data/media-grid.js
@@ -7,7 +7,7 @@ function getActiveMediaFrame() {
 	const visibleFrames = Array.from( document.querySelectorAll( '.media-frame' ) )
 		.filter( ( frame ) => getComputedStyle( frame ).display !== 'none' );
 
-	return visibleFrames.at( -1 ) || null; // Most recently opened visible frame
+	return visibleFrames[ visibleFrames.length - 1 ] || null; // Most recently opened visible frame
 }
 
 /**

--- a/pages/media-library/index.js
+++ b/pages/media-library/index.js
@@ -43,7 +43,7 @@ function initializeMediaLibrary() {
 		const visibleContainers = Array.from( document.querySelectorAll( '.supports-drag-drop' ) )
 			.filter( ( container ) => getComputedStyle( container ).display !== 'none' );
 
-		const activeContainer = visibleContainers.at( -1 ); // Most recent visible container
+		const activeContainer = visibleContainers[ visibleContainers.length - 1 ]; // Most recent visible container
 
 		if ( activeContainer ) {
 			const rootElement = activeContainer.querySelector( '#rt-transcoder-media-library-root' );
@@ -65,7 +65,7 @@ function initializeMediaLibrary() {
 	const visibleFrames = Array.from( document.querySelectorAll( '.media-frame' ) )
 		.filter( ( frame ) => getComputedStyle( frame ).display !== 'none' );
 
-	const activeFrame = visibleFrames.at( -1 ); // Most recently opened visible frame
+	const activeFrame = visibleFrames[ visibleFrames.length - 1 ]; // Most recently opened visible frame
 
 	let rootElement = null;
 


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/488

This pull request primarily updates how the code retrieves the last element from arrays, replacing the use of the `.at(-1)` method with the more widely supported `[array.length - 1]` pattern. Additionally, it includes a minor bug fix for string prefix checking, as well as a small update to ensure a required file is loaded before checking for plugin activation.

Array access compatibility updates:

* Replaced all uses of `.at(-1)` with `[array.length - 1]` when retrieving the most recently opened or visible frame/container in the media library JavaScript code. This change improves compatibility with environments where `.at()` is not supported. (`assets/src/js/media-library/views/attachment-browser.js`, `pages/media-library/data/media-grid.js`, `pages/media-library/index.js`) [[1]](diffhunk://#diff-fb7c950b71c9461563537f8c0937e81f6ff688496066c97a24ae6d3d6e0fb1deL91-R91) [[2]](diffhunk://#diff-fb7c950b71c9461563537f8c0937e81f6ff688496066c97a24ae6d3d6e0fb1deL112-R112) [[3]](diffhunk://#diff-352fbb346c4d84633b05cf169cdd19f4238799e9b1fa11b7ef2faffc564a59c8L10-R10) [[4]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aL46-R46) [[5]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aL68-R68)

Bug fixes and code improvements:

* Updated the check for whether an image is GoDAM-hosted by replacing `str_starts_with` with `strpos(..., 'godam_') === 0`, improving compatibility and correctness. (`inc/helpers/custom-functions.php`)
* Added a `require_once` for the WordPress plugin functions file before using `is_plugin_active`, preventing potential errors if the function is not already loaded. (`inc/classes/class-plugin.php`)

Other changes:

* Removed an unnecessary call to `wp_enqueue_media()` from the admin enqueue scripts function, likely as part of cleanup or optimization. (`inc/classes/class-assets.php`)