### PR TITLE
Fix - GoDAM Video Block UX Improvements

### DIFF
--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -108,10 +108,6 @@
 		"showShareButton": {
 			"type": "boolean",
 			"default": false
-		},
-		"engagements": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"supports": {

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -108,6 +108,10 @@
 		"showShareButton": {
 			"type": "boolean",
 			"default": false
+		},
+		"playerHeight": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -42,7 +42,7 @@
 		},
 		"preload": {
 			"type": "string",
-			"default": "metadata"
+			"default": "auto"
 		},
 		"blob": {
 			"type": "string",

--- a/assets/src/blocks/godam-player/components/ThumbnailPanel.js
+++ b/assets/src/blocks/godam-player/components/ThumbnailPanel.js
@@ -1,0 +1,222 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useRef } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Spinner } from '@wordpress/components';
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
+
+const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+/**
+ * ThumbnailPanel — scrollable grid of all available video thumbnails for the block Inspector.
+ *
+ * Fetches auto-generated and custom thumbnails from the GoDAM REST API and renders them
+ * as clickable tiles. The active poster (block-level override or global default) is
+ * highlighted with a selection ring. An upload tile at the end opens the WP Media Library
+ * to set a fully custom image as the block-level poster.
+ *
+ * @param {Object}   props               Component props.
+ * @param {number}   props.attachmentId  WordPress attachment ID for the video.
+ * @param {string}   props.poster        Block-level poster override (attribute).
+ * @param {string}   props.defaultPoster Global/fallback poster from attachment meta.
+ * @param {Function} props.onSelect      Called with { url } when a thumbnail tile is chosen.
+ * @param {Function} props.onRemove      Called when the user resets to the global thumbnail.
+ *
+ * @return {JSX.Element|null} The rendered thumbnail panel, or null when no video is selected.
+ */
+export default function ThumbnailPanel( {
+	attachmentId,
+	poster,
+	defaultPoster,
+	onSelect,
+	onRemove,
+} ) {
+	const [ thumbnails, setThumbnails ] = useState( [] );
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	// Tracks the URL of the image uploaded via the "+" button.
+	// Kept separately from `poster` so it persists when the user selects a
+	// different thumbnail from the list.
+	const [ customUploadedPoster, setCustomUploadedPoster ] = useState( null );
+
+	// Ref lets the fetch callback read the latest poster without adding it
+	// as an effect dependency (which would re-trigger the fetch on every selection).
+	const posterRef = useRef( poster );
+	posterRef.current = poster;
+
+	useEffect( () => {
+		if ( ! attachmentId ) {
+			setThumbnails( [] );
+			setCustomUploadedPoster( null );
+			return;
+		}
+
+		let cancelled = false;
+		setIsLoading( true );
+		setCustomUploadedPoster( null );
+
+		apiFetch( {
+			path: `/godam/v1/media-library/get-video-thumbnail?attachment_id=${ attachmentId }`,
+		} )
+			.then( ( response ) => {
+				if ( cancelled || ! response?.success ) {
+					return;
+				}
+
+				const {
+					thumbnails: autoThumbs = [],
+					customThumbnails = [],
+				} = response.data;
+
+				const thumbList = [
+					...customThumbnails.map( ( url ) => ( { url, isCustom: true } ) ),
+					...autoThumbs.map( ( url ) => ( { url, isCustom: false } ) ),
+				];
+
+				setThumbnails( thumbList );
+
+				// If the saved poster is not in the server list it was uploaded
+				// directly in the block editor — restore it as the custom tile.
+				const currentPoster = posterRef.current;
+				if ( currentPoster && ! thumbList.some( ( t ) => t.url === currentPoster ) ) {
+					setCustomUploadedPoster( currentPoster );
+				}
+			} )
+			.catch( () => {
+				// Silently ignore — defaultPoster will still show if available.
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ attachmentId ] );
+
+	// Highlight the block-level override when set, otherwise highlight the global default.
+	const activePoster = poster || defaultPoster;
+
+	// Called when a new image is uploaded via the "+" button.
+	function handleCustomUpload( image ) {
+		setCustomUploadedPoster( image.url );
+		onSelect( image );
+	}
+
+	// Called when the "×" button or "Reset to global" is clicked.
+	function handleRemoveCustom() {
+		setCustomUploadedPoster( null );
+		onRemove();
+	}
+
+	if ( ! attachmentId ) {
+		return null;
+	}
+
+	return (
+		<div className="godam-thumbnail-panel">
+			<p className="godam-thumbnail-panel__label">
+				{ __( 'Video Thumbnail', 'godam' ) }
+			</p>
+
+			{ isLoading ? (
+				<div className="godam-thumbnail-panel__spinner">
+					<Spinner />
+				</div>
+			) : (
+				<div className="godam-thumbnail-grid">
+					{ /* Upload tile — hidden while a custom thumbnail is present */ }
+					{ ! customUploadedPoster && (
+						<div className="godam-thumbnail-tile godam-thumbnail-upload-tile">
+							<MediaUploadCheck>
+								<MediaUpload
+									title={ __( 'Upload Custom Thumbnail', 'godam' ) }
+									onSelect={ handleCustomUpload }
+									allowedTypes={ VIDEO_POSTER_ALLOWED_MEDIA_TYPES }
+									render={ ( { open } ) => (
+										<Button
+											onClick={ open }
+											className="godam-thumbnail-upload-btn"
+											aria-label={ __( 'Upload custom thumbnail', 'godam' ) }
+										>
+											<span aria-hidden="true">+</span>
+										</Button>
+									) }
+								/>
+							</MediaUploadCheck>
+						</div>
+					) }
+
+					{ /* Block-level custom poster — persists independently of which tile is active */ }
+					{ customUploadedPoster && (
+						<div
+							className={ `godam-thumbnail-tile godam-thumbnail-custom-block-tile${ activePoster === customUploadedPoster ? ' is-selected' : '' }` }
+							title={ __( 'Custom uploaded thumbnail', 'godam' ) }
+							role="button"
+							tabIndex={ 0 }
+							onClick={ () => onSelect( { url: customUploadedPoster } ) }
+							onKeyDown={ ( e ) => {
+								if ( e.key === 'Enter' || e.key === ' ' ) {
+									onSelect( { url: customUploadedPoster } );
+								}
+							} }
+							aria-label={ __( 'Select custom thumbnail', 'godam' ) }
+							aria-pressed={ activePoster === customUploadedPoster }
+						>
+							<img src={ customUploadedPoster } alt={ __( 'Custom thumbnail', 'godam' ) } draggable="false" />
+							<button
+								type="button"
+								className="godam-thumbnail-delete-btn"
+								onClick={ ( e ) => {
+									e.stopPropagation();
+									handleRemoveCustom();
+								} }
+								aria-label={ __( 'Remove custom thumbnail', 'godam' ) }
+							>
+								&#x2715;
+							</button>
+						</div>
+					) }
+
+					{ thumbnails.map( ( thumb ) => (
+						<button
+							key={ thumb.url }
+							type="button"
+							className={
+								`godam-thumbnail-tile${ activePoster === thumb.url
+									? ' is-selected'
+									: '' }`
+							}
+							onClick={ () => onSelect( { url: thumb.url } ) }
+							aria-label={
+								/* translators: %s: thumbnail URL */
+								sprintf( __( 'Select thumbnail: %s', 'godam' ), thumb.url )
+							}
+							aria-pressed={ activePoster === thumb.url }
+						>
+							<img src={ thumb.url } alt="" draggable="false" />
+						</button>
+					) ) }
+				</div>
+			) }
+
+			{ !! poster && (
+				<p className="godam-thumbnail-override-notice">
+					{ __( 'Block override active.', 'godam' ) }
+					{ ' ' }
+					<Button
+						variant="link"
+						isDestructive
+						onClick={ handleRemoveCustom }
+					>
+						{ __( 'Reset to global', 'godam' ) }
+					</Button>
+				</p>
+			) }
+		</div>
+	);
+}

--- a/assets/src/blocks/godam-player/components/ThumbnailPanel.js
+++ b/assets/src/blocks/godam-player/components/ThumbnailPanel.js
@@ -3,6 +3,7 @@
  */
 import { useState, useEffect, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import { Button, Spinner } from '@wordpress/components';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
@@ -58,7 +59,7 @@ export default function ThumbnailPanel( {
 		setCustomUploadedPoster( null );
 
 		apiFetch( {
-			path: `/godam/v1/media-library/get-video-thumbnail?attachment_id=${ attachmentId }`,
+			path: addQueryArgs( '/godam/v1/media-library/get-video-thumbnail', { attachment_id: attachmentId } ),
 		} )
 			.then( ( response ) => {
 				if ( cancelled || ! response?.success ) {
@@ -153,28 +154,21 @@ export default function ThumbnailPanel( {
 
 					{ /* Block-level custom poster — persists independently of which tile is active */ }
 					{ customUploadedPoster && (
-						<div
-							className={ `godam-thumbnail-tile godam-thumbnail-custom-block-tile${ activePoster === customUploadedPoster ? ' is-selected' : '' }` }
-							title={ __( 'Custom uploaded thumbnail', 'godam' ) }
-							role="button"
-							tabIndex={ 0 }
-							onClick={ () => onSelect( { url: customUploadedPoster } ) }
-							onKeyDown={ ( e ) => {
-								if ( e.key === 'Enter' || e.key === ' ' ) {
-									onSelect( { url: customUploadedPoster } );
-								}
-							} }
-							aria-label={ __( 'Select custom thumbnail', 'godam' ) }
-							aria-pressed={ activePoster === customUploadedPoster }
-						>
-							<img src={ customUploadedPoster } alt={ __( 'Custom thumbnail', 'godam' ) } draggable="false" />
+						<div className="godam-thumbnail-custom-block-wrapper">
+							<button
+								type="button"
+								className={ `godam-thumbnail-tile godam-thumbnail-custom-block-tile${ activePoster === customUploadedPoster ? ' is-selected' : '' }` }
+								title={ __( 'Custom uploaded thumbnail', 'godam' ) }
+								onClick={ () => onSelect( { url: customUploadedPoster } ) }
+								aria-label={ __( 'Select custom thumbnail', 'godam' ) }
+								aria-pressed={ activePoster === customUploadedPoster }
+							>
+								<img src={ customUploadedPoster } alt={ __( 'Custom thumbnail', 'godam' ) } draggable="false" />
+							</button>
 							<button
 								type="button"
 								className="godam-thumbnail-delete-btn"
-								onClick={ ( e ) => {
-									e.stopPropagation();
-									handleRemoveCustom();
-								} }
+								onClick={ handleRemoveCustom }
 								aria-label={ __( 'Remove custom thumbnail', 'godam' ) }
 							>
 								&#x2715;

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -24,9 +24,8 @@ const options = [
  * @return {WPElement} The video settings component.
  */
 const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false } ) => {
-	const { autoplay, controls, loop, muted, preload, showShareButton, engagements } =
+	const { autoplay, controls, loop, muted, preload, showShareButton } =
 	attributes;
-	const showEngagementSetting = window?.godamSettings?.enableGlobalVideoEngagement ?? false;
 	const showShareButtonSetting = window?.godamSettings?.enableGlobalVideoShare ?? false;
 
 	// Show a specific help for autoplay setting.
@@ -59,7 +58,6 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 			loop: toggleAttribute( 'loop' ),
 			muted: toggleAttribute( 'muted' ),
 			controls: toggleAttribute( 'controls' ),
-			engagements: toggleAttribute( 'engagements' ),
 			showShareButton: toggleAttribute( 'showShareButton' ),
 		};
 	}, [ setAttributes ] );
@@ -126,17 +124,6 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 					hideCancelButton
 				/>
 			) }
-			{
-				showEngagementSetting && (
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Enable Likes & Comments', 'godam' ) }
-						onChange={ toggleFactory.engagements }
-						checked={ !! engagements }
-						help={ __( 'Engagement will only be visible for transcoded videos', 'godam' ) }
-					/>
-				)
-			}
 		</>
 	);
 };

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -8,6 +8,7 @@ import { useMemo, useCallback } from '@wordpress/element';
 const options = [
 	{ value: 'auto', label: __( 'Auto', 'godam' ) },
 	{ value: 'metadata', label: __( 'Metadata', 'godam' ) },
+	{ value: 'thumbnail', label: __( 'Preload Only Video Thumbnail', 'godam' ) },
 	{ value: 'none', label: _x( 'None', 'Preload value', 'godam' ) },
 ];
 
@@ -24,7 +25,7 @@ const options = [
  * @return {WPElement} The video settings component.
  */
 const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false } ) => {
-	const { autoplay, controls, loop, muted, preload, showShareButton } =
+	const { autoplay, controls, loop, muted, preload, preloadPoster, showShareButton } =
 	attributes;
 	const showShareButtonSetting = window?.godamSettings?.enableGlobalVideoShare ?? false;
 
@@ -62,8 +63,23 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 		};
 	}, [ setAttributes ] );
 
+	const selectedPreloadValue = useMemo( () => {
+		if ( preloadPoster ) {
+			return 'thumbnail';
+		}
+
+		return preload || 'auto';
+	}, [ preload, preloadPoster ] );
+
 	const onChangePreload = useCallback( ( value ) => {
-		setAttributes( { preload: value } );
+		if ( 'thumbnail' === value ) {
+			// Keep video preload off while preloading only poster image.
+			setAttributes( { preload: 'none', preloadPoster: true } );
+
+			return;
+		}
+
+		setAttributes( { preload: value, preloadPoster: false } );
 	}, [ setAttributes ] );
 
 	return (
@@ -118,10 +134,11 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 					label={ __( 'Preload', 'godam' ) }
-					value={ preload }
+					value={ selectedPreloadValue }
 					onChange={ onChangePreload }
 					options={ options }
 					hideCancelButton
+					help={ __( 'Choose how the video should preload.', 'godam' ) }
 				/>
 			) }
 		</>

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -64,7 +64,10 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 	}, [ setAttributes ] );
 
 	const selectedPreloadValue = useMemo( () => {
-		if ( preloadPoster ) {
+		// Only report 'thumbnail' when the legacy preloadPoster flag is set
+		// AND preload is already 'none', so existing content with preloadPoster=true
+		// but a non-'none' preload value is not misrepresented in the UI.
+		if ( preloadPoster && ( ! preload || 'none' === preload ) ) {
 			return 'thumbnail';
 		}
 

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -22,7 +22,6 @@ import {
 	BlockControls,
 	InspectorControls,
 	MediaUpload,
-	MediaUploadCheck,
 	MediaReplaceFlow,
 	useBlockProps,
 } from '@wordpress/block-editor';
@@ -42,6 +41,7 @@ import Video from './VideoJS';
 import TracksEditor from './track-uploader';
 import { Caption } from './caption';
 import VideoSEOModal from './components/VideoSEOModal.js';
+import ThumbnailPanel from './components/ThumbnailPanel.js';
 import { appendTimezoneOffsetToUTC, isSEODataEmpty, secondsToISO8601, stripHtmlTags } from './utils/index.js';
 import './editor.scss';
 import { ReactComponent as icon } from '../../images/godam-video-filled.svg';
@@ -49,7 +49,6 @@ import { canManageAttachment } from '../../js/media-library/utility';
 import { isFeaturePremium } from '../../js/premium-features.js';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
-const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 /**
  * Edit component for the GoDAM Player block.
@@ -74,7 +73,6 @@ function VideoEdit( {
 } ) {
 	const instanceId = useInstanceId( VideoEdit );
 	const videoPlayer = useRef();
-	const posterImageButton = useRef();
 
 	const {
 		id,
@@ -620,12 +618,7 @@ function VideoEdit( {
 		}
 
 		setAttributes( nextAttributes );
-
-		// Move focus back to the Media Upload button.
-		posterImageButton.current.focus();
 	}
-
-	const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
 	return (
 		<>
@@ -698,50 +691,13 @@ function VideoEdit( {
 									/>
 								</BaseControl>
 
-								<BaseControl
-									id={ `video-block__poster-image-${ instanceId }` }
-									label={ __( 'Video Thumbnail', 'godam' ) }
-									__nextHasNoMarginBottom
-								>
-									<MediaUploadCheck>
-										<div className="editor-video-poster-control">
-											<MediaUpload
-												title={ __( 'Select Video Thumbnail', 'godam' ) }
-												onSelect={ onSelectPoster }
-												allowedTypes={ VIDEO_POSTER_ALLOWED_MEDIA_TYPES }
-												render={ ( { open } ) => (
-													<Button
-														__next40pxDefaultSize
-														variant="primary"
-														onClick={ open }
-														ref={ posterImageButton }
-														aria-describedby={ videoPosterDescription }
-													>
-														{ ! poster ? __( 'Select', 'godam' ) : __( 'Replace', 'godam' ) }
-													</Button>
-												) }
-											/>
-											<p id={ videoPosterDescription } hidden>
-												{ poster
-													? sprintf(
-														/* translators: %s: poster image URL. */
-														__( 'The current poster image url is %s', 'godam' ),
-														poster,
-													)
-													: __( 'There is no poster image currently selected', 'godam' ) }
-											</p>
-											{ !! poster && (
-												<Button
-													__next40pxDefaultSize
-													onClick={ onRemovePoster }
-													variant="tertiary"
-												>
-													{ __( 'Remove', 'godam' ) }
-												</Button>
-											) }
-										</div>
-									</MediaUploadCheck>
-								</BaseControl>
+								<ThumbnailPanel
+									attachmentId={ id }
+									poster={ poster }
+									defaultPoster={ defaultPoster }
+									onSelect={ onSelectPoster }
+									onRemove={ onRemovePoster }
+								/>
 
 								<BaseControl
 									id={ `video-block__video--selected-aspect-ratio-${ instanceId }` }

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -14,6 +14,8 @@ import {
 	PanelBody,
 	Spinner,
 	Placeholder,
+	ToggleControl,
+	RangeControl,
 	SelectControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -24,6 +26,7 @@ import {
 	MediaUpload,
 	MediaReplaceFlow,
 	useBlockProps,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { useRef, useEffect, useState, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -49,6 +52,36 @@ import { canManageAttachment } from '../../js/media-library/utility';
 import { isFeaturePremium } from '../../js/premium-features.js';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
+
+// Define allowed blocks for the overlay.
+const ALLOWED_BLOCKS = [
+	'core/paragraph',
+	'core/heading',
+	'core/button',
+	'core/image',
+	'core/group',
+	'core/columns',
+	'core/column',
+	'core/spacer',
+	'core/html',
+	'core/shortcode',
+];
+
+// Define template for initial blocks.
+const TEMPLATE = [
+	[ 'core/group', {
+		className: 'godam-video-overlay',
+		layout: {
+			type: 'default',
+			inherit: true,
+		},
+	}, [
+		[ 'core/heading', {
+			level: 2,
+			placeholder: __( 'Add a heading…', 'godam' ),
+		} ],
+	] ],
+];
 
 /**
  * Edit component for the GoDAM Player block.
@@ -86,6 +119,9 @@ function VideoEdit( {
 		muted,
 		loop,
 		preload,
+		verticalAlignment,
+		overlayTimeRange,
+		showOverlay,
 		aspectRatio,
 		videoWidth,
 		videoHeight,
@@ -620,6 +656,39 @@ function VideoEdit( {
 		setAttributes( nextAttributes );
 	}
 
+	// Add function to handle vertical alignment change.
+	const onChangeVerticalAlignment = ( alignment ) => {
+		setAttributes( { verticalAlignment: alignment } );
+	};
+
+	// Format time for display.
+	const formatTime = ( seconds ) => {
+		const hours = Math.floor( seconds / 3600 );
+		const minutes = Math.floor( ( seconds % 3600 ) / 60 );
+		const remainingSeconds = Math.floor( seconds % 60 );
+
+		let timeString = '';
+
+		if ( hours > 0 ) {
+			timeString += `${ hours } hour${ hours !== 1 ? 's' : '' }`;
+		}
+
+		if ( minutes > 0 ) {
+			if ( timeString ) {
+				timeString += ', ';
+			}
+			timeString += `${ minutes } minute${ minutes !== 1 ? 's' : '' }`;
+		}
+
+		if ( remainingSeconds > 0 || timeString === '' ) {
+			if ( timeString ) {
+				timeString += ', ';
+			}
+			timeString += `${ remainingSeconds } second${ remainingSeconds !== 1 ? 's' : '' }`;
+		}
+
+		return timeString;
+	};
 	return (
 		<>
 			{ isSingleSelected && (
@@ -732,6 +801,57 @@ function VideoEdit( {
 					}
 				</PanelBody>
 
+				{ /* Only show additional settings when not inside a Query Loop */ }
+				{ ! isInsideQueryLoop && (
+					<PanelBody title={ __( 'Overlay Blocks', 'godam' ) }>
+						<ToggleControl
+							label={ __( 'Show overlay blocks', 'godam' ) }
+							checked={ showOverlay }
+							onChange={ ( value ) => setAttributes( { showOverlay: value } ) }
+							help={ __( 'Display blocks on top of the video player.', 'godam' ) }
+						/>
+
+						{ showOverlay && (
+							<>
+								<SelectControl
+									label={ __( 'Vertical alignment', 'godam' ) }
+									value={ verticalAlignment }
+									options={ [
+										{ label: __( 'Top', 'godam' ), value: 'top' },
+										{ label: __( 'Center', 'godam' ), value: 'center' },
+										{ label: __( 'Bottom', 'godam' ), value: 'bottom' },
+									] }
+									onChange={ onChangeVerticalAlignment }
+									help={ __( 'Choose where to position the overlay blocks vertically.', 'godam' ) }
+								/>
+
+								<RangeControl
+									label={ __( 'Time range', 'godam' ) }
+									value={ overlayTimeRange }
+									onChange={ ( value ) => setAttributes( { overlayTimeRange: value } ) }
+									min={ 0 }
+									max={ duration || 100 }
+									step={ 0.1 }
+									help={ sprintf(
+										/* translators: %s: formatted time */
+										__( 'Overlay will be visible for %s from the start of the video.', 'godam' ),
+										formatTime( overlayTimeRange || 0 ),
+									) }
+								/>
+
+								{ duration > 0 && (
+									<p style={ { fontSize: '12px', color: '#757575', marginTop: '8px' } }>
+										{ sprintf(
+											/* translators: %s: formatted time */
+											__( 'Video duration: %s', 'godam' ),
+											formatTime( duration ),
+										) }
+									</p>
+								) }
+							</>
+						) }
+					</PanelBody>
+				) }
 			</InspectorControls>
 			{
 				isInsideQueryLoop ? (
@@ -753,6 +873,22 @@ function VideoEdit( {
 
 						<figure { ...blockProps }>
 							<div className="godam-video-wrapper">
+								{ showOverlay && (
+									<div
+										className={ `godam-video-overlay-container godam-overlay-alignment-${ verticalAlignment }` }
+									>
+										<InnerBlocks
+											allowedBlocks={ ALLOWED_BLOCKS }
+											template={ TEMPLATE }
+											templateLock={ false }
+											renderAppender={ isSingleSelected ? InnerBlocks.ButtonBlockAppender : false }
+											__experimentalLayout={ {
+												type: 'default',
+												inherit: true,
+											} }
+										/>
+									</div>
+								) }
 								{ videoComponent }
 								{ !! temporaryURL && <Spinner /> }
 							</div>

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -14,7 +14,6 @@ import {
 	PanelBody,
 	Spinner,
 	Placeholder,
-	ToggleControl,
 	SelectControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -743,14 +742,6 @@ function VideoEdit( {
 										</div>
 									</MediaUploadCheck>
 								</BaseControl>
-
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Preload Video Thumbnail', 'godam' ) }
-									help={ __( 'Enable to show the video thumbnail faster when the page loads. Recommended for videos placed near the top of your page.', 'godam' ) }
-									onChange={ ( value ) => setAttributes( { preloadPoster: value } ) }
-									checked={ attributes?.preloadPoster }
-								/>
 
 								<BaseControl
 									id={ `video-block__video--selected-aspect-ratio-${ instanceId }` }

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -15,7 +15,6 @@ import {
 	Spinner,
 	Placeholder,
 	ToggleControl,
-	RangeControl,
 	SelectControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -27,7 +26,6 @@ import {
 	MediaUploadCheck,
 	MediaReplaceFlow,
 	useBlockProps,
-	InnerBlocks,
 } from '@wordpress/block-editor';
 import { useRef, useEffect, useState, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
@@ -53,36 +51,6 @@ import { isFeaturePremium } from '../../js/premium-features.js';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
-
-// Define allowed blocks for the overlay.
-const ALLOWED_BLOCKS = [
-	'core/paragraph',
-	'core/heading',
-	'core/button',
-	'core/image',
-	'core/group',
-	'core/columns',
-	'core/column',
-	'core/spacer',
-	'core/html',
-	'core/shortcode',
-];
-
-// Define template for initial blocks.
-const TEMPLATE = [
-	[ 'core/group', {
-		className: 'godam-video-overlay',
-		layout: {
-			type: 'default',
-			inherit: true,
-		},
-	}, [
-		[ 'core/heading', {
-			level: 2,
-			placeholder: __( 'Add a heading…', 'godam' ),
-		} ],
-	] ],
-];
 
 /**
  * Edit component for the GoDAM Player block.
@@ -121,9 +89,6 @@ function VideoEdit( {
 		muted,
 		loop,
 		preload,
-		verticalAlignment,
-		overlayTimeRange,
-		showOverlay,
 		aspectRatio,
 		videoWidth,
 		videoHeight,
@@ -663,40 +628,6 @@ function VideoEdit( {
 
 	const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
-	// Add function to handle vertical alignment change.
-	const onChangeVerticalAlignment = ( alignment ) => {
-		setAttributes( { verticalAlignment: alignment } );
-	};
-
-	// Format time for display.
-	const formatTime = ( seconds ) => {
-		const hours = Math.floor( seconds / 3600 );
-		const minutes = Math.floor( ( seconds % 3600 ) / 60 );
-		const remainingSeconds = Math.floor( seconds % 60 );
-
-		let timeString = '';
-
-		if ( hours > 0 ) {
-			timeString += `${ hours } hour${ hours !== 1 ? 's' : '' }`;
-		}
-
-		if ( minutes > 0 ) {
-			if ( timeString ) {
-				timeString += ', ';
-			}
-			timeString += `${ minutes } minute${ minutes !== 1 ? 's' : '' }`;
-		}
-
-		if ( remainingSeconds > 0 || timeString === '' ) {
-			if ( timeString ) {
-				timeString += ', ';
-			}
-			timeString += `${ remainingSeconds } second${ remainingSeconds !== 1 ? 's' : '' }`;
-		}
-
-		return timeString;
-	};
-
 	return (
 		<>
 			{ isSingleSelected && (
@@ -763,7 +694,6 @@ function VideoEdit( {
 												{ label: __( 'None', 'godam' ), value: 'none' },
 												{ label: __( 'Show Player Controls', 'godam' ), value: 'show-player-controls' },
 												{ label: __( 'Start Preview', 'godam' ), value: 'start-preview' },
-												{ label: __( 'Shadow Overlay', 'godam' ), value: 'shadow-overlay' },
 											]
 										}
 									/>
@@ -855,57 +785,6 @@ function VideoEdit( {
 					}
 				</PanelBody>
 
-				{ /* Only show additional settings when not inside a Query Loop */ }
-				{ ! isInsideQueryLoop && (
-					<PanelBody title={ __( 'Overlay Blocks', 'godam' ) }>
-						<ToggleControl
-							label={ __( 'Show overlay blocks', 'godam' ) }
-							checked={ showOverlay }
-							onChange={ ( value ) => setAttributes( { showOverlay: value } ) }
-							help={ __( 'Display blocks on top of the video player.', 'godam' ) }
-						/>
-
-						{ showOverlay && (
-							<>
-								<SelectControl
-									label={ __( 'Vertical alignment', 'godam' ) }
-									value={ verticalAlignment }
-									options={ [
-										{ label: __( 'Top', 'godam' ), value: 'top' },
-										{ label: __( 'Center', 'godam' ), value: 'center' },
-										{ label: __( 'Bottom', 'godam' ), value: 'bottom' },
-									] }
-									onChange={ onChangeVerticalAlignment }
-									help={ __( 'Choose where to position the overlay blocks vertically.', 'godam' ) }
-								/>
-
-								<RangeControl
-									label={ __( 'Time range', 'godam' ) }
-									value={ overlayTimeRange }
-									onChange={ ( value ) => setAttributes( { overlayTimeRange: value } ) }
-									min={ 0 }
-									max={ duration || 100 }
-									step={ 0.1 }
-									help={ sprintf(
-										/* translators: %s: formatted time */
-										__( 'Overlay will be visible for %s from the start of the video.', 'godam' ),
-										formatTime( overlayTimeRange || 0 ),
-									) }
-								/>
-
-								{ duration > 0 && (
-									<p style={ { fontSize: '12px', color: '#757575', marginTop: '8px' } }>
-										{ sprintf(
-											/* translators: %s: formatted time */
-											__( 'Video duration: %s', 'godam' ),
-											formatTime( duration ),
-										) }
-									</p>
-								) }
-							</>
-						) }
-					</PanelBody>
-				) }
 			</InspectorControls>
 			{
 				isInsideQueryLoop ? (
@@ -927,22 +806,6 @@ function VideoEdit( {
 
 						<figure { ...blockProps }>
 							<div className="godam-video-wrapper">
-								{ showOverlay && (
-									<div
-										className={ `godam-video-overlay-container godam-overlay-alignment-${ verticalAlignment }` }
-									>
-										<InnerBlocks
-											allowedBlocks={ ALLOWED_BLOCKS }
-											template={ TEMPLATE }
-											templateLock={ false }
-											renderAppender={ isSingleSelected ? InnerBlocks.ButtonBlockAppender : false }
-											__experimentalLayout={ {
-												type: 'default',
-												inherit: true,
-											} }
-										/>
-									</div>
-								) }
 								{ videoComponent }
 								{ !! temporaryURL && <Spinner /> }
 							</div>

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -19,6 +19,8 @@ import {
 	SelectControl,
 	ToolbarButton,
 	ToolbarGroup,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -125,6 +127,7 @@ function VideoEdit( {
 		aspectRatio,
 		videoWidth,
 		videoHeight,
+		playerHeight,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const [ defaultPoster, setDefaultPoster ] = useState( '' );
@@ -152,6 +155,34 @@ function VideoEdit( {
 
 		return '';
 	}, [ aspectRatio, videoWidth, videoHeight ] );
+
+	// When a player height is set, derive a max-width from the height + aspect ratio.
+	// This mirrors the video-editor pattern: width = height × (arW / arH).
+	// Applying max-width lets Video.js fill that width with fluid: true, which naturally
+	// produces the desired height via the aspect-ratio padding trick.
+	const computedMaxWidth = useMemo( () => {
+		if ( ! playerHeight || ! calculatedAspectRatio ) {
+			return null;
+		}
+		const heightMatch = playerHeight.match( /^(\d+(?:\.\d+)?)([a-z%]*)$/ );
+		if ( ! heightMatch ) {
+			return null;
+		}
+
+		const unit = heightMatch[ 2 ] || 'px';
+		const arMatch = calculatedAspectRatio.match( /^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/ );
+		if ( ! arMatch ) {
+			return null;
+		}
+		const arH = parseFloat( arMatch[ 2 ] );
+		if ( ! arH ) {
+			return null;
+		}
+
+		const heightValue = parseFloat( heightMatch[ 1 ] );
+		const arW = parseFloat( arMatch[ 1 ] );
+		return `${ Math.round( heightValue * ( arW / arH ) ) }${ unit }`;
+	}, [ playerHeight, calculatedAspectRatio ] );
 
 	// Memoize video options to prevent unnecessary rerenders.
 	const videoOptions = useMemo( () => {
@@ -597,6 +628,7 @@ function VideoEdit( {
 
 	const blockProps = useBlockProps( {
 		className: classes,
+		...( computedMaxWidth ? { style: { maxWidth: computedMaxWidth } } : {} ),
 	} );
 
 	if ( ! src && ! temporaryURL && ! isInsideQueryLoop ) {
@@ -783,6 +815,14 @@ function VideoEdit( {
 										help={ __( 'Choose the aspect ratio for the video player.', 'godam' ) }
 									/>
 								</BaseControl>
+
+								<UnitControl
+									__nextHasNoMarginBottom
+									label={ __( 'Height', 'godam' ) }
+									value={ playerHeight || '' }
+									onChange={ ( value ) => setAttributes( { playerHeight: value || '' } ) }
+									help={ __( 'Set the video height. Width is auto-calculated from the aspect ratio.', 'godam' ) }
+								/>
 
 								<BaseControl
 									id={ `video-block__tracks-editor-${ instanceId }` }

--- a/assets/src/blocks/godam-player/editor.scss
+++ b/assets/src/blocks/godam-player/editor.scss
@@ -6,7 +6,7 @@
 .wp-block-godam-video {
 	width: 100%;
 	min-width: 0; // Allow shrinking in flex layouts (Row/Stack)
-	
+
 	// Ensure the figure takes full width
 	> figure {
 		width: 100%;
@@ -18,21 +18,18 @@
 		position: relative;
 		width: 100%;
 	}
-}
 
-.wp-block-godam-video .godam-editor-video-placeholder {
-	width: 100%;
-	height: 100%;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: #e5e5e5;
-	border-radius: 6px;
-	position: relative;
-	aspect-ratio: 16 / 9;
-}
-
-.wp-block-godam-video {
+	.godam-editor-video-placeholder {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: #e5e5e5;
+		border-radius: 6px;
+		position: relative;
+		aspect-ratio: 16 / 9;
+	}
 
 	.godam-video-container {
 		position: relative;
@@ -65,15 +62,195 @@
 			}
 		}
 	}
+}
 
-	@keyframes godam-spin {
+@keyframes godam-spin {
 
-		0% {
-			transform: rotate(0deg);
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+// Video Thumbnail panel in the block Inspector sidebar
+.godam-thumbnail-panel {
+	margin-bottom: 16px;
+
+	&__label {
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: #1e1e1e;
+		margin: 0 0 8px;
+	}
+
+	&__spinner {
+		display: flex;
+		justify-content: center;
+		padding: 8px 0;
+	}
+
+	.godam-thumbnail-grid {
+		display: flex !important;
+		flex-direction: row;
+		flex-wrap: nowrap;
+		overflow-x: auto;
+		gap: 6px;
+		padding: 4px 2px;
+		margin: 0;
+		scrollbar-width: thin;
+		scrollbar-color: #ccc transparent;
+
+		&::-webkit-scrollbar {
+			height: 4px;
 		}
 
-		100% {
-			transform: rotate(360deg);
+		&::-webkit-scrollbar-track {
+			background: transparent;
 		}
+
+		&::-webkit-scrollbar-thumb {
+			background: #ccc;
+			border-radius: 2px;
+		}
+	}
+
+	.godam-thumbnail-tile {
+		flex: 0 0 auto;
+		width: 72px;
+		height: 48px;
+		border: 2px solid transparent;
+		border-radius: 4px;
+		overflow: hidden;
+		cursor: pointer;
+		transition: border-color 0.1s ease, box-shadow 0.1s ease;
+		padding: 0;
+		background: #f0f0f0;
+		position: relative;
+
+		img {
+			display: block;
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			pointer-events: none;
+		}
+
+		&:hover {
+			border-color: #a0a0a0;
+		}
+
+		&:focus {
+			outline: none;
+			border-color: var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 2px var(--wp-admin-theme-color, #007cba);
+		}
+
+		&.is-selected {
+			border-color: var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 2px var(--wp-admin-theme-color, #007cba), inset 0 0 0 1px #fff;
+
+			&::after {
+				content: '\2713';
+				position: absolute;
+				bottom: 3px;
+				right: 3px;
+				width: 14px;
+				height: 14px;
+				background: var(--wp-admin-theme-color, #007cba);
+				color: #fff;
+				font-size: 9px;
+				font-weight: 700;
+				line-height: 1.56;
+				text-align: center;
+				border-radius: 50%;
+				z-index: 1;
+			}
+		}
+
+		&.godam-thumbnail-upload-tile {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			border-style: dashed;
+			border-color: #949494;
+			background: transparent;
+
+			&:hover {
+				border-color: var(--wp-admin-theme-color, #007cba);
+			}
+		}
+
+		/* Block-level custom thumbnail uploaded via the block editor "+" button */
+		&.godam-thumbnail-custom-block-tile {
+			cursor: default;
+
+			.godam-thumbnail-delete-btn {
+				position: absolute;
+				top: 3px;
+				right: 3px;
+				width: 16px;
+				height: 16px;
+				padding: 0;
+				background: rgba(0, 0, 0, 0.55);
+				color: #fff;
+				border: none;
+				border-radius: 50%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				cursor: pointer;
+				font-size: 10px;
+				line-height: 1;
+				z-index: 2;
+				transition: background 0.1s ease;
+
+				&:hover {
+					background: #cc1818;
+				}
+			}
+
+			/* When selected, push checkmark to bottom-right so it doesn't overlap the delete btn */
+			&.is-selected::after {
+				bottom: 3px;
+				right: 3px;
+				top: auto;
+			}
+		}
+	}
+}
+
+.godam-thumbnail-upload-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	font-size: 22px;
+	font-weight: 300;
+	color: #757575;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	line-height: 1;
+
+	&:hover {
+		color: var(--wp-admin-theme-color, #007cba);
+	}
+}
+
+.godam-thumbnail-override-notice {
+	font-size: 11px;
+	color: #757575;
+	margin: 0;
+
+	.components-button.is-link {
+		font-size: 11px;
+		vertical-align: baseline;
 	}
 }

--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -24,7 +24,70 @@ import './api/godam-api.js';
 /**
  * Initialize player on DOM content loaded
  */
-document.addEventListener( 'DOMContentLoaded', () => new PlayerManager() );
+document.addEventListener( 'DOMContentLoaded', () => {
+	new PlayerManager();
+
+	// Scroll to a specific video and optionally seek to a timestamp when the URL
+	// hash matches #godam-video-{jobId} and an optional ?t={seconds} query param is present.
+	const hash = window.location.hash;
+	if ( hash && hash.startsWith( '#godam-video-' ) ) {
+		const jobId = hash.replace( '#godam-video-', '' );
+		const searchParams = new URLSearchParams( window.location.search );
+		const startTime = parseFloat( searchParams.get( 't' ) );
+
+		const scrollToVideo = () => {
+			const videoEl = document.querySelector( `video[data-job_id="${ CSS.escape( jobId ) }"]` );
+			const container = videoEl?.closest( '.godam-video-wrapper' ) || videoEl?.closest( 'figure' );
+			if ( container ) {
+				container.scrollIntoView( { behavior: 'smooth', block: 'center' } );
+			}
+		};
+
+		// Wait for player initialization and layout to complete before scrolling.
+		setTimeout( scrollToVideo, 500 );
+
+		// Seek to the timestamp when the specific player is fully ready.
+		// We use 'godamPlayerReady' (fires per-player from within player.ready()) rather than
+		// 'godamAllPlayersReady' because the latter can fire before Video.js has initialised
+		// the player instance, causing getPlayer() to return null and the seek to be lost.
+		if ( ! isNaN( startTime ) && startTime > 0 ) {
+			const onPlayerReady = ( event ) => {
+				const { videoElement, player } = event.detail;
+
+				// Only act on the specific video targeted by the URL hash.
+				if ( ! videoElement || videoElement.dataset.job_id !== jobId ) {
+					return;
+				}
+
+				// This is our player – remove the listener so it only runs once.
+				document.removeEventListener( 'godamPlayerReady', onPlayerReady );
+
+				const seekToTime = () => player.currentTime( startTime );
+
+				// If media metadata is already loaded, seek immediately.
+				if ( player.readyState() >= 1 ) {
+					seekToTime();
+					return;
+				}
+
+				// For media not yet loaded: seek as soon as metadata is available.
+				player.one( 'loadedmetadata', seekToTime );
+
+				// Also seek on the first play event to cover the race where
+				// loadedmetadata fires before our listener above is bound,
+				// or for HLS streams where currentTime must be set after play starts.
+				player.one( 'play', () => {
+					if ( player.currentTime() < startTime ) {
+						seekToTime();
+					}
+					player.off( 'loadedmetadata', seekToTime );
+				} );
+			};
+
+			document.addEventListener( 'godamPlayerReady', onPlayerReady );
+		}
+	}
+} );
 
 /**
  * Handle Content Security Policy (CSP) violations related to blob workers

--- a/assets/src/js/godam-player/managers/shareManager.js
+++ b/assets/src/js/godam-player/managers/shareManager.js
@@ -267,7 +267,11 @@ class ShareManager {
 		const encodedLink = encodeURI( videoLink );
 		const message = encodeURIComponent( __( 'Check out this video!', 'godam' ) );
 
-		return { videoLink, embedUrl, embedCode, encodedLink, message };
+		// Build page link: current WP page URL with an anchor pointing to this video block.
+		const pageBase = window.location.origin + window.location.pathname;
+		const pageLink = `${ pageBase }#godam-video-${ jobId }`;
+
+		return { videoLink, embedUrl, embedCode, encodedLink, message, pageLink };
 	}
 
 	/**
@@ -302,7 +306,8 @@ class ShareManager {
 					</div>
 				</div>
 				<div class="${ MODAL_POPUP_CLASS }__footer">
-					${ this.renderCopySection( 'page-link', videoLink, __( 'Page Link', 'godam' ) ) }
+					${ this.renderCopySection( 'wp-page-link', '', __( 'Page Link', 'godam' ) ) }
+					${ this.renderCopySection( 'page-link', videoLink, __( 'GoDAM Central', 'godam' ) ) }
 					${ this.renderCopySection( 'embed-code', embedCode, __( 'Embed', 'godam' ) ) }
 				</div>
 				<div class="${ MODAL_POPUP_CLASS }__timestamp-container">
@@ -352,11 +357,12 @@ class ShareManager {
 	setupModalEventListeners( container, socialLinks, urls ) {
 		const cancelButton = container.querySelector( '.share-modal-popup__close-button' );
 		const copyPageLink = container.querySelector( '.copy-page-link' );
+		const copyWpPageLink = container.querySelector( '.copy-wp-page-link' );
 		const copyEmbedCode = container.querySelector( '.copy-embed-code' );
 
 		this.setupSocialLinkUrls( container, socialLinks, urls );
 		this.setupModalCloseHandlers( container, cancelButton );
-		this.setupCopyButtonHandlers( copyPageLink, copyEmbedCode );
+		this.setupCopyButtonHandlers( copyPageLink, copyWpPageLink, copyEmbedCode );
 		this.setupTimestampControls( container, socialLinks, urls );
 	}
 
@@ -423,12 +429,14 @@ class ShareManager {
 	/**
 	 * Sets up copy button event handlers.
 	 *
-	 * @param {HTMLElement} copyPageLink  - Page link copy button.
-	 * @param {HTMLElement} copyEmbedCode - Embed code copy button.
+	 * @param {HTMLElement} copyPageLink   - GoDAM Central link copy button.
+	 * @param {HTMLElement} copyWpPageLink - WP page link copy button.
+	 * @param {HTMLElement} copyEmbedCode  - Embed code copy button.
 	 */
-	setupCopyButtonHandlers( copyPageLink, copyEmbedCode ) {
+	setupCopyButtonHandlers( copyPageLink, copyWpPageLink, copyEmbedCode ) {
 		const copyButtons = [
 			{ button: copyPageLink, inputSelector: '.page-link' },
+			{ button: copyWpPageLink, inputSelector: '.wp-page-link' },
 			{ button: copyEmbedCode, inputSelector: '.embed-code' },
 		];
 
@@ -468,6 +476,19 @@ class ShareManager {
 		const fullEmbed = timestamp ? `<iframe src="${ urls.embedUrl }?t=${ timestamp }"></iframe>` : urls.embedCode;
 		const encodedHref = encodeURI( fullPage );
 
+		const wpPageLinkInput = container.querySelector( '.wp-page-link' );
+
+		// WP page link: append timestamp query param before the hash anchor.
+		if ( wpPageLinkInput ) {
+			const wpPageBase = urls.pageLink || '';
+			const hashIndex = wpPageBase.indexOf( '#' );
+			const wpPagePath = hashIndex !== -1 ? wpPageBase.slice( 0, hashIndex ) : wpPageBase;
+			const wpPageHash = hashIndex !== -1 ? wpPageBase.slice( hashIndex ) : '';
+			wpPageLinkInput.value = timestamp
+				? `${ wpPagePath }?t=${ timestamp }${ wpPageHash }`
+				: wpPageBase;
+		}
+
 		pageLinkInput.value = fullPage;
 		embedInput.value = fullEmbed;
 
@@ -496,6 +517,13 @@ class ShareManager {
 
 		if ( ! checkbox || ! input || ! pageLinkInput || ! embedInput ) {
 			return;
+		}
+
+		const wpPageLinkInput = container.querySelector( '.wp-page-link' );
+
+		// Initialize wp-page-link input value via JS (DOMPurify may strip it from HTML attributes).
+		if ( wpPageLinkInput ) {
+			wpPageLinkInput.value = urls.pageLink || '';
 		}
 
 		input.readOnly = ! checkbox.checked;

--- a/assets/src/js/godam-player/managers/shareManager.js
+++ b/assets/src/js/godam-player/managers/shareManager.js
@@ -268,8 +268,10 @@ class ShareManager {
 		const message = encodeURIComponent( __( 'Check out this video!', 'godam' ) );
 
 		// Build page link: current WP page URL with an anchor pointing to this video block.
-		const pageBase = window.location.origin + window.location.pathname;
-		const pageLink = `${ pageBase }#godam-video-${ jobId }`;
+		// Use URL API to preserve any existing query params while replacing only the hash.
+		const pageUrl = new URL( window.location.href );
+		pageUrl.hash = `godam-video-${ jobId }`;
+		const pageLink = pageUrl.toString();
 
 		return { videoLink, embedUrl, embedCode, encodedLink, message, pageLink };
 	}
@@ -478,15 +480,21 @@ class ShareManager {
 
 		const wpPageLinkInput = container.querySelector( '.wp-page-link' );
 
-		// WP page link: append timestamp query param before the hash anchor.
+		// WP page link: update/append the timestamp query param while preserving
+		// any existing query params and the hash anchor.
 		if ( wpPageLinkInput ) {
 			const wpPageBase = urls.pageLink || '';
-			const hashIndex = wpPageBase.indexOf( '#' );
-			const wpPagePath = hashIndex !== -1 ? wpPageBase.slice( 0, hashIndex ) : wpPageBase;
-			const wpPageHash = hashIndex !== -1 ? wpPageBase.slice( hashIndex ) : '';
-			wpPageLinkInput.value = timestamp
-				? `${ wpPagePath }?t=${ timestamp }${ wpPageHash }`
-				: wpPageBase;
+			if ( timestamp && wpPageBase ) {
+				try {
+					const wpPageUrl = new URL( wpPageBase, window.location.origin );
+					wpPageUrl.searchParams.set( 't', timestamp );
+					wpPageLinkInput.value = wpPageUrl.toString();
+				} catch ( error ) {
+					wpPageLinkInput.value = wpPageBase;
+				}
+			} else {
+				wpPageLinkInput.value = wpPageBase;
+			}
 		}
 
 		pageLinkInput.value = fullPage;

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -131,7 +131,10 @@ if ( $godam_is_virtual ) {
 	}
 }
 
-$godam_video_preview = isset( $attributes['preview'] ) ? $attributes['preview'] : false;
+$godam_video_preview      = isset( $attributes['preview'] ) ? $attributes['preview'] : false;
+$godam_overlay_time_range = ! empty( $attributes['overlayTimeRange'] ) ? floatval( $attributes['overlayTimeRange'] ) : 0;
+$godam_show_overlay       = isset( $attributes['showOverlay'] ) ? $attributes['showOverlay'] : false;
+$godam_vertical_alignment = ! empty( $attributes['verticalAlignment'] ) ? esc_attr( $attributes['verticalAlignment'] ) : 'center';
 
 $godam_src                = ! empty( $attributes['src'] ) ? esc_url( $attributes['src'] ) : '';
 $godam_transcoded_url     = ! empty( $attributes['transcoded_url'] ) ? esc_url( $attributes['transcoded_url'] ) : '';
@@ -377,7 +380,7 @@ $godam_video_config = wp_json_encode(
 		'preview'          => $godam_video_preview,
 		'layers'           => $godam_frontend_layers, // contains list of layers (premium layers filtered when no API key).
 		'chapters'         => ! empty( $godam_meta_data['chapters'] ) ? $godam_meta_data['chapters'] : array(), // contains list of chapters.
-		'overlayTimeRange' => 0, // Add overlay time range to video config.
+		'overlayTimeRange' => $godam_overlay_time_range, // Add overlay time range to video config.
 		'playerSkin'       => $godam_player_skin, // Add player skin to video config. Add brand image to video config.
 		'aspectRatio'      => $godam_aspect_ratio,
 		'showShareBtn'     => true === $godam_global_video_share ? $godam_show_share_btn : false,
@@ -512,6 +515,19 @@ if ( $godam_should_preload_poster ) {
 	<div <?php echo wp_kses_data( $godam_figure_attributes ); ?>>
 		<figure id="godam-player-container-<?php echo esc_attr( $godam_instance_id ); ?>">
 			<div class="godam-video-wrapper">
+				<?php if ( $godam_show_overlay && ! empty( $godam_inner_blocks_content ) ) : ?>
+					<div
+						class="godam-video-overlay-container godam-overlay-alignment-<?php echo esc_attr( $godam_vertical_alignment ); ?>"
+						data-overlay-content
+						data-overlay-time-range="<?php echo esc_attr( $godam_overlay_time_range ); ?>"
+					>
+						<?php
+						// Safely output the inner blocks content.
+						echo wp_kses_post( $godam_inner_blocks_content );
+						?>
+					</div>
+				<?php endif; ?>
+
 				<div class="godam-video-placeholder godam-animate-video-loading">
 					<div class="animate-play-btn">
 						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
@@ -530,6 +546,10 @@ if ( $godam_should_preload_poster ) {
 				</div>
 
 				<div class="easydam-video-container loading godam-<?php echo esc_attr( strtolower( $godam_player_skin ) ); ?>-skin" >
+					<?php if ( isset( $godam_hover_select ) && 'shadow-overlay' === $godam_hover_select ) : ?>
+						<div class="godam-player-overlay"></div>
+					<?php endif; ?>
+
 					<?php if ( $godam_should_preload_poster ) : ?>
 						<img
 							class="godam-poster-image"

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -430,6 +430,28 @@ if ( ! empty( $godam_ad_tag_url ) ) {
 
 $godam_instance_id = 'video_' . bin2hex( random_bytes( 8 ) );
 
+// When a player height is set, derive max-width = height × (arW / arH), mirroring
+// the video-editor approach. This lets Video.js (fluid:true) fill the width and
+// naturally reach the desired height via the aspect-ratio padding trick.
+$godam_player_height      = ! empty( $attributes['playerHeight'] ) ? $attributes['playerHeight'] : '';
+$godam_computed_max_width = '';
+if ( ! empty( $godam_player_height ) && preg_match( '/^\d+:\d+$/', $godam_aspect_ratio ) ) {
+	preg_match( '/^([\d.]+)([a-z%]*)$/', $godam_player_height, $godam_height_match );
+	if ( ! empty( $godam_height_match[1] ) ) {
+		$godam_height_value  = (float) $godam_height_match[1];
+		$godam_allowed_units = array( 'px', 'em', 'rem', 'vh', 'vw', '%' );
+		$godam_height_unit   = ( isset( $godam_height_match[2] ) && in_array( $godam_height_match[2], $godam_allowed_units, true ) )
+			? $godam_height_match[2]
+			: 'px';
+		$godam_ar_parts      = explode( ':', $godam_aspect_ratio );
+		$godam_ar_w          = (float) $godam_ar_parts[0];
+		$godam_ar_h          = (float) $godam_ar_parts[1];
+		if ( $godam_ar_h > 0 && $godam_ar_w > 0 ) {
+			$godam_computed_max_width = round( $godam_height_value * ( $godam_ar_w / $godam_ar_h ) ) . $godam_height_unit;
+		}
+	}
+}
+
 // Create custom inline styles in a more maintainable way.
 $godam_custom_css_properties = array(
 	'--rtgodam-control-bar-color'      => $godam_easydam_control_bar_color,
@@ -440,6 +462,10 @@ $godam_custom_css_properties = array(
 
 if ( ! empty( $godam_aspect_ratio ) ) {
 	$godam_custom_css_properties['--rtgodam-video-aspect-ratio'] = str_replace( ':', '/', $godam_aspect_ratio );
+}
+
+if ( ! empty( $godam_computed_max_width ) ) {
+	$godam_custom_css_properties['max-width'] = $godam_computed_max_width;
 }
 
 // Build the inline style string, escaping each value.

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -131,10 +131,7 @@ if ( $godam_is_virtual ) {
 	}
 }
 
-$godam_video_preview      = isset( $attributes['preview'] ) ? $attributes['preview'] : false;
-$godam_overlay_time_range = ! empty( $attributes['overlayTimeRange'] ) ? floatval( $attributes['overlayTimeRange'] ) : 0;
-$godam_show_overlay       = isset( $attributes['showOverlay'] ) ? $attributes['showOverlay'] : false;
-$godam_vertical_alignment = ! empty( $attributes['verticalAlignment'] ) ? esc_attr( $attributes['verticalAlignment'] ) : 'center';
+$godam_video_preview = isset( $attributes['preview'] ) ? $attributes['preview'] : false;
 
 $godam_src                = ! empty( $attributes['src'] ) ? esc_url( $attributes['src'] ) : '';
 $godam_transcoded_url     = ! empty( $attributes['transcoded_url'] ) ? esc_url( $attributes['transcoded_url'] ) : '';
@@ -380,7 +377,7 @@ $godam_video_config = wp_json_encode(
 		'preview'          => $godam_video_preview,
 		'layers'           => $godam_frontend_layers, // contains list of layers (premium layers filtered when no API key).
 		'chapters'         => ! empty( $godam_meta_data['chapters'] ) ? $godam_meta_data['chapters'] : array(), // contains list of chapters.
-		'overlayTimeRange' => $godam_overlay_time_range, // Add overlay time range to video config.
+		'overlayTimeRange' => 0, // Add overlay time range to video config.
 		'playerSkin'       => $godam_player_skin, // Add player skin to video config. Add brand image to video config.
 		'aspectRatio'      => $godam_aspect_ratio,
 		'showShareBtn'     => true === $godam_global_video_share ? $godam_show_share_btn : false,
@@ -515,19 +512,6 @@ if ( $godam_should_preload_poster ) {
 	<div <?php echo wp_kses_data( $godam_figure_attributes ); ?>>
 		<figure id="godam-player-container-<?php echo esc_attr( $godam_instance_id ); ?>">
 			<div class="godam-video-wrapper">
-				<?php if ( $godam_show_overlay && ! empty( $godam_inner_blocks_content ) ) : ?>
-					<div
-						class="godam-video-overlay-container godam-overlay-alignment-<?php echo esc_attr( $godam_vertical_alignment ); ?>"
-						data-overlay-content
-						data-overlay-time-range="<?php echo esc_attr( $godam_overlay_time_range ); ?>"
-					>
-						<?php
-						// Safely output the inner blocks content.
-						echo wp_kses_post( $godam_inner_blocks_content );
-						?>
-					</div>
-				<?php endif; ?>
-
 				<div class="godam-video-placeholder godam-animate-video-loading">
 					<div class="animate-play-btn">
 						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
@@ -546,10 +530,6 @@ if ( $godam_should_preload_poster ) {
 				</div>
 
 				<div class="easydam-video-container loading godam-<?php echo esc_attr( strtolower( $godam_player_skin ) ); ?>-skin" >
-					<?php if ( isset( $godam_hover_select ) && 'shadow-overlay' === $godam_hover_select ) : ?>
-						<div class="godam-player-overlay"></div>
-					<?php endif; ?>
-
 					<?php if ( $godam_should_preload_poster ) : ?>
 						<img
 							class="godam-poster-image"


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/957

This pull request introduces a significant redesign of the video thumbnail (poster) selection and preload experience for the Godam video player block. The update replaces the previous single-upload button and toggle with a modern, scrollable thumbnail panel in the block inspector, enabling users to choose from auto-generated, custom, or uploaded thumbnails. It also streamlines the preload settings, adding an explicit "Preload Only Video Thumbnail" option for improved performance and clarity. Several legacy options and code paths are removed for a cleaner UI.

The most important changes are:

**Video Thumbnail (Poster) Selection Overhaul**
* Adds a new `ThumbnailPanel` React component that displays all available thumbnails (auto-generated, custom, and uploaded) in a scrollable grid, with a dedicated upload button and clear selection/highlight UI. This replaces the previous single upload button and toggle. (`assets/src/blocks/godam-player/components/ThumbnailPanel.js`, `assets/src/blocks/godam-player/edit.js`, `assets/src/blocks/godam-player/editor.scss`) [[1]](diffhunk://#diff-8ef389641b0e223fd7a8a6153e70bf26c93a292604bb3a587651b14142921ab7R1-R222) [[2]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66R47-L55) [[3]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L766-R768) [[4]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdR77-R255)
* Updates the block inspector UI to use the new panel for poster selection, removing the old `MediaUpload` and toggle controls for poster/preload. (`assets/src/blocks/godam-player/edit.js`)

**Preload Settings Improvements**
* Adds a new "Preload Only Video Thumbnail" option to the preload dropdown, allowing users to load just the poster image for better performance, especially on above-the-fold videos. (`assets/src/blocks/godam-player/edit-common-settings.js`) [[1]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cR11) [[2]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL62-R82) [[3]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL123-L139)
* Changes the default `preload` value from `"metadata"` to `"auto"` in the block's schema, aligning with modern browser recommendations. (`assets/src/blocks/godam-player/block.json`)

**Schema and Attribute Cleanup**
* Removes the deprecated `engagements` attribute and related UI, simplifying the block's attributes and settings. (`assets/src/blocks/godam-player/block.json`, `assets/src/blocks/godam-player/edit-common-settings.js`) [[1]](diffhunk://#diff-0452960eaa8ba8724cc49af281678ab3c7d21abd9ed841f2362d9aa0e7b14d3dL111-L114) [[2]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL27-L29) [[3]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL123-L139)

**Styling Enhancements**
* Adds comprehensive styles for the new thumbnail panel, including grid layout, focus/selection states, upload tile, and accessibility improvements. (`assets/src/blocks/godam-player/editor.scss`)

**Code Cleanup**
* Removes unused imports, refs, and legacy code related to the old thumbnail and engagement settings. (`assets/src/blocks/godam-player/edit.js`, `assets/src/blocks/godam-player/editor.scss`) [[1]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L27) [[2]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L110) [[3]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L659-L665) [[4]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdL21-R22) [[5]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdL35-L36) [[6]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdR65)

These changes modernize the video block's thumbnail and preload experience, making it more intuitive and performant for users.

## Recordings
### Page Link with video reference in Share Modal

https://github.com/user-attachments/assets/d20b2121-ceaf-4df2-82ef-2508d90aa9b4

### Overlay blocks present, Preload thumbnail in preload options
https://github.com/user-attachments/assets/c86156a0-1d44-4df5-907a-5ff4d4cb5d03

### Thumbnail Override, Height setting

https://github.com/user-attachments/assets/98b3fa5a-e9fd-4cca-b3bb-66ae6ffa285f

