### PR TITLE
fix: For All data remove Days parameter

### DIFF
--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -67,7 +67,7 @@ class Analytics extends Base {
 					'permission_callback' => '__return_true',
 					'args'                => array(
 						'days'     => array(
-							'required'          => true,
+							'required'          => false,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
 						),
@@ -109,7 +109,7 @@ class Analytics extends Base {
 					'permission_callback' => '__return_true',
 					'args'                => array(
 						'days'     => array(
-							'required'          => true,
+							'required'          => false,
 							'type'              => 'integer',
 							'sanitize_callback' => 'absint',
 						),
@@ -327,12 +327,16 @@ class Analytics extends Base {
 
 		$microservice_url = RTGODAM_ANALYTICS_BASE . '/processed-analytics/history/';
 		$params           = array(
-			'days'          => $days,
 			'video_id'      => $video_id,
 			'site_url'      => $site_url,
 			'account_token' => $account_token,
 			'api_key'       => $api_key,
 		);
+
+		// Only add days parameter if it's provided.
+		if ( ! empty( $days ) ) {
+			$params['days'] = $days;
+		}
 
 		$history_url = add_query_arg( $params, $microservice_url );
 		$response    = wp_remote_get( $history_url );
@@ -472,13 +476,19 @@ class Analytics extends Base {
 			);
 		}
 
+		$params = array(
+			'site_url'      => $site_url,
+			'account_token' => $account_token,
+			'api_key'       => $api_key,
+		);
+
+		// Only add days parameter if it's provided.
+		if ( ! empty( $days ) ) {
+			$params['days'] = $days;
+		}
+
 		$endpoint = add_query_arg(
-			array(
-				'days'          => $days,
-				'site_url'      => $site_url,
-				'account_token' => $account_token,
-				'api_key'       => $api_key,
-			),
+			$params,
 			RTGODAM_ANALYTICS_BASE . '/dashboard/metrics/history/'
 		);
 

--- a/pages/analytics/PlaybackPerformance.js
+++ b/pages/analytics/PlaybackPerformance.js
@@ -39,16 +39,17 @@ export default function PlaybackPerformanceDashboard( {
 			case '1Y':
 				return 365;
 			case 'All':
-				return 730; // Set a large value for "All"
+				return null; // Return null to fetch all available days
 			default:
 				return 7;
 		}
 	};
 
 	// Fetch analytics data based on selected period
+	const days = getDaysFromPeriod( selectedPeriod );
 	const dashboardHistoryResult = useFetchDashboardMetricsHistoryQuery(
 		{
-			days: getDaysFromPeriod( selectedPeriod ),
+			...( days !== null && { days } ),
 			siteUrl: window.location.origin,
 		},
 		{ skip: mode !== 'dashboard' },
@@ -58,7 +59,7 @@ export default function PlaybackPerformanceDashboard( {
 		{
 			videoId: attachmentID,
 			siteUrl: window.location.origin,
-			days: getDaysFromPeriod( selectedPeriod ),
+			...( days !== null && { days } ),
 		},
 		{ skip: mode === 'dashboard' || ! attachmentID },
 	);


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-analytics/issues/91

This pull request updates how the `days` parameter is handled in both the backend REST API and the frontend analytics dashboard. The main goal is to make the `days` parameter optional, allowing for more flexible queries—especially for "All" time periods—by only including `days` when it is explicitly set.

**Backend (REST API) changes:**

* Made the `days` parameter optional (no longer required) for relevant REST API endpoints in `class-analytics.php`. [[1]](diffhunk://#diff-4617dbe0a16be576ac81172d19da6aedc271d2825d3d85b19f4d3945fb4400c1L70-R70) [[2]](diffhunk://#diff-4617dbe0a16be576ac81172d19da6aedc271d2825d3d85b19f4d3945fb4400c1L112-R112)
* Updated both `fetch_analytics_history` and `fetch_dashboard_history` methods to only add the `days` parameter to API requests if it is provided, preventing unnecessary or empty values from being sent. [[1]](diffhunk://#diff-4617dbe0a16be576ac81172d19da6aedc271d2825d3d85b19f4d3945fb4400c1L330-R340) [[2]](diffhunk://#diff-4617dbe0a16be576ac81172d19da6aedc271d2825d3d85b19f4d3945fb4400c1L475-R491)

**Frontend (Analytics Dashboard) changes:**

* Modified the period selection logic in `PlaybackPerformance.js` so that choosing "All" returns `null` for `days`, signaling the backend to fetch all available data.
* Updated API call parameters to only include `days` if it is not `null`, aligning with the new backend logic. [[1]](diffhunk://#diff-9dc32e0c347e752da1fb3b8cd3c6d165dcdfb96a5d1b4d150d01bd7da3f03ecaL42-R52) [[2]](diffhunk://#diff-9dc32e0c347e752da1fb3b8cd3c6d165dcdfb96a5d1b4d150d01bd7da3f03ecaL61-R62)


## Screenshot


<img width="1470" height="725" alt="Screenshot 2026-02-05 at 1 49 49 PM" src="https://github.com/user-attachments/assets/3aa51a09-cbe2-4b61-8569-57fecfe639e9" />

