### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy_on_push.yml
+++ b/.github/workflows/deploy_on_push.yml
@@ -5,6 +5,10 @@ on:
       - develop
   workflow_dispatch:
 name: Deploy on Push
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/phpcs_on_pull_request.yml
+++ b/.github/workflows/phpcs_on_pull_request.yml
@@ -1,5 +1,10 @@
 on: pull_request
 name: Inspections
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   runPHPCSInspection:
     name: Run PHPCS inspection

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR adds explicit `permissions:` blocks to all GitHub Actions workflows to follow the principle of least privilege and resolve security scanning alerts.

## Changes

### 1. **phpcs_on_pull_request.yml**
- Added `permissions: contents: read, pull-requests: write`
- Grants minimal permissions needed to checkout code and post PR comments

### 2. **release_on_tag.yml**
- Added `permissions: contents: write`
- Grants write access needed to create GitHub releases and upload artifacts

### 3. **deploy_on_push.yml**
- Added `permissions: contents: read`
- Grants read-only access for code checkout and deployment

## Security Impact

**Resolves:** Code scanning alerts [#1](https://github.com/rtCamp/godam/security/code-scanning/1), [#2](https://github.com/rtCamp/godam/security/code-scanning/2), [#3](https://github.com/rtCamp/godam/security/code-scanning/3)

Previously, these workflows ran with default GITHUB_TOKEN permissions which could be overly permissive. This change explicitly limits each workflow to only the permissions it needs.

## References

- GitHub Documentation: [Workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- Related issue: rtCamp/support#245