### PR TITLE
Revert "Fixed console error on two column modal for virtual media"

### DIFF
--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -701,7 +701,7 @@ export default AttachmentDetailsTwoColumn?.extend( {
 			// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
 			if ( undefined !== virtual && virtual ) {
 				const videoUrl = this.model.get( 'transcoded_url' ); // Ensure it's a valid .mp4
-				const $container = this.$el.find( '.wp-video > div' );
+				const $container = this.$el.find( '.wp-video' );
 				const videoId = 'videojs-player-' + this.model.get( 'id' ); // Unique ID
 
 				// Clear default preview, Create a <video> element to be used by Video.js.


### PR DESCRIPTION
Issue - [Unexpected Uncaught TypeError on Two column screen (rtCamp/godam#1550)](https://github.com/rtCamp/godam/issues/1550)

Reverts rtCamp/godam#1552

### Screen Recording of side effects of the PR:
When opening any virtual media, especially with vertical aspect ratio, it leads to a large empty area below the video.

https://github.com/user-attachments/assets/e633ea15-64a9-416d-aa6c-ba423ecd1745

