### PR TITLE
feat: Add GoDAM CDN image support and srcset integration

### DIFF
--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -293,7 +293,13 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 						update_post_meta( $attachment_id, 'rtgodam_transcoded_url', esc_url_raw( $post_array['download_url'] ) );
 
 						// Request CDN image subsizes and store them in dedicated meta.
-						\RTGODAM\Inc\REST_API\Media_Library::get_instance()->request_image_subsizes_for_attachment( $job_id, $attachment_id );
+						$subsize_result = \RTGODAM\Inc\REST_API\Media_Library::get_instance()->request_image_subsizes_for_attachment( $job_id, $attachment_id );
+
+						if ( is_wp_error( $subsize_result ) || empty( $subsize_result ) ) {
+							// translators: %s is replaced with the attachment ID for which subsizes generation failed.
+							$flag = sprintf( __( 'Failed to generate image subsizes for attachment ID %s.', 'godam' ), $attachment_id );
+							error_log( $flag ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Logging the error for debugging purposes.
+						}
 					}
 				} else {
 					$flag = __( 'Something went wrong. The required attachment id does not exists. It must have been deleted.', 'godam' );

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -925,71 +925,6 @@ class Media_Library_Ajax {
 	}
 
 	/**
-	 * Find best matching GoDAM CDN size for requested dimensions.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array        $rtgodam_image_sizes CDN size array.
-	 * @param string|array $size               Requested size.
-	 * @return array|false
-	 */
-	private function find_best_rtgodam_size( $rtgodam_image_sizes, $size ) {
-		if ( empty( $rtgodam_image_sizes ) || ! is_array( $rtgodam_image_sizes ) ) {
-			return false;
-		}
-
-		$candidate = false;
-
-		if ( is_string( $size ) && isset( $rtgodam_image_sizes[ $size ] ) ) {
-			$candidate = $rtgodam_image_sizes[ $size ];
-		} else {
-			$target_width  = 0;
-			$target_height = 0;
-
-			if ( is_string( $size ) ) {
-				$wp_image_sizes = wp_get_registered_image_subsizes();
-				if ( isset( $wp_image_sizes[ $size ] ) ) {
-					$target_width  = (int) $wp_image_sizes[ $size ]['width'];
-					$target_height = (int) $wp_image_sizes[ $size ]['height'];
-				}
-			} elseif ( is_array( $size ) ) {
-				$target_width  = isset( $size[0] ) ? (int) $size[0] : 0;
-				$target_height = isset( $size[1] ) ? (int) $size[1] : 0;
-			}
-
-			if ( $target_width > 0 ) {
-				$best_diff = PHP_INT_MAX;
-				foreach ( $rtgodam_image_sizes as $rtgodam_size ) {
-					if ( empty( $rtgodam_size['width'] ) || empty( $rtgodam_size['height'] ) ) {
-						continue;
-					}
-
-					$width  = (int) $rtgodam_size['width'];
-					$height = (int) $rtgodam_size['height'];
-					$diff   = abs( $target_width - $width ) + abs( $target_height - $height );
-
-					if ( $diff < $best_diff ) {
-						$best_diff = $diff;
-						$candidate = $rtgodam_size;
-					}
-				}
-			}
-		}
-
-		if ( empty( $candidate['url'] ) ) {
-			return false;
-		}
-
-		return array(
-			'url'      => esc_url( $candidate['url'] ),
-			'width'    => isset( $candidate['width'] ) ? (int) $candidate['width'] : 0,
-			'height'   => isset( $candidate['height'] ) ? (int) $candidate['height'] : 0,
-			'file'     => isset( $candidate['file'] ) ? sanitize_file_name( $candidate['file'] ) : '',
-			'filesize' => isset( $candidate['filesize'] ) ? (int) $candidate['filesize'] : 0,
-		);
-	}
-
-	/**
 	 * Filter srcset calculation for virtual media to use full URLs.
 	 *
 	 * @since 1.5.0
@@ -1021,7 +956,7 @@ class Media_Library_Ajax {
 			return $sources;
 		}
 
-		// if rtgodam_image_sizes meta exists, use it to build the srcset. 
+		// If rtgodam_image_sizes meta exists, use it to build the srcset. 
 		// This is the case for GoDAM-managed images which may not be virtual but still need correct srcset URLs.
 		if ( ! empty( $rtgodam_image_sizes ) ) {
 
@@ -1029,6 +964,11 @@ class Media_Library_Ajax {
 			$new_sources = array();
 			// Sources element should have only url, descriptor, value. Remove any extra data added for our internal use.
 			foreach ( $rtgodam_image_sizes as &$image_size ) {
+				// Skip entries that do not have a valid URL or width to avoid invalid srcset entries.
+				if ( empty( $image_size['url'] ) || empty( $image_size['width'] ) ) {
+					continue;
+				}
+
 				$new_sources[] = array(
 					'url'        => isset( $image_size['url'] ) ? esc_url( $image_size['url'] ) : '',
 					'descriptor' => 'w',
@@ -1065,7 +1005,7 @@ class Media_Library_Ajax {
 	/**
 	 * Replace final rendered content <img> src with CDN URL when available.
 	 *
-	 * @since 1.5.0
+	 * @since n.e.x.t
 	 *
 	 * @param string $filtered_image Full <img> tag.
 	 * @param string $context        Render context.
@@ -1088,7 +1028,7 @@ class Media_Library_Ajax {
 		}
 
 		$updated_image = preg_replace(
-			'/\ssrc="[^"]*"/',
+			'/\bsrc="[^"]*"/',
 			' src="' . esc_url( $cdn_src ) . '"',
 			$filtered_image,
 			1

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -491,7 +491,7 @@ class Media_Library extends Base {
 	/**
 	 * Request image subsizes generation from GoDAM for an image attachment.
 	 *
-	 * @since 1.5.0
+	 * @since n.e.x.t
 	 *
 	 * @param string $job_id        The GoDAM job ID.
 	 * @param int    $attachment_id The WordPress attachment ID.


### PR DESCRIPTION
Fixes: #1453 

- Store GoDAM CDN image subsizes in dedicated meta for both virtual and WP-uploaded images.
- Update REST callback to trigger CDN subsizes request after image transcoding.
- Add filters to serve CDN URLs for images and srcset in frontend and admin.
- Enhance srcset and <img> tag rendering to use GoDAM CDN URLs when available.
- Refactor image meta update logic for virtual and native images.

This pull request introduces comprehensive improvements to how GoDAM CDN image subsizes are handled and integrated with the WordPress media library. The main focus is on storing, retrieving, and using CDN-derived image sizes for both virtual (GoDAM-managed) and standard WordPress-uploaded images, ensuring correct CDN URLs are used in image outputs and srcsets.

**Enhancements to CDN image subsizes handling:**

* Added a new meta field, `rtgodam_image_sizes`, to store GoDAM CDN image subsizes for attachments, and ensured these are used for both virtual and standard images without altering WordPress's native metadata for standard uploads. [[1]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104L349-R356) [[2]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R390-R399) [[3]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R439-R456) [[4]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R487-R503)
* Implemented logic to select the best matching CDN image size for requested dimensions, improving accuracy of image delivery from the CDN.

**Integration with WordPress image rendering and srcset:**

* Updated the `filter_virtual_media_srcset` method to build the image srcset array from GoDAM CDN subsizes when available, ensuring the correct URLs and descriptors are used in the generated HTML. [[1]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4L917-R1005) [[2]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R1016-R1044) [[3]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R1060-R1098)
* Added a filter to replace the rendered `<img>` tag's `src` attribute with the CDN URL when available, so images in content always point to the correct CDN resource. [[1]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R53) [[2]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R1060-R1098)

**Workflow and API improvements:**

* Added a method to request GoDAM CDN image subsizes generation for an attachment, integrating this step into the callback handler for transcoded images. [[1]](diffhunk://#diff-2c8260c84a22b264dd8ccfd5d58e5306e47db95a97a82118b0d72176c3b2baf2R294-R296) [[2]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R487-R503)
* Modified the attachment URL filter to use the transcoded CDN URL for images when available, ensuring direct links to attachments also use the CDN.

These changes collectively ensure that GoDAM CDN image sizes are correctly stored, selected, and output throughout the WordPress media pipeline, improving performance and consistency for sites using GoDAM-managed media.