### PR TITLE
Make Video SEO feature free

### DIFF
--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -549,7 +549,7 @@ function rtgodam_get_premium_layer_types() {
  * @return string[] Array of premium feature slugs.
  */
 function rtgodam_get_premium_features() {
-	// Add 'seo' to the array above to gate SEO features behind a Pro license, for example.
+	// Add 'seo' to the returned array below to gate SEO features behind a Pro license, for example.
 	return array();
 }
 


### PR DESCRIPTION
Fixes: https://github.com/rtCamp/godam-core/issues/899

This pull request makes a small change to the `rtgodam_get_premium_features` function, updating it so that no features are currently gated behind a Pro license. The previous gating of the 'seo' feature has been removed.