### PR TITLE
Fix godam-tab video mpd url source

### DIFF
--- a/assets/src/js/media-library/views/attachment-details.js
+++ b/assets/src/js/media-library/views/attachment-details.js
@@ -114,10 +114,10 @@ export default AttachmentDetails?.extend( {
 		AttachmentDetails.prototype.render.apply( this, arguments );
 
 		const hlsUrl = this.model.get( 'hls_url' );
-		const attachmentUrl = this.model.get( 'url' );
+		const mpdUrl = this.model.get( 'mpd_url' );
 
 		// Skip the local Media Library attachments.
-		if ( ( ! attachmentUrl || ! isMpd( attachmentUrl ) ) && ( ! hlsUrl || ! isM3U8( hlsUrl ) ) ) {
+		if ( ( ! mpdUrl || ! isMpd( mpdUrl ) ) && ( ! hlsUrl || ! isM3U8( hlsUrl ) ) ) {
 			return this;
 		}
 
@@ -126,13 +126,13 @@ export default AttachmentDetails?.extend( {
 		// No need to check if table exists, as if it did we would have returned early on link checks.
 		const tableBody = createTable( this.el );
 
-		if ( attachmentUrl && isMpd( attachmentUrl ) ) {
+		if ( mpdUrl && isMpd( mpdUrl ) ) {
 			tableBody.appendChild(
 				createAttachmentField( {
 					id: attachmentId,
 					fieldName: 'transcoded_url',
 					fieldLabel: __( 'Transcoded CDN URL (MPD)', 'godam' ),
-					url: attachmentUrl,
+					url: mpdUrl,
 					helpText: __( 'The URL of the transcoded file is generated automatically and cannot be edited.', 'godam' ),
 				} ),
 			);


### PR DESCRIPTION
**Fixes:** #1464 

This pull request updates the handling of transcoded media URLs in the `AttachmentDetails` view of the media library. The main change is to consistently use the `mpd_url` property instead of the generic `url` property for MPD files, which improves clarity and accuracy when displaying transcoded CDN URLs.

Media URL handling improvements:

* Replaced usage of the `url` property with `mpd_url` for MPD files throughout the `AttachmentDetails` view logic, ensuring the correct transcoded file URL is used in both validation and display. [[1]](diffhunk://#diff-5ec6ce9de52a7fbd2182a418dc036456c8e732f74a1b78de6428bd916b69bca1L117-R120) [[2]](diffhunk://#diff-5ec6ce9de52a7fbd2182a418dc036456c8e732f74a1b78de6428bd916b69bca1L129-R135)


## Screenshots
| Media Type | Before | After | Detail |
| ----------- | ------- | ------ | ---------- |
| Video | <img width="1470" height="728" alt="Screenshot 2026-01-07 at 4 52 55 PM" src="https://github.com/user-attachments/assets/0435b54c-08ff-406a-81fa-fe80c5410a0c" /> | <img width="1470" height="728" alt="Screenshot 2026-01-07 at 4 52 31 PM" src="https://github.com/user-attachments/assets/dc74e21a-21f7-4988-8566-3f6a24170145" /> | Added MPD URL and oEmbed URL field for GoDAM tab media |
