### PR TITLE
Fix the aspectRatio compatibility issue on godam video block

### DIFF
--- a/assets/src/blocks/godam-player/VideoJS.js
+++ b/assets/src/blocks/godam-player/VideoJS.js
@@ -42,8 +42,12 @@ export const VideoJS = ( props ) => {
 
 			const videojsOptions = { ...options };
 
+			if ( ! options.aspectRatio ) {
+				videojsOptions.aspectRatio = '16:9';
+			}
+
 			if ( options.aspectRatio && ! /^\d+:\d+$/.test( options.aspectRatio ) ) {
-				// Remove aspectRatio from options as we will set it later
+				// Unset the aspectRatio from videojsOptions as we will set it later
 				delete videojsOptions.aspectRatio;
 			}
 


### PR DESCRIPTION
This pull request introduces a small but important change to the default behavior of the `VideoJS` component. Now, if the `aspectRatio` option is not provided, it will default to `'16:9'`, ensuring more consistent video display. Additionally, the logic for unsetting invalid `aspectRatio` values has been clarified.

* Defaulted the `aspectRatio` property to `'16:9'` in `videojsOptions` when not provided, and clarified the logic for removing invalid `aspectRatio` values in the `VideoJS` component (`assets/src/blocks/godam-player/VideoJS.js`).