### PR TITLE
Unified the video editor URL validation guide message for CTA, ADs, and Hotspot layers

### DIFF
--- a/pages/video-editor/components/ads/CustomAdSettings.js
+++ b/pages/video-editor/components/ads/CustomAdSettings.js
@@ -14,6 +14,7 @@ import React, { useState, useEffect } from 'react';
  * Internal dependencies
  */
 import { updateLayerField } from '../../redux/slice/videoSlice';
+import { isValidURL } from '../../utils';
 import { replace, trash } from '@wordpress/icons';
 
 const CustomAdSettings = ( { layerID } ) => {
@@ -49,19 +50,6 @@ const CustomAdSettings = ( { layerID } ) => {
 		} );
 
 		fileFrame.open();
-	};
-
-	// URL validation function
-	const isValidURL = ( url ) => {
-		if ( ! url || url.trim() === '' ) {
-			return true; // Empty is valid (optional field)
-		}
-		try {
-			const parsedUrl = new URL( url );
-			return [ 'http:', 'https:' ].includes( parsedUrl.protocol );
-		} catch {
-			return false;
-		}
 	};
 
 	// Validate URL on component load

--- a/pages/video-editor/components/cta/ImageCTA.js
+++ b/pages/video-editor/components/cta/ImageCTA.js
@@ -27,6 +27,7 @@ import ColorPickerButton from '../shared/color-picker/ColorPickerButton.jsx';
  * Internal dependencies
  */
 import { updateLayerField } from '../../redux/slice/videoSlice';
+import { isValidURL } from '../../utils';
 
 /**
  * Layout SVG Icon Components
@@ -231,7 +232,7 @@ const ImageCTA = ( { layerID } ) => {
 
 	// Validate URL on component load
 	useEffect( () => {
-		if ( layer?.imageLink && ! isValidUrl( layer.imageLink ) ) {
+		if ( layer?.imageLink && ! isValidURL( layer.imageLink ) ) {
 			setUrlError( __( 'Please enter a valid URL (e.g., https://example.com)', 'godam' ) );
 		}
 	}, [] );
@@ -243,31 +244,13 @@ const ImageCTA = ( { layerID } ) => {
 	};
 
 	/**
-	 * Validates if the given string is a valid URL.
-	 *
-	 * @param {string} url The URL string to validate.
-	 * @return {boolean} True if valid, false otherwise.
-	 */
-	const isValidUrl = ( url ) => {
-		if ( ! url || url.trim() === '' ) {
-			return true; // Empty is valid (optional field)
-		}
-		try {
-			const parsedUrl = new URL( url );
-			return [ 'http:', 'https:' ].includes( parsedUrl.protocol );
-		} catch ( e ) {
-			return false;
-		}
-	};
-
-	/**
 	 * Handles URL field change with validation.
 	 *
 	 * @param {string} value The new URL value.
 	 */
 	const handleUrlChange = ( value ) => {
 		updateField( 'imageLink', value );
-		if ( value && ! isValidUrl( value ) ) {
+		if ( value && ! isValidURL( value ) ) {
 			setUrlError( __( 'Please enter a valid URL (e.g., https://example.com)', 'godam' ) );
 		} else {
 			setUrlError( '' );

--- a/pages/video-editor/components/layers/HotspotLayer.js
+++ b/pages/video-editor/components/layers/HotspotLayer.js
@@ -31,6 +31,7 @@ import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { updateLayerField } from '../../redux/slice/videoSlice';
+import { isValidURL } from '../../utils';
 import { v4 as uuidv4 } from 'uuid';
 import LayerControls from '../LayerControls';
 import FontAwesomeIconPicker from '../hotspot/FontAwesomeIconPicker';
@@ -206,24 +207,6 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 
 	// For now we are enabling all the features
 	const isValidAPIKey = true;
-
-	/**
-	 * Validates if the given string is a valid URL.
-	 *
-	 * @param {string} url The URL string to validate.
-	 * @return {boolean} True if valid, false otherwise.
-	 */
-	const isValidURL = ( url = '' ) => {
-		if ( ! url || url.trim() === '' ) {
-			return true; // Empty is valid (optional field)
-		}
-		try {
-			const parsedUrl = new URL( url );
-			return [ 'http:', 'https:' ].includes( parsedUrl.protocol );
-		} catch {
-			return false;
-		}
-	};
 
 	// Validate existing hotspot links on component load
 	useEffect( () => {

--- a/pages/video-editor/utils/index.js
+++ b/pages/video-editor/utils/index.js
@@ -5,6 +5,24 @@ import apiFetch from '@wordpress/api-fetch';
 
 const MEDIA_ENDPOINT = '/wp-json/wp/v2/media';
 
+/**
+ * Validates if the given string is a valid URL.
+ *
+ * @param {string} url The URL string to validate.
+ * @return {boolean} True if valid, false otherwise.
+ */
+export const isValidURL = ( url ) => {
+	if ( ! url || url.trim() === '' ) {
+		return true; // Empty is valid (optional field)
+	}
+	try {
+		const parsedUrl = new URL( url );
+		return [ 'http:', 'https:' ].includes( parsedUrl.protocol );
+	} catch {
+		return false;
+	}
+};
+
 function createBlockDelimiter( { blockName, attrs = {}, innerHTML = '' } ) {
 	const name = blockName.replace( /^core\//, '' );
 	const hasAttributes = Object.keys( attrs ).length > 0;


### PR DESCRIPTION
Fixes: https://github.com/rtCamp/godam/issues/1536#issuecomment-3840405378 (Ref: https://github.com/rtCamp/godam/issues/1536#issuecomment-3840346518)

This PR updates AD and Hotspot validation to match the existing CTA validation pattern.

This pull request improves the user experience and validation logic for URL input fields in both the custom ad settings and hotspot layer components of the video editor. The main focus is on providing clearer, more consistent validation feedback and ensuring that invalid URLs are flagged as soon as the components load.

**Validation logic improvements:**

* Added an initial validation check on component load for both the ad click link (`CustomAdSettings.js`) and hotspot links (`HotspotLayer.js`) to immediately flag invalid URLs if present. [[1]](diffhunk://#diff-270980c0443a2924997841ef379d84b2fa31588f39efb97a83fe9d99b1459585R56-R73) [[2]](diffhunk://#diff-cc8f25ee0ba0c63a5a0e4bc2d60dbd2a25b017461aa758d25ef353f1900bdf4cR213-R230)

**User interface and feedback enhancements:**

* Updated the validation message style for invalid URLs in both components to use a yellow warning style and clearer language, improving consistency and user guidance. [[1]](diffhunk://#diff-270980c0443a2924997841ef379d84b2fa31588f39efb97a83fe9d99b1459585R173-R190) [[2]](diffhunk://#diff-cc8f25ee0ba0c63a5a0e4bc2d60dbd2a25b017461aa758d25ef353f1900bdf4cL366-R390)

**Code maintenance:**

* Cleaned up input className usage by removing conditional error classes in favor of consistent styling. [[1]](diffhunk://#diff-270980c0443a2924997841ef379d84b2fa31588f39efb97a83fe9d99b1459585R173-R190) [[2]](diffhunk://#diff-cc8f25ee0ba0c63a5a0e4bc2d60dbd2a25b017461aa758d25ef353f1900bdf4cL366-R390)
* Added `useEffect` import to `CustomAdSettings.js` to support the new validation logic.


https://github.com/user-attachments/assets/5f9f29b0-f84d-442f-b1ea-ef7fbfeb26df

