### PR TITLE
Fix video.js poster update using getPlayer with null guard

### DIFF
--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -363,8 +363,12 @@ export default AttachmentDetailsTwoColumn?.extend( {
 
 		// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
 		if ( undefined !== virtual && virtual ) {
-			const videoPlayer = videojs( 'videojs-player-' + this.model.get( 'id' ) );
-			videoPlayer.poster( selected );
+			const playerId = 'videojs-player-' + this.model.get( 'id' );
+			const player = videojs.getPlayer( playerId );
+
+			if ( player ) {
+				player.poster( selected );
+			}
 		}
 
 		setTimeout( () => {
@@ -518,8 +522,12 @@ export default AttachmentDetailsTwoColumn?.extend( {
 
 				// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
 				if ( undefined !== virtual && virtual ) {
-					const videoPlayer = videojs( 'videojs-player-' + model.get( 'id' ) );
-					videoPlayer.poster( thumbnailURL );
+					const playerId = 'videojs-player-' + model.get( 'id' );
+					const player = videojs.getPlayer( playerId );
+
+					if ( player ) {
+						player.poster( thumbnailURL );
+					}
 				}
 
 				/**


### PR DESCRIPTION
Fixes #1550 
### What changed
- Replaced direct `videojs()` calls with `videojs.getPlayer()`
- Added null guard before calling `poster()`

### Why
- Prevents JS errors when the Video.js player is not yet initialized
- Fixes poster update issues for virtual (proxy) videos in Media Library

### Scope
- Media Library attachment details view only
- No functional or behavioral change outside this flow
