### PR TITLE
refactor: replace item width range input with S/M/L size selector in gallery-v2

### DIFF
--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -48,7 +48,9 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 	const { videoId } = attributes;
 	const layout = context[ 'godam/galleryV2/layout' ] || 'carousel';
 	const showTitle = context[ 'godam/galleryV2/showTitle' ] !== false;
-	const itemWidth = context[ 'godam/galleryV2/itemWidth' ] || 180;
+	const itemWidthRaw = context[ 'godam/galleryV2/itemWidth' ] || 'M';
+	const itemWidthMap = { S: 200, M: 260, L: 320 };
+	const itemWidth = itemWidthMap[ itemWidthRaw ] || itemWidthMap.M;
 	const viewRatio = context[ 'godam/galleryV2/viewRatio' ] || '16:9';
 	const { removeBlock } = useDispatch( 'core/block-editor' );
 
@@ -146,7 +148,7 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 	const blockProps = useBlockProps( {
 		className: `godam-gallery-v2-item godam-gallery-v2-item--${ layout } godam-gallery-v2-item--ratio-${ viewRatio.replace( ':', '-' ) }`,
 		style: {
-			'--godam-gallery-item-width': `${ itemWidth }px`,
+			'--godam-gallery-item-width': `${ itemWidth }px`, // resolved from size key
 		},
 	} );
 

--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -13,8 +13,8 @@
 			"default": "query"
 		},
 		"itemWidth": {
-			"type": "number",
-			"default": 180
+			"type": "string",
+			"default": "M"
 		},
 		"count": {
 			"type": "number",

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -13,8 +13,8 @@ import {
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
-	SelectControl,
 	RangeControl,
+	SelectControl,
 	ToggleControl,
 	FormTokenField,
 	DatePicker,
@@ -295,10 +295,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 	const blockGap = resolveBlockGap( attributes.style );
 
+	const itemWidthMap = { S: 200, M: 260, L: 320 };
+	const itemWidthPx = itemWidthMap[ itemWidth ] || itemWidthMap.M;
+
 	const blockProps = useBlockProps( {
 		className: `godam-gallery-v2 godam-gallery-v2--${ mode }`,
 		style: {
-			'--godam-gallery-item-width': `${ itemWidth }px`,
+			'--godam-gallery-item-width': `${ itemWidthPx }px`,
 			'--godam-gallery-gap': blockGap,
 		},
 	} );
@@ -527,16 +530,18 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						<ToggleGroupControlOption label="1:1" value="1:1" />
 						<ToggleGroupControlOption label="16:9" value="16:9" />
 					</ToggleGroupControl>
-					<RangeControl
+					<ToggleGroupControl
 						__nextHasNoMarginBottom
-						label={ __( 'Item Width', 'godam' ) }
+						isBlock
+						label={ __( 'Item Size', 'godam' ) }
 						value={ itemWidth }
-						onChange={ ( value ) => setAttributes( { itemWidth: value } ) }
-						min={ 180 }
-						max={ 600 }
-						step={ 10 }
-						help={ __( 'Width of each gallery item in pixels.', 'godam' ) }
-					/>
+						onChange={ ( value ) => value && setAttributes( { itemWidth: value } ) }
+						help={ __( 'Size of each gallery item.', 'godam' ) }
+					>
+						<ToggleGroupControlOption label={ __( 'S', 'godam' ) } value="S" />
+						<ToggleGroupControlOption label={ __( 'M', 'godam' ) } value="M" />
+						<ToggleGroupControlOption label={ __( 'L', 'godam' ) } value="L" />
+					</ToggleGroupControl>
 					<ToggleControl
 						label={ __( 'Show Video Titles and Dates', 'godam' ) }
 						checked={ !! showTitle }

--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -214,7 +214,13 @@ $layout              = isset( $attributes['layout'] ) ? sanitize_key( $attribute
 $view_ratio          = isset( $attributes['viewRatio'] ) ? $attributes['viewRatio'] : '16:9';
 $allowed_ratios      = array( '16:9', '4:3', '9:16', '3:4', '1:1' );
 $view_ratio          = in_array( $view_ratio, $allowed_ratios, true ) ? $view_ratio : '16:9';
-$item_width          = isset( $attributes['itemWidth'] ) ? max( 180, absint( $attributes['itemWidth'] ) ) : 180;
+$item_width_size     = isset( $attributes['itemWidth'] ) ? $attributes['itemWidth'] : 'M';
+$item_width_map      = array(
+	'S' => 200,
+	'M' => 260,
+	'L' => 320,
+);
+$item_width          = isset( $item_width_map[ $item_width_size ] ) ? $item_width_map[ $item_width_size ] : 260;
 $show_title          = ! isset( $attributes['showTitle'] ) || (bool) $attributes['showTitle'];
 $enable_more_items   = array_key_exists( 'enableMoreItems', $attributes ) ? ! empty( $attributes['enableMoreItems'] ) : true;
 $more_items_behavior = isset( $attributes['moreItemsBehavior'] ) ? sanitize_key( $attributes['moreItemsBehavior'] ) : '';

--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -1,5 +1,5 @@
 .godam-gallery-v2 {
-	--godam-gallery-item-width: 180px;
+	--godam-gallery-item-width: 200px;
 	--godam-gallery-gap: 16px;
 
 	width: 100%;


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/957

This pull request updates the way gallery item widths are handled in the Godam Gallery V2 block. Instead of specifying an exact pixel value for item width, users now select from predefined size options ("S", "M", "L"), which map to specific pixel widths. This change is reflected across the block's attributes, editor controls, rendering logic, and default styles for a more consistent and user-friendly experience.

**Attribute and Data Model Changes:**
- Changed the `itemWidth` attribute in `block.json` from a number (default 180) to a string (default "M"), representing size keys instead of pixel values.

**Editor UI and Logic Updates:**
- Replaced the numeric `RangeControl` for item width selection in the block editor with a `ToggleGroupControl` offering "S", "M", and "L" options, each mapped to fixed pixel widths (200, 260, 320 respectively).
- Updated the logic in `edit.js` and `edit.js` for both the gallery and gallery item blocks to resolve the selected size key to its corresponding pixel value for styling. [[1]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R298-R304) [[2]](diffhunk://#diff-3324e9b9615fbf8655a587728572a291c97bd674f7d47f2f59269becf01daab6L51-R53) [[3]](diffhunk://#diff-3324e9b9615fbf8655a587728572a291c97bd674f7d47f2f59269becf01daab6L149-R151)

**Rendering and Style Consistency:**
- Updated the server-side render function to interpret the new string-based `itemWidth` and map it to the correct pixel width for output.
- Changed the default CSS custom property for gallery item width from `180px` to `200px` to match the new "S" size default.

## Demo

https://github.com/user-attachments/assets/4d997d92-7e60-453e-9599-d3267c35a31f

