### PR TITLE
fix: Make hotspot tooltip visible inside video container always

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -961,6 +961,24 @@ body.godam-share-modal-open {
 	opacity: 0;
 	transition: opacity 0.2s ease, visibility 0.2s ease;
 	word-wrap: break-word;
+
+	/* Create an invisible bridge between hotspot and tooltip for smooth hover */
+	&::before {
+		content: "";
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 10px;
+
+		/* Default: tooltip is above hotspot, so bridge is below tooltip */
+		top: 100%;
+	}
+
+	/* When tooltip is below hotspot, bridge should be above tooltip */
+	&.tooltip-bottom::before {
+		top: auto;
+		bottom: 100%;
+	}
 }
 
 .fullscreen-layer .hotspot-tooltip {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1217, #1463 

This pull request improves the positioning and usability of tooltips in the Godam player, especially when tooltips are near the edges of the video container. The main changes include enhanced logic for positioning tooltips to prevent overflow, and a new CSS bridge to ensure smooth hover interactions between hotspots and tooltips.

**Tooltip positioning improvements:**

* The `positionTooltip` method in `hotspotLayerManager.js` now constrains tooltips within the video container, calculates available space above and below the hotspot, and adjusts placement to prevent overflow on all sides. It also ensures tooltips remain fully visible and aligned, even near container edges.

**CSS enhancements for hover usability:**

* Added a pseudo-element (`::before`) in `godam-player.scss` to create an invisible bridge between the hotspot and tooltip, improving hover interactions and preventing accidental tooltip closure when moving the mouse between the two. The bridge adapts depending on whether the tooltip is above or below the hotspot.


## Recording


https://github.com/user-attachments/assets/25bf59eb-3030-4fc8-bf3c-f43e67a00c0f

