### PR TITLE
fix: Disable PostHog automatic data collection

### DIFF
--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -512,15 +512,12 @@ function rtgodam_verify_api_key( $api_key, $save = false ) {
 		rtgodam_set_api_key_status( Api_Key_Status::VALID );
 		rtgodam_clear_api_key_invalid_timestamp();
 
-		// Enable PostHog tracking once API key is activated or plugin is updated with active API key.
+		// Auto-enable PostHog tracking only when the user has never made a consent choice.
+		// If posthog_initialized is already true the user has either opted in or explicitly opted out — respect that decision.
 		$settings = get_option( 'rtgodam-settings', array() );
-		if ( $save || empty( $settings['general']['posthog_initialized'] ) ) {
+		if ( empty( $settings['general']['posthog_initialized'] ) ) {
 			$settings['general']['enable_posthog_tracking'] = true;
 			$settings['general']['posthog_initialized']     = true;
-			update_option( 'rtgodam-settings', $settings );
-		} elseif ( ! empty( $settings['general']['posthog_initialized'] ) && ! $settings['general']['enable_posthog_tracking'] && $save ) {
-			// If user previously opted out but is now activating an API key, re-enable tracking.
-			$settings['general']['enable_posthog_tracking'] = true;
 			update_option( 'rtgodam-settings', $settings );
 		}
 

--- a/pages/utils/posthog.js
+++ b/pages/utils/posthog.js
@@ -13,7 +13,7 @@ const initPostHog = () => {
 
 	const posthogKey = posthogConfig.key || '';
 	const posthogHost = posthogConfig.host || '';
-	const posthogEnabled = posthogConfig.enabled !== '0'; // Enable by default, disable on 0, "0", or false
+	const posthogEnabled = posthogConfig.enabled === '1' || posthogConfig.enabled === 1; // Only enable when explicitly opted in; never default to enabled.
 
 	if ( ! posthogEnabled ) {
 		return posthog;


### PR DESCRIPTION
Issue - Hotfix for https://github.com/rtCamp/godam-core/issues/936

This pull request updates the logic for enabling PostHog tracking to better respect user consent and privacy. Now, PostHog tracking is only enabled if the user has explicitly opted in, rather than being enabled by default or re-enabled automatically in certain scenarios.

**User consent and tracking logic improvements:**

* In `admin/godam-transcoder-functions.php`, PostHog tracking is now auto-enabled only if the user has never made a consent choice (i.e., `posthog_initialized` is empty). If the user has already opted in or out, their decision is respected and not overridden, even when activating an API key.
* In `pages/utils/posthog.js`, PostHog tracking is now enabled only when the configuration value is explicitly set to `'1'` or `1`, ensuring tracking is never enabled by default and only after explicit user consent.