### PR TITLE
Fix WordPress permission issues and UX tweaks for GoDAM (Issue #1239)

### DIFF
--- a/inc/classes/class-elementor-widgets.php
+++ b/inc/classes/class-elementor-widgets.php
@@ -48,7 +48,7 @@ class Elementor_Widgets {
 
 	/**
 	 * Scripts for elementor frontend rendering.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function enqueue_scripts() {
@@ -74,7 +74,6 @@ class Elementor_Widgets {
 			array(),
 			filemtime( RTGODAM_PATH . 'assets/build/css/godam-audio.css' )
 		);
-		
 
 		wp_register_script(
 			'godam-elementor-frontend',
@@ -120,6 +119,11 @@ class Elementor_Widgets {
 	 * Register Widgets.
 	 */
 	public function widgets_registered() {
+
+		if ( is_admin() && ! current_user_can( 'publish_posts' ) ) {
+			return;
+		}
+
 		\Elementor\Plugin::$instance->widgets_manager->register( new GoDAM_Video() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Gallery() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Audio() );

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -216,10 +216,6 @@ class Plugin {
 			return;
 		}
 
-		if ( is_admin() && ! rtgodam_check_user_permission( 'publish_posts' ) ) {
-			return;
-		}
-
 		Elementor_Widgets::get_instance();
 	}
 
@@ -234,10 +230,6 @@ class Plugin {
 		}
 
 		if ( ! is_plugin_active( 'js_composer/js_composer.php' ) ) {
-			return;
-		}
-
-		if ( is_admin() && ! rtgodam_check_user_permission( 'publish_posts' ) ) {
 			return;
 		}
 

--- a/inc/classes/wpbakery-elements/class-wpb-godam-audio.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-audio.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class WPB_GoDAM_Audio
- * 
+ *
  * @since 1.6.0
  *
  * @package GoDAM
@@ -23,7 +23,7 @@ class WPB_GoDAM_Audio {
 
 	/**
 	 * WPB_GoDAM_Audio constructor.
-	 * 
+	 *
 	 * @since 1.6.0
 	 */
 	protected function __construct() {
@@ -40,7 +40,7 @@ class WPB_GoDAM_Audio {
 
 	/**
 	 * Setup hooks.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @return void
@@ -51,13 +51,17 @@ class WPB_GoDAM_Audio {
 
 	/**
 	 * Map audio element to WPBakery.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @return void
 	 */
 	public function godam_audio() {
 		if ( ! function_exists( 'vc_map' ) ) {
+			return;
+		}
+
+		if ( is_admin() && ! current_user_can( 'publish_posts' ) ) {
 			return;
 		}
 
@@ -146,7 +150,7 @@ class WPB_GoDAM_Audio {
 							'not_empty' => true,
 						),
 					),
-					
+
 					// Caption Settings.
 					array(
 						'type'        => 'textfield',

--- a/inc/classes/wpbakery-elements/class-wpb-godam-params.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-params.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * Class WPB_GoDAM_Params
  *
  * @since 1.6.0
- * 
+ *
  * @package GoDAM
  */
 class WPB_GoDAM_Params {
@@ -40,20 +40,24 @@ class WPB_GoDAM_Params {
 
 	/**
 	 * Setup custom params.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @return void
 	 */
 	public function setup_custom_params() {
 
-		vc_add_shortcode_param( 
+		if ( is_admin() && ! current_user_can( 'publish_posts' ) ) {
+			return;
+		}
+
+		vc_add_shortcode_param(
 			'video_selector',
 			array( $this, 'video_selector_settings_field' ),
 			RTGODAM_URL . 'assets/build/js/wpbakery-video-selector-param.min.js'
 		);
 
-		vc_add_shortcode_param( 
+		vc_add_shortcode_param(
 			'audio_selector',
 			array( $this, 'audio_selector_settings_field' ),
 			RTGODAM_URL . 'assets/build/js/wpbakery-audio-selector-param.min.js'
@@ -73,7 +77,7 @@ class WPB_GoDAM_Params {
 
 	/**
 	 * Video selector settings field.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @param array  $settings Field settings.
@@ -84,7 +88,7 @@ class WPB_GoDAM_Params {
 		$button_text   = ! empty( $value ) ? esc_html__( 'Replace', 'godam' ) : esc_html__( 'Select video', 'godam' );
 		$preview_html  = '';
 		$remove_button = '';
-		
+
 		// If a video is selected, show preview and remove button.
 		if ( ! empty( $value ) && is_numeric( $value ) ) {
 			$attachment = wp_get_attachment_url( $value );
@@ -97,7 +101,7 @@ class WPB_GoDAM_Params {
 				$remove_button = '<button class="button video-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
 			}
 		}
-		
+
 		return '<div class="video_selector_block">'
 			. '<input name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput video_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
@@ -112,7 +116,7 @@ class WPB_GoDAM_Params {
 
 	/**
 	 * Audio selector settings field.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @param array  $settings Field settings.
@@ -123,7 +127,7 @@ class WPB_GoDAM_Params {
 		$button_text   = ! empty( $value ) ? esc_html__( 'Replace', 'godam' ) : esc_html__( 'Select audio', 'godam' );
 		$preview_html  = '';
 		$remove_button = '';
-		
+
 		// If an audio is selected, show preview and remove button.
 		if ( ! empty( $value ) && is_numeric( $value ) ) {
 			$attachment = wp_get_attachment_url( $value );
@@ -136,7 +140,7 @@ class WPB_GoDAM_Params {
 				$remove_button = '<button class="button audio-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
 			}
 		}
-		
+
 		return '<div class="audio_selector_block">'
 			. '<input name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput audio_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
@@ -151,7 +155,7 @@ class WPB_GoDAM_Params {
 
 	/**
 	 * Image Src selector settings field.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @param array  $settings Field settings.
@@ -162,15 +166,15 @@ class WPB_GoDAM_Params {
 		$button_text   = ! empty( $value ) ? esc_html__( 'Replace', 'godam' ) : esc_html__( 'Select image', 'godam' );
 		$preview_html  = '';
 		$remove_button = '';
-		
+
 		// If an image is selected, show preview and remove button.
 		if ( ! empty( $value ) ) {
 			$preview_html  = '<div class="image-src-selector-preview" style="margin-top: 10px;">
                 <img src="' . esc_url( $value ) . '" alt="" style="max-width: 300px; height: auto;" />
             </div>';
-			$remove_button = '<button class="button image-src-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';            
+			$remove_button = '<button class="button image-src-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
 		}
-		
+
 		return '<div class="image_src_selector_block">'
 			. '<input name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput image_src_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
@@ -185,7 +189,7 @@ class WPB_GoDAM_Params {
 
 	/**
 	 * Textfield hidden settings field.
-	 * 
+	 *
 	 * @since 1.6.0
 	 *
 	 * @param array  $settings Field settings.
@@ -195,6 +199,6 @@ class WPB_GoDAM_Params {
 	public function textfield_hidden_settings_field( $settings, $value ) {
 		return '<input style="pointer-events: none; opacity: 0.5;" name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput textfield_hidden_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
-			esc_attr( $settings['type'] ) . '_field" value="' . esc_attr( $value ) . '" />';        
+			esc_attr( $settings['type'] ) . '_field" value="' . esc_attr( $value ) . '" />';
 	}
 }

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php
@@ -61,6 +61,10 @@ class WPB_GoDAM_Video_Gallery {
 			return;
 		}
 
+		if ( is_admin() && ! current_user_can( 'publish_posts' ) ) {
+			return;
+		}
+
 		vc_map(
 			array(
 				'name'        => esc_html__( 'GoDAM Video Gallery', 'godam' ),

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video.php
@@ -59,6 +59,10 @@ class WPB_GoDAM_Video {
 			return;
 		}
 
+		if ( is_admin() && ! current_user_can( 'publish_posts' ) ) {
+			return;
+		}
+
 		vc_map(
 			array(
 				'name'        => esc_html__( 'GoDAM Video', 'godam' ),

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1129,28 +1129,3 @@ function rtgodam_convert_to_https_url( $urls ) {
 
 	return set_url_scheme( $urls, 'https' );
 }
-
-/**
- * Checks if the current user has a specific permission.
- *
- * This function checks if the current user has a specific permission.
- * If the permission is not set, the function will return false.
- * If the permission is set, the function will return true.
- *
- * @param string $permission_type The permission type to check.
- *
- * @return bool True if the user has the permission, false otherwise.
- */
-function rtgodam_check_user_permission( $permission_type ) {
-
-	// Ensure pluggable functions are loaded before capability checks.
-	if ( ! function_exists( 'wp_get_current_user' ) ) {
-		require_once ABSPATH . WPINC . '/pluggable.php';
-	}
-
-	if ( ! function_exists( 'current_user_can' ) ) {
-		return false;
-	}
-
-	return current_user_can( $permission_type );
-}


### PR DESCRIPTION
## Description

This PR addresses multiple WordPress permission and UX issues reported in [#1239](https://github.com/rtCamp/godam/issues/1239).

1. Fixes an issue where users with the Contributor role experienced infinite loading when using the GoDAM video functionality.
2. Only loads GoDAM data when the user has sufficient capabilities.
3. Restricts access to GoDAM related blocks from editor for Contributors and below roles.
4. Authors are allowed to view analytics.

## Testing Instructions

1. Log in as a Contributor.
2. GoDAM related blocks from editor are not accessible.
