### PR TITLE
Implement endpoint to share the WordPress site godam settings, if correct api_key is provided.

### DIFF
--- a/inc/classes/rest-api/class-settings.php
+++ b/inc/classes/rest-api/class-settings.php
@@ -166,8 +166,13 @@ class Settings extends Base {
 	 */
 	public function verify_api_key_permission( $request ) {
 		$authorization_header = $request->get_header( 'authorization' );
-		$provided_api_key     = trim( str_replace( 'Bearer ', '', $authorization_header ) );
-		$stored_api_key       = get_option( 'rtgodam-api-key' );
+
+		if ( null === $authorization_header ) {
+			return new \WP_Error( 'api_key_required', __( 'GoDAM API key is required.', 'godam' ), array( 'status' => 403 ) );
+		}
+
+		$provided_api_key = trim( str_replace( 'Bearer ', '', $authorization_header ) );
+		$stored_api_key   = get_option( 'rtgodam-api-key' );
 
 		if ( empty( $provided_api_key ) ) {
 			return new \WP_Error( 'api_key_required', __( 'GoDAM API key is required.', 'godam' ), array( 'status' => 403 ) );


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-core/issues/158

This pull request adds a new REST API route to the settings API for securely sharing GoDAM settings with an external service. The route includes permission verification using an API key, ensuring that only authorized requests can access the settings.

New REST API endpoint for GoDAM settings:

* Added a new REST route `/get-godam-settings` to expose GoDAM settings to external services, with a required `api_key` argument for authentication.

Security and permission handling:

* Introduced the `verify_godam_permission` method to validate the provided API key against the stored key, returning a `WP_Error` if the key is missing or invalid.