### PR TITLE
Center custom icon images in media library thumbnails

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -808,5 +808,5 @@ to ensure proper responsiveness and avoid layout issues.
  * generated thumbnail sizes available.
  */
 .wp-core-ui .attachments-browser .attachment .thumbnail .centered img.icon {
-	transform: translate(-50%, -50%) !important;
+		transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1131

This pull request adds a targeted CSS override to fix alignment issues for custom icon images in the WordPress media library. The change ensures that icons are properly centered within thumbnails, especially for virtual attachments and media without generated thumbnail sizes.

Styling and layout fixes:

* Added a CSS rule in `admin.scss` to reset the transform property for `.wp-core-ui .attachments-browser .attachment .thumbnail .centered img.icon`, ensuring icons are centered by overriding WordPress's default misaligned positioning.