### PR TITLE
Disabled screen capture if it is not supported by the OS restriction

### DIFF
--- a/assets/src/js/godam-recorder/index.js
+++ b/assets/src/js/godam-recorder/index.js
@@ -148,7 +148,7 @@ class UppyVideoUploader {
 		}
 
 		// Optional ScreenCapture support.
-		if ( this.selectorArray.includes( 'screen_capture' ) ) {
+		if ( this.selectorArray.includes( 'screen_capture' ) && this.isScreenCaptureAvailable() ) {
 			this.uppy.use( ScreenCapture, { audio: true } );
 		}
 
@@ -352,6 +352,19 @@ class UppyVideoUploader {
 			// Re-render preview on AJAX validation errors.
 			this.processVideoUpload( restoredFile, 'restored' );
 		}
+	}
+
+	/**
+	 * Checks if the browser supports screen capture.
+	 *
+	 * @return {boolean} True if screen capture is supported, false otherwise.
+	 */
+	isScreenCaptureAvailable() {
+		return (
+			typeof navigator !== 'undefined' &&
+			navigator.mediaDevices &&
+			typeof navigator.mediaDevices.getDisplayMedia === 'function'
+		);
 	}
 }
 


### PR DESCRIPTION
# 🛠️ Fix: Screencast Blank Screen on Mobile Devices (Issue #1043)

## 🔍 Problem Summary

When users attempted to use the screencast feature on mobile devices with a video that has a recorder form layer, the shared screen appeared blank. This made it impossible to see the screen content during screencast sessions on both Android and iOS devices.

## Steps to reproduce:

1. Add any video to a page that has a form layer with a recorder.
2. Open the page on a mobile device.
3. Start screen sharing (screencast).
4. Observe that the shared screen is blank instead of showing actual content.

## ✅ What This PR Fixes

Disabled screen capture if it is not supported by the Browser/OS restriction.

## Issue
https://github.com/rtCamp/godam/issues/1043