### PR TITLE
fix: Make charts scrollable on mobile

### DIFF
--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -173,7 +173,8 @@ const Analytics = ( { attachmentID } ) => {
 		const originalVideoEl = document.getElementById( 'original-analytics-video' );
 
 		const videoOptions = {
-			fluid: true,
+			width: 525,
+			height: 320,
 			mute: true,
 			controls: false,
 			// VHS (HLS/DASH) initial configuration to prefer a ~14 Mbps start.
@@ -229,7 +230,8 @@ const Analytics = ( { attachmentID } ) => {
 		}
 
 		videojs( 'analytics-video', {
-			aspectRatio: '16:9',
+			width: 830,
+			height: 467,
 			// VHS (HLS/DASH) initial configuration to prefer a ~14 Mbps start.
 			// This only affects the initial bandwidth guess; VHS will continue to measure actual throughput and adapt.
 			html5: {
@@ -306,30 +308,6 @@ const Analytics = ( { attachmentID } ) => {
 		}
 		return 'left-greater right-greater';
 	};
-
-	useEffect( () => {
-		const handleResize = () => {
-			const smallSize = window.innerWidth <= 1024;
-			const analyticsContainer = document.getElementById( 'root-video-analytics' );
-
-			if ( analyticsContainer ) {
-				if ( smallSize ) {
-					analyticsContainer.style.overflow = 'hidden';
-				} else {
-					analyticsContainer.style.overflow = 'auto';
-				}
-			}
-		};
-
-		// Initial check
-		handleResize();
-
-		// Add listener
-		window.addEventListener( 'resize', handleResize );
-
-		// Cleanup
-		return () => window.removeEventListener( 'resize', handleResize );
-	}, [] );
 
 	return (
 		<div className="godam-analytics-container">
@@ -408,7 +386,7 @@ const Analytics = ( { attachmentID } ) => {
 					<div>
 						<div className="subheading-container flex flex-row max-md:flex-row-reverse pt-6">
 							{ attachmentData?.title?.rendered
-								? <div className="subheading">{ __( 'Analytics report of', 'godam' ) }
+								? <div className="subheading">{ __( 'Analytics report of', 'godam' ) } { ' ' }
 									<span dangerouslySetInnerHTML={ {
 										__html: DOMPurify.sanitize( attachmentData?.title?.rendered ),
 									} }></span></div> : <div className="subheading">{ __( 'Analytics report', 'godam' ) }</div>
@@ -473,15 +451,17 @@ const Analytics = ( { attachmentID } ) => {
 								<div className="min-w-full lg:min-w-[750px]">
 									<div>
 										<div className="video-container">
-											<RenderVideo
-												attachmentData={ attachmentData }
-												attachmentID={ attachmentID }
-												videoId={ 'analytics-video' }
-											/>
-											<div className="video-chart-container">
-												<div id="chart-container">
-													<svg id="line-chart" width="640" height="300"></svg>
-													<div className="line-chart-tooltip"></div>
+											<div className="video-inner-container">
+												<RenderVideo
+													attachmentData={ attachmentData }
+													attachmentID={ attachmentID }
+													videoId={ 'analytics-video' }
+												/>
+												<div className="video-chart-container">
+													<div id="chart-container">
+														<svg id="line-chart" width="830" height="300"></svg>
+														<div className="line-chart-tooltip"></div>
+													</div>
 												</div>
 											</div>
 										</div>
@@ -607,8 +587,8 @@ const Analytics = ( { attachmentID } ) => {
 											</div>
 										) }
 										{ mediaLibraryAttachment && (
-											<div className="flex gap-12 w-full h-full pt-6 justify-center">
-												<div className="block w-[525px] h-[350px]">
+											<div className="flex gap-12 w-full h-full pt-6 justify-center min-w-max">
+												<div className="block w-[525px] h-[350px] shrink-0">
 													<div className="relative">
 														<RenderVideo
 															attachmentData={ attachmentData }
@@ -628,7 +608,7 @@ const Analytics = ( { attachmentID } ) => {
 													</div>
 												</div>
 												<div className="w-px bg-gray-200 mx-4 divide-dashed"></div>
-												<div className="block w-[525px] h-[350px]">
+												<div className="block w-[525px] h-[350px] shrink-0">
 													<div className="relative">
 														<RenderVideo
 															attachmentData={ mediaLibraryAttachment }

--- a/pages/analytics/charts.js
+++ b/pages/analytics/charts.js
@@ -298,7 +298,8 @@ async function main() {
 	const heatmapData = JSON.parse( allTimeHeatmap );
 
 	const videoPlayer = videojs( 'analytics-video', {
-		fluid: true,
+		width: 830,
+		height: 467, // 16:9 ratio for 830 width
 		mute: true,
 		controls: false,
 		// VHS (HLS/DASH) initial configuration to prefer a ~14 Mbps start.
@@ -323,7 +324,7 @@ async function main() {
 		'#line-chart',
 		videoPlayer,
 		'.line-chart-tooltip',
-		Math.min( 830, window.innerWidth - 100 ),
+		830,
 		300,
 	);
 	generateHeatmap( heatmapData, '#heatmap', videoPlayer );

--- a/pages/analytics/index.scss
+++ b/pages/analytics/index.scss
@@ -40,6 +40,7 @@
 		@apply flex bg-white justify-between py-6 md:px-10 pt-8;
 
 		.analytics-info-container {
+
 			.analytics-info {
 
 				width: calc(50% - 8px);
@@ -138,12 +139,17 @@
 
 	// Video Chart styles
 	.video-container {
-		position: relative;
-		width: 830px;
+		width: 100%;
+		overflow-x: auto;
 
 		@media screen and (max-width: 1024px) {
-			width: 100%;
+			width: calc(100vw - 80px); // Constraint width to viewport minus padding.
 		}
+	}
+
+	.video-inner-container {
+		position: relative;
+		width: 830px;
 	}
 
 	.video-chart-container {
@@ -169,6 +175,7 @@
 		svg {
 			position: relative;
 			top: 4px;
+			max-width: none;
 		}
 
 		.line {


### PR DESCRIPTION
This pull request updates the video analytics page to provide a more consistent and responsive layout for video players and charts. The main focus is on standardizing video/chart dimensions, improving layout structure, and cleaning up unnecessary code for better maintainability.

**Video and Chart Sizing Standardization:**

* Set explicit `width` and `height` for both the main analytics video (`830x467`) and the comparison/original videos (`525x320`), replacing the previous use of `fluid` sizing in `Analytics.js` and `charts.js`. [[1]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dL176-R177) [[2]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dL232-R234) [[3]](diffhunk://#diff-d323a0ab4311db9e82869ab1b9e34c23570326a78a6a8e89070fc39efee612ffL301-R302)
* Updated the line chart SVG to a fixed width of `830`, matching the video player for alignment. [[1]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dR454-R467) [[2]](diffhunk://#diff-d323a0ab4311db9e82869ab1b9e34c23570326a78a6a8e89070fc39efee612ffL326-R327)

**Layout and Responsiveness Improvements:**

* Wrapped the video/chart area in a `.video-inner-container` with a fixed width, and made `.video-container` horizontally scrollable for small screens, ensuring the layout remains usable on all devices. [[1]](diffhunk://#diff-e13049dfecab9d94dd7b9785adf8df88a9ec87b30f563e3eb7f4fe2923845f40L141-R154) [[2]](diffhunk://#diff-e13049dfecab9d94dd7b9785adf8df88a9ec87b30f563e3eb7f4fe2923845f40R178) [[3]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dR454-R467)
* Added `shrink-0` and `min-w-max` classes to prevent video containers from shrinking in flex layouts, maintaining consistent sizing in side-by-side video comparison views. [[1]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dL610-R591) [[2]](diffhunk://#diff-90c49a0bdb3403e30f255add390c6b384e89f35863fdbee3bb3b98f50d00501dL631-R611)

**Code Cleanup and Minor UI Tweaks:**

* Removed the `useEffect` that dynamically set `overflow` on the analytics container based on window size, as the new layout handles overflow via CSS.
* Added a space after the "Analytics report of" label for improved readability.
* Minor SCSS improvements for layout consistency, including a small fix to the `.analytics-info-container` and `.video-chart-container svg` max-width. [[1]](diffhunk://#diff-e13049dfecab9d94dd7b9785adf8df88a9ec87b30f563e3eb7f4fe2923845f40R43) [[2]](diffhunk://#diff-e13049dfecab9d94dd7b9785adf8df88a9ec87b30f563e3eb7f4fe2923845f40R178)

## Recording

https://github.com/user-attachments/assets/284d9054-bd03-41a6-bbac-ad7721c27056

