### PR TITLE
Show the oEmbed URL for godam tab video items

### DIFF
--- a/assets/src/js/media-library/views/attachment-details.js
+++ b/assets/src/js/media-library/views/attachment-details.js
@@ -137,7 +137,7 @@ export default AttachmentDetails?.extend( {
 		// No need to check if table exists, as if it did we would have returned early on link checks.
 		const tableBody = createTable( this.el );
 
-		if ( mime.startsWith( 'video/' ) && oEmbeddedVideoUrl ) {
+		if ( oEmbeddedVideoUrl ) {
 			tableBody.appendChild(
 				createAttachmentField( {
 					id: attachmentId,

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -106,7 +106,17 @@ class Media_Library_Ajax {
 			'mpd_url'               => $item['transcoded_file_path'] ?? '',
 		);
 
+		// Set icon with fallback to default mime type icon for audio and PDF.
 		$result['icon'] = $item['thumbnail_url'] ?? '';
+
+		// If no thumbnail URL, use WordPress default icons for audio and PDF.
+		if ( empty( $result['icon'] ) ) {
+			if ( 'audio' === $item['job_type'] ) {
+				$result['icon'] = includes_url( 'images/media/audio.png' );
+			} elseif ( 'application/pdf' === $item['mime_type'] ) {
+				$result['icon'] = includes_url( 'images/media/document.png' );
+			}
+		}
 
 		if ( 'stream' === $item['job_type'] ) {
 			$result['type'] = 'video';
@@ -360,7 +370,17 @@ class Media_Library_Ajax {
 
 			// Set the icon to be used for the virtual media preview.
 			// Populate the image field used by the media library to show previews.
-			$icon_url          = wp_mime_type_icon( $attachment->ID, '.svg' );
+			$icon_url = wp_mime_type_icon( $attachment->ID );
+			
+			// For audio and PDF, ensure we use the default icons.
+			if ( empty( $icon_url ) || strpos( $icon_url, '.svg' ) !== false ) {
+				if ( $is_audio ) {
+					$icon_url = includes_url( 'images/media/audio.png' );
+				} elseif ( $is_pdf ) {
+					$icon_url = includes_url( 'images/media/document.png' );
+				}
+			}
+			
 			$response['image'] = array();
 
 			if ( ! empty( $icon_url ) ) {


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1464

This pull request updates the `AttachmentDetails` view in the media library to provide an oEmbed URL for video attachments. The main focus is on enhancing the video attachment details by conditionally displaying an oEmbed URL field, making it easier to embed videos on other platforms.

Enhancements for video attachments:

* Added logic to check if the attachment's MIME type is a video and, if so, construct an oEmbed video URL using the REST API base and the attachment ID.
* Updated the details rendering to display a new "oEmbed Video URL" field for video attachments, including a help text explaining its purpose.
* Add the fallback thumbnail URL for Audio and PDF media types.

<img width="1470" height="729" alt="Screenshot 2026-01-16 at 3 00 22 PM" src="https://github.com/user-attachments/assets/b0e80e45-5cf5-4a1a-85eb-d4b679d23055" />

<img width="1470" height="707" alt="Screenshot 2026-01-16 at 3 54 47 PM" src="https://github.com/user-attachments/assets/8c247be7-25ab-4b1e-8da9-3ea5a5d7bff9" />
