### PR TITLE
fix: Make GoDAM Gallery Player loading async

### DIFF
--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -313,7 +313,10 @@ document.addEventListener( 'click', async function( e ) {
 										dispatch( engagementStore ).initiateCommentModal( newVideoId, siteUrl, engagementId, skipEngagements ).then( () => {
 											window.galleryScroll = true;
 										} );
-										playerInstance.play();
+										playerInstance.play().catch( ( error ) => {
+											// eslint-disable-next-line no-console
+											console.warn( 'Failed to start gallery playback:', error );
+										} );
 									};
 
 									if ( newVideoEngagementsData ) {
@@ -326,27 +329,44 @@ document.addEventListener( 'click', async function( e ) {
 									dispatch( engagementStore ).initiateCommentModal( newVideoId, siteUrl, engagementId, true ).then( () => {
 										window.galleryScroll = true;
 									} );
-									playerInstance.play();
+									playerInstance.play().catch( ( error ) => {
+										// eslint-disable-next-line no-console
+										console.warn( 'Failed to start gallery playback:', error );
+									} );
 								}
 							};
 
 							// Get the video element for this modal
 							const videoPlayerElement = modal.querySelector( '.video-js' );
 							const videojs = window.videojs;
-							// Check if player is already ready (fallback for synchronous initialization)
-							const existingPlayer = videoPlayerElement ? videojs.getPlayer( videoPlayerElement ) : null;
-							if ( existingPlayer ) {
-								setupGalleryPlayer( existingPlayer );
+
+							// Clean up any previous event listener for this modal
+							if ( modal._galleryPlayerReadyHandler ) {
+								document.removeEventListener( 'godamPlayerReady', modal._galleryPlayerReadyHandler );
+								modal._galleryPlayerReadyHandler = null;
+							}
+
+							if ( videojs ) {
+								// Check if player is already ready (fallback for synchronous initialization)
+								const existingPlayer = videoPlayerElement ? videojs.getPlayer( videoPlayerElement ) : null;
+								if ( existingPlayer ) {
+									setupGalleryPlayer( existingPlayer );
+								} else {
+									// Listen for the godamPlayerReady event (async initialization)
+									const onPlayerReady = ( event ) => {
+										// Ensure this event is for our video element
+										if ( event.detail.videoElement === videoPlayerElement ) {
+											setupGalleryPlayer( event.detail.player );
+											document.removeEventListener( 'godamPlayerReady', onPlayerReady );
+											modal._galleryPlayerReadyHandler = null;
+										}
+									};
+									modal._galleryPlayerReadyHandler = onPlayerReady;
+									document.addEventListener( 'godamPlayerReady', onPlayerReady );
+								}
 							} else {
-								// Listen for the godamPlayerReady event (async initialization)
-								const onPlayerReady = ( event ) => {
-									// Ensure this event is for our video element
-									if ( event.detail.videoElement === videoPlayerElement || videoPlayerElement.contains( event.detail.videoElement ) ) {
-										setupGalleryPlayer( event.detail.player );
-										document.removeEventListener( 'godamPlayerReady', onPlayerReady );
-									}
-								};
-								document.addEventListener( 'godamPlayerReady', onPlayerReady );
+								// eslint-disable-next-line no-console
+								console.error( 'Video.js is not loaded. Cannot initialize player.' );
 							}
 						}
 					}
@@ -369,15 +389,51 @@ document.addEventListener( 'click', async function( e ) {
 		// Initialize the video player
 		if ( typeof GODAMPlayer === 'function' ) {
 			GODAMPlayer( modal );
-			// Find the video player and start playing
-			const videoPlayer = modal.querySelector( '.video-js' );
-			if ( videoPlayer && videoPlayer.player ) {
-				videoPlayer.player.play();
+			// Wait for player to be ready before trying to play
+			const videoPlayerElement = modal.querySelector( '.video-js' );
+			const videojs = window.videojs;
+
+			// Clean up any previous event listener for this modal
+			if ( modal._initialPlayerReadyHandler ) {
+				document.removeEventListener( 'godamPlayerReady', modal._initialPlayerReadyHandler );
+				modal._initialPlayerReadyHandler = null;
+			}
+
+			if ( videojs && videoPlayerElement ) {
+				// Check if player is already ready
+				const existingPlayer = videojs.getPlayer( videoPlayerElement );
+				if ( existingPlayer ) {
+					existingPlayer.play().catch( ( error ) => {
+						// eslint-disable-next-line no-console
+						console.warn( 'Failed to start initial playback:', error );
+					} );
+				} else {
+					// Listen for the godamPlayerReady event
+					const onInitialPlayerReady = ( event ) => {
+						if ( event.detail.videoElement === videoPlayerElement ) {
+							event.detail.player.play();
+							document.removeEventListener( 'godamPlayerReady', onInitialPlayerReady );
+							modal._initialPlayerReadyHandler = null;
+						}
+					};
+					modal._initialPlayerReadyHandler = onInitialPlayerReady;
+					document.addEventListener( 'godamPlayerReady', onInitialPlayerReady );
+				}
 			}
 		}
 
 		// Close handlers
 		const close = () => {
+			// Clean up event listeners to prevent memory leaks
+			if ( modal._initialPlayerReadyHandler ) {
+				document.removeEventListener( 'godamPlayerReady', modal._initialPlayerReadyHandler );
+				modal._initialPlayerReadyHandler = null;
+			}
+			if ( modal._galleryPlayerReadyHandler ) {
+				document.removeEventListener( 'godamPlayerReady', modal._galleryPlayerReadyHandler );
+				modal._galleryPlayerReadyHandler = null;
+			}
+
 			// Send heatmap (type 2) for the current video on close BEFORE disposing/removing
 			const currentId = parseInt( modal.dataset.currentVideoId || 0, 10 );
 			if ( currentId ) {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/535
Ref - [QA Issues Point 2](https://docs.google.com/document/d/1KDpp3WxD6g8c0_J-p9SR5PzO148xZbgF3V97gyMmWOs/edit?addon_store&tab=t.pqbkedgxc5xu#heading=h.22s5apr78fh)
This pull request refactors the logic for initializing and playing the video player in the Godam Gallery modal to better handle both synchronous and asynchronous player initialization. The changes improve reliability when starting video playback and engagement modals, especially in cases where the video player may not be immediately available.

**Improvements to video player initialization and playback:**

* Refactored the code to use a `setupGalleryPlayer` helper function, ensuring that engagement modal setup and video playback are handled consistently for both synchronous and asynchronous player initialization.
* Added logic to check if the video player instance already exists using `videojs.getPlayer`; if not, the code now listens for a custom `godamPlayerReady` event to handle asynchronous initialization before proceeding with engagement and playback.
* Ensured that video playback (`play()`) is always called on the correct player instance, and engagement modals are reliably initiated regardless of initialization timing.