### PR TITLE
fix: Add proper error handling when Ads are blocked

### DIFF
--- a/assets/src/js/godam-player/managers/adsManager.js
+++ b/assets/src/js/godam-player/managers/adsManager.js
@@ -12,16 +12,36 @@ export default class AdsManager {
 	 * Setup ads integration
 	 */
 	setupAdsIntegration() {
-		if ( this.config.adTagUrl ) {
-			this.player.ima( {
-				id: 'content_video',
-				adTagUrl: this.config.adTagUrl,
-			} );
-		} else if ( this.config.globalAdsSettings?.enable_global_video_ads && this.config.globalAdsSettings?.adTagUrl ) {
-			this.player.ima( {
-				id: 'content_video',
-				adTagUrl: this.config.globalAdsSettings.adTagUrl,
-			} );
+		// Check if IMA plugin is available
+		if ( typeof this.player.ima !== 'function' ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'GoDAM: VideoJS IMA plugin not available. Ads will be disabled.' );
+			return;
+		}
+
+		// Check if Google IMA SDK is loaded (blocked by ad blockers)
+		if ( typeof window.google === 'undefined' || typeof window.google.ima === 'undefined' ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'GoDAM: Google IMA SDK not available (likely blocked by ad blocker). Ads will be disabled.' );
+			return;
+		}
+
+		try {
+			if ( this.config.adTagUrl ) {
+				this.player.ima( {
+					id: 'content_video',
+					adTagUrl: this.config.adTagUrl,
+				} );
+			} else if ( this.config.globalAdsSettings?.enable_global_video_ads && this.config.globalAdsSettings?.adTagUrl ) {
+				this.player.ima( {
+					id: 'content_video',
+					adTagUrl: this.config.globalAdsSettings.adTagUrl,
+				} );
+			}
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'GoDAM: Failed to initialize ads. Ad layers will be disabled, but other layers will continue to work.', error );
+			// Continue with player initialization, don't let ad failures break the player.
 		}
 	}
 }


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1340

This pull request improves the robustness of the ads integration in the `AdsManager` class by adding checks and error handling to prevent ad-related failures from affecting the rest of the video player functionality. The main focus is on gracefully handling missing dependencies and initialization errors.

**Ads integration robustness improvements:**

* Added a check to verify if the VideoJS IMA plugin (`this.player.ima`) is available before attempting to initialize ads. If not available, a warning is logged and ads are disabled.
* Added a check to ensure the Google IMA SDK (`window.google.ima`) is loaded—typically blocked by ad blockers—before initializing ads. If missing, a warning is logged and ads are disabled.
* Wrapped the ad initialization logic in a `try-catch` block to handle any unexpected errors gracefully, logging a warning and allowing the player to continue functioning without ads if initialization fails.

## Recordings (with Ads being blocked)
### Before

https://github.com/user-attachments/assets/f4b9102e-7e8f-4e61-8d46-cacff480d326


### After

https://github.com/user-attachments/assets/51c67823-fd74-4770-93ae-3c8bafbf7300

