### PR TITLE
Fix the email, firstname, lastname 0 value passed to transcoding request

### DIFF
--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -348,14 +348,16 @@ class RTGODAM_Transcoder_Handler {
 			// Get author name with fallback to username.
 			$author_first_name = '';
 			$author_last_name  = '';
+			$author_email      = '';
 
 			if ( $attachment_author ) {
-				$author_first_name = $attachment_author->first_name;
-				$author_last_name  = $attachment_author->last_name;
+				$author_first_name = $attachment_author->first_name ?? '';
+				$author_last_name  = $attachment_author->last_name ?? '';
+				$author_email      = $attachment_author->user_email ?? '';
 
 				// If first and last names are empty, use username as fallback.
 				if ( empty( $author_first_name ) && empty( $author_last_name ) ) {
-					$author_first_name = $attachment_author->user_login;
+					$author_first_name = $attachment_author->user_login ?? '';
 				}
 			}
 
@@ -379,7 +381,7 @@ class RTGODAM_Transcoder_Handler {
 						'watermark'            => boolval( $rtgodam_watermark ),
 						'resolutions'          => array( 'auto' ),
 						'video_quality'        => $rtgodam_video_compress_quality,
-						'wp_author_email'      => apply_filters( 'godam_author_email_to_send', $attachment_author ? $attachment_author->user_email : '', $attachment_id ),
+						'wp_author_email'      => apply_filters( 'godam_author_email_to_send', $author_email, $attachment_id ),
 						'wp_site'              => $site_url,
 						'wp_author_first_name' => apply_filters( 'godam_author_first_name_to_send', $author_first_name, $attachment_id ),
 						'wp_author_last_name'  => apply_filters( 'godam_author_last_name_to_send', $author_last_name, $attachment_id ),

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -218,14 +218,16 @@ class Media_Library_Ajax {
 		// Get author name with fallback to username.
 		$author_first_name = '';
 		$author_last_name  = '';
+		$author_email      = '';
 
 		if ( $attachment_author ) {
-			$author_first_name = $attachment_author->first_name;
-			$author_last_name  = $attachment_author->last_name;
+			$author_first_name = $attachment_author->first_name ?? '';
+			$author_last_name  = $attachment_author->last_name ?? '';
+			$author_email      = $attachment_author->user_email ?? '';
 
 			// If first and last names are empty, use username as fallback.
 			if ( empty( $author_first_name ) && empty( $author_last_name ) ) {
-				$author_first_name = $attachment_author->user_login;
+				$author_first_name = $attachment_author->user_login ?? '';
 			}
 		}
 
@@ -251,7 +253,7 @@ class Media_Library_Ajax {
 			'orignal_file_name'    => $file_name ?? $file_title,
 			'callback_url'         => rawurlencode( $callback_url ),
 			'status_callback'      => rawurlencode( $status_callback_url ),
-			'wp_author_email'      => apply_filters( 'godam_author_email_to_send', $attachment_author ? $attachment_author->user_email : '', $attachment_id ),
+			'wp_author_email'      => apply_filters( 'godam_author_email_to_send', $author_email, $attachment_id ),
 			'wp_site'              => $site_url,
 			'wp_author_first_name' => apply_filters( 'godam_author_first_name_to_send', $author_first_name, $attachment_id ),
 			'wp_author_last_name'  => apply_filters( 'godam_author_last_name_to_send', $author_last_name, $attachment_id ),

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -524,12 +524,13 @@ function rtgodam_send_video_to_godam_for_transcoding( $form_type = '', $form_tit
 	$site_url     = get_site_url();
 
 	// Get author name with fallback to username.
-	$author_first_name = $current_user->first_name;
-	$author_last_name  = $current_user->last_name;
+	$author_first_name = $current_user->first_name ?? '';
+	$author_last_name  = $current_user->last_name ?? '';
+	$author_email      = $current_user->user_email ?? '';
 
 	// If first and last names are empty, use username as fallback.
 	if ( empty( $author_first_name ) && empty( $author_last_name ) ) {
-		$author_first_name = $current_user->user_login;
+		$author_first_name = $current_user->user_login ?? '';
 	}
 
 	$body = array_merge(
@@ -547,7 +548,7 @@ function rtgodam_send_video_to_godam_for_transcoding( $form_type = '', $form_tit
 			'watermark'            => boolval( $rtgodam_watermark ),
 			'resolutions'          => array( 'auto' ),
 			'folder_name'          => ! empty( $form_title ) ? $form_title : __( 'Gravity forms', 'godam' ),
-			'wp_author_email'      => apply_filters( 'godam_author_email_to_send', $current_user->user_email, 0 ),
+			'wp_author_email'      => apply_filters( 'godam_author_email_to_send', $author_email, 0 ),
 			'wp_site'              => $site_url,
 			'wp_author_first_name' => apply_filters( 'godam_author_first_name_to_send', $author_first_name, 0 ),
 			'wp_author_last_name'  => apply_filters( 'godam_author_last_name_to_send', $author_last_name, 0 ),


### PR DESCRIPTION
**Fixes:** #1537 

This pull request improves the way author information is handled when sending media metadata for transcoding and uploading. The main change is to ensure that the author's email, first name, and last name are always set to a valid string (never null), even if the author object is missing or some fields are unset. This prevents potential errors and makes the code more robust.

**Improvements to author information handling:**

* All author fields (`first_name`, `last_name`, `user_email`, and `user_login`) are now set using the null coalescing operator (`?? ''`), ensuring they default to an empty string if not present. This applies to `admin/class-rtgodam-transcoder-handler.php`, `inc/classes/class-media-library-ajax.php`, and `inc/helpers/custom-functions.php`. [[1]](diffhunk://#diff-4f7d5e41b95ad49276b75df0eccbc9295818361e0ad9f8949e6d7f5d7e079868R351-R360) [[2]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R221-R230) [[3]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27L527-R533)

**Consistent use of author email in metadata:**

* The `wp_author_email` field in the metadata arrays now consistently uses the new `$author_email` variable, which is always a string, rather than directly accessing the potentially unset property. This change is applied wherever media metadata is prepared for transcoding or uploading. [[1]](diffhunk://#diff-4f7d5e41b95ad49276b75df0eccbc9295818361e0ad9f8949e6d7f5d7e079868L382-R384) [[2]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4L254-R256) [[3]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27L550-R551)

## Screenshots
<img width="1466" height="343" alt="Screenshot 2026-01-20 at 11 06 00 AM" src="https://github.com/user-attachments/assets/c1a2a070-3085-4d56-88f9-93d36f16e9c5" />
<img width="361" height="728" alt="Screenshot 2026-01-20 at 11 05 31 AM" src="https://github.com/user-attachments/assets/c5b4c9f4-5b4c-482c-9534-fae20bb7393a" />
