### PR TITLE
Fix - Pagination for GoDAM Tab videos

### DIFF
--- a/assets/src/js/media-library/models/attachments.js
+++ b/assets/src/js/media-library/models/attachments.js
@@ -147,7 +147,9 @@ const GODAMAttachmentCollection = wp?.media?.model?.Query?.extend(
 						const items = response.data;
 						const totalCount = parseInt( response.total_count ?? response.total_items, 10 ) || 0;
 						const totalPages = parseInt( response.total_pages, 10 ) || 0;
-						const currentPage = parseInt( response.current_page ?? page, 10 ) || page;
+						const currentPage = Math.max( 1, parseInt( response.current_page ?? page, 10 ) || page );
+						const loadedCount = this.length + items.length;
+						const effectiveTotal = totalCount > 0 ? totalCount : loadedCount;
 						let hasMore = items.length === perPage;
 
 						if ( totalPages > 0 ) {
@@ -167,9 +169,9 @@ const GODAMAttachmentCollection = wp?.media?.model?.Query?.extend(
 						}
 
 						// Update total counts.
-						this.total = totalCount;
+						this.total = effectiveTotal;
 						// WordPress uses this field for the "Showing x of y media items" footer text.
-						this.totalAttachments = totalCount;
+						this.totalAttachments = effectiveTotal;
 						this.totalPages = totalPages;
 						this.currentPage = currentPage;
 

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1383,7 +1383,7 @@ class Media_Library extends Base {
 			$response     = $body->message->files;
 			$total        = isset( $body->message->total_count ) ? absint( $body->message->total_count ) : 0;
 			$total_pages  = isset( $body->message->total_pages ) ? absint( $body->message->total_pages ) : 0;
-			$current_page = isset( $body->message->current_page ) ? absint( $body->message->current_page ) : $page;
+			$current_page = isset( $body->message->current_page ) ? max( 1, absint( $body->message->current_page ) ) : $page;
 			$has_more     = isset( $body->message->has_more ) ? (bool) $body->message->has_more : ( $total_pages > 0 ? $current_page < $total_pages : false );
 
 			$all_items = array();


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/824

This pull request adds improved pagination support for the media library's GoDAM attachment collection, both in the frontend JavaScript model and the backend REST API. The changes ensure accurate tracking of total items, pages, and the current page, and provide more robust handling of pagination state.

**Pagination enhancements**

* Added `totalPages` and `currentPage` properties to the `GODAMAttachmentCollection` model, and updated their values based on API responses for more accurate pagination tracking. [[1]](diffhunk://#diff-15dc1d15963bf40257662a0f0bcef16442f54e2372e2b18387991b4001c7ebadR84-R85) [[2]](diffhunk://#diff-15dc1d15963bf40257662a0f0bcef16442f54e2372e2b18387991b4001c7ebadR148-R174)
* Improved calculation of the `hasMore` property in the JavaScript model to account for total pages, current page, and explicit API flags, making pagination behavior more reliable.

**REST API improvements**

* Added `total_pages` and `current_page` variables to the REST API handler, and updated their values using upstream API responses for better pagination metadata. [[1]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104L1293-R1296) [[2]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104L1382-R1387)
* Modified the REST API response to include `total_count`, `total_pages`, and `current_page` fields, allowing the frontend to consume accurate pagination information.

## Screenshot

<img width="1465" height="874" alt="Screenshot 2026-02-11 at 12 56 01 PM" src="https://github.com/user-attachments/assets/947e9816-7c90-41fb-8c5d-07fdce8734d5" />
