### PR TITLE
Add description field to virtual media

### DIFF
--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -94,6 +94,7 @@ class Media_Library_Ajax {
 		$result = array(
 			'id'                    => $item['name'],
 			'title'                 => $title,
+			'description'           => $item['description'] ?? '',
 			'filename'              => $item['orignal_file_name'] ?? $item['name'],
 			'url'                   => isset( $item['transcoded_mp4_url'] ) ? $item['transcoded_mp4_url'] : ( isset( $item['transcoded_file_path'] ) ? $item['transcoded_file_path'] : '' ),
 			'mime'                  => isset( $item['transcoded_mp4_url'] ) ? 'video/mp4' : $computed_mime,


### PR DESCRIPTION
Fixes: #1192 

This pull request makes a small improvement to the `prepare_godam_media_item` function by ensuring that the media item's description is always included in the result array, defaulting to an empty string if not set.

- Added the `description` field to the prepared media item, defaulting to an empty string if not present.


https://github.com/user-attachments/assets/3ea6ede2-a117-4792-8ad4-82f710b1f147

