### PR TITLE
fix: PCP Errors

### DIFF
--- a/assets/src/blocks/godam-pdf/render.php
+++ b/assets/src/blocks/godam-pdf/render.php
@@ -20,13 +20,13 @@ if ( ! $godam_attachment_id && empty( $godam_src ) ) {
 
 $godam_sources = array();
 if ( ! empty( $godam_attachment_id ) && is_numeric( $godam_attachment_id ) ) { 
-	$pdf_url            = wp_get_attachment_url( $godam_attachment_id );
-	$pdf_transcoded_url = get_post_meta( $godam_attachment_id, 'rtgodam_transcoded_url', true );
-	if ( ! empty( $pdf_transcoded_url ) ) {
-		$godam_sources[] = $pdf_transcoded_url;
+	$godam_pdf_url            = wp_get_attachment_url( $godam_attachment_id );
+	$godam_pdf_transcoded_url = get_post_meta( $godam_attachment_id, 'rtgodam_transcoded_url', true );
+	if ( ! empty( $godam_pdf_transcoded_url ) ) {
+		$godam_sources[] = $godam_pdf_transcoded_url;
 	}
-	if ( ! empty( $pdf_url ) ) {
-		$godam_sources[] = $pdf_url;
+	if ( ! empty( $godam_pdf_url ) ) {
+		$godam_sources[] = $godam_pdf_url;
 	}
 } else {
 	$godam_sources[] = $godam_src;

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: rtcamp, elifvish, subodhrajpopat, kuldipchaudhary, prachigarg19, juzar, geekofshire, nazmulhassann20, abhinavbelhekar03, gautam23, mukulsingh27, hbhalodia
 Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 1.4.7
 License: GPLv2 or later


### PR DESCRIPTION
Issue - [[Release] GoDAM v1.4.8 (rtCamp/godam-core#535)](https://github.com/rtCamp/godam-core/issues/535)
This needs to be tested again and merged after all other fixes have been merged.

### Overview
This pull request includes minor updates to improve code clarity and documentation accuracy.

* Documentation update:
  * [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R5): Updated the "Tested up to" field to WordPress version 6.9 to reflect compatibility with the latest release.

* Code clarity improvement:
  * [`assets/src/blocks/godam-pdf/render.php`](diffhunk://#diff-e14d939380a30f19de788068c5446671ce9bafb9ee7f6a9d49d86fe2c93899ccL23-R29): Renamed variables from `pdf_url` and `pdf_transcoded_url` to `godam_pdf_url` and `godam_pdf_transcoded_url` for consistency and better readability.

### After Screenshot (Only Warnings remaining):

<img width="1465" height="793" alt="Screenshot 2025-12-05 at 6 19 24 PM" src="https://github.com/user-attachments/assets/78ac8749-3591-4d85-993f-5c868b2602d1" />
