### PR TITLE
Fixed Image CTA (Portrait) Cut Off in Safari Instead of Being Responsive

### DIFF
--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -282,9 +282,11 @@
     flex-direction: row;
     gap: 30px;
     max-width: 600px;
+	width: 100%;
     background-color: #fff;
     align-items: center;
 	padding: 20px;
+	margin: auto;
 
     h2 {
         font-size: 32px;
@@ -320,7 +322,8 @@
 
 .vertical-image-cta-container {
     flex-direction: column;
-    width: 300px;
+    max-width: 300px;
+	width: 100%;
     border-radius: 36px;
 
     img {
@@ -343,7 +346,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	height: 100%;
+	min-height: 100%;
 	width: 100%;
 }
 
@@ -351,6 +354,8 @@
 	position: absolute;
 	top: 0;
 	bottom: 0;
+	left: 0;
+	right: 0;
 	overflow: auto;
 	padding: 2rem 1rem; 
 

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -328,9 +328,11 @@
 	flex-direction: row;
 	gap: 30px;
 	max-width: 600px;
+	width: 100%;
 	background-color: #fff;
 	align-items: center;
 	padding: 20px;
+	margin: auto;
 
 	h2 {
 		font-size: clamp(20px, 4vw, 32px);
@@ -370,7 +372,8 @@
 
 .vertical-image-cta-container {
 	flex-direction: column;
-	width: 300px;
+	width: 100%;
+	max-width: 300px;
 	border-radius: 36px;
 
 	img {
@@ -398,18 +401,16 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	height: 100%;
+	min-height: 100%;
 	width: 100%;
-
-	@container easydam-layer-container (max-width: 500px) {
-		height: auto;
-	}
 }
 
 .image-cta-overlay-container {
 	position: absolute;
 	top: 0;
 	bottom: 0;
+	left: 0;
+	right: 0;
 	overflow: auto;
 	padding: 2rem 1rem;
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Image CTA (Portrait) was being cut off in Safari instead of scaling responsively. The problem was caused by Safari’s handling of sizing and aspect-ratio behavior, which differed from other modern browsers.

## Problem

- In Safari, the portrait Image CTA did not resize correctly.
- Parts of the image were clipped when viewed on certain screen sizes.
- The same layout behaved as expected in Chrome and Firefox.

## Solution

- Added necessary CSS adjustments to ensure consistent responsive behavior in Safari.
- Ensured the portrait image scales correctly without being cut off.
- Kept the fix scoped to styling only, with no impact on markup or functionality.

## Impact

- Improves cross-browser consistency, specifically for Safari users.
- Ensures the Image CTA remains fully visible and responsive across devices.
- No breaking changes or side effects expected.

## Testing

- Verified on Safari (desktop).
- Confirmed no regressions in Chrome and Firefox.
- Checked responsiveness across multiple viewport sizes

Issue: https://github.com/rtCamp/godam/issues/1145