### PR TITLE
Update dependencies to address security vulnerabilities and Dependabot alerts[2]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
 				"@wordpress/server-side-render": "6.10.0",
 				"browserslist": "4.25.1",
 				"cross-env": "10.1.0",
-				"css-minimizer-webpack-plugin": "7.0.4",
+				"css-minimizer-webpack-plugin": "8.0.0",
 				"emoji-picker-react": "4.13.3",
 				"eslint": "8.57.1",
 				"eslint-plugin-eslint-comments": "3.2.0",
@@ -14352,9 +14352,9 @@
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
-			"integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.1.tgz",
+			"integrity": "sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -16575,9 +16575,9 @@
 			}
 		},
 		"node_modules/css-minimizer-webpack-plugin": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-7.0.4.tgz",
-			"integrity": "sha512-2iACis+P8qdLj1tHcShtztkGhCNIRUajJj7iX0IM9a5FA0wXGwjV8Nf6+HsBjBfb4LO8TTAVoetBbM54V6f3+Q==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-8.0.0.tgz",
+			"integrity": "sha512-9bEpzHs8gEq6/cbEj418jXL/YWjBUD2YTLLk905Npt2JODqnRITin0+So5Vx4Dp5vyi2Lpt9pp2QHzQ7fdxNrw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16586,10 +16586,10 @@
 				"jest-worker": "^30.0.5",
 				"postcss": "^8.4.40",
 				"schema-utils": "^4.2.0",
-				"serialize-javascript": "^6.0.2"
+				"serialize-javascript": "^7.0.3"
 			},
 			"engines": {
-				"node": ">= 18.12.0"
+				"node": ">= 20.9.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -17192,16 +17192,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.32"
-			}
-		},
-		"node_modules/css-minimizer-webpack-plugin/node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
 			}
 		},
 		"node_modules/css-minimizer-webpack-plugin/node_modules/stylehacks": {
@@ -27450,16 +27440,6 @@
 				"marked": "14.0.0"
 			}
 		},
-		"node_modules/monaco-editor/node_modules/dompurify": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"peer": true,
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
-			}
-		},
 		"node_modules/motion-dom": {
 			"version": "11.18.1",
 			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
@@ -30706,16 +30686,6 @@
 				"node": ">= 12.0.0"
 			}
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -30864,26 +30834,17 @@
 			}
 		},
 		"node_modules/react-draggable": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
-			"integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+			"integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
 			"license": "MIT",
 			"dependencies": {
-				"clsx": "^1.1.1",
+				"clsx": "^2.1.1",
 				"prop-types": "^15.8.1"
 			},
 			"peerDependencies": {
 				"react": ">= 16.3.0",
 				"react-dom": ">= 16.3.0"
-			}
-		},
-		"node_modules/react-draggable/node_modules/clsx": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/react-easy-crop": {
@@ -30991,13 +30952,13 @@
 			}
 		},
 		"node_modules/react-rnd": {
-			"version": "10.5.2",
-			"resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
-			"integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+			"version": "10.5.3",
+			"resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.3.tgz",
+			"integrity": "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==",
 			"license": "MIT",
 			"dependencies": {
-				"re-resizable": "6.11.2",
-				"react-draggable": "4.4.6",
+				"re-resizable": "^6.11.2",
+				"react-draggable": "^4.5.0",
 				"tslib": "2.6.2"
 			},
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"@wordpress/server-side-render": "6.10.0",
 		"browserslist": "4.25.1",
 		"cross-env": "10.1.0",
-		"css-minimizer-webpack-plugin": "7.0.4",
+		"css-minimizer-webpack-plugin": "8.0.0",
 		"emoji-picker-react": "4.13.3",
 		"eslint": "8.57.1",
 		"eslint-plugin-eslint-comments": "3.2.0",
@@ -104,7 +104,10 @@
 			"serialize-javascript@<7.0.3": "7.0.3",
 			"webpack-dev-server@<5.2.1": "5.2.1"
 		},
-		"minimatch@>=9.0.0 <9.0.7": "9.0.7"
+		"minimatch@>=9.0.0 <9.0.7": "9.0.7",
+		"monaco-editor": {
+			"dompurify": "3.3.2"
+		}
 	},
 	"scripts": {
 		"start:blocks": "wp-scripts start --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./assets/src/blocks/ --output-path=./assets/build/blocks/",


### PR DESCRIPTION
Followup to this PR: https://github.com/rtCamp/godam/pull/1690

## What Why How

- Fix dependabot alerts 


## Security Audit Summary

Fixes the following alerts
1. https://github.com/rtCamp/godam/security/dependabot/118
2. https://github.com/rtCamp/godam/security/dependabot/117



## Screenshots of the overriden packages 

The compromised versions for the packages have been overriden, to confirm this please verify the screenshots below

<img width="854" height="252" alt="image" src="https://github.com/user-attachments/assets/363c344d-7117-42d5-81a9-0e1ee136008e" />

### Testing

- [ ] `npm install` completes without errors in both theme directories
- [ ] `npm audit` reports no high/critical vulnerabilities
- [ ] Build process runs successfully