### PR TITLE
Started storing the transcoded image url in attachment postmeta

### DIFF
--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -287,7 +287,7 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 						// Setting the transcoded PDF URL.
 						update_post_meta( $attachment_id, 'rtgodam_transcoded_url', esc_url_raw( $post_array['download_url'] ) );
 					}
-					
+
 					if ( 'image' === $job_type && isset( $post_array['download_url'] ) && ! empty( $post_array['download_url'] ) ) {
 						// Setting the transcoded Image URL.
 						update_post_meta( $attachment_id, 'rtgodam_transcoded_url', esc_url_raw( $post_array['download_url'] ) );

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -184,7 +184,7 @@ class Media_Library_Ajax {
 			}
 		}
 
-		if ( ! defined( 'RTGODAM_TRANSCODER_CALLBACK_URL' ) || empty( RTGODAM_TRANSCODER_CALLBACK_URL ) ) {
+		if ( ! defined( 'RTGODAM_TRANSCODER_CALLBACK_URL' ) ) {
 			include_once RTGODAM_PATH . 'admin/class-rtgodam-transcoder-rest-routes.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 			define( 'RTGODAM_TRANSCODER_CALLBACK_URL', \RTGODAM_Transcoder_Rest_Routes::get_callback_url() );
 		}


### PR DESCRIPTION
This pull request introduces improvements to the transcoding workflow for media uploads, specifically enhancing callback URL handling and ensuring that transcoded image URLs are properly saved. The most important changes are grouped below:

Transcoding callback and status URL handling:

* In `class-media-library-ajax.php`, the code now defines and sets the `RTGODAM_TRANSCODER_CALLBACK_URL` constant using a method from `RTGODAM_Transcoder_Rest_Routes`, ensuring the callback URL is always available and correct. Additionally, a separate REST API endpoint for transcoding status updates is set with `status_callback_url`. These URLs are now included in the request parameters for media uploads.

Transcoded image URL storage:

* In `class-rtgodam-transcoder-rest-routes.php`, the code now checks for image transcoding jobs and saves the transcoded image URL to the attachment's post meta, ensuring that the URL is stored for both PDF and image job types.