### PR TITLE
feat: Add Start Free text to analytics API Key banner

### DIFF
--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -376,20 +376,20 @@ const Analytics = ( { attachmentID } ) => {
 						? <div className="api-key-overlay-banner">
 							<p className="api-key-overlay-banner-header">
 								{ __(
-									'Upgrade to unlock the media performance report.',
+									'Upgrade to unlock the media performance report or sign up for a free plan.',
 									'godam',
 								) }
 							</p>
 
 							<p className="api-key-overlay-banner-footer">
-								{ __( 'If you already have a premium plan, connect your', 'godam' ) }
+								{ __( 'If you already have a plan, connect your', 'godam' ) }
 								{ ' ' }
 								<a href={ adminUrl } target="_blank" rel="noopener noreferrer">
 									{ __( 'API in the settings', 'godam' ) }
 								</a>
 							</p>
 
-							<a href={ `https://godam.io/pricing?utm_campaign=buy-plan&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=analytics` } className="components-button godam-button is-primary" target="_blank" rel="noopener noreferrer">{ __( 'Buy Plan', 'godam' ) }</a>
+							<a href={ `https://godam.io/pricing?utm_campaign=start-free&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=analytics` } className="components-button godam-button is-primary" target="_blank" rel="noopener noreferrer">{ __( 'Start Free', 'godam' ) }</a>
 						</div>
 						:	<div className="api-key-overlay-banner">
 							<p>

--- a/pages/analytics/index.scss
+++ b/pages/analytics/index.scss
@@ -336,7 +336,7 @@
 	}
 
 	// Style the buy button to not take full width
-	a.components-button.godam-button.is-primary {
+	a.components-button.godam-button {
 		align-self: center;
 		width: auto;
 		display: inline-block;

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -218,20 +218,20 @@ const Dashboard = () => {
 							<div className="api-key-overlay-banner">
 								<p className="api-key-overlay-banner-header">
 									{ __(
-										'Upgrade to unlock the media performance report.',
+										'Upgrade to unlock the media performance report or sign up for a free plan.',
 										'godam',
 									) }
 								</p>
 
 								<p className="api-key-overlay-banner-footer">
-									{ __( 'If you already have a premium plan, connect your', 'godam' ) }
+									{ __( 'If you already have a plan, connect your', 'godam' ) }
 									{ ' ' }
 									<a href={ adminUrl } target="_blank" rel="noopener noreferrer">
 										{ __( 'API in the settings', 'godam' ) }
 									</a>
 								</p>
 
-								<a href={ `https://godam.io/pricing?utm_campaign=buy-plan&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=analytics` } className="components-button godam-button is-primary" target="_blank" rel="noopener noreferrer">{ __( 'Buy Plan', 'godam' ) }</a>
+								<a href={ `https://godam.io/pricing?utm_campaign=start-free&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=analytics` } className="components-button godam-button is-primary" target="_blank" rel="noopener noreferrer">{ __( 'Start Free', 'godam' ) }</a>
 							</div>
 						</>
 						:	<div className="api-key-overlay-banner">

--- a/pages/dashboard/index.scss
+++ b/pages/dashboard/index.scss
@@ -52,7 +52,7 @@
 	}
 
 	// Style the buy button to not take full width
-	a.components-button.godam-button.is-primary {
+	a.components-button.godam-button {
 		align-self: center;
 		width: auto;
 		display: inline-block;


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/625

This pull request updates the messaging and call-to-action for users without a plan, making it clearer that a free plan is available and updating the associated button and styling. The changes also ensure consistency across both the analytics and dashboard pages.

**User Interface and Messaging Updates:**

* Updated the overlay banner messages in both `Analytics.js` and `Dashboard.js` to mention the availability of a free plan and changed the call-to-action button text from "Buy Plan" to "Start Free". The associated link UTM parameters were also updated to reflect the new campaign. [[1]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dL379-R392) [[2]](diffhunk://#diff-d74bb21410b6c9985a24e269b09f8e7eca804aa5aa8e55276267233d6c568822L221-R234)
* Simplified the footer text in the overlay banner to refer to "a plan" instead of specifically "a premium plan" for clarity and inclusivity. [[1]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dL379-R392) [[2]](diffhunk://#diff-d74bb21410b6c9985a24e269b09f8e7eca804aa5aa8e55276267233d6c568822L221-R234)

**Styling Adjustments:**

* Updated the CSS selectors in both `index.scss` files for the analytics and dashboard pages to apply button styling to all `.godam-button` buttons, not just those with the `.is-primary` class, ensuring consistent appearance for the new "Start Free" button. [[1]](diffhunk://#diff-e13049dfecab9d94dd7b9785adf8df88a9ec87b30f563e3eb7f4fe2923845f40L339-R339) [[2]](diffhunk://#diff-c0eea2cb80e9dc4f7a05491e4738332764ae7504855e44b9dd849274bb9a1727L55-R55)

<img width="1470" height="830" alt="Screenshot 2025-12-30 at 11 22 34 AM" src="https://github.com/user-attachments/assets/5014af9f-4644-4c3e-9765-35f6f5519307" />
