### PR TITLE
Move GoDAM reel pops extra settings under advance settings section

### DIFF
--- a/integrations/woocommerce/assets/css/godam-reel-pops-metabox.scss
+++ b/integrations/woocommerce/assets/css/godam-reel-pops-metabox.scss
@@ -1,0 +1,208 @@
+/**
+ * GoDAM Reel Pops — Product Metabox Admin Styles
+ */
+
+.godam-reel-pops-metabox {
+	padding: 15px;
+}
+
+.godam-reel-pops-video-list {
+	margin-top: 15px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-bottom: 1.5rem;
+}
+
+.godam-reel-pops-video-item {
+	width: calc(33.333% - 10px);
+	min-width: 240px;
+	position: relative;
+	background: #f9f9f9;
+	border: 1px solid #ddd;
+	padding: 12px;
+	border-radius: 4px;
+	box-sizing: border-box;
+
+	&.ui-sortable-helper {
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		opacity: 0.9;
+	}
+
+	input[type="text"] {
+		width: 100%;
+	}
+}
+
+.godam-reel-pops-drag-handle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	min-width: 20px;
+	cursor: grab;
+	color: #aaa;
+	font-size: 18px;
+	user-select: none;
+	padding-right: 4px;
+	flex-shrink: 0;
+
+	&:active {
+		cursor: grabbing;
+	}
+}
+
+.godam-reel-pops-video-placeholder {
+	border: 2px dashed #b9b9b9;
+	background: #f3f3f3;
+	border-radius: 4px;
+	min-height: 96px;
+}
+
+.godam-reel-pops-video-thumb {
+    min-width: 70px;
+	width: 70px;
+	height: 70px;
+	border-radius: 4px;
+	background: #111;
+	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: #fff;
+	font-size: 11px;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+}
+
+.godam-reel-pops-video-item-header {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+	gap: 10px;
+
+	strong {
+		font-size: 14px;
+		display: block;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 180px;
+	}
+}
+
+.godam-reel-pops-video-meta {
+	line-height: 1.4;
+}
+
+.godam-reel-pops-video-remove {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	border: 1px solid #ccc;
+	background: #fff;
+	color: #a00;
+	cursor: pointer;
+	line-height: 1;
+}
+
+.godam-reel-pops-video-item-controls {
+	display: flex;
+	gap: 8px;
+}
+
+// Settings grid
+.godam-reel-pops-settings-grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 15px;
+	margin-top: 15px;
+}
+
+.godam-reel-pops-setting-item {
+
+	label {
+		display: block;
+		margin-bottom: 5px;
+		font-weight: 600;
+	}
+
+	select,
+	input[type="number"] {
+		width: 100%;
+	}
+}
+
+// Advanced Settings collapsible subpanel
+.godam-reel-pops-advanced-panel {
+	margin-top: 16px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	overflow: hidden;
+
+	> summary {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 10px 14px;
+		background: #f6f7f7;
+		font-weight: 600;
+		cursor: pointer;
+		user-select: none;
+		list-style: none;
+		outline: none;
+		border-bottom: 1px solid transparent;
+
+		&::-webkit-details-marker {
+			display: none;
+		}
+	}
+
+	&[open] > summary {
+		border-bottom-color: #ddd;
+	}
+
+	.godam-reel-pops-settings-grid {
+		margin-top: 0;
+		padding: 14px;
+	}
+}
+
+.godam-reel-pops-advanced-chevron {
+	display: inline-block;
+	transition: transform 0.2s ease;
+	margin-left: auto;
+	color: #666;
+	font-style: normal;
+
+	.godam-reel-pops-advanced-panel[open] & {
+		transform: rotate(180deg);
+	}
+}
+
+// Responsive
+@media (max-width: 782px) {
+
+	.godam-reel-pops-settings-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.godam-reel-pops-video-item {
+		width: calc(50% - 10px);
+		min-width: 0;
+	}
+}
+
+@media (max-width: 580px) {
+
+	.godam-reel-pops-video-item {
+		width: 100%;
+	}
+}

--- a/integrations/woocommerce/classes/class-wc-reel-pops-metabox.php
+++ b/integrations/woocommerce/classes/class-wc-reel-pops-metabox.php
@@ -94,121 +94,11 @@ class WC_Reel_Pops_Metabox {
 		wp_enqueue_media();
 		wp_enqueue_script( 'jquery-ui-sortable' );
 
-		wp_add_inline_style(
-			'wp-admin',
-			'
-			.godam-reel-pops-metabox { padding: 15px; }
-			.godam-reel-pops-video-list {
-				margin-top: 15px;
-				display: flex;
-				flex-wrap: wrap;
-				gap: 10px;
-				margin-bottom: 1.5rem;
-			}
-			.godam-reel-pops-video-item {
-				width: calc(33.333% - 10px);
-				min-width: 240px;
-				position: relative;
-				background: #f9f9f9;
-				border: 1px solid #ddd;
-				padding: 12px;
-				border-radius: 4px;
-				box-sizing: border-box;
-			}
-			.godam-reel-pops-video-item.ui-sortable-helper {
-				box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-				opacity: 0.9;
-			}
-			.godam-reel-pops-drag-handle {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				width: 20px;
-				min-width: 20px;
-				cursor: grab;
-				color: #aaa;
-				font-size: 18px;
-				user-select: none;
-				padding-right: 4px;
-				flex-shrink: 0;
-			}
-			.godam-reel-pops-drag-handle:active { cursor: grabbing; }
-			.godam-reel-pops-video-placeholder {
-				border: 2px dashed #b9b9b9;
-				background: #f3f3f3;
-				border-radius: 4px;
-				min-height: 96px;
-			}
-			.godam-reel-pops-video-thumb {
-				width: 70px;
-				height: 70px;
-				border-radius: 4px;
-				background: #111;
-				overflow: hidden;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				color: #fff;
-				font-size: 11px;
-			}
-			.godam-reel-pops-video-thumb img {
-				width: 100%;
-				height: 100%;
-				object-fit: cover;
-			}
-			.godam-reel-pops-video-item-header {
-				display: flex;
-				justify-content: flex-start;
-				align-items: center;
-				gap: 10px;
-			}
-			.godam-reel-pops-video-item-header strong {
-				font-size: 14px;
-				display: block;
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				max-width: 180px;
-			}
-			.godam-reel-pops-video-meta { line-height: 1.4; }
-			.godam-reel-pops-video-remove {
-				position: absolute;
-				top: 8px;
-				right: 8px;
-				width: 24px;
-				height: 24px;
-				border-radius: 50%;
-				border: 1px solid #ccc;
-				background: #fff;
-				color: #a00;
-				cursor: pointer;
-				line-height: 1;
-			}
-			.godam-reel-pops-video-item-controls { display: flex; gap: 8px; }
-			.godam-reel-pops-video-item input[type="text"] { width: 100%; }
-			.godam-reel-pops-settings-grid {
-				display: grid;
-				grid-template-columns: repeat(2, 1fr);
-				gap: 15px;
-				margin-top: 15px;
-			}
-			.godam-reel-pops-setting-item label {
-				display: block;
-				margin-bottom: 5px;
-				font-weight: 600;
-			}
-			.godam-reel-pops-setting-item select,
-			.godam-reel-pops-setting-item input[type="number"] {
-				width: 100%;
-			}
-			@media (max-width: 782px) {
-				.godam-reel-pops-settings-grid { grid-template-columns: 1fr; }
-				.godam-reel-pops-video-item { width: calc(50% - 10px); min-width: 0; }
-			}
-			@media (max-width: 580px) {
-				.godam-reel-pops-video-item { width: 100%; }
-			}
-		'
+		wp_enqueue_style(
+			'godam-reel-pops-metabox',
+			RTGODAM_URL . 'assets/build/integrations/woocommerce/css/godam-reel-pops-metabox.css',
+			array(),
+			rtgodam_wc_get_asset_version( RTGODAM_PATH . 'assets/build/integrations/woocommerce/css/godam-reel-pops-metabox.css' )
 		);
 	}
 
@@ -303,7 +193,14 @@ class WC_Reel_Pops_Metabox {
 				</button>
 			</div>
 
-			<div class="godam-reel-pops-settings-grid">
+			<details class="godam-reel-pops-advanced-panel" id="godam-reel-pops-advanced-panel">
+				<summary>
+					<?php esc_html_e( 'Advanced Settings', 'godam' ); ?>
+					<em class="godam-reel-pops-advanced-chevron" aria-hidden="true">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+					</em>
+				</summary>
+				<div class="godam-reel-pops-settings-grid">
 				<div class="godam-reel-pops-setting-item">
 					<label for="godam_reel_pops_aspect_ratio"><?php esc_html_e( 'Aspect Ratio', 'godam' ); ?></label>
 					<select name="godam_reel_pops[aspectRatio]" id="godam_reel_pops_aspect_ratio">
@@ -404,7 +301,8 @@ class WC_Reel_Pops_Metabox {
 						<?php esc_html_e( 'Enable video navigations on modal', 'godam' ); ?>
 					</label>
 				</div>
-			</div>
+				</div>
+			</details>
 		</div>
 
 		<script type="text/javascript">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -228,6 +228,7 @@ const woocommerceIntegration = {
 		'godam-product-editor-gallery': path.resolve( process.cwd(), 'integrations', 'woocommerce', 'assets', 'css', 'godam-product-editor-gallery.scss' ),
 		'godam-product-gallery': path.resolve( process.cwd(), 'integrations', 'woocommerce', 'assets', 'css', 'godam-product-gallery.scss' ),
 		'godam-reels-skin': path.resolve( process.cwd(), 'integrations', 'woocommerce', 'assets', 'css', 'godam-reels-skin.scss' ),
+		'godam-reel-pops-metabox': path.resolve( process.cwd(), 'integrations', 'woocommerce', 'assets', 'css', 'godam-reel-pops-metabox.scss' ),
 	},
 	output: {
 		path: path.resolve( process.cwd(), 'assets', 'build', 'integrations', 'woocommerce', 'js' ),


### PR DESCRIPTION
This pull request refactors how admin styles are handled for the GoDAM Reel Pops product metabox in WooCommerce, moving from inline styles to a dedicated SCSS file and updating the asset pipeline accordingly. It also introduces a new advanced settings panel in the metabox UI for improved organization and user experience.

**Admin Styles Refactoring and Asset Pipeline Update:**

* Replaced all inline CSS for the metabox with a dedicated SCSS file, `godam-reel-pops-metabox.scss`, for better maintainability and scalability. [[1]](diffhunk://#diff-460c395fd4765d6fbdbc54c41f537e970a1c4329be1d64ad8977bc1c227301daR1-R208) [[2]](diffhunk://#diff-de97780b3b137d2243be962787d536e52824d8f909f4d238d77bb07ec7765c1bL97-R101)
* Updated the Webpack configuration to include `godam-reel-pops-metabox.scss` in the build process, ensuring the new stylesheet is compiled and available as an asset.

**UI Improvements:**

* Introduced an advanced settings collapsible panel (`godam-reel-pops-advanced-panel`) in the metabox UI, grouping advanced settings for improved clarity and user experience. [[1]](diffhunk://#diff-de97780b3b137d2243be962787d536e52824d8f909f4d238d77bb07ec7765c1bR196-R202) [[2]](diffhunk://#diff-de97780b3b137d2243be962787d536e52824d8f909f4d238d77bb07ec7765c1bR305)

## Demo

https://github.com/user-attachments/assets/11d6a80f-279c-4a0c-9b27-0ea1df9570f8

