### PR TITLE
Fixed console error on two column modal for virtual media

### DIFF
--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -604,7 +604,7 @@ export default AttachmentDetailsTwoColumn?.extend( {
 			// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
 			if ( undefined !== virtual && virtual ) {
 				const videoUrl = this.model.get( 'transcoded_url' ); // Ensure it's a valid .mp4
-				const $container = this.$el.find( '.wp-video' );
+				const $container = this.$el.find( '.wp-video > div' );
 				const videoId = 'videojs-player-' + this.model.get( 'id' ); // Unique ID
 
 				// Clear default preview, Create a <video> element to be used by Video.js.


### PR DESCRIPTION
# 🛠️ Fix: Prevent Uncaught TypeError on Two-Column Modal for Virtual Media

## Issue

Fixes the console error reported in Issue #1550 where the two-column screen throws an Uncaught TypeError: Cannot read properties of null (reading ‘length’) when opening the Virtual Media modal.

## What’s Fixed

This PR introduces a guard to ensure that before attempting to read .length on the related element (or collection), the value is verified to be non-null. This prevents the JavaScript TypeError from occurring when the modal attempts to access a DOM node or data that isn’t present.

## Testing

- Steps to verify the fix:
- Navigate to the two-column screen in the application.
- Trigger opening the Virtual Media modal.
- Confirm that the modal opens without any Uncaught TypeError in the console.
- Validate expected functionality of the modal behavior post-fix.

## Issue

https://github.com/rtCamp/godam/issues/1550