### PR TITLE
fix: Console errors in Media Library

### DIFF
--- a/assets/src/js/media-library/views/filters/media-library-taxonomy-filter.js
+++ b/assets/src/js/media-library/views/filters/media-library-taxonomy-filter.js
@@ -20,8 +20,10 @@ MediaLibraryTaxonomyFilter = MediaLibraryTaxonomyFilter?.extend( {
 				},
 			};
 		} else {
-			const props = this.filters[ this.el.value ].props;
-			this.model.set( props );
+			const props = this.filters[ this.el.value ]?.props;
+			if ( props ) {
+				this.model.set( props );
+			}
 		}
 	},
 

--- a/pages/media-library/index.js
+++ b/pages/media-library/index.js
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
  */
 import store from './redux/store';
 import { resetUIState } from './redux/slice/folders';
+import { triggerFilterChange } from './data/media-grid.js';
 import App from './App';
 import './index.scss';
 
@@ -79,6 +80,9 @@ function setupMediaModalCloseDetection() {
 
 							// Media modal was closed, reset React state
 							store.dispatch( resetUIState() );
+
+							// Also trigger WordPress media filter change to sync
+							triggerFilterChange( 'all' );
 						// Also check if it contains media modal children
 						} else if ( node.querySelector && node.querySelector( '.media-modal' ) ) {
 							// Clean up any React roots in child modals
@@ -95,6 +99,9 @@ function setupMediaModalCloseDetection() {
 							} );
 
 							store.dispatch( resetUIState() );
+
+							// Also trigger WordPress media filter change to sync
+							triggerFilterChange( 'all' );
 						}
 					}
 				} );
@@ -116,6 +123,9 @@ function setupMediaModalCloseDetection() {
 		// If modal count decreased, a modal was closed
 		if ( currentModalCount < lastModalCount ) {
 			store.dispatch( resetUIState() );
+
+			// Also trigger WordPress media filter change to sync
+			triggerFilterChange( 'all' );
 		}
 
 		lastModalCount = currentModalCount;
@@ -146,6 +156,9 @@ function setupMediaModalCloseDetection() {
 
 				// Reset React state after modal closes
 				store.dispatch( resetUIState() );
+
+				// Also trigger WordPress media filter change to sync
+				triggerFilterChange( 'all' );
 			}, 100 ); // Small delay to ensure modal is fully closed
 
 			return result;

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -3,11 +3,6 @@
  */
 import { createSlice } from '@reduxjs/toolkit';
 
-/**
- * Internal dependencies
- */
-import { triggerFilterChange } from '../../data/media-grid.js';
-
 let selectedFolderId = -1;
 
 const urlParams = new URLSearchParams( window.location.search );
@@ -340,9 +335,6 @@ const slice = createSlice( {
 			state.selectedFolder = {
 				id: -1,
 			};
-
-			// Also trigger WordPress media filter change to sync
-			triggerFilterChange( 'all' );
 
 			// Close all modals
 			state.modals = {


### PR DESCRIPTION
Issue: https://github.com/rtCamp/godam/issues/1413

This PR fixes console errors in the Media Library modal by:

- Removing the side effect (triggerFilterChange('all')) from the `resetUIState` Redux reducer in `folders.js` and calling it after [dispatching resetUIState()](https://github.com/rtCamp/godam/blob/86ca9c133e65fe187f6c87fc8bc271763b99b9e5/pages/media-library/index.js#L81), ensuring reducer purity. This was likely happening due to [this page redirection](https://github.com/rtCamp/godam/blob/86ca9c133e65fe187f6c87fc8bc271763b99b9e5/pages/media-library/data/media-grid.js#L38) which was being called in the [folder.js reducer's resetUIState slice](https://github.com/rtCamp/godam/blob/86ca9c133e65fe187f6c87fc8bc271763b99b9e5/pages/media-library/redux/slice/folders.js#L345). [Here's a reference](https://stackoverflow.com/a/67118734/19726929) to a similar solution.
- Adding a check before accessing [props in `media-library-taxonomy-filter.js`](https://github.com/rtCamp/godam/blob/86ca9c133e65fe187f6c87fc8bc271763b99b9e5/assets/src/js/media-library/views/filters/media-library-taxonomy-filter.js#L23) to prevent undefined errors when switching folders.

Tested:
- Media modal open/close (no console errors)
- Media selection, uploading, transcoding, custom thumbnail uploads
- Media Folders sidebar in Media Uploader (GoDAM Video Block)