### PR TITLE
Add hotfix to videojs config for Safari, and iOS device playback

### DIFF
--- a/assets/src/js/godam-player/managers/configurationManager.js
+++ b/assets/src/js/godam-player/managers/configurationManager.js
@@ -99,9 +99,9 @@ export default class ConfigurationManager {
 			// forces VHS even on Safari and iOS devices
 			// This will override native HLS playback with VHS to support features like quality selection.
 			this.videoSetupControls.html5.vhs.overrideNative = true;
-			this.videoSetupControls.html5.nativeAudioTracks = true;
-			this.videoSetupControls.html5.nativeVideoTracks = true;
-			this.videoSetupControls.html5.nativeTextTracks = true;
+			this.videoSetupControls.html5.nativeAudioTracks = false;
+			this.videoSetupControls.html5.nativeVideoTracks = false;
+			this.videoSetupControls.html5.nativeTextTracks = false;
 		}
 
 		this.isPreviewEnabled = this.videoSetupOptions?.preview;


### PR DESCRIPTION
**Fixes:** #788 

This pull request makes a targeted change to the `ConfigurationManager` class to improve compatibility and feature support for video playback. The main adjustment is to disable the use of native tracks in the HTML5 video player configuration, ensuring that custom features like quality selection work consistently across browsers.

**Video playback configuration changes:**

* Set `nativeAudioTracks`, `nativeVideoTracks`, and `nativeTextTracks` to `false` in the `videoSetupControls.html5` configuration, overriding the default behavior and ensuring custom track handling is used instead of native browser implementations.