### PR TITLE
Fix: Destroy VideoJS player when Attachment Modal is closed in Media Library

### DIFF
--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -62,7 +62,7 @@ function destroyVideoJSPlayersInContainer( container ) {
 	container.querySelectorAll( 'video' ).forEach( ( videoElement ) => {
 		try {
 			videoElement.pause();
-			videoElement.currentTime = videoElement.currentTime;
+			videoElement.currentTime = 0;
 		} catch ( error ) {
 			// Silent fail.
 		}


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1626

This pull request adds logic to ensure that Video.js players embedded in the WordPress media modal are properly disposed of when the modal is closed. This prevents videos from continuing to play in the background and frees up resources, addressing a gap not handled by WordPress core's default mediaelement cleanup. The main changes include importing Video.js, implementing a cleanup function, and monkey-patching the modal close behavior.

**Video.js Player Cleanup Integration:**

* Added import of the `videojs` library to `assets/src/js/media-library/index.js` to enable Video.js player management.
* Implemented the `destroyVideoJSPlayersInContainer` function to find and dispose of all Video.js players within a given container, with fallbacks for native video elements.
* Introduced the `setupModalCloseCleanup` method in the `MediaLibrary` class, which monkey-patches the WordPress media modal's `close` method to call the new cleanup function before closing the modal.
* Updated the `MediaLibrary.initialize()` method to invoke the modal cleanup setup during initialization.

### Expected Result
When Attachment Modal containing VideoJS player (for virtual media) is closed, the VideoJS player should be destroyed and not continue playing.