### PR TITLE
fix: `i18n` dependency in Form Recorder

### DIFF
--- a/inc/classes/everest-forms/class-everest-forms-field-godam-video.php
+++ b/inc/classes/everest-forms/class-everest-forms-field-godam-video.php
@@ -479,6 +479,7 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 				);
 
 				if ( file_exists( $godam_recorder_asset_file ) ) {
+					// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is constant.
 					$godam_recorder_asset = include $godam_recorder_asset_file;
 				}
 

--- a/inc/classes/fluentforms/fields/class-recorder-field.php
+++ b/inc/classes/fluentforms/fields/class-recorder-field.php
@@ -292,6 +292,7 @@ class Recorder_Field extends BaseFieldManager {
 			);
 
 			if ( file_exists( $godam_recorder_asset_file ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is constant.
 				$godam_recorder_asset = include $godam_recorder_asset_file;
 			}
 

--- a/inc/classes/gravity-forms/class-init.php
+++ b/inc/classes/gravity-forms/class-init.php
@@ -110,6 +110,7 @@ class Init {
 			);
 
 			if ( file_exists( $godam_recorder_asset_file ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is constant.
 				$godam_recorder_asset = include $godam_recorder_asset_file;
 			}
 

--- a/inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php
+++ b/inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php
@@ -340,6 +340,7 @@ class Ninja_Forms_Field_Godam_Recorder extends \NF_Abstracts_Field {
 			);
 
 			if ( file_exists( $godam_recorder_asset_file ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is constant.
 				$godam_recorder_asset = include $godam_recorder_asset_file;
 			}
 

--- a/inc/classes/sureforms/class-assets.php
+++ b/inc/classes/sureforms/class-assets.php
@@ -90,6 +90,7 @@ class Assets {
 			);
 
 			if ( file_exists( $godam_recorder_asset_file ) ) {
+				// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is constant.
 				$godam_recorder_asset = include $godam_recorder_asset_file;
 			}
 

--- a/inc/classes/wpforms/class-wpforms-integration.php
+++ b/inc/classes/wpforms/class-wpforms-integration.php
@@ -77,6 +77,7 @@ class WPForms_Integration {
 		);
 
 		if ( file_exists( $godam_recorder_asset_file ) ) {
+			// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is constant.
 			$godam_recorder_asset = include $godam_recorder_asset_file;
 		}
 


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1138

This pull request updates the script dependencies for the `godam-recorder-script` across multiple form integration classes. The main change is the addition of the `wp-i18n` dependency, which is used for internationalization support in WordPress JavaScript. This ensures that the recorder script can properly handle translations and localized strings in all supported form plugins.

Dependency updates for internationalization:

* Added `wp-i18n` as a dependency to the `godam-recorder-script` in the following classes and methods:
  * `class-everest-forms-field-godam-video.php` (`render_evf_recorder_scripts`)
  * `class-recorder-field.php` (`render_recorder_script`)
  * `class-init.php` (`enqueue_godam_recorder_scripts`)
  * `class-ninja-forms-field-godam-recorder.php` (`frontend_enqueue_scripts`)
  * `class-assets.php` (`load_scripts`)
  * `class-wpforms-integration.php` (`register_assets`)

## Screen Recording
### Tested with Ninja Forms, Everest Forms and Fluent Form
https://github.com/user-attachments/assets/79bb01ee-22c2-467e-ba6f-922e68b5d9ad

