### PR TITLE
fix: API Keys removed automatically

### DIFF
--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -380,7 +380,7 @@ function rtgodam_verify_api_key( $api_key, $save = false ) {
 		if ( ! defined( 'RTGODAM_API_KEY' ) ) {
 			return new \WP_Error(
 				'localhost_blocked',
-				__( 'API key verification is blocked for HTTP connections or localhost environments. To use production API keys on localhost, please add the following constant to your wp-config.php file: define(\'RTGODAM_API_KEY\', \'your-api-key-here\');', 'godam' ),
+				__( 'API key verification is blocked for localhost environments. To use production API keys on localhost, please add the following constant to your wp-config.php file: define(\'RTGODAM_API_KEY\', \'your-api-key-here\');', 'godam' ),
 				array( 'status' => 403 )
 			);
 		}

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -681,12 +681,13 @@ function rtgodam_is_local_environment() {
 	$whitelist = array( '127.0.0.1', '::1', 'localhost' );
 
 	// phpcs:disable -- Disabling phpcs as its not manipulating any data, just reading server variables, and function is used for local environment check only.
-	$server_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( $_SERVER[ 'REMOTE_ADDR' ], FILTER_VALIDATE_IP ) : '';
-	$host        = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+	// We do NOT use REMOTE_ADDR because it can be 127.0.0.1 for loopback requests (Server processes) on hosted sites.
+	// Instead, we rely on HTTP_HOST to detect if the site is actually hosted on localhost/local domains.
+	$host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 	// phpcs:enable
 
 	$is_localhost = (
-		in_array( $server_addr, $whitelist, true ) ||
+		in_array( $host, $whitelist, true ) ||
 		strpos( $host, '.local' ) !== false ||
 		strpos( $host, '.test' ) !== false
 	);


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1290

This pull request updates the logic for detecting local environments and clarifies related error messaging. The main focus is to make local environment checks more reliable by switching from IP-based detection to host-based detection, and to update the API key verification error message accordingly.

**Local environment detection improvements:**

* Updated the `rtgodam_is_local_environment` function in `inc/helpers/custom-functions.php` to use the `HTTP_HOST` server variable instead of `REMOTE_ADDR` for determining if the environment is local. This avoids false positives on hosted sites that use loopback addresses internally.

**Error message update:**

* Modified the error message in `rtgodam_verify_api_key` in `admin/godam-transcoder-functions.php` to remove the reference to HTTP connections, now only mentioning localhost environments for API key verification blocking.

<img width="1305" height="753" alt="Screenshot 2025-12-18 at 5 00 13 PM" src="https://github.com/user-attachments/assets/87a4b820-1222-4b4c-ab7b-91e02e1e0e64" />
