### PR TITLE
fix: Rename Video Quality options

### DIFF
--- a/pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx
@@ -10,11 +10,11 @@ import { Panel, PanelBody, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const QUALITY_OPTIONS = [
-	{ label: __( 'Highest quality', 'godam' ), value: 100 },
-	{ label: __( 'Higher quality', 'godam' ), value: 80 },
-	{ label: __( 'Medium quality', 'godam' ), value: 60 },
-	{ label: __( 'Lower quality', 'godam' ), value: 40 },
-	{ label: __( 'Lowest quality', 'godam' ), value: 20 },
+	{ label: __( 'Highest quality (100%)', 'godam' ), value: 100 },
+	{ label: __( 'Higher quality (80%)', 'godam' ), value: 80 },
+	{ label: __( 'Medium quality (60%)', 'godam' ), value: 60 },
+	{ label: __( 'Lower quality (40%)', 'godam' ), value: 40 },
+	{ label: __( 'Lowest quality (20%)', 'godam' ), value: 20 },
 ];
 
 const VideoCompressQuality = ( { handleSettingChange } ) => {


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/779

Renamed Video Quality options:

```js

const QUALITY_OPTIONS = [
	{ label: __( 'Highest quality (100%)', 'godam' ), value: 100 },
	{ label: __( 'Higher quality (80%)', 'godam' ), value: 80 },
	{ label: __( 'Medium quality (60%)', 'godam' ), value: 60 },
	{ label: __( 'Lower quality (40%)', 'godam' ), value: 40 },
	{ label: __( 'Lowest quality (20%)', 'godam' ), value: 20 },
];
```