### PR TITLE
Fix the url missmatch of virtual image source set

### DIFF
--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -914,7 +914,8 @@ class Media_Library_Ajax {
 			return $sources;
 		}
 
-		if ( empty( $image_meta['sizes'] ) || ! is_array( $image_meta['sizes'] ) ) {
+		// Rebuild sources array for virtual media.
+		if ( empty( $sources ) || ! is_array( $sources ) ) {
 			return $sources;
 		}
 
@@ -926,7 +927,7 @@ class Media_Library_Ajax {
 
 			// Get last string after the last slash in the file url.
 			$file_basename = basename( $source['url'] );
-				
+
 			// Rebuild the full URL using the base URL and the file basename.
 			$url = $base_url . ltrim( $file_basename, '/' );
 


### PR DESCRIPTION
Fixes: #1347 (https://github.com/rtCamp/godam/issues/1347#issuecomment-3759807153)

This pull request simplifies and refines the logic for generating the `srcset` for virtual media images in the `filter_virtual_media_srcset` function. The main change is a switch from rebuilding the `sources` array based on image metadata to directly updating the URLs in the existing `sources` array, and the removal of special handling for thumbnail images.

Key changes to virtual media srcset handling:

* Removed logic that skipped `srcset` generation for thumbnail image sizes, ensuring all image sizes now have a `srcset` generated.
* Changed the approach from reconstructing the `sources` array from image metadata to iterating over the existing `sources` and updating each source's URL to use the correct base URL and filename.

## Screencast
https://app.godam.io/web/video/nfgf5h2vss