### PR TITLE
fix(layers): add negative time value validation in LayersHeader

### DIFF
--- a/pages/video-editor/components/layers/LayersHeader.js
+++ b/pages/video-editor/components/layers/LayersHeader.js
@@ -64,7 +64,7 @@ const LayersHeader = ( { layer, goBack, duration } ) => {
 				<Button icon={ arrowLeft } onClick={ goBack } />
 				<p className="text-base flex items-center gap-1">
 					{ layerName }
-					{ __( ' layer at', 'godam' ) }{ isEditing ? (
+					{ ' ' + __( 'layer at', 'godam' ) }{ isEditing ? (
 						<TextControl
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ false }
@@ -85,7 +85,8 @@ const LayersHeader = ( { layer, goBack, duration } ) => {
 								// Convert to number for validation
 								const floatValue = parseFloat( normalizedValue );
 
-								if ( floatValue > duration ) {
+								// Reject negative or over-duration values
+								if ( floatValue < 0 || floatValue > duration ) {
 									return;
 								}
 


### PR DESCRIPTION
Issue: #1445 

Description:

Adds validation to prevent negative time values in layer timestamp input field.

Problem:
The layer time input field in the video editor allowed users to enter negative values such as -10 or -999. 

Changes:
Add negative value validation check in LayersHeader.js onChange handler
Reject input values less than zero before updating layer state
Fix i18n flanking whitespace lint error in translation string

Files Modified:
[LayersHeader.js](vscode-file://vscode-app/c:/Users/ASUS/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Testing:
- Navigate to Video Editor
- Add any layer type
- Click to edit layer time
- Attempt to enter negative values such as -10 or -999
- Verify that negative values are rejected and layer time remains valid

Demo:


https://github.com/user-attachments/assets/5c121c2d-f472-4f10-8d12-f5a5c68d4c93



@subodhr258 


