### PR TITLE
Fix: prevent comment overflow.

### DIFF
--- a/assets/src/css/_video-engagement.scss
+++ b/assets/src/css/_video-engagement.scss
@@ -622,6 +622,8 @@
         &-text {
             font-size: clamp( 0.75rem, 2vw, 0.875rem );
             line-height: 1.3;
+            word-break: break-word;
+            overflow-wrap: break-word;
 
             &.deleted-text {
                 color: var( --godam-video-engagement-brand-neutral-shades-100 );


### PR DESCRIPTION
Fixes: #1532

Wrap long comment text in the engagement panel to stop UI overflow.


| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/52e5d193-977b-4017-bfa1-6affeaea87c4)| ![image-after](https://github.com/user-attachments/assets/9c3ba2e9-b6b6-4502-a476-8df942740547)

| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/0f013190-5800-4bee-8a96-a8a9a44e66df)| ![image-after](https://github.com/user-attachments/assets/f25a91df-a73c-43e4-9b98-d90ea3db701b)
