### PR TITLE
Disable godam tab for feature image media selector

### DIFF
--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -20,7 +20,7 @@ const l10n = wp?.media?.view?.l10n;
  *
  * @since n.e.x.t
  *
- * @param {*} frame
+ * @param {wp.media.view.MediaFrame} frame
  * @return {boolean} True if featured image context, false otherwise.
  */
 const checkIfFeatureImage = ( frame ) => {
@@ -31,13 +31,6 @@ const checkIfFeatureImage = ( frame ) => {
 
 		// Featured image context
 		if ( stateId === 'featured-image' || frame.id === 'featured-image' ) {
-			return true;
-		}
-	}
-
-	// Check frame title for featured image
-	if ( frame && frame.title && typeof frame.title === 'string' ) {
-		if ( frame.title.toLowerCase().includes( 'featured' ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/534#issuecomment-3550726977

This pull request introduces a safeguard to prevent GoDAM-specific media frame functionality from interfering with the featured image context in the media library. The main change is the addition of a utility function to detect if the current media frame is being used for a featured image, and then using this check to conditionally apply GoDAM-specific logic.

Key changes:

**Featured Image Context Detection**

* Added a new `checkIfFeatureImage` function to reliably detect if the current media frame is in a featured image context, based on frame state, ID, or title. This helps avoid unintended behavior when the media modal is opened for selecting a featured image.

**Conditional GoDAM Functionality**

* Updated the `GoDAMMediaFrameShared.browseRouter` method to skip GoDAM-specific router modifications when in a featured image context, ensuring compatibility and preventing UI conflicts.

## Before
https://github.com/user-attachments/assets/03067778-c7c0-41db-99e7-b4f1fd05feaa



## After
https://github.com/user-attachments/assets/8554b57c-a443-45d5-9ef2-4a4ddb27ef58



**Note:** This will not disable the godam tab for media selector opened by core/feature image block. As there is no trace available to detect whether Media selector context if its feature-image or what!!
<img width="588" height="277" alt="Screenshot 2025-12-05 at 4 11 12 PM" src="https://github.com/user-attachments/assets/91b8a53b-9991-4ce5-a292-50723cf01bd2" />

