### PR TITLE
Cache site data only if there is valid response

### DIFF
--- a/assets/src/js/media-library/utility.js
+++ b/assets/src/js/media-library/utility.js
@@ -91,7 +91,7 @@ async function addManageMediaButton() {
 					},
 				} );
 			const result = await response.json();
-			if ( 'success' === result?.status && null !== result?.data?.message?.folder_id ) {
+			if ( 'success' === result?.status && false !== result?.data && null !== result?.data?.message?.folder_id ) {
 				const mediaUrl = `${ godamMediaLink }?page=1&viewMode=grid&tab=Folder&folder=${ result?.data?.message?.folder_id }`;
 				button.href = mediaUrl;
 			}

--- a/inc/classes/rest-api/class-site.php
+++ b/inc/classes/rest-api/class-site.php
@@ -84,7 +84,7 @@ class Site extends Base {
 				return $site_data_response;
 			}
 
-			if ( ! isset( $site_data_response['message']['error'] ) ) {
+			if ( ! empty( $site_data_response['message']['folder_id'] ) ) {
 				// Cache the response data for future requests.
 				rtgodam_cache_set( $cache_key, $site_data_response, 86400 );
 				$site_data = $site_data_response;


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/535

Ref: [QA Issues Point 5](https://docs.google.com/document/d/1KDpp3WxD6g8c0_J-p9SR5PzO148xZbgF3V97gyMmWOs/edit?addon_store&tab=t.pqbkedgxc5xu#heading=h.2xn2554fhe)

This PR ensures that data fetched from the external API is cached only if the request returns a valid success response. If the API call encounters any error (e.g., network failure, malformed data, error status), the system will skip caching to prevent storing invalid or incomplete data.