### PR TITLE
Show media folder name in attachment details

### DIFF
--- a/assets/src/js/media-library/views/attachment-details.js
+++ b/assets/src/js/media-library/views/attachment-details.js
@@ -113,6 +113,25 @@ export default AttachmentDetails?.extend( {
 	render() {
 		AttachmentDetails.prototype.render.apply( this, arguments );
 
+        const godamFolder = this.model.get( 'godam_folder' );
+        
+        // Display folder name if attachment belongs to a GoDAM folder.
+        if ( godamFolder && godamFolder.name && ! this.el.querySelector( '.compat-field-godam_folder' ) ) {
+        	const tableBody =
+        		this.el.querySelector( 'tbody' ) || createTable( this.el );
+        
+        	tableBody.appendChild(
+        		createAttachmentField( {
+        			id: this.model.get( 'id' ),
+        			fieldName: 'godam_folder',
+        			fieldLabel: __( 'Folder', 'godam' ),
+        			url: godamFolder.name,
+        			helpText: __( 'Media folder this file belongs to.', 'godam' ),
+        		} )
+        	);
+        }
+
+
 		const hlsUrl = this.model.get( 'hls_url' );
 		const attachmentUrl = this.model.get( 'url' );
 
@@ -123,8 +142,11 @@ export default AttachmentDetails?.extend( {
 
 		const attachmentId = this.model.get( 'id' );
 
-		// No need to check if table exists, as if it did we would have returned early on link checks.
-		const tableBody = createTable( this.el );
+		// Reuse existing compat table or create one if needed.
+
+		const tableBody =
+	this.el.querySelector( 'tbody' ) || createTable( this.el );
+
 
 		if ( attachmentUrl && isMpd( attachmentUrl ) ) {
 			tableBody.appendChild(

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1632,4 +1632,45 @@ class Media_Library extends Base {
 
 		return $prepared;
 	}
+
 }
+
+
+
+
+/**
+ * Add media folder information to attachment REST API response.
+ *
+ * This enables displaying the folder name
+ * in Media Library attachment details.
+ */
+add_filter( 'rest_prepare_attachment', function ( $response, $post, $request ) {
+
+	// Ensure this is a valid attachment response.
+	if ( empty( $response->data ) || 'attachment' !== $post->post_type ) {
+		return $response;
+	}
+
+	// Get assigned media-folder terms.
+	$terms = wp_get_object_terms( $post->ID, 'media-folder' );
+
+	if ( is_wp_error( $terms ) || empty( $terms ) ) {
+		$response->data['godam_folder'] = null;
+		return $response;
+	}
+
+	// GoDAM currently supports one folder per attachment.
+	$term = $terms[0];
+
+	$response->data['godam_folder'] = array(
+		'id'   => $term->term_id,
+		'name' => $term->name,
+	);
+
+	return $response;
+}, 10, 3 );
+
+
+
+
+


### PR DESCRIPTION
### What does this PR do?

This PR adds the media folder name to the attachment details panel in the WordPress Media Library.

When a media item is assigned to a GoDAM folder, the folder name is now displayed as a read-only field in the attachment details view. This makes it easier to understand where a file is organized without switching back to the folder view.

### How it works

- Exposes the assigned `media-folder` term via the attachment REST API response.
- Extends the Media Library attachment details UI to render the folder name when available.
- Ensures the field is added only once and does not affect non-GoDAM or unassigned media.

### Why this is needed

Currently, once a media item is selected, there’s no clear way to know which folder it belongs to. Displaying the folder name improves usability and matches the expected behavior shown in the issue.

### Testing

- Selected media items assigned to a GoDAM folder and verified the folder name appears in attachment details.
- Verified no change in behavior for media without folders or for local Media Library attachments.
