### PR TITLE
Revamp/video product gallery autoplay

### DIFF
--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/block.json
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/block.json
@@ -46,7 +46,8 @@
     "godam/videoProductGallery/layout",
     "godam/videoProductGallery/viewRatio",
     "godam/videoProductGallery/itemWidth",
-    "godam/videoProductGallery/showAddToCart"
+    "godam/videoProductGallery/showAddToCart",
+    "godam/videoProductGallery/showPlayButton"
   ],
   "supports": {
     "reusable": false,

--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
@@ -58,6 +58,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	const layout = context[ 'godam/videoProductGallery/layout' ] || 'carousel';
 	const viewRatio = context[ 'godam/videoProductGallery/viewRatio' ] || '9:16';
 	const showAddToCart = context[ 'godam/videoProductGallery/showAddToCart' ] !== false;
+	const showPlayButton = context[ 'godam/videoProductGallery/showPlayButton' ] !== false;
 
 	// Convert ratio to CSS-friendly format
 	const ratioClass = viewRatio.replace( ':', '-' );
@@ -229,9 +230,11 @@ export default function Edit( { attributes, setAttributes, context } ) {
 												alt={ videoTitle || __( 'Video thumbnail', 'godam' ) }
 												className="godam-gallery-item__thumbnail"
 											/>
-											<div className="godam-gallery-item__play-icon">
-												<PlayIcon />
-											</div>
+											{ showPlayButton && (
+												<div className="godam-gallery-item__play-icon">
+													<PlayIcon />
+												</div>
+											) }
 										</>
 									);
 								}

--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
@@ -220,23 +220,36 @@ export default function Edit( { attributes, setAttributes, context } ) {
 							role="button"
 							tabIndex={ 0 }
 						>
-							{ videoId && videoThumbnail ? (
-								<>
-									<img
-										src={ videoThumbnail }
-										alt={ videoTitle || __( 'Video thumbnail', 'godam' ) }
-										className="godam-gallery-item__thumbnail"
-									/>
-									<div className="godam-gallery-item__play-icon">
-										<PlayIcon />
+							{ ( () => {
+								if ( videoId && videoThumbnail ) {
+									return (
+										<>
+											<img
+												src={ videoThumbnail }
+												alt={ videoTitle || __( 'Video thumbnail', 'godam' ) }
+												className="godam-gallery-item__thumbnail"
+											/>
+											<div className="godam-gallery-item__play-icon">
+												<PlayIcon />
+											</div>
+										</>
+									);
+								}
+								if ( videoId ) {
+									return (
+										<div className="godam-gallery-item__placeholder">
+											<span style={ { width: 48, height: 48 } }>{ videoIcon }</span>
+											{ videoTitle && <span>{ videoTitle }</span> }
+										</div>
+									);
+								}
+								return (
+									<div className="godam-gallery-item__placeholder">
+										{ videoIcon }
+										<span>{ __( 'Select Video', 'godam' ) }</span>
 									</div>
-								</>
-							) : (
-								<div className="godam-gallery-item__placeholder">
-									{ videoIcon }
-									<span>{ __( 'Select Video', 'godam' ) }</span>
-								</div>
-							) }
+								);
+							} )() }
 						</div>
 					) }
 				/>

--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/editor.scss
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/editor.scss
@@ -66,11 +66,6 @@
 			margin-left: 2px;
 		}
 	}
-
-	&:hover .godam-gallery-item__play-icon {
-		opacity: 1;
-		transform: scale(1.1);
-	}
 }
 
 .godam-video-product-gallery-item {

--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/editor.scss
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/editor.scss
@@ -47,10 +47,23 @@
 		object-fit: cover;
 	}
 
+	.godam-gallery-item__placeholder-title {
+		font-size: 11px;
+		color: #555;
+		text-align: center;
+		padding: 0 8px;
+		max-width: 100%;
+		overflow: hidden;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+	}
+
 	.godam-gallery-item__play-icon {
 		position: absolute;
-		width: 28px;
-		height: 28px;
+		width: 48px;
+		height: 48px;
 		background: rgba(0, 0, 0, 0.6);
 		border-radius: 50%;
 		display: flex;
@@ -61,8 +74,8 @@
 		transition: opacity 0.2s ease, transform 0.2s ease;
 
 		svg {
-			width: 18px;
-			height: 18px;
+			width: 22px;
+			height: 22px;
 			margin-left: 2px;
 		}
 	}

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/block.json
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/block.json
@@ -31,13 +31,13 @@
       "type": "number",
       "default": 12
     },
-    "count": {
-      "type": "number",
-      "default": 12
-    },
     "autoplay": {
       "type": "boolean",
       "default": false
+    },
+    "showPlayButton": {
+      "type": "boolean",
+      "default": true
     },
     "categories": {
       "type": "array",

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/block.json
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/block.json
@@ -56,7 +56,8 @@
     "godam/videoProductGallery/layout": "layout",
     "godam/videoProductGallery/viewRatio": "viewRatio",
     "godam/videoProductGallery/itemWidth": "itemWidth",
-    "godam/videoProductGallery/showAddToCart": "showAddToCart"
+    "godam/videoProductGallery/showAddToCart": "showAddToCart",
+    "godam/videoProductGallery/showPlayButton": "showPlayButton"
   },
   "supports": {
     "anchor": true,

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/edit.js
@@ -499,7 +499,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Show Play Button', 'godam' ) }
-						help={ __( 'Shows an overlay play button whenever a video is not playing. On mobile, this still appears when autoplay is off.', 'godam' ) }
+						help={ __( 'Shows an overlay play button whenever a video is not playing.', 'godam' ) }
 						checked={ !! showPlayButton }
 						onChange={ ( value ) => setAttributes( { showPlayButton: value } ) }
 					/>

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/edit.js
@@ -49,6 +49,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		itemWidth,
 		count = 12,
 		autoplay,
+		showPlayButton,
 		categories = [],
 		products = [],
 		showAddToCart,
@@ -489,11 +490,18 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						label={ __( 'Autoplay', 'godam' ) }
 						help={
 							autoplay
-								? __( 'Videos will autoplay when visible.', 'godam' )
-								: __( 'Videos will not autoplay.', 'godam' )
+								? __( 'Visible videos autoplay one at a time and continue through the full video.', 'godam' )
+								: __( 'Videos only play when hovered.', 'godam' )
 						}
 						checked={ !! autoplay }
 						onChange={ ( value ) => setAttributes( { autoplay: value } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show Play Button', 'godam' ) }
+						help={ __( 'Shows an overlay play button whenever a video is not playing. On mobile, this still appears when autoplay is off.', 'godam' ) }
+						checked={ !! showPlayButton }
+						onChange={ ( value ) => setAttributes( { showPlayButton: value } ) }
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/edit.js
@@ -305,11 +305,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 										<span>{ __( 'Product Video', 'godam' ) }</span>
 									</div>
 								) }
-								<div className="godam-gallery-item__play-icon">
-									<svg viewBox="0 0 24 24" fill="currentColor">
-										<path d="M8 5v14l11-7z" />
-									</svg>
-								</div>
+								{ showPlayButton && (
+									<div className="godam-gallery-item__play-icon">
+										<svg viewBox="0 0 24 24" fill="currentColor">
+											<path d="M8 5v14l11-7z" />
+										</svg>
+									</div>
+								) }
 							</div>
 							<div className="godam-gallery-item__product">
 								<a href="#" className="godam-gallery-item__product-link" onClick={ ( event ) => event.preventDefault() }>

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
@@ -282,6 +282,7 @@ if ( is_string( $block_gap_raw ) && str_starts_with( $block_gap_raw, 'var:preset
 	$block_gap = $block_gap_raw;
 }
 $show_add_to_cart = isset( $attributes['showAddToCart'] ) ? (bool) $attributes['showAddToCart'] : true;
+$show_play_button = isset( $attributes['showPlayButton'] ) ? (bool) $attributes['showPlayButton'] : false;
 $wc_ajax_url      = class_exists( 'WC_AJAX' ) ? WC_AJAX::get_endpoint( '%%endpoint%%' ) : '';
 
 // Convert ratio to CSS class format.
@@ -327,6 +328,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-layout'           => $layout,
 		'data-ratio'            => $view_ratio,
 		'data-autoplay'         => $autoplay ? 'true' : 'false',
+		'data-show-play-button' => $show_play_button ? 'true' : 'false',
 		'data-show-add-to-cart' => $show_add_to_cart ? 'true' : 'false',
 		'data-ajax-url'         => admin_url( 'admin-ajax.php' ),
 		'data-wc-ajax-url'      => $wc_ajax_url,
@@ -347,20 +349,18 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<!-- Video Section + Dropdown section(if available) -->
 				<div class="godam-gallery-item__video-and-dropdown">
 					<div class="godam-gallery-item__video-wrapper">
-						<?php if ( ! $autoplay ) : ?>
-							<div class="godam-gallery-item__play-icon" aria-hidden="true">
-								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="28" height="28">
-									<path d="M8 5v14l11-7z"/>
-								</svg>
-							</div>
-						<?php endif; ?>
+						<div class="godam-gallery-item__play-icon" aria-hidden="true">
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="28" height="28">
+								<path d="M8 5v14l11-7z"/>
+							</svg>
+						</div>
 						<?php
 						// Render the video using the godam_video shortcode.
 						echo do_shortcode(
 							sprintf(
-								'[godam_video id="%d" muted="true" loop="true" autoplay="%s" controls="true" aspect_ratio="%s" godam_context="godam-video-product-gallery" showShareButton="1"]',
+								'[godam_video id="%d" muted="true" loop="false" autoplay="%s" controls="true" aspect_ratio="%s" godam_context="godam-video-product-gallery" showShareButton="1"]',
 								$item['videoId'],
-								$autoplay ? 'true' : 'false',
+								'false',
 								esc_attr( $view_ratio )
 							)
 						);

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
@@ -349,11 +349,13 @@ $wrapper_attributes = get_block_wrapper_attributes(
 				<!-- Video Section + Dropdown section(if available) -->
 				<div class="godam-gallery-item__video-and-dropdown">
 					<div class="godam-gallery-item__video-wrapper">
-						<div class="godam-gallery-item__play-icon" aria-hidden="true">
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="28" height="28">
-								<path d="M8 5v14l11-7z"/>
-							</svg>
-						</div>
+					<?php if ( $show_play_button ) : ?>
+					<div class="godam-gallery-item__play-icon" aria-hidden="true">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="28" height="28">
+							<path d="M8 5v14l11-7z"/>
+						</svg>
+					</div>
+					<?php endif; ?>
 						<?php
 						// Render the video using the godam_video shortcode.
 						echo do_shortcode(

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
@@ -282,7 +282,7 @@ if ( is_string( $block_gap_raw ) && str_starts_with( $block_gap_raw, 'var:preset
 	$block_gap = $block_gap_raw;
 }
 $show_add_to_cart = isset( $attributes['showAddToCart'] ) ? (bool) $attributes['showAddToCart'] : true;
-$show_play_button = isset( $attributes['showPlayButton'] ) ? (bool) $attributes['showPlayButton'] : false;
+$show_play_button = isset( $attributes['showPlayButton'] ) ? (bool) $attributes['showPlayButton'] : true;
 $wc_ajax_url      = class_exists( 'WC_AJAX' ) ? WC_AJAX::get_endpoint( '%%endpoint%%' ) : '';
 
 // Convert ratio to CSS class format.

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/style.scss
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/style.scss
@@ -76,32 +76,39 @@
 	}
 }
 
-// Play icon overlay — shown when autoplay is off, hidden on hover.
+// Play icon overlay — visible only when runtime marks the item as idle.
 .godam-gallery-item__play-icon {
 	position: absolute;
-	top: 8px;
-	left: 8px;
+	top: 50%;
+	left: 50%;
 	z-index: 2;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 28px;
-	height: 28px;
+	width: 48px;
+	height: 48px;
 	border-radius: 50%;
 	background: rgba(0, 0, 0, 0.5);
+	backdrop-filter: blur(4px);
 	color: #fff;
 	pointer-events: none;
+	opacity: 0;
+	transform: translate(-50%, -50%);
 	transition: opacity 0.2s ease;
 
 	svg {
-		width: 14px;
-		height: 14px;
+		width: 22px;
+		height: 22px;
 	}
 }
 
-// Hide play icon when the gallery item is hovered.
-.godam-video-product-gallery-item:hover .godam-gallery-item__play-icon {
-	opacity: 0;
+.godam-video-product-gallery-item--show-play-button .godam-gallery-item__play-icon {
+	opacity: 1;
+}
+
+// Hide play icon on the actively autoplaying item.
+.godam-video-product-gallery-item--autoplaying .godam-gallery-item__play-icon {
+	opacity: 0 !important;
 }
 
 // Gallery Item.
@@ -507,6 +514,16 @@
 				aspect-ratio: unset !important;
 			}
 		}
+
+		.godam-gallery-item__play-icon {
+			opacity: 0 !important;
+			display: none !important;
+		}
+
+		.vjs-play-control {
+			display: none !important;
+			opacity: 0 !important;
+		}
 	}
 }
 
@@ -523,7 +540,7 @@
 	max-height: 90dvh !important;
 	flex-shrink: 0;
 	border-radius: var(--godam-vpg-modal-radius) !important;
-	overflow: hidden auto !important;
+	overflow: hidden !important;
 
 	@media screen and (max-width: 600px) {
 		max-height: 100dvh !important;
@@ -1146,7 +1163,9 @@ body.admin-bar {
 		}
 
 		@keyframes bounce {
+
 			0%, 100% { transform: translateX(-50%) translateY(0); }
+
 			50% { transform: translateX(-50%) translateY(6px); }
 		}
 

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
@@ -451,6 +451,7 @@ import { dispatch } from '@wordpress/data';
 			}
 
 			this.stopInactiveAutoplayItems( item );
+			item.classList.add( 'godam-video-product-gallery-item--autoplaying' );
 			this.syncPreviewVideo( item, true, { restart: true, muted: true } );
 			this.updateVideoPreloadStrategy();
 		}
@@ -480,6 +481,7 @@ import { dispatch } from '@wordpress/data';
 				return;
 			}
 
+			item.classList.remove( 'godam-video-product-gallery-item--autoplaying' );
 			this.syncPreviewVideo( item, false, { reset: true, muted: true } );
 			this.updateVideoPreloadStrategy();
 		}

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
@@ -29,6 +29,7 @@ import { dispatch } from '@wordpress/data';
 
 	const galleryInstances = new Set();
 	let isGlobalClickBound = false;
+	let isGlobalResizeBound = false;
 
 	/**
 	 * Route document-level keyboard navigation to the currently active modal.
@@ -208,6 +209,15 @@ import { dispatch } from '@wordpress/data';
 				} );
 				isGlobalClickBound = true;
 			}
+
+			if ( ! isGlobalResizeBound ) {
+				window.addEventListener( 'resize', () => {
+					galleryInstances.forEach( ( instance ) => {
+						instance.handleGalleryResize();
+					} );
+				} );
+				isGlobalResizeBound = true;
+			}
 		}
 
 		init() {
@@ -224,7 +234,6 @@ import { dispatch } from '@wordpress/data';
 			this.initAddToCart();
 			this.initModal();
 			this.initMobileSwipe();
-			window.addEventListener( 'resize', this.handleGalleryResize );
 
 			this.handleDropdownScrollState();
 			this.initDropdownToggle();
@@ -381,8 +390,7 @@ import { dispatch } from '@wordpress/data';
 			return !! (
 				video &&
 				! video.paused &&
-				! video.ended &&
-				video.currentTime > 0
+				! video.ended
 			);
 		}
 
@@ -572,6 +580,8 @@ import { dispatch } from '@wordpress/data';
 
 		/**
 		 * Move autoplay to the next visible gallery item in DOM order.
+		 *
+		 * @param {Element|null} currentItem The current autoplay item.
 		 */
 		advanceAutoplaySequence( currentItem = this.autoplayActiveItem ) {
 			if ( ! this.autoplay || this.modalOpen ) {
@@ -590,6 +600,7 @@ import { dispatch } from '@wordpress/data';
 
 		/**
 		 * Reconcile autoplay state with the latest viewport visibility.
+		 * @param preferredItem
 		 */
 		syncAutoplaySequence( preferredItem = null ) {
 			if ( ! this.autoplay ) {

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
@@ -17,8 +17,8 @@ import { dispatch } from '@wordpress/data';
 
 	// Shared product HTML cache across all gallery instances on the page.
 	const productHtmlCache = new Map();
-	const PREVIEW_DURATION = 5;
 	const AUTOPLAY_VISIBILITY_THRESHOLD = 0.5;
+	const HOVER_INTENT_DELAY_MS = 200;
 	const MOBILE_BREAKPOINT = 600;
 	const SWIPE_THRESHOLD = 50; // Minimum vertical drag (px) to commit a swipe navigation.
 	const WHEEL_THRESHOLD = 80; // Accumulated deltaY (px) required to trigger a wheel navigation.
@@ -158,6 +158,7 @@ import { dispatch } from '@wordpress/data';
 			this.element = element;
 			this.layout = element.dataset.layout || 'carousel';
 			this.autoplay = element.dataset.autoplay === 'true';
+			this.showPlayButton = element.dataset.showPlayButton === 'true';
 			this.container = element.querySelector( '.godam-video-product-gallery__container' );
 			this.items = Array.from( element.querySelectorAll( '.godam-video-product-gallery-item' ) );
 			this.prevBtn = element.querySelector( '.godam-video-product-gallery__nav--prev' );
@@ -183,6 +184,17 @@ import { dispatch } from '@wordpress/data';
 			this._wheelResetTimer = null;
 			this._slideNavigating = false; // Shared lock — only one slide animation at a time.
 
+			// Autoplay sequencing state.
+			this.autoplayActiveItem = null;
+			this.hoverActiveItem = null;
+			this.hoverIntentTimers = new Map();
+
+			this.handleGalleryResize = () => {
+				this.updateNavVisibility();
+				this.updateAllPlayButtonStates();
+				this.updateVideoPreloadStrategy();
+			};
+
 			this.createModalElements();
 			this.init();
 
@@ -203,113 +215,506 @@ import { dispatch } from '@wordpress/data';
 				this.initCarousel();
 			}
 
+			this.initHoverPlay();
+
 			if ( this.autoplay ) {
 				this.initAutoplay();
-			} else {
-				this.initHoverPlay();
 			}
 
 			this.initAddToCart();
 			this.initModal();
 			this.initMobileSwipe();
+			window.addEventListener( 'resize', this.handleGalleryResize );
 
 			this.handleDropdownScrollState();
 			this.initDropdownToggle();
+			this.updateAllPlayButtonStates();
+			this.updateVideoPreloadStrategy();
 		}
 
 		/**
-		 * Use IntersectionObserver to autoplay the first 5 seconds of each video
-		 * in a loop when ≥50% visible, and pause when they scroll out of view.
+		 * Track which items are autoplay-eligible based on viewport visibility.
 		 */
 		initAutoplay() {
 			this.autoplayObserver = new IntersectionObserver(
 				( entries ) => {
 					entries.forEach( ( entry ) => {
 						entry.target.dataset.isInViewport = entry.isIntersecting ? 'true' : 'false';
-						this.syncPreviewVideo( entry.target, entry.isIntersecting );
 					} );
+
+					this.syncAutoplaySequence();
 				},
 				{ threshold: AUTOPLAY_VISIBILITY_THRESHOLD },
 			);
 
 			this.items.forEach( ( item ) => {
-				const video = item.querySelector( 'video' );
-				if ( video ) {
-					// Store the time-update handler so we can remove/re-attach it.
-					video._godamTimeUpdate = () => {
-						if ( video.currentTime >= PREVIEW_DURATION ) {
-							video.currentTime = 0;
-						}
-					};
-					video.addEventListener( 'timeupdate', video._godamTimeUpdate );
-				}
 				item.dataset.isInViewport = 'false';
 				this.autoplayObserver.observe( item );
 			} );
 		}
 
 		/**
-		 * Play the first 5 seconds of each video in a loop on hover.
-		 * Used when autoplay is disabled — videos stay paused until the user hovers.
+		 * Attach hover interactions and playback state tracking for each item.
 		 */
 		initHoverPlay() {
 			this.items.forEach( ( item ) => {
 				const video = item.querySelector( 'video' );
 				if ( video ) {
-					// Loop video back to start after PREVIEW_DURATION seconds.
-					video._godamTimeUpdate = () => {
-						if ( video.currentTime >= PREVIEW_DURATION ) {
-							video.currentTime = 0;
-						}
-					};
-					video.addEventListener( 'timeupdate', video._godamTimeUpdate );
+					this.initItemVideoState( item, video );
 				}
 
-				// Play on hover.
 				item.addEventListener( 'mouseenter', () => {
-					this.syncPreviewVideo( item, true );
+					this.scheduleItemHoverStart( item );
 				} );
 
-				// Stop on hover out.
 				item.addEventListener( 'mouseleave', () => {
-					this.syncPreviewVideo( item, false );
+					this.handleItemHoverEnd( item );
 				} );
 			} );
 		}
 
 		/**
-		 * Start or stop preview playback for a gallery item.
+		 * Track playback state for an item so UI and autoplay stay in sync.
+		 *
+		 * @param {Element}          item  The gallery item.
+		 * @param {HTMLVideoElement} video The gallery video element.
+		 */
+		initItemVideoState( item, video ) {
+			if ( ! item || ! video || video._godamGalleryStateBound ) {
+				return;
+			}
+
+			video._godamGalleryStateBound = true;
+
+			[ 'play', 'pause', 'waiting', 'loadedmetadata' ].forEach( ( eventName ) => {
+				video.addEventListener( eventName, () => {
+					this.refreshPlayButtonState( item );
+					this.updateVideoPreloadStrategy();
+				} );
+			} );
+
+			// When Video.js finishes loading sources (e.g. HLS/DASH via MSE),
+			// retry autoplay if it was attempted before the player was ready.
+			video.addEventListener( 'loadeddata', () => {
+				if (
+					this.autoplay &&
+					! this.modalOpen &&
+					item === this.autoplayActiveItem &&
+					item.dataset.isInViewport === 'true' &&
+					! this.isVideoPlaying( video )
+				) {
+					video.play().catch( () => {} );
+				}
+			}, { once: true } );
+
+			video.addEventListener( 'ended', () => {
+				this.refreshPlayButtonState( item );
+
+				if (
+					this.autoplay &&
+					! this.modalOpen &&
+					item === this.autoplayActiveItem
+				) {
+					this.advanceAutoplaySequence( item );
+					return;
+				}
+
+				this.updateVideoPreloadStrategy();
+			} );
+		}
+
+		/**
+		 * Get the primary video element for a gallery item.
+		 *
+		 * @param {Element} item The gallery item.
+		 * @return {HTMLVideoElement|null} The video element, if found.
+		 */
+		getItemVideo( item ) {
+			return item?.querySelector( 'video' ) || null;
+		}
+
+		/**
+		 * Start or stop playback for a gallery item.
 		 *
 		 * @param {Element} item       The gallery item.
-		 * @param {boolean} shouldPlay Whether preview playback should run.
+		 * @param {boolean} shouldPlay Whether playback should run.
+		 * @param {Object}  options    Playback options.
 		 */
-		syncPreviewVideo( item, shouldPlay ) {
+		syncPreviewVideo( item, shouldPlay, options = {} ) {
 			const video = item?.querySelector( 'video' );
 			if ( ! video ) {
 				return;
 			}
 
 			if ( shouldPlay ) {
-				video.currentTime = 0;
+				if ( options.restart ) {
+					video.currentTime = 0;
+				}
+
+				if ( Object.prototype.hasOwnProperty.call( options, 'muted' ) ) {
+					video.muted = !! options.muted;
+				}
+
 				video.play().catch( () => {} );
 				return;
 			}
 
 			video.pause();
-			video.currentTime = 0;
+			if ( options.reset !== false ) {
+				video.currentTime = 0;
+			}
+
+			if ( Object.prototype.hasOwnProperty.call( options, 'muted' ) ) {
+				video.muted = !! options.muted;
+			}
+
+			this.refreshPlayButtonState( item );
 		}
 
 		/**
-		 * Sync preview playback for every gallery item using the latest observer state.
+		 * Returns true when the provided video is actively playing.
+		 *
+		 * @param {HTMLVideoElement|null} video The gallery video element.
+		 * @return {boolean} Whether the video is currently playing.
 		 */
-		syncVisiblePreviewVideos() {
+		isVideoPlaying( video ) {
+			return !! (
+				video &&
+				! video.paused &&
+				! video.ended &&
+				video.currentTime > 0
+			);
+		}
+
+		/**
+		 * Schedule hover playback after a short intent delay.
+		 *
+		 * @param {Element} item The hovered gallery item.
+		 */
+		scheduleItemHoverStart( item ) {
+			if (
+				! item ||
+				this.modalOpen ||
+				item.classList.contains( 'godam-video-product-gallery-item--modal' )
+			) {
+				return;
+			}
+
+			this.clearItemHoverTimer( item );
+
+			const timerId = setTimeout( () => {
+				this.hoverIntentTimers.delete( item );
+				this.handleItemHoverStart( item );
+			}, HOVER_INTENT_DELAY_MS );
+
+			this.hoverIntentTimers.set( item, timerId );
+		}
+
+		/**
+		 * Cancel a pending hover intent timer.
+		 *
+		 * @param {Element} item The gallery item.
+		 */
+		clearItemHoverTimer( item ) {
+			if ( ! this.hoverIntentTimers.has( item ) ) {
+				return;
+			}
+
+			clearTimeout( this.hoverIntentTimers.get( item ) );
+			this.hoverIntentTimers.delete( item );
+		}
+
+		/**
+		 * Handle hover playback start for a gallery item.
+		 *
+		 * @param {Element} item The hovered gallery item.
+		 */
+		handleItemHoverStart( item ) {
+			if (
+				! item ||
+				this.modalOpen ||
+				item.classList.contains( 'godam-video-product-gallery-item--modal' )
+			) {
+				return;
+			}
+
+			this.hoverActiveItem = item;
+
+			if ( this.autoplay ) {
+				if ( this.autoplayActiveItem === item ) {
+					this.updateVideoPreloadStrategy();
+					return;
+				}
+
+				this.playAutoplayItem( item, { restart: true } );
+				return;
+			}
+
+			this.stopInactiveAutoplayItems( item );
+			this.syncPreviewVideo( item, true, { restart: true, muted: true } );
+			this.updateVideoPreloadStrategy();
+		}
+
+		/**
+		 * Handle hover playback end for a gallery item.
+		 *
+		 * @param {Element} item The gallery item losing hover.
+		 */
+		handleItemHoverEnd( item ) {
+			this.clearItemHoverTimer( item );
+
+			if (
+				! item ||
+				this.modalOpen ||
+				item.classList.contains( 'godam-video-product-gallery-item--modal' )
+			) {
+				return;
+			}
+
+			if ( this.hoverActiveItem === item ) {
+				this.hoverActiveItem = null;
+			}
+
+			if ( this.autoplay ) {
+				this.updateVideoPreloadStrategy();
+				return;
+			}
+
+			this.syncPreviewVideo( item, false, { reset: true, muted: true } );
+			this.updateVideoPreloadStrategy();
+		}
+
+		/**
+		 * Return gallery items currently eligible for autoplay in DOM order.
+		 *
+		 * @return {Element[]} Visible gallery items.
+		 */
+		getVisibleAutoplayItems() {
+			return this.items.filter(
+				( item ) => item.dataset.isInViewport === 'true',
+			);
+		}
+
+		/**
+		 * Pause and reset all autoplay candidates except the active one.
+		 *
+		 * @param {Element|null} activeItem Item that should remain playing.
+		 */
+		stopInactiveAutoplayItems( activeItem = null ) {
+			this.items.forEach( ( item ) => {
+				if ( item !== activeItem ) {
+					item.classList.remove( 'godam-video-product-gallery-item--autoplaying' );
+					this.syncPreviewVideo( item, false, { reset: true, muted: true } );
+				}
+			} );
+		}
+
+		/**
+		 * Return the next eligible autoplay item in DOM order.
+		 *
+		 * @param {Element|null} currentItem The current autoplay item.
+		 * @return {Element|null} The next visible gallery item.
+		 */
+		getNextAutoplayItem( currentItem = this.autoplayActiveItem ) {
+			const visibleItems = this.getVisibleAutoplayItems();
+
+			if ( visibleItems.length === 0 ) {
+				return null;
+			}
+
+			const currentIndex = visibleItems.indexOf( currentItem );
+			const nextIndex = currentIndex === -1
+				? 0
+				: ( currentIndex + 1 ) % visibleItems.length;
+
+			return visibleItems[ nextIndex ];
+		}
+
+		/**
+		 * Start full playback for the active autoplay item.
+		 *
+		 * @param {Element} item    The gallery item to play.
+		 * @param {Object}  options Playback options.
+		 */
+		playAutoplayItem( item, options = {} ) {
+			if ( ! item ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			this.autoplayActiveItem = item;
+			item.classList.add( 'godam-video-product-gallery-item--autoplaying' );
+			this.stopInactiveAutoplayItems( item );
+			this.syncPreviewVideo( item, true, {
+				restart: options.restart !== false,
+				muted: true,
+			} );
+			this.updateVideoPreloadStrategy();
+		}
+
+		/**
+		 * Stop autoplay sequencing and reset all preview videos.
+		 */
+		stopAutoplaySequence() {
+			if ( this.autoplayActiveItem ) {
+				this.autoplayActiveItem.classList.remove( 'godam-video-product-gallery-item--autoplaying' );
+				this.syncPreviewVideo( this.autoplayActiveItem, false, {
+					reset: true,
+					muted: true,
+				} );
+			}
+
+			this.autoplayActiveItem = null;
+			this.updateVideoPreloadStrategy();
+		}
+
+		/**
+		 * Move autoplay to the next visible gallery item in DOM order.
+		 */
+		advanceAutoplaySequence( currentItem = this.autoplayActiveItem ) {
+			if ( ! this.autoplay || this.modalOpen ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			const nextItem = this.getNextAutoplayItem( currentItem );
+			if ( ! nextItem ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			this.playAutoplayItem( nextItem, { restart: true } );
+		}
+
+		/**
+		 * Reconcile autoplay state with the latest viewport visibility.
+		 */
+		syncAutoplaySequence( preferredItem = null ) {
 			if ( ! this.autoplay ) {
 				return;
 			}
 
+			if ( this.modalOpen ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			const visibleItems = this.getVisibleAutoplayItems();
+
+			if ( visibleItems.length === 0 ) {
+				this.stopInactiveAutoplayItems();
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			if ( preferredItem && visibleItems.includes( preferredItem ) ) {
+				this.playAutoplayItem( preferredItem, { restart: true } );
+				return;
+			}
+
+			if (
+				this.autoplayActiveItem &&
+				visibleItems.includes( this.autoplayActiveItem )
+			) {
+				this.stopInactiveAutoplayItems( this.autoplayActiveItem );
+				this.updateVideoPreloadStrategy();
+				return;
+			}
+
+			this.playAutoplayItem( visibleItems[ 0 ], { restart: true } );
+		}
+
+		/**
+		 * Return the leading playback item for preload decisions.
+		 *
+		 * @return {Element|null} The item currently driving playback.
+		 */
+		getCurrentPlaybackItem() {
+			if ( this.modalOpen ) {
+				return this.modalOriginalItem;
+			}
+
+			return this.autoplay ? this.autoplayActiveItem : this.hoverActiveItem;
+		}
+
+		/**
+		 * Update the preload strategy so only the active and next videos can eagerly load.
+		 */
+		updateVideoPreloadStrategy() {
+			const currentItem = this.getCurrentPlaybackItem();
+			const nextItem = this.modalOpen || ! this.autoplay
+				? null
+				: this.getNextAutoplayItem( currentItem );
+
 			this.items.forEach( ( item ) => {
-				this.syncPreviewVideo( item, item.dataset.isInViewport === 'true' );
+				const video = this.getItemVideo( item );
+				if ( ! video ) {
+					return;
+				}
+
+				const preloadValue = item === currentItem || item === nextItem
+					? 'auto'
+					: 'metadata';
+
+				if ( video.preload !== preloadValue ) {
+					video.preload = preloadValue;
+					video.setAttribute( 'preload', preloadValue );
+				}
 			} );
+		}
+
+		/**
+		 * Determine whether the play button overlay should be visible for an item.
+		 *
+		 * @param {Element} item The gallery item.
+		 * @return {boolean} Whether the play button should be shown.
+		 */
+		shouldShowPlayButton( item ) {
+			const video = this.getItemVideo( item );
+			if ( ! video ) {
+				return false;
+			}
+
+			const enabled = this.showPlayButton || ( ! this.autoplay && window.innerWidth <= MOBILE_BREAKPOINT );
+			return enabled && ! this.isVideoPlaying( video );
+		}
+
+		/**
+		 * Refresh the play button state for a single gallery item.
+		 *
+		 * @param {Element} item The gallery item.
+		 */
+		refreshPlayButtonState( item ) {
+			if ( ! item ) {
+				return;
+			}
+
+			item.classList.toggle(
+				'godam-video-product-gallery-item--show-play-button',
+				this.shouldShowPlayButton( item ),
+			);
+		}
+
+		/**
+		 * Refresh play button visibility for the whole gallery.
+		 */
+		updateAllPlayButtonStates() {
+			this.items.forEach( ( item ) => {
+				this.refreshPlayButtonState( item );
+			} );
+		}
+
+		/**
+		 * Sync gallery playback after external state changes.
+		 */
+		syncVisiblePreviewVideos() {
+			if ( this.autoplay ) {
+				this.syncAutoplaySequence();
+				return;
+			}
+
+			this.updateAllPlayButtonStates();
+			this.updateVideoPreloadStrategy();
 		}
 
 		/**
@@ -579,10 +984,20 @@ import { dispatch } from '@wordpress/data';
 			this.modalOriginalItem = this.items[ index ];
 			activeModalGallery = this;
 
-			// Pause all gallery preview videos.
-			this.items.forEach( ( item ) => {
-				this.syncPreviewVideo( item, false );
+			this.hoverIntentTimers.forEach( ( timerId ) => {
+				clearTimeout( timerId );
 			} );
+			this.hoverIntentTimers.clear();
+
+			// Pause all gallery preview videos.
+			if ( this.autoplay ) {
+				this.stopAutoplaySequence();
+			} else {
+				this.items.forEach( ( item ) => {
+					this.syncPreviewVideo( item, false, { reset: true, muted: true } );
+				} );
+			}
+			this.hoverActiveItem = null;
 
 			// Create a placeholder clone to maintain gallery layout.
 			this.modalPlaceholder = this.modalOriginalItem.cloneNode( true );
@@ -595,14 +1010,16 @@ import { dispatch } from '@wordpress/data';
 			// Add modal class to the original element.
 			this.modalOriginalItem.classList.add( 'godam-video-product-gallery-item--modal' );
 
-			// Unmute and play the full video (remove 5s loop limit).
+			// Always autoplay the modal video from the start.
 			const modalVideo = this.modalOriginalItem.querySelector( 'video' );
 			if ( modalVideo ) {
-				// Remove the 5-second preview limiter.
-				if ( modalVideo._godamTimeUpdate ) {
-					modalVideo.removeEventListener( 'timeupdate', modalVideo._godamTimeUpdate );
-				}
-
+				// Modal playback should always start when a video is opened, regardless
+				// of the gallery autoplay setting.
+				modalVideo.loop = false;
+				modalVideo.autoplay = true;
+				modalVideo.muted = false;
+				modalVideo.preload = 'auto';
+				modalVideo.setAttribute( 'preload', 'auto' );
 				modalVideo.currentTime = 0;
 				modalVideo.play().catch( () => {} );
 			}
@@ -696,12 +1113,8 @@ import { dispatch } from '@wordpress/data';
 			if ( video ) {
 				video.pause();
 				video.muted = true;
+				video.autoplay = false;
 				video.currentTime = 0;
-
-				// Re-attach the 5-second preview limiter if autoplay is enabled.
-				if ( this.autoplay && video._godamTimeUpdate ) {
-					video.addEventListener( 'timeupdate', video._godamTimeUpdate );
-				}
 			}
 
 			// Move original item back into gallery (before placeholder).
@@ -1197,7 +1610,6 @@ import { dispatch } from '@wordpress/data';
 			}
 			this.updateNavVisibility();
 			this.container.addEventListener( 'scroll', () => this.updateNavVisibility() );
-			window.addEventListener( 'resize', () => this.updateNavVisibility() );
 			if ( this.prevBtn ) {
 				this.prevBtn.addEventListener( 'click', () => this.scrollCarousel( -1 ) );
 			}

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
@@ -227,7 +227,7 @@ import { dispatch } from '@wordpress/data';
 
 			this.initHoverPlay();
 
-			if ( this.autoplay ) {
+			if ( this.autoplay && this.layout === 'carousel' ) {
 				this.initAutoplay();
 			}
 
@@ -245,6 +245,14 @@ import { dispatch } from '@wordpress/data';
 		 * Track which items are autoplay-eligible based on viewport visibility.
 		 */
 		initAutoplay() {
+			// On desktop carousel, observe items relative to the scroll container so
+			// items scrolled out of the carousel (but still in the browser viewport)
+			// are correctly treated as out-of-view.
+			// On mobile carousel, use the default browser viewport (root: null) so the
+			// full-width single-item layout is observed correctly without a container root.
+			const isMobile = window.innerWidth <= MOBILE_BREAKPOINT;
+			const observerRoot = isMobile ? null : this.container;
+
 			this.autoplayObserver = new IntersectionObserver(
 				( entries ) => {
 					entries.forEach( ( entry ) => {
@@ -253,7 +261,7 @@ import { dispatch } from '@wordpress/data';
 
 					this.syncAutoplaySequence();
 				},
-				{ threshold: AUTOPLAY_VISIBILITY_THRESHOLD },
+				{ root: observerRoot, threshold: AUTOPLAY_VISIBILITY_THRESHOLD },
 			);
 
 			this.items.forEach( ( item ) => {

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
@@ -227,7 +227,7 @@ import { dispatch } from '@wordpress/data';
 
 			this.initHoverPlay();
 
-			if ( this.autoplay && this.layout === 'carousel' ) {
+			if ( this.autoplay ) {
 				this.initAutoplay();
 			}
 
@@ -245,13 +245,13 @@ import { dispatch } from '@wordpress/data';
 		 * Track which items are autoplay-eligible based on viewport visibility.
 		 */
 		initAutoplay() {
-			// On desktop carousel, observe items relative to the scroll container so
-			// items scrolled out of the carousel (but still in the browser viewport)
-			// are correctly treated as out-of-view.
-			// On mobile carousel, use the default browser viewport (root: null) so the
-			// full-width single-item layout is observed correctly without a container root.
+			// Carousel on desktop: observe relative to the scroll container so items
+			// scrolled out of the carousel (but still in the browser viewport) are
+			// correctly treated as out-of-view.
+			// Grid (any screen) and mobile carousel: use the browser viewport (null)
+			// because items are in normal document flow, not a scroll container.
 			const isMobile = window.innerWidth <= MOBILE_BREAKPOINT;
-			const observerRoot = isMobile ? null : this.container;
+			const observerRoot = ( this.layout === 'carousel' && ! isMobile ) ? this.container : null;
 
 			this.autoplayObserver = new IntersectionObserver(
 				( entries ) => {
@@ -317,7 +317,7 @@ import { dispatch } from '@wordpress/data';
 					this.autoplay &&
 					! this.modalOpen &&
 					item === this.autoplayActiveItem &&
-					item.dataset.isInViewport === 'true' &&
+					( this.layout === 'grid' || item.dataset.isInViewport === 'true' ) &&
 					! this.isVideoPlaying( video )
 				) {
 					video.play().catch( () => {} );
@@ -534,6 +534,19 @@ import { dispatch } from '@wordpress/data';
 		 * @return {Element|null} The next visible gallery item.
 		 */
 		getNextAutoplayItem( currentItem = this.autoplayActiveItem ) {
+			// Grid: cycle through every item in DOM order regardless of visibility.
+			if ( this.layout === 'grid' ) {
+				if ( this.items.length === 0 ) {
+					return null;
+				}
+				const currentIndex = this.items.indexOf( currentItem );
+				const nextIndex = currentIndex === -1
+					? 0
+					: ( currentIndex + 1 ) % this.items.length;
+				return this.items[ nextIndex ];
+			}
+
+			// Carousel: only consider viewport-visible items.
 			const visibleItems = this.getVisibleAutoplayItems();
 
 			if ( visibleItems.length === 0 ) {
@@ -620,6 +633,18 @@ import { dispatch } from '@wordpress/data';
 				return;
 			}
 
+			// Grid: play sequentially through all items in DOM order.
+			// Viewport changes must never interrupt or reset the active item —
+			// only kick-start playback when nothing is active yet.
+			if ( this.layout === 'grid' ) {
+				if ( ! this.autoplayActiveItem ) {
+					this.playAutoplayItem( this.items[ 0 ], { restart: true } );
+				}
+				// Already playing — leave it alone.
+				return;
+			}
+
+			// Carousel: viewport-driven logic.
 			const visibleItems = this.getVisibleAutoplayItems();
 
 			if ( visibleItems.length === 0 ) {

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/view.js
@@ -1019,7 +1019,7 @@ import { dispatch } from '@wordpress/data';
 				// of the gallery autoplay setting.
 				modalVideo.loop = false;
 				modalVideo.autoplay = true;
-				modalVideo.muted = false;
+				modalVideo.muted = true;
 				modalVideo.preload = 'auto';
 				modalVideo.setAttribute( 'preload', 'auto' );
 				modalVideo.currentTime = 0;


### PR DESCRIPTION
**Fixes:** #1786 

This pull request enhances the Godam Video Product Gallery block by introducing a new "Show Play Button" feature, refining the play icon's appearance and behavior, and making minor improvements to the block's controls and styles. The main focus is on giving users more control over the video play button overlay, especially for mobile and non-autoplay scenarios.

**New Feature: Play Button Overlay**
- Added a new `showPlayButton` attribute to the block, allowing users to toggle the visibility of a play button overlay when videos are not playing. The default is enabled. [[1]](diffhunk://#diff-1e9e19e0ae0a6d770046eacacbe5f1d46ab316d1f98fb529b1607c9f55a1bf33L34-R41) [[2]](diffhunk://#diff-d5b8c5382be2af4cefdf2417e0fa3ac8ca125c09876a82cd5d19d877f55d9ab0R52)
- Introduced a corresponding toggle control in the block editor UI for "Show Play Button," with descriptive help text.

**Rendering and Behavior Updates**
- Updated the PHP render logic to pass the `showPlayButton` state to the frontend and use it for rendering the play icon overlay. [[1]](diffhunk://#diff-94dc82df6f0f10e04a7f54b4dc7eda48a53313fcbc11d1a621e9b82ff1809df9R285) [[2]](diffhunk://#diff-94dc82df6f0f10e04a7f54b4dc7eda48a53313fcbc11d1a621e9b82ff1809df9R331)
- Changed the video shortcode to always disable autoplay in the markup, aligning with the new play button logic.

**Styling Improvements**
- Refined the play icon overlay's position, size, and visibility: it now appears centered, larger, and only when the item is idle (not autoplaying or playing).
- On mobile, the play icon and native play controls are completely hidden for a cleaner experience.
- Minor style tweaks to modal overflow handling and keyframe animation formatting. [[1]](diffhunk://#diff-67be43459e5693c7a56a46cdfebbda7c00524d33c1867954418d5fb8afa6e238L526-R543) [[2]](diffhunk://#diff-67be43459e5693c7a56a46cdfebbda7c00524d33c1867954418d5fb8afa6e238R1166-R1168)

## Demo

https://github.com/user-attachments/assets/2b39e2e1-2f4d-48b0-b832-9b5f9b8e249e


