### PR TITLE
fix: Clean up zip file from media folder

### DIFF
--- a/inc/classes/media-library/class-media-folders-rest-api.php
+++ b/inc/classes/media-library/class-media-folders-rest-api.php
@@ -143,6 +143,6 @@ class Media_Folders_REST_API {
 	 * @param string $zip_path The path to the ZIP file to be cleaned up.
 	 */
 	public function godam_cleanup_zip_file( $zip_path ) {
-		Media_Folder_Utils::get_instance()->godam_cleanup_zip_file( $zip_path );
+		Media_Folder_Create_Zip::get_instance()->godam_cleanup_zip_file( $zip_path );
 	}
 }


### PR DESCRIPTION
This pull request updates the implementation of the `godam_cleanup_zip_file` method to use a more appropriate utility class for ZIP file cleanup.

Refactoring and code correctness:

* Updated the `godam_cleanup_zip_file` method in `class-media-folders-rest-api.php` to call `Media_Folder_Create_Zip::get_instance()` instead of `Media_Folder_Utils::get_instance()`, ensuring the ZIP file cleanup logic is handled by the correct class.


### Screenshot
Tested with deletion after 5 seconds:

<img width="267" height="272" alt="Screenshot 2025-12-11 at 1 47 53 PM" src="https://github.com/user-attachments/assets/b6c9c079-a5a3-4099-a092-fdbc0214d80f" />
