### PR TITLE
fix: video player controls buttons shift position in fullscreen on mobile.

### DIFF
--- a/assets/src/js/godam-player/engagement.js
+++ b/assets/src/js/godam-player/engagement.js
@@ -1191,6 +1191,26 @@ function CommentBox( props ) {
 		videoContainer.appendChild( currentVideo );
 		document.body.classList.add( 'no-scroll' );
 
+		// Trigger a resize after moving the current video into the modal container
+		// to reposition the skip control buttons according to the new dimensions,
+		// particularly for mobile devices.
+
+		// Prefer triggering a scoped resize on the Video.js player first
+		// instead of dispatching a global window resize event.
+		const videoElement = videoContainer?.querySelector( 'video' );
+		let resizeHandled = false;
+		if ( videoElement && window.videojs ) {
+			try {
+				const player = window.videojs.getPlayer( videoElement );
+				player.trigger( 'resize' );
+				resizeHandled = true;
+			} catch ( error ) {
+				// Fall back to dispatching a global window resize event.
+			}
+		}
+		if ( ! resizeHandled ) {
+			window.dispatchEvent( new Event( 'resize' ) );
+		}
 		return () => {
 			if ( currentVideoParent && currentVideo ) {
 				currentVideoParent.insertBefore( currentVideo, currentVideoParent.firstChild );


### PR DESCRIPTION
Fixes: #1527.

In mobile view, when a video has engagement options enabled and the comment box is open, the player controls (pause and seek/forward) change position unexpectedly when entering fullscreen.


| Before | After |
| ------ | ------ |
| ![image-before](https://github.com/user-attachments/assets/aa69cc97-b591-424b-8cd8-32daa03361c2) | ![image-after](https://github.com/user-attachments/assets/3c8ccae0-f0fb-4f2a-9427-de3d09a3ac17)
