### PR TITLE
fix: Update GET to POST requests for Oembed and Engagements

### DIFF
--- a/inc/classes/class-embed.php
+++ b/inc/classes/class-embed.php
@@ -80,9 +80,17 @@ class Embed {
 			return null;
 		}
 
-		$embed_url = RTGODAM_API_BASE . '/api/method/godam_core.api.oembed.get_oembed?url=' . rawurlencode( $url );
+		$embed_url = RTGODAM_API_BASE . '/api/method/godam_core.api.oembed.get_oembed';
 
-		$response = wp_remote_get( $embed_url );
+		$response = wp_remote_post(
+			$embed_url,
+			array(
+				'body'    => wp_json_encode( array( 'url' => $url ) ),
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+			)
+		);
 
 		if ( is_wp_error( $response ) ) {
 			return false;

--- a/inc/classes/rest-api/class-engagement.php
+++ b/inc/classes/rest-api/class-engagement.php
@@ -713,8 +713,15 @@ class Engagement extends Base {
 		}
 
 		$comments_endpoint = RTGODAM_API_BASE . '/api/method/godam_core.api.comment.get_wp_comments';
-		$comments_url      = add_query_arg( $query_params, $comments_endpoint );
-		$comments_response = wp_remote_get( $comments_url );
+		$comments_response = wp_remote_post(
+			$comments_endpoint,
+			array(
+				'body'    => wp_json_encode( $query_params ),
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+			)
+		);
 		$process_response  = $this->process_response( $comments_response );
 
 		if ( $process_response instanceof WP_REST_Response || empty( $process_response['message']['comments'] ) || ! is_array( $process_response['message']['comments'] ) ) {
@@ -798,8 +805,15 @@ class Engagement extends Base {
 		}
 
 		$likes_endpoint   = RTGODAM_API_BASE . '/api/method/godam_core.api.comment.get_wp_likes';
-		$likes_url        = add_query_arg( $query_params, $likes_endpoint );
-		$likes_response   = wp_remote_get( $likes_url );
+		$likes_response   = wp_remote_post(
+			$likes_endpoint,
+			array(
+				'body'    => wp_json_encode( $query_params ),
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+			)
+		);
 		$process_response = $this->process_response( $likes_response );
 
 		if ( $process_response instanceof WP_REST_Response || empty( $process_response['message']['status'] ) || 'success' !== $process_response['message']['status'] ) {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1330

This pull request updates how API requests are made for oEmbed data, comments, and likes, switching from GET requests with query parameters to POST requests with JSON bodies. This change improves data handling and aligns with modern API standards.

**API request method updates:**

* Changed the oEmbed API call in `class-embed.php` to use `wp_remote_post` with a JSON body instead of `wp_remote_get` with a query parameter.

* Updated the comments retrieval in `class-engagement.php` to use `wp_remote_post` with a JSON body, replacing the previous GET request.

* Updated the likes retrieval in `class-engagement.php` to use `wp_remote_post` with a JSON body, replacing the previous GET request.