### PR TITLE
Minor UI improvements for preloading poster

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -685,15 +685,13 @@ function VideoEdit( {
 									</MediaUploadCheck>
 								</BaseControl>
 
-								{ !! poster && (
-									<ToggleControl
-										__nextHasNoMarginBottom
-										label={ __( 'Preload Video Thumbnail', 'godam' ) }
-										help={ __( 'Enable to show the video thumbnail faster when the page loads. Recommended for videos placed near the top of your page.', 'godam' ) }
-										onChange={ ( value ) => setAttributes( { preloadPoster: value } ) }
-										checked={ attributes?.preloadPoster }
-									/>
-								) }
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Preload Video Thumbnail', 'godam' ) }
+									help={ __( 'Enable to show the video thumbnail faster when the page loads. Recommended for videos placed near the top of your page.', 'godam' ) }
+									onChange={ ( value ) => setAttributes( { preloadPoster: value } ) }
+									checked={ attributes?.preloadPoster }
+								/>
 
 								{ canManageAttachment( attachmentAuthorId ) && (
 									<BaseControl

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1565,7 +1565,7 @@ body.godam-share-modal-open {
 		}
 	}
 
-	&:has(.vjs-hidden) {
+	&:has(.easydam-player.vjs-hidden) {
 
 		.godam-poster-image {
 			display: block;


### PR DESCRIPTION
## Summary

- Hide the poster once the Video.js is loaded because it shows its own poster.
- Show the poster preloading option only if the poster is selected to avoid overwhelming the user.

Related issue: #1348
