### PR TITLE
hotfix: Fix Media Folder Manager breaking issue

### DIFF
--- a/pages/media-library/index.js
+++ b/pages/media-library/index.js
@@ -23,21 +23,6 @@ const Index = () => {
 document.addEventListener( 'DOMContentLoaded', initializeMediaLibrary );
 document.addEventListener( 'media-frame-opened', initializeMediaLibrary );
 
-// Clean up React when media modal is closed - important to ensure clean state on modal reopen
-document.addEventListener( 'click', ( event ) => {
-	if ( event.target.closest( '.media-modal-close, .media-modal-backdrop' ) ) {
-		setTimeout( () => {
-			const rootElements = document.querySelectorAll( '#rt-transcoder-media-library-root' );
-			rootElements.forEach( ( rootElement ) => {
-				if ( rootElement._reactRoot ) {
-					rootElement._reactRoot.unmount();
-					delete rootElement._reactRoot;
-				}
-			} );
-		}, 100 );
-	}
-} );
-
 function initializeMediaLibrary() {
 	if ( window.elementor ) {
 		const visibleContainers = Array.from( document.querySelectorAll( '.supports-drag-drop' ) )


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1327
This pull request removes the event listener that cleaned up the React root when the media modal was closed in the `pages/media-library/index.js` file. This change simplifies the event handling logic and may affect how the React component is unmounted when closing the media modal.

**Event handling and cleanup:**

* Removed the event listener for clicks on `.media-modal-close` and `.media-modal-backdrop` that previously unmounted the React root and cleaned up the `#rt-transcoder-media-library-root` element when the media modal was closed. (`pages/media-library/index.js`)