### PR TITLE
Fix: fullscreen layer font size

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1354,6 +1354,15 @@ body.godam-share-modal-open {
 
 	&.vjs-fullscreen {
 
+		// Fix for Forms confirmation message font size issue for fullscreen videos
+		.form-container {
+			font-size: initial;
+		}
+
+		.easydam-layer {
+			font-size: initial;
+		}
+
 		.vjs-custom-fullscreen-exit-control {
 			display: block !important;
 		}
@@ -1569,15 +1578,6 @@ body.godam-share-modal-open {
 	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9 );
 	cursor: pointer;
 	overflow: hidden;
-
-	// Fix for Forms confirmation message font size issue for fullscreen videos
-	.form-container {
-		font-size: initial;
-	}
-
-	.easydam-layer {
-		font-size: initial;
-	}
 }
 
 .video-js .vjs-time-tooltip,


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1463 ([High] Success message of forms is too small in full screen.)

This pull request makes fixes to the GoDAM video player fullscreen font-size related issues for Form, CTA, Polls layers.

**Control bar z-index adjustment:**

* Moved the `z-index: 8;` property from `.video-js .vjs-control-bar` to `.vjs-control-bar` within the `body.godam-share-modal-open` selector to ensure proper stacking context when the share modal is open. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L449-L452) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79R1035)

**Fullscreen video overlay fixes:**

* Added CSS rules to reset `font-size` for `.form-container` and `.easydam-layer` inside fullscreen videos, fixing confirmation message font size issues.

