### PR TITLE
Replace @import with @use on godam-player styles

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -6,7 +6,7 @@
  */
 
 // import videojs styles
-@import "video.js/dist/video-js.css";
+@use "video.js/dist/video-js.css";
 
 // CF7 Form style.
 @use "./cf7-godam-theme";


### PR DESCRIPTION
This pull request updates the way external stylesheets are imported in the `godam-player.scss` file to use the more modern and recommended `@use` syntax instead of `@import`.

Styling import modernization:

* Replaced `@import` with `@use` for including `video.js/dist/video-js.css` in `godam-player.scss`, aligning with best practices for Sass stylesheet management.