### PR TITLE
Fix carousel track horizontal padding in product gallery

### DIFF
--- a/integrations/woocommerce/assets/css/godam-product-gallery.scss
+++ b/integrations/woocommerce/assets/css/godam-product-gallery.scss
@@ -212,7 +212,7 @@
 		scroll-behavior: smooth;
 		scroll-snap-type: x mandatory;
 		gap: 1rem;
-		padding: 40px 0.75rem;
+		padding: 2.5rem 0.75rem;
 		flex: 1;
 
 		scroll-padding-left: 24px;

--- a/integrations/woocommerce/blocks/godam-product-gallery/editor.scss
+++ b/integrations/woocommerce/blocks/godam-product-gallery/editor.scss
@@ -128,7 +128,7 @@
 		scroll-behavior: smooth;
 		scroll-snap-type: x mandatory;
 		gap: 1rem;
-		padding: 40px 0.75rem;
+		padding: 2.5rem 0.75rem;
 		flex: 1;
 
 		scroll-padding-left: 24px;


### PR DESCRIPTION
This PR updates the horizontal padding of the product gallery carousel track to improve edge spacing and scroll alignment.
The change ensures better visual balance and consistent spacing, especially on mobile screens.


<img width="993" height="714" alt="Screenshot 2026-02-16 at 5 30 24 PM" src="https://github.com/user-attachments/assets/c352bb47-40db-415b-af03-2aa2a0d6317a" />
