### PR TITLE
Fix: Input validation in thumbnail count

### DIFF
--- a/pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx
@@ -27,7 +27,15 @@ const VideoThumbnails = ( { handleSettingChange } ) => {
 
 	const validateVideoThumbnails = () => {
 		const value = parseInt( videoThumbnailsInput, 10 );
-		const validatedValue = Number.isNaN( value ) || value < 1 || value > 10 ? 1 : value;
+		let validatedValue;
+
+		if ( Number.isNaN( value ) || value < 1 ) {
+			validatedValue = 1;
+		} else if ( value > 10 ) {
+			validatedValue = 10;
+		} else {
+			validatedValue = value;
+		}
 
 		setVideoThumbnailsInput( String( validatedValue ) );
 		if ( validatedValue !== videoThumbnails ) {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1254

This pull request updates the `VideoThumbnails` component to improve the user input experience for setting the number of video thumbnails. The changes introduce local state management for the input field, input validation, and synchronization with Redux state, ensuring the value remains within the allowed range.

**Input handling and validation improvements:**

* Added local state (`videoThumbnailsInput`) to manage the input value, allowing users to temporarily enter invalid values before validation.
* Introduced an `onBlur` handler (`validateVideoThumbnails`) to validate and correct the input when the field loses focus, ensuring the value is between 1 and 10. [[1]](diffhunk://#diff-edb269501c981c15d822f92d6acc4741cf45f7a56ee4ae46d9a670b864ca5c00R16-R35) [[2]](diffhunk://#diff-edb269501c981c15d822f92d6acc4741cf45f7a56ee4ae46d9a670b864ca5c00L39-R53)
* Updated the input field to use `videoThumbnailsInput` as its value and to restrict changes to at most two digits using a regular expression. [[1]](diffhunk://#diff-edb269501c981c15d822f92d6acc4741cf45f7a56ee4ae46d9a670b864ca5c00R16-R35) [[2]](diffhunk://#diff-edb269501c981c15d822f92d6acc4741cf45f7a56ee4ae46d9a670b864ca5c00L39-R53)
* Added a `useEffect` to synchronize the local input state with Redux state when `videoThumbnails` changes.

**Dependency updates:**

* Imported `useEffect` and `useState` from React to support the new state management logic.

## Recording
https://github.com/user-attachments/assets/7a9e3ef7-9f8f-43ba-abfb-f88069cfce7c

