### PR TITLE
Feat: Custom icon support on WooCommerce Layer

### DIFF
--- a/assets/src/js/godam-player/managers/layers/wooCommerceLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/wooCommerceLayerManager.js
@@ -483,10 +483,10 @@ export default class WooCommerceLayerManager {
 		hotspotDiv.style.height = `${ pixelDiameter }px`;
 
 		// Background color
-		hotspotDiv.style.backgroundColor = hotspot.icon ? 'white' : ( hotspot.backgroundColor || '#0c80dfa6' );
+		hotspotDiv.style.backgroundColor = ( hotspot.icon || hotspot.customIconUrl ) ? 'white' : ( hotspot.backgroundColor || '#0c80dfa6' );
 
 		// Create content
-		const hotspotContent = this.createProductHotspotContent( hotspot, miniCart );
+		const hotspotContent = this.createProductHotspotContent( hotspot, miniCart, hotspotDiv );
 		hotspotDiv.appendChild( hotspotContent );
 
 		return hotspotDiv;
@@ -495,11 +495,12 @@ export default class WooCommerceLayerManager {
 	/**
 	 * Create hotspot content
 	 *
-	 * @param {Object}  hotspot  - Product Hotspot configuration object
-	 * @param {boolean} miniCart - Minicart toggle value
+	 * @param {Object}      hotspot    - Product Hotspot configuration object
+	 * @param {boolean}     miniCart   - Minicart toggle value
+	 * @param {HTMLElement} hotspotDiv - Parent hotspot div element
 	 * @return {HTMLElement} Created content element
 	 */
-	createProductHotspotContent( hotspot, miniCart ) {
+	createProductHotspotContent( hotspot, miniCart, hotspotDiv ) {
 		const hotspotContent = document.createElement( 'div' );
 		hotspotContent.classList.add( 'hotspot-content' );
 		hotspotContent.style.position = 'relative';
@@ -509,6 +510,9 @@ export default class WooCommerceLayerManager {
 		if ( hotspot.icon ) {
 			const iconEl = this.createProductHotspotIcon( hotspot.icon );
 			hotspotContent.appendChild( iconEl );
+		} else if ( hotspot.customIconUrl ) {
+			const customIconEl = this.createCustomIcon( hotspot.customIconUrl, hotspot.backgroundColor, hotspotDiv );
+			hotspotContent.appendChild( customIconEl );
 		} else {
 			hotspotContent.classList.add( 'no-icon' );
 		}
@@ -538,6 +542,48 @@ export default class WooCommerceLayerManager {
 		iconEl.style.color = '#000';
 
 		return iconEl;
+	}
+
+	/**
+	 * Create custom icon element
+	 *
+	 * @param {string}      customIconUrl   - URL of the custom icon
+	 * @param {string}      backgroundColor - Background color for fallback
+	 * @param {HTMLElement} hotspotDiv      - Parent hotspot div element
+	 * @return {HTMLElement} Created custom icon element
+	 */
+	createCustomIcon( customIconUrl, backgroundColor, hotspotDiv ) {
+		const customIconEl = document.createElement( 'img' );
+		customIconEl.src = customIconUrl;
+		customIconEl.alt = __( 'Custom Icon', 'godam' );
+		customIconEl.style.width = '50%';
+		customIconEl.style.height = '50%';
+		customIconEl.style.maxWidth = '100%';
+		customIconEl.style.maxHeight = '100%';
+		customIconEl.style.objectFit = 'contain';
+		customIconEl.style.display = 'block';
+		customIconEl.style.margin = 'auto';
+		customIconEl.style.pointerEvents = 'none';
+
+		// Add error handling for failed image loads - convert to normal hotspot point
+		customIconEl.onerror = function() {
+			// Remove the failed image element
+			customIconEl.remove();
+
+			// Get the hotspot content container
+			const hotspotContent = hotspotDiv?.querySelector( '.hotspot-content' );
+			if ( hotspotContent ) {
+				// Add no-icon class to show as normal hotspot
+				hotspotContent.classList.add( 'no-icon' );
+			}
+
+			// Reset hotspot background to default (non-icon) color
+			if ( hotspotDiv ) {
+				hotspotDiv.style.backgroundColor = backgroundColor || '#0c80dfa6';
+			}
+		};
+
+		return customIconEl;
 	}
 
 	/**

--- a/integrations/woocommerce/pages/components/FontAwesomeIconPicker.js
+++ b/integrations/woocommerce/pages/components/FontAwesomeIconPicker.js
@@ -8,7 +8,8 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 /**
  * WordPress dependencies
  */
-import { Dropdown, TextControl, Button } from '@wordpress/components';
+import { Dropdown, TextControl, Button, Notice } from '@wordpress/components';
+import { trash } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 // Add all free solid icons to the library
@@ -17,6 +18,21 @@ library.add( fas );
 const FontAwesomeIconPicker = ( { productHotspot, disabled = false, index, productHotspots, updateField } ) => {
 	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const [ isOpen, setIsOpen ] = useState( false ); // eslint-disable-line no-unused-vars
+
+	/**
+	 * State to manage the notice message and visibility.
+	 */
+	const [ notice, setNotice ] = useState( { message: '', status: 'success', isVisible: false } );
+
+	/**
+	 * To show a notice message.
+	 *
+	 * @param {string} message Text to display in the notice.
+	 * @param {string} status  Status of the notice, can be 'success', 'error', etc.
+	 */
+	const showNotice = ( message, status = 'success' ) => {
+		setNotice( { message, status, isVisible: true } );
+	};
 
 	const iconList = Object.values( fas )
 		.map( ( icon ) => ( {
@@ -39,9 +55,65 @@ const FontAwesomeIconPicker = ( { productHotspot, disabled = false, index, produ
 		updateField(
 			'productHotspots',
 			productHotspots.map( ( h2, j ) =>
-				j === index ? { ...h2, icon: null } : h2,
+				j === index ? { ...h2, icon: null, customIconUrl: null, customIconId: null } : h2,
 			),
 		);
+	};
+
+	// Handle custom icon upload
+	const handleUploadCustomIcon = () => {
+		const fileFrame = wp.media( {
+			title: __( 'Select or Upload Custom Icon', 'godam' ),
+			button: {
+				text: __( 'Use this icon', 'godam' ),
+			},
+			library: {
+				type: 'image', // Allow all image types
+			},
+			multiple: false, // Disable multiple selection
+		} );
+
+		fileFrame.on( 'select', function() {
+			const attachment = fileFrame.state().get( 'selection' ).first().toJSON();
+
+			// Check if the selected file is an image
+			if ( attachment.type !== 'image' ) {
+				showNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				return;
+			}
+
+			// Clear any existing notice on successful upload
+			setNotice( { message: '', status: 'success', isVisible: false } );
+
+			// Update hotspot with custom icon and clear FontAwesome icon
+			updateField(
+				'productHotspots',
+				productHotspots.map( ( h2, j ) =>
+					j === index
+						? {
+							...h2,
+							customIconUrl: attachment.url,
+							customIconId: attachment.id,
+							icon: null, // Clear FontAwesome icon when custom icon is selected
+						}
+						: h2,
+				),
+			);
+		} );
+
+		// If there's already a custom icon selected, pre-select it in the media library
+		if ( productHotspot.customIconId ) {
+			const attachment = wp.media.attachment( productHotspot.customIconId );
+			attachment.fetch();
+
+			fileFrame.on( 'open', function() {
+				const selection = fileFrame.state().get( 'selection' );
+				selection.reset();
+				selection.add( attachment );
+			} );
+		}
+
+		fileFrame.open();
 	};
 
 	return (
@@ -60,7 +132,8 @@ const FontAwesomeIconPicker = ( { productHotspot, disabled = false, index, produ
 							onClick={ onToggle }
 							aria-expanded={ isDropDownOpen }
 							variant="secondary"
-							className="flex-grow flex items-center gap-2"
+							size="compact"
+							className="flex-grow flex items-center gap-2 godam-button px-3"
 							disabled={ disabled }
 						>
 							{ productHotspot.icon ? (
@@ -116,7 +189,7 @@ const FontAwesomeIconPicker = ( { productHotspot, disabled = false, index, produ
 													'productHotspots',
 													productHotspots.map( ( h2, j ) =>
 														j === index
-															? { ...h2, icon: iconName }
+															? { ...h2, icon: iconName, customIconUrl: null, customIconId: null }
 															: h2,
 													),
 												);
@@ -144,16 +217,51 @@ const FontAwesomeIconPicker = ( { productHotspot, disabled = false, index, produ
 					) }
 				/>
 
-				{ productHotspot.icon && (
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ handleUploadCustomIcon }
+					className="flex-shrink-0 flex items-center gap-2 godam-button px-3"
+					disabled={ disabled }
+				>
+					{ productHotspot.customIconUrl ? (
+						<>
+							<img
+								src={ productHotspot.customIconUrl }
+								alt={ __( 'Custom Icon', 'godam' ) }
+								style={ {
+									width: '20px',
+									height: '20px',
+									objectFit: 'contain',
+								} }
+							/>
+							<span>{ __( 'Custom Icon', 'godam' ) }</span>
+						</>
+					) : (
+						<span>{ __( 'Custom Icon', 'godam' ) }</span>
+					) }
+				</Button>
+
+				{ ( productHotspot.icon || productHotspot.customIconUrl ) && (
 					<Button
 						variant="secondary"
+						size="compact"
 						onClick={ handleReset }
-						className="flex-shrink-0"
+						className="flex-shrink-0 godam-button"
+						icon={ trash }
 					>
-						{ __( 'Reset', 'godam' ) }
 					</Button>
 				) }
 			</div>
+			{ notice.isVisible && (
+				<Notice
+					className="my-4"
+					status={ notice.status }
+					onRemove={ () => setNotice( { ...notice, isVisible: false } ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
 		</div>
 	);
 };

--- a/integrations/woocommerce/pages/components/WoocommerceLayer.js
+++ b/integrations/woocommerce/pages/components/WoocommerceLayer.js
@@ -341,10 +341,9 @@ const ProductHotspotPreview = ( { productHotspot, index, productCache } ) => {
 					alt={ __( 'Custom Icon', 'godam' ) }
 					className="pointer-events-none"
 					style={ {
-						width: '100%',
-						height: '100%',
-						color: '#941d1d',
-						objectFit: 'cover',
+						width: '50%',
+						height: '50%',
+						objectFit: 'contain',
 					} }
 				/>
 			) : null }

--- a/integrations/woocommerce/pages/components/WoocommerceLayer.js
+++ b/integrations/woocommerce/pages/components/WoocommerceLayer.js
@@ -323,7 +323,8 @@ const ProductHotspotPreview = ( { productHotspot, index, productCache } ) => {
 	const productData = productCache[ productHotspot.productId ] || null;
 
 	return (
-		<div className={ `hotspot-content flex items-center justify-center ${ ! productHotspot.icon ? 'no-icon' : '' }` }>
+		<div className={ `hotspot-content flex items-center justify-center ${ ! ( productHotspot.icon || productHotspot.customIconUrl ) ? 'no-icon' : '' }` }>
+			{ /* eslint-disable-next-line no-nested-ternary */ }
 			{ productHotspot.icon ? (
 				<FontAwesomeIcon
 					icon={ [ 'fas', productHotspot.icon ] }
@@ -332,6 +333,18 @@ const ProductHotspotPreview = ( { productHotspot, index, productCache } ) => {
 						width: '50%',
 						height: '50%',
 						color: '#000',
+					} }
+				/>
+			) : productHotspot.customIconUrl ? (
+				<img
+					src={ productHotspot.customIconUrl }
+					alt={ __( 'Custom Icon', 'godam' ) }
+					className="pointer-events-none"
+					style={ {
+						width: '100%',
+						height: '100%',
+						color: '#941d1d',
+						objectFit: 'cover',
 					} }
 				/>
 			) : null }
@@ -942,7 +955,7 @@ const WoocommerceLayer = ( { layerID, goBack, duration } ) => {
 								onClick={ () => setExpandedProductHotspotIndex( index ) }
 								className="hotspot circle"
 								style={ {
-									backgroundColor: productHotspot.icon ? 'white' : productHotspot.backgroundColor || '#0c80dfa6',
+									backgroundColor: ( productHotspot.icon || productHotspot.customIconUrl ) ? 'white' : productHotspot.backgroundColor || '#0c80dfa6',
 									zIndex: 20,
 								} }
 							>


### PR DESCRIPTION
## In the PR

- Add custom icon support for frontend, video editor, and side panel
- Improve icon rendering consistency across components

Refs rtCamp/godam-core#735

## Screenshots

<img width="1470" height="834" alt="Screenshot 2026-04-06 at 1 17 54 PM" src="https://github.com/user-attachments/assets/219e79e1-6ee2-4a57-b698-4389baceb0dc" />

<img width="1469" height="841" alt="Screenshot 2026-04-06 at 1 16 39 PM" src="https://github.com/user-attachments/assets/c9804091-94ff-4f12-a256-7184b4a76f9c" />
