### PR TITLE
fix: Apply URI encoding for PDF

### DIFF
--- a/assets/src/blocks/godam-pdf/view.js
+++ b/assets/src/blocks/godam-pdf/view.js
@@ -92,7 +92,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					const exists = await pdfExists( busted );
 
 					if ( exists ) {
-						pdfObject.setAttribute( 'data', busted );
+						pdfObject.setAttribute( 'data', encodeURI( busted ) );
 						return;
 					}
 				}
@@ -211,7 +211,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				newObject.type = 'application/pdf';
 				newObject.width = '100%';
 				newObject.height = '100%';
-				newObject.setAttribute( 'data', newSource );
+				newObject.setAttribute( 'data', encodeURI( newSource ) );
 				newObject.setAttribute( 'data-sources', sourcesData );
 				newObject.setAttribute( 'data-current-index', sourceIndex );
 


### PR DESCRIPTION
This pull request makes a minor improvement to how PDF sources are handled in the `godam-pdf` block's view script. The main change is that PDF URLs are now URI-encoded before being set as the `data` attribute on `<object>` elements, which helps prevent issues with special characters in file names or paths.

- PDF URL encoding:
  * Updated both existing and newly created `<object>` elements to use `encodeURI()` when setting the `data` attribute with the PDF source URL, ensuring proper handling of special characters. (`assets/src/blocks/godam-pdf/view.js`) [[1]](diffhunk://#diff-5af89d32487980fd9729530bffb6649092ff307437975e6cd48fca63a9e1740fL95-R95) [[2]](diffhunk://#diff-5af89d32487980fd9729530bffb6649092ff307437975e6cd48fca63a9e1740fL214-R214)