### PR TITLE
feat: Add BFCM Banner timer

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -263,8 +263,11 @@ class RTGODAM_Transcoder_Admin {
 		}
 
 		$show_offer_banner = get_option( 'rtgodam-offer-banner', 1 );
-
-		if ( ! rtgodam_is_api_key_valid() && $show_offer_banner ) {
+		$timezone          = wp_timezone();
+		$current_time      = new \DateTime( 'now', $timezone );
+		$end_time          = new \DateTime( '2025-12-14 23:59:59', $timezone );
+		
+		if ( $current_time <= $end_time && ! rtgodam_is_api_key_valid() && $show_offer_banner ) {
 			$host = wp_parse_url( home_url(), PHP_URL_HOST );
 
 			$banner_image = RTGODAM_URL . 'assets/src/images/BFCM.png';

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -308,7 +308,11 @@ class Assets {
 		);
 
 		if ( ! rtgodam_is_api_key_valid() ) {
-			$godam_settings_obj['showOfferBanner']             = get_option( 'rtgodam-offer-banner', '1' );
+			$timezone     = wp_timezone();
+			$current_time = new \DateTime( 'now', $timezone );
+			$end_time     = new \DateTime( '2025-12-14 23:59:59', $timezone );
+
+			$godam_settings_obj['showOfferBanner']             = ( $current_time <= $end_time ) && ( '0' !== get_option( 'rtgodam-offer-banner', '1' ) );
 			$godam_settings_obj['showOfferBannerNonce']        = wp_create_nonce( 'godam-dismiss-offer-banner-nonce' );
 			$godam_settings_obj['enableGlobalVideoEngagement'] = false;
 		}

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -560,8 +560,12 @@ class Media_Library_Ajax {
 
 		$show_offer_banner = get_option( 'rtgodam-offer-banner', 1 );
 
+		$timezone     = wp_timezone();
+		$current_time = new \DateTime( 'now', $timezone );
+		$end_time     = new \DateTime( '2025-12-14 23:59:59', $timezone );
+
 		// Only show on the Media Library page.
-		if ( $screen && 'upload' === $screen->base && ! rtgodam_is_api_key_valid() && $show_offer_banner ) {
+		if ( $current_time <= $end_time && $screen && 'upload' === $screen->base && ! rtgodam_is_api_key_valid() && $show_offer_banner ) {
 			$host = wp_parse_url( home_url(), PHP_URL_HOST );
 
 			$banner_image = RTGODAM_URL . 'assets/src/images/BFCM.png';

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -605,12 +605,17 @@ class Pages {
 				$rtgodam_user_data
 			);
 
+			$timezone     = wp_timezone();
+			$current_time = new \DateTime( 'now', $timezone );
+			$end_time     = new \DateTime( '2025-12-14 23:59:59', $timezone );
+
 			wp_localize_script(
 				'godam-page-script-dashboard',
 				'videoData',
 				array(
-					'adminUrl'     => admin_url( 'admin.php?page=rtgodam_settings#video-settings' ),
-					'godamBaseUrl' => RTGODAM_IO_API_BASE,
+					'adminUrl'       => admin_url( 'admin.php?page=rtgodam_settings#video-settings' ),
+					'godamBaseUrl'   => RTGODAM_IO_API_BASE,
+					'showBFCMBanner' => ( $current_time <= $end_time ),
 				)
 			);
 

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -40,6 +40,8 @@ const Dashboard = () => {
 	const topVideosData = topVideosResponse?.videos || [];
 	const totalTopVideosPages = topVideosResponse?.totalPages || 1;
 
+	const showBFCMBanner = window.videoData?.showBFCMBanner;
+
 	useEffect( () => {
 		const loadingEl = document.getElementById( 'loading-analytics-animation' );
 		const container = document.getElementById( 'dashboard-container' );
@@ -195,22 +197,24 @@ const Dashboard = () => {
 
 					{ dashboardMetrics?.errorType === 'invalid_key' || dashboardMetrics?.errorType === 'missing_key'
 						? <>
-							<div className="annual-plan-offer-banner dashboard-modal-banner">
-								<a
-									href={ `${ window?.videoData?.godamBaseUrl }/pricing?utm_campaign=bfcm-offer&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=dashboard-modal-banner` }
-									className="annual-plan-offer-banner__link"
-									target="_blank"
-									rel="noopener noreferrer"
-									aria-label={ __( 'Claim the GoDAM Black Friday & Cyber Monday offer', 'godam' ) }
-								>
-									<img
-										src={ BFCMBanner }
-										alt={ __( 'Black Friday & Cyber Monday offer from GoDAM', 'godam' ) }
-										className="annual-plan-offer-banner__image"
-										loading="lazy"
-									/>
-								</a>
-							</div>
+							{ showBFCMBanner && (
+								<div className="annual-plan-offer-banner dashboard-modal-banner">
+									<a
+										href={ `${ window?.videoData?.godamBaseUrl }/pricing?utm_campaign=bfcm-offer&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=dashboard-modal-banner` }
+										className="annual-plan-offer-banner__link"
+										target="_blank"
+										rel="noopener noreferrer"
+										aria-label={ __( 'Claim the GoDAM Black Friday & Cyber Monday offer', 'godam' ) }
+									>
+										<img
+											src={ BFCMBanner }
+											alt={ __( 'Black Friday & Cyber Monday offer from GoDAM', 'godam' ) }
+											className="annual-plan-offer-banner__image"
+											loading="lazy"
+										/>
+									</a>
+								</div>
+							) }
 							<div className="api-key-overlay-banner">
 								<p className="api-key-overlay-banner-header">
 									{ __(

--- a/pages/video-editor/AttachmentPicker.jsx
+++ b/pages/video-editor/AttachmentPicker.jsx
@@ -20,7 +20,8 @@ const AttachmentPicker = ( { handleAttachmentClick } ) => {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ page, setPage ] = useState( 1 );
 	const [ attachments, setAttachments ] = useState( [] );
-	const [ showOfferBanner, setShowOfferBanner ] = useState( ( '0' !== window?.godamSettings?.showOfferBanner ) );
+	// showOfferBanner will now be a boolean (true/false) based on PHP calculation passed via godamSettings, or '0' if dismissed
+	const [ showOfferBanner, setShowOfferBanner ] = useState( window?.godamSettings?.showOfferBanner && '0' !== window?.godamSettings?.showOfferBanner );
 
 	const handleDismissBanner = () => {
 		setShowOfferBanner( false );


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/535

This pull request introduces a time-based restriction for displaying the Black Friday/Cyber Monday (BFCM) offer banner across the plugin’s admin dashboard and media library. The banner will now only be shown if the current date is before December 14, 2025, and the API key is not valid. The logic is consistently applied in both PHP and JavaScript, ensuring that the banner is only visible during the promotional period.

**BFCM Offer Banner Display Logic Updates:**

* Added checks in `admin/class-rtgodam-transcoder-admin.php`, `inc/classes/class-media-library-ajax.php`, and `inc/classes/class-assets.php` to ensure the BFCM offer banner is only shown if the current time is before December 14, 2025, and the API key is invalid. [[1]](diffhunk://#diff-bba9a8790490fbd0993b7d9a8c4774a21fc0934049d7431e92595d67dd4dea49R266-R270) [[2]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R563-R568) [[3]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dL311-R315)
* Updated `inc/classes/class-pages.php` to pass the calculated `showBFCMBanner` flag to JavaScript, allowing the dashboard to conditionally display the banner based on the current date.

**Frontend Integration:**

* Modified `pages/dashboard/Dashboard.js` to use the new `showBFCMBanner` flag for rendering the offer banner only during the valid promotional period. [[1]](diffhunk://#diff-d74bb21410b6c9985a24e269b09f8e7eca804aa5aa8e55276267233d6c568822R43-R44) [[2]](diffhunk://#diff-d74bb21410b6c9985a24e269b09f8e7eca804aa5aa8e55276267233d6c568822R200) [[3]](diffhunk://#diff-d74bb21410b6c9985a24e269b09f8e7eca804aa5aa8e55276267233d6c568822R217)
* Updated `pages/video-editor/AttachmentPicker.jsx` to handle the new boolean logic for `showOfferBanner`, ensuring consistency with the backend calculation.