### PR TITLE
feat: Add preload poster functionality to video block

### DIFF
--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -37,6 +37,9 @@
 		"poster": {
 			"type": "string"
 		},
+		"preloadPoster": {
+			"type": "boolean"
+		},
 		"preload": {
 			"type": "string",
 			"default": "metadata"

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -240,7 +240,7 @@ function VideoEdit( {
 				} catch ( error ) {
 					// Show error notice if fetching media fails.
 					const message = sprintf(
-						/* translators: %s: Label of the video text track e.g: "French subtitles". */
+						/* translators: %d: Label of the video text track e.g: "French subtitles". */
 						_x( 'Failed to load video data with id: %d', 'video caption', 'godam' ),
 						id,
 					);
@@ -684,6 +684,14 @@ function VideoEdit( {
 										</div>
 									</MediaUploadCheck>
 								</BaseControl>
+
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Preload Video Thumbnail', 'godam' ) }
+									help={ __( 'Enable to show the video thumbnail faster when the page loads. Recommended for videos placed near the top of your page.', 'godam' ) }
+									onChange={ ( value ) => setAttributes( { preloadPoster: value } ) }
+									checked={ attributes?.preloadPoster }
+								/>
 
 								{ canManageAttachment( attachmentAuthorId ) && (
 									<BaseControl

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -101,6 +101,16 @@
 	pointer-events: none; /* Prevent interaction with the overlay */
 }
 
+.godam-poster-image {
+	position:absolute;
+	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9);
+	width: 100%;
+	height: auto;
+	max-height: 100%;
+	object-fit:contain;
+	background-color: #000;
+}
+
 .vjs-audio-button.vjs-menu-button {
 	display: none;
 }
@@ -195,6 +205,15 @@
 	border-radius: 4px;
 }
 
+.poll-container button:hover {
+	background-color: #1a5d99;
+}
+
+.poll-container button:disabled {
+	background-color: #ccc;
+	cursor: not-allowed;
+}
+
 // Only apply default styles to plain buttons without any classes
 .easydam-layer--cta-html button:not([class]),
 .video-js .easydam-layer--cta-html button:not([class]) {
@@ -256,15 +275,6 @@
 .poll-container .wp-polls-form {
 	max-width: 300px;
 	margin: auto;
-}
-
-.poll-container button:hover {
-	background-color: #1a5d99;
-}
-
-.poll-container button:disabled {
-	background-color: #ccc;
-	cursor: not-allowed;
 }
 
 .editor-video-customisation-cta,

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -43,6 +43,7 @@ $controls       = isset( $attributes['controls'] ) ? $attributes['controls'] : t
 $loop           = ! empty( $attributes['loop'] );
 $muted          = ! empty( $attributes['muted'] );
 $poster         = ! empty( $attributes['poster'] ) ? esc_url( $attributes['poster'] ) : '';
+$preload_poster = ! empty( $attributes['preloadPoster'] );
 $preload        = ! empty( $attributes['preload'] ) ? esc_attr( $attributes['preload'] ) : 'auto';
 $hover_select   = isset( $attributes['hoverSelect'] ) ? $attributes['hoverSelect'] : 'none';
 $caption        = ! empty( $attributes['caption'] ) ? esc_html( $attributes['caption'] ) : '';
@@ -219,6 +220,8 @@ $player_skin            = isset( $godam_settings['video_player']['player_skin'] 
 $ads_settings           = isset( $godam_settings['ads_settings'] ) ? $godam_settings['ads_settings'] : array();
 $ads_settings           = wp_json_encode( $ads_settings );
 
+$video_poster = empty( $poster ) ? $poster_image : $poster;
+
 // Build the video setup options for data-setup.
 $video_setup = array(
 	'controls'    => $controls,
@@ -226,7 +229,7 @@ $video_setup = array(
 	'loop'        => $loop,
 	'muted'       => $muted,
 	'preload'     => $preload,
-	'poster'      => empty( $poster ) ? $poster_image : $poster,
+	'poster'      => $video_poster,
 	'fluid'       => true,
 	'flvjs'       => array(
 		'mediaDataSource' => array(
@@ -386,6 +389,16 @@ if ( empty( $attachment_title ) ) {
 	$attachment_title = basename( get_attached_file( $attachment_id ) );
 }
 
+// Preload poster image if enabled to improve performance, especially LCP.
+if ( $preload_poster && ! empty( $video_poster ) ) {
+	add_action(
+		'wp_head',
+		function () use ( $video_poster ) {
+			printf( '<link rel="preload" as="image" fetchpriority="high" href="%s">', esc_url( $video_poster ) );
+		}
+	);
+}
+
 ?>
 
 <?php if ( ! empty( $sources ) ) : ?>
@@ -415,6 +428,14 @@ if ( empty( $attachment_title ) ) {
 						<path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"/>
 					</svg>
 				</div>
+				<?php if ( $preload_poster && ! empty( $video_poster ) ) : ?>
+					<img
+						class="godam-poster-image"
+						src="<?php echo esc_url( $video_poster ); ?>"
+						alt=""
+						fetchpriority="high"
+					/>
+				<?php endif; ?>
 				<video
 					class="easydam-player video-js vjs-big-play-centered vjs-hidden"
 					data-options="<?php echo esc_attr( $video_config ); ?>"


### PR DESCRIPTION
**Issue:**
- #1348 

## Overview
We're running an experiment to preload video posters to improve the Largest Contentful Paint (LCP), especially when the video is placed near the top of the page. This feature is optional, disabled by default, and can be turned on through the block settings.

## How It Works
Currently, video poster images begin loading only after JavaScript (JS) has been executed. This is because the GoDAM player relies on Video.js, which operates using JS.

### With this update:
There's a new option to preload the video poster. If this option is enabled, the poster image is included in the initial HTML.

This allows the image to start rendering during the first page load, improving LCP. Additionally, the image will be preloaded with a high fetch priority to ensure it loads as quickly as possible.
