### PR TITLE
Fix - CTA Image for Abnormal Inputs

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -372,7 +372,6 @@
 		height: auto;
 		min-height: 0;
 		border-radius: 8px;
-		object-fit: contain;
 		object-fit: cover;
 	}
 
@@ -419,7 +418,7 @@
 	.image-cta-description {
 		padding: 0;
 		align-items: center;
-		flex-shrink: 0;      /* Text section won't shrink */
+		flex-shrink: 0; /* Text section won't shrink */
 	}
 
 	.image-cta-btn {


### PR DESCRIPTION
Issues - https://github.com/rtCamp/godam/issues/1145, https://github.com/rtCamp/godam/issues/1162

This pull request updates the styles in `godam-player.scss` to improve the responsiveness and appearance of image CTA (Call To Action) components, especially on smaller screens. The main changes focus on image sizing and aspect ratios, text truncation, button appearance, and container layout adjustments for a more consistent and visually appealing UI.

**Image and Layout Responsiveness:**
* Updated `.image-cta-no-image` and image styles to use `max-width`, `aspect-ratio`, and `object-fit` for better image scaling and consistency across different screen sizes. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L315-R317) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L362-R381) [[3]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79R400-R416) [[4]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L461-R504) [[5]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L503-R554)
* Improved `.vertical-image-cta-container` with `max-height`, `overflow: hidden`, and enhanced image and text alignment for better vertical layouts.

**Text Truncation and Typography:**
* Applied multi-line truncation (`-webkit-line-clamp`) and adjusted font sizes for headings and paragraphs in responsive containers to prevent text overflow and maintain readability. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79R426-R455) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L503-R554)

**Button and Container Adjustments:**
* Modified `.image-cta-btn` padding, width, and line height for a more compact and consistent button appearance, especially within flex containers. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L301-R301) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L362-R381)
* Adjusted `.image-cta-parent-container` and other containers for better alignment, reduced padding, and improved use of available space. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79R426-R455) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L461-R504)

**Minor Cleanups:**
* Removed redundant `max-width: 100%` from some image styles for clarity and consistency.

## Recording

https://github.com/user-attachments/assets/40bf3332-da53-4d7d-b377-a8613b08c2c1

## Screenshots

<img width="617" height="841" alt="Screenshot 2026-01-13 at 7 01 03 PM" src="https://github.com/user-attachments/assets/33adcb73-86a2-41d9-8502-1e5e46e35233" />
<img width="321" height="188" alt="Screenshot 2026-01-13 at 7 00 45 PM" src="https://github.com/user-attachments/assets/cc9f73e1-3330-4a5d-bfd7-fc83bbfa95bf" />

<img width="678" height="386" alt="Screenshot 2026-01-13 at 7 00 36 PM" src="https://github.com/user-attachments/assets/2c1ce311-e130-4afd-b021-cd60afbd6648" />

## No Image placeholder Recording

https://github.com/user-attachments/assets/839c8cdc-e18a-4fd1-b1e5-22c946fede62

