### PR TITLE
Update the phpcs comment location

### DIFF
--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -240,13 +240,14 @@ class Analytics extends Base {
 			$post_details = array();
 
 			if ( ! empty( $post_ids ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 				$posts = get_posts(
 					array(
 						'post__in'         => $post_ids,
 						'post_type'        => 'any',
 						'posts_per_page'   => -1,
 						'orderby'          => 'post__in',
-						'suppress_filters' => false, // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+						'suppress_filters' => false,
 					)
 				);
 


### PR DESCRIPTION
This pull request makes a minor update to the `fetch_analytics_data` method in `class-analytics.php` by adjusting the use of code comments related to PHPCS (PHP CodeSniffer) warnings.

- Code quality/comment update:
  * Removed the inline PHPCS ignore comment from the `suppress_filters` parameter and instead added a single PHPCS ignore comment before the `get_posts` call for improved clarity and maintainability.