### PR TITLE
Fix: Weird popup in Media Uploader modal #1432

### DIFF
--- a/pages/media-library/components/modal/FolderCreationModal.jsx
+++ b/pages/media-library/components/modal/FolderCreationModal.jsx
@@ -110,6 +110,7 @@ const FolderCreationModal = () => {
 				title={ __( 'Create a new folder', 'godam' ) }
 				onRequestClose={ () => dispatch( closeModal( 'folderCreation' ) ) }
 				className="modal__container"
+				bodyOpenClassName="folder-creation-modal-open"
 			>
 				<TextControl
 					ref={ inputRef }


### PR DESCRIPTION
## Problem

When using Replace → Media Library → New folder, a modal popup appears. Closing it leaves a white background popup stuck and the UI behaves incorrectly, with another popup visible on top.

## Root Cause (observed)

The folder creation modal did not apply a dedicated bodyOpenClassName, which can cause modal/backdrop/body-state handling issues (e.g., leftover overlay/body state) when nested within the Media Uploader modal flow.

## Solution

Add a bodyOpenClassName to the folder creation modal so opening/closing the modal consistently toggles a predictable body class for styling/state cleanup.

## Change

1. Updated pages/media-library/components/modal/FolderCreationModal.jsx
2. Added: bodyOpenClassName="folder-creation-modal-open" 

Issue - https://github.com/rtCamp/godam/issues/1432