### PR TITLE
fix: Image cropped on What's New page

### DIFF
--- a/pages/whats-new/index.scss
+++ b/pages/whats-new/index.scss
@@ -280,14 +280,15 @@ $grey-text: #5f6368;
 .card {
 
 	&-image {
-		height: 200px;
 		overflow: hidden;
+		display: flex;
+		justify-content: center;
+		align-items: center;
 
 		img {
 			width: 100%;
 			height: 100%;
-			object-fit: cover;
-			border-radius: 1rem;
+			object-fit: contain;
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the styling for the card image section in `pages/whats-new/index.scss` to improve image alignment and presentation.

Card image styling improvements:

* The `.card-image` container now uses flexbox to center its contents both vertically and horizontally, ensuring consistent image alignment.
* The `img` element within `.card-image` now uses `object-fit: contain` instead of `cover`, so images are fully visible without cropping.

## Before
<img width="719" height="271" alt="image" src="https://github.com/user-attachments/assets/fc7abf91-3df7-439a-8e74-1b8a845cd8b7" />

## After
<img width="1467" height="876" alt="Screenshot 2025-12-19 at 4 58 14 PM" src="https://github.com/user-attachments/assets/669ac24d-3a47-4afd-a7b1-8d3bc5885098" />
