### PR TITLE
Fix/encode pdf uri

### DIFF
--- a/assets/src/blocks/godam-pdf/view.js
+++ b/assets/src/blocks/godam-pdf/view.js
@@ -222,7 +222,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					const downloadLink = newFallback.querySelector( 'a' );
 					if ( downloadLink ) {
 						if ( isSafePdfUrl( newSource ) ) {
-							downloadLink.href = newSource;
+							downloadLink.href = encodeURI( newSource );
 						}
 					}
 					newObject.appendChild( newFallback );


### PR DESCRIPTION
This pull request makes a small change to how PDF download links are handled in the `assets/src/blocks/godam-pdf/view.js` file. The change ensures that the `href` attribute for download links is properly encoded for safe usage.

* The `href` for the download link is now set using `encodeURI(newSource)` instead of the raw `newSource`, improving URL safety.