### PR TITLE
fix: Update subscription plan link

### DIFF
--- a/pages/godam/components/GoDAMHeader.jsx
+++ b/pages/godam/components/GoDAMHeader.jsx
@@ -15,7 +15,7 @@ import godamLogo from '../../../assets/src/images/godam-logo.png';
 
 const GodamHeader = () => {
 	const helpLink = window.godamRestRoute?.apiBase + '/helpdesk';
-	const upgradePlanLink = window.godamRestRoute?.apiBase + '/subscription/plans';
+	const upgradePlanLink = window.godamRestRoute?.apiBase + '/web/billing?tab=Plans';
 	const pricingLink = `https://godam.io/pricing?utm_campaign=buy-plan&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=header`;
 	const godamMediaLink = window.godamRestRoute?.apiBase + '/web/media-library';
 	const [ mediaLink, setMediaLink ] = useState( godamMediaLink );

--- a/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
@@ -26,7 +26,7 @@ const VideoEngagement = ( { handleSettingChange } ) => {
 					<Button
 						className="godam-button"
 						icon={ unlock }
-						href="https://app.godam.io/subscription/plans"
+						href="https://app.godam.io/web/billing?tab=Plans"
 						target="_blank"
 						variant="primary"
 					>

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -93,7 +93,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 					<Button
 						className="godam-button"
 						icon={ unlock }
-						href="https://app.godam.io/subscription/plans"
+						href="https://app.godam.io/web/billing?tab=Plans"
 						target="_blank"
 						variant="primary"
 					>


### PR DESCRIPTION
This pull request updates the URLs for the "upgrade plan" and related billing links throughout the GoDAM plugin UI to point to the new billing page with the appropriate tab selected. This ensures users are directed to the correct location for managing or upgrading their subscription plans.

**Billing and subscription link updates:**

* Updated the `upgradePlanLink` in `GoDAMHeader.jsx` to point to `/web/billing?tab=Plans` instead of `/subscription/plans`.
* Changed the "Upgrade Plan" button links in both `VideoEngagement.jsx` and `VideoWatermark.jsx` to use the new `/web/billing?tab=Plans` URL. [[1]](diffhunk://#diff-bc5d8c011dc32e2237d2a4b734a2f968280e24fb3f9132d95ec8c78f8562c175L29-R29) [[2]](diffhunk://#diff-4d5e66af148438d16b2aef5e592f1c1d2560f10d810e88f3f1c776492f20a924L96-R96)