### PR TITLE
Fix camera and microphone permissions for GoDAM Recorder form field

### DIFF
--- a/inc/classes/class-headers.php
+++ b/inc/classes/class-headers.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Class to handle site HTTP headers.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc;
+
+defined( 'ABSPATH' ) || exit;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+/**
+ * Class Headers
+ */
+class Headers {
+
+	use Singleton;
+
+	/**
+	 * Construct method.
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Setup hooks.
+	 *
+	 * @return void
+	 */
+	public function setup_hooks() {
+		add_action( 'wp_headers', array( $this, 'fix_camera_microphone_permissions' ) );
+	}
+
+	/**
+	 * Fix camera and microphone permissions for GoDAM video recorder form field.
+	 *
+	 * @param array $headers The current HTTP headers.
+	 *
+	 * @return array Modified headers with updated Permissions-Policy.
+	 */
+	public function fix_camera_microphone_permissions( $headers ) {
+		// Only modify headers for frontend pages.
+		if ( is_admin() ) {
+			return $headers;
+		}
+
+		// Get the current policy or start with a blank string.
+		$policy = isset( $headers['Permissions-Policy'] ) ? $headers['Permissions-Policy'] : '';
+
+		// Define what we need.
+		$requirements = array(
+			'camera'     => '(self)',
+			'microphone' => '(self)',
+		);
+
+		foreach ( $requirements as $feature => $value ) {
+			if ( strpos( $policy, $feature ) !== false ) {
+				// Feature exists: Update its value to (self).
+				$policy = preg_replace(
+					'/' . $feature . '=\([^)]*\)/',
+					$feature . '=' . $value,
+					$policy
+				);
+			} else {
+				// Feature missing: Append it gracefully.
+				$separator = ( '' === $policy ) ? '' : ', ';
+				$policy   .= $separator . $feature . '=' . $value;
+			}
+		}
+
+		$headers['Permissions-Policy'] = $policy;
+		return $headers;
+	}
+}

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -21,6 +21,7 @@ use RTGODAM\Inc\Video_Embed;
 use RTGODAM\Inc\Video_Permalinks;
 use RTGODAM\Inc\Video_Engagement;
 use RTGODAM\Inc\Update;
+use RTGODAM\Inc\Headers;
 
 use RTGODAM\Inc\Post_Types\GoDAM_Video;
 
@@ -98,6 +99,7 @@ class Plugin {
 		Video_Embed::get_instance();
 		Video_Permalinks::get_instance();
 		Embed::get_instance();
+		Headers::get_instance();
 
 		// Load shortcodes.
 		GoDAM_Player::get_instance();


### PR DESCRIPTION
## Description

This PR fixes camera and microphone permission issues affecting the **GoDAM Recorder** form field by ensuring the site sends an appropriate `Permissions-Policy` header on frontend requests.

A new `RTGODAM\Inc\Headers` class hooks into `wp_headers` and guarantees that:

- `camera=(self)`
- `microphone=(self)`

are present in the `Permissions-Policy` header. If either directive already exists, its value is updated to `(self)`; if missing, it’s appended. Admin requests are left untouched.
I went with this approach, because there is no other way to update permission policy header data without affecting existing values.

<img width="476" height="40" alt="image" src="https://github.com/user-attachments/assets/3c1402f9-5412-445a-b9ef-a4a742bc90f8" />


## Issue

https://github.com/rtCamp/godam/issues/1560

## Testing

- Open a frontend page where the GoDAM Recorder field is used and verify camera/microphone access is granted in the browser.
- Confirm the response headers include a `Permissions-Policy` with `camera=(self)` and `microphone=(self)` (e.g., via DevTools → Network → Response Headers).
- Verify wp-admin pages are unaffected (no header changes applied in admin context).
