### PR TITLE
Fix - PCP errors

### DIFF
--- a/inc/classes/assets/class-ima-assets.php
+++ b/inc/classes/assets/class-ima-assets.php
@@ -7,6 +7,10 @@
 
 namespace RTGODAM\Inc\Assets;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/assets/class-jetpack-form-assets.php
+++ b/inc/classes/assets/class-jetpack-form-assets.php
@@ -7,6 +7,10 @@
 
 namespace RTGODAM\Inc\Assets;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/class-elementor-widgets.php
+++ b/inc/classes/class-elementor-widgets.php
@@ -7,6 +7,10 @@
 
 namespace RTGODAM\Inc;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Elementor_Controls\Godam_Media;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Audio;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Gallery;

--- a/inc/classes/class-rewrite.php
+++ b/inc/classes/class-rewrite.php
@@ -8,6 +8,10 @@
 
 namespace RTGODAM\Inc;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/class-video-embed.php
+++ b/inc/classes/class-video-embed.php
@@ -8,6 +8,10 @@
 
 namespace RTGODAM\Inc;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/class-video-engagement.php
+++ b/inc/classes/class-video-engagement.php
@@ -7,6 +7,10 @@
 
 namespace RTGODAM\Inc;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 use WP_Error;
 

--- a/inc/classes/class-video-preview.php
+++ b/inc/classes/class-video-preview.php
@@ -8,6 +8,10 @@
 
 namespace RTGODAM\Inc;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php
+++ b/inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php
@@ -7,6 +7,10 @@
  * @since 1.4.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Get the primary field data.
 $godam_primary = $field['properties']['inputs']['primary'] ?? array();
 

--- a/inc/classes/fluentforms/class-form-submit.php
+++ b/inc/classes/fluentforms/class-form-submit.php
@@ -7,6 +7,10 @@
 
 namespace RTGODAM\Inc\FluentForms;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/lifter-lms/class-lifter-lms.php
+++ b/inc/classes/lifter-lms/class-lifter-lms.php
@@ -10,6 +10,10 @@
 
 namespace RTGODAM\Inc\Lifter_LMS;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**

--- a/inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php
+++ b/inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php
@@ -7,6 +7,10 @@
  * @since 1.3.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Check if the field is not a video field.
 if ( ! isset( $field['type'] ) || 'godam_record' !== $field['type'] ) {
 	return;

--- a/inc/classes/wpforms/wpforms-field-godam-record-entry-view.php
+++ b/inc/classes/wpforms/wpforms-field-godam-record-entry-view.php
@@ -7,6 +7,10 @@
  * @since 1.3.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use RTGODAM\Inc\WPForms\WPForms_Integration_Helper;
 
 $godam_form_id  = absint( $form_data['id'] );

--- a/inc/classes/wpforms/wpforms-field-godam-record-frontend.php
+++ b/inc/classes/wpforms/wpforms-field-godam-record-frontend.php
@@ -7,6 +7,10 @@
  * @since 1.3.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $godam_video_upload_button_id = wp_unique_id( 'uppy-video-upload-' );
 
 // Define data.


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/653

This pull request adds a security check to multiple PHP files across the codebase to prevent direct access to these files outside of the WordPress environment. Specifically, it adds a check to see if `ABSPATH` is defined, and if not, the script exits. This is a common best practice in WordPress development to enhance security.

Security improvements:

* Added `if ( ! defined( 'ABSPATH' ) ) { exit; }` checks at the top of all relevant PHP files to prevent unauthorized direct access. This change was applied to the following files:
  * `inc/classes/assets/class-ima-assets.php`
  * `inc/classes/assets/class-jetpack-form-assets.php`
  * `inc/classes/class-elementor-widgets.php`
  * `inc/classes/class-rewrite.php`
  * `inc/classes/class-video-embed.php`
  * `inc/classes/class-video-engagement.php`
  * `inc/classes/class-video-preview.php`
  * `inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php`
  * `inc/classes/fluentforms/class-form-submit.php`
  * `inc/classes/lifter-lms/class-lifter-lms.php`
  * `inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php`
  * `inc/classes/wpforms/wpforms-field-godam-record-entry-view.php`
  * `inc/classes/wpforms/wpforms-field-godam-record-frontend.php`