### PR TITLE
fix: Unknown error when Re-transcoding without Job ID

### DIFF
--- a/inc/classes/rest-api/class-transcoding.php
+++ b/inc/classes/rest-api/class-transcoding.php
@@ -604,13 +604,18 @@ class Transcoding extends Base {
 		$wp_metadata              = array();
 		$wp_metadata['mime_type'] = $mime_type;
 
+		// Check if media has been transcoded before and has a job ID.
+		$transcoded_url   = get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true );
+		$existing_job_id  = get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true );
+		$is_retranscoding = ! empty( $transcoded_url ) || ! empty( $existing_job_id );
+
 		// Retranscode the media.
 		if ( preg_match( '/image/i', $mime_type ) ) {
 			$transcoder = Media_Library_Ajax::get_instance();
-			$transcoder->upload_media_to_frappe_backend( $attachment_id, true );
+			$transcoder->upload_media_to_frappe_backend( $attachment_id, $is_retranscoding );
 		} else {
 			$transcoder = new \RTGODAM_Transcoder_Handler( true );
-			$transcoder->wp_media_transcoding( $wp_metadata, $attachment_id, true, true );
+			$transcoder->wp_media_transcoding( $wp_metadata, $attachment_id, true, $is_retranscoding );
 		}
 
 		// Check if the transcoding job ID is set.


### PR DESCRIPTION
Issue - #1098 

This pull request updates the retranscoding logic to better handle cases where media has already been transcoded. The main change is to check for existing transcoding metadata before initiating a retranscoding operation, and to pass this information to the relevant transcoder methods.

**Retranscoding logic improvements:**

* Added a check for existing transcoded URLs and job IDs in the media's post meta, and set an `$is_retranscoding` flag accordingly. This flag is now passed to both `upload_media_to_frappe_backend` and `wp_media_transcoding` methods to indicate whether the operation is a retranscoding.

## Screenshots

### Before

<img width="1095" height="579" alt="Screenshot 2026-02-05 at 3 43 32 PM" src="https://github.com/user-attachments/assets/784a759c-93bc-4835-89b7-17af1a26166d" />

### After

<img width="1102" height="543" alt="Screenshot 2026-02-05 at 3 43 42 PM" src="https://github.com/user-attachments/assets/0f8949c7-190d-45d4-ad2c-becfd9fc5656" />
