### PR TITLE
fix: Elementor Widget Overlap for mobile screens

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1538,16 +1538,15 @@ body.godam-share-modal-open {
 	position: relative;
 }
 
-/* Elementor Widget Fix - Prevent collapse and overlap */
-.elementor-widget-godam-video figure[id^="godam-player-container"] {
-	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9);
-	display: block;
-}
-
 /* Ensure Elementor widget wrapper maintains proper dimensions */
 .elementor-widget-godam-video {
 	width: 100%;
 	flex-shrink: 0;
+
+	figure[id^="godam-player-container"] {
+		aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9);
+		display: block;
+	}
 }
 
 .easydam-video-container {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam.io/issues/371

This pull request improves the display and layout of the Godam video player when used as an Elementor widget. The main focus is on preventing layout issues such as collapsing and overlapping of the video player within Elementor containers.

Elementor widget compatibility and layout fixes:

* Added CSS rules to `figure[id^="godam-player-container"]` to enforce an aspect ratio and block display, preventing collapse and overlap in Elementor widgets.
* Updated `.elementor-widget-godam-video` styles to ensure the widget wrapper maintains proper width and does not shrink, preserving correct dimensions in Elementor layouts.

## Screenshots


### Before
<img width="685" height="794" alt="Screenshot 2025-11-12 at 11 56 59 PM" src="https://github.com/user-attachments/assets/0462287b-8d79-497f-967e-bf1d37a4d167" />

### After
<img width="660" height="791" alt="Screenshot 2025-11-12 at 11 58 28 PM" src="https://github.com/user-attachments/assets/58e03dd8-60e3-4cfe-9cc8-f83e55ace02a" />
