### PR TITLE
Fix the Copy Block button breaking block on editor issue

### DIFF
--- a/pages/video-editor/utils/index.js
+++ b/pages/video-editor/utils/index.js
@@ -30,7 +30,7 @@ function createGoDAMVideoBlockMarkup( attrs ) {
 function createVideoAttributes( attachmentId, mediaData ) {
 	const baseAttrs = {
 		id: Number( attachmentId ),
-		aspectRatio: '16/9',
+		aspectRatio: '16:9',
 	};
 
 	if ( ! mediaData ) {


### PR DESCRIPTION
This pull request makes a minor update to the default aspect ratio format in the video attributes utility function. The change updates the aspect ratio value from '16/9' to the more standard '16:9' format. 

- Updated the default `aspectRatio` value from '16/9' to '16:9' in the `createVideoAttributes` function in `pages/video-editor/utils/index.js`.

## Screencast

https://github.com/user-attachments/assets/2982fff6-5b58-4748-98d8-25785d9df55e

