### PR TITLE
Fix: Negative Time Value Vulnerability in Layer Header #1445

### DIFF
--- a/pages/video-editor/components/layers/LayersHeader.js
+++ b/pages/video-editor/components/layers/LayersHeader.js
@@ -76,6 +76,9 @@ const LayersHeader = ( { layer, goBack, duration } ) => {
 								// Remove leading zeros
 								let normalizedValue = value.replace( /^0+(?=\d)/, '' );
 
+								// Prevent negative values
+								normalizedValue = parseFloat( normalizedValue ) < 0 ? '0' : normalizedValue;
+
 								// Limit to 2 decimal places
 								if ( normalizedValue.includes( '.' ) ) {
 									const [ intPart, decimalPart ] = normalizedValue.split( '.' );


### PR DESCRIPTION
## Context

This pull request fixes a bug reported in Issue #1445 where the Video Editor Layers Header allowed users to enter negative time values. 

Negative values such as -10 or -999 caused layers to be positioned incorrectly at the start of the video and led to undefined behavior during playback due to invalid seek times.

## What Changed

1. Added validation in LayersHeader.js to prevent negative time values when editing a layer’s start time.
2. Ensures user input is clamped to valid (non-negative) values before updating state.
3. Prevents invalid layer positions and protects the video player from undefined seek operations.

## Issue Reference

Closes: [#1445](https://github.com/rtCamp/godam/issues/1445)