### PR TITLE
Fetch video and product details dynamically in gallery item editor

### DIFF
--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/block.json
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/block.json
@@ -13,33 +13,9 @@
       "type": "number",
       "default": 0
     },
-    "videoUrl": {
-      "type": "string",
-      "default": ""
-    },
-    "videoThumbnail": {
-      "type": "string",
-      "default": ""
-    },
-    "videoTitle": {
-      "type": "string",
-      "default": ""
-    },
     "productId": {
       "type": "number",
       "default": 0
-    },
-    "productName": {
-      "type": "string",
-      "default": ""
-    },
-    "productPrice": {
-      "type": "string",
-      "default": ""
-    },
-    "productImage": {
-      "type": "string",
-      "default": ""
     }
   },
   "usesContext": [

--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
@@ -43,15 +43,7 @@ const PlayIcon = () => (
  * @return {JSX.Element} Element to render.
  */
 export default function Edit( { attributes, setAttributes, context } ) {
-	const {
-		videoId,
-		videoThumbnail,
-		videoTitle,
-		productId,
-		productName,
-		productPrice,
-		productImage,
-	} = attributes;
+	const { videoId, productId } = attributes;
 
 	// Get context from parent block.
 	// eslint-disable-next-line no-unused-vars
@@ -70,52 +62,64 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	const [ isSearching, setIsSearching ] = useState( false );
 	const productSearchInputRef = useRef( null );
 
-	// Get video details when videoId changes
-	const videoMedia = useSelect(
+	// Derive video display details from the media store (never saved to attributes).
+	const { videoThumbnail, videoTitle } = useSelect(
 		( select ) => {
-			if ( videoId > 0 ) {
-				return select( 'core' ).getMedia( videoId );
+			if ( ! videoId ) {
+				return { videoThumbnail: '', videoTitle: '' };
 			}
-			return null;
+			const media = select( 'core' ).getMedia( videoId );
+			if ( ! media ) {
+				return { videoThumbnail: '', videoTitle: '' };
+			}
+			return {
+				videoThumbnail:
+					media.meta?.rtgodam_media_video_thumbnail ||
+					media.media_details?.sizes?.thumbnail?.source_url ||
+					media.media_details?.sizes?.medium?.source_url ||
+					'',
+				videoTitle: media.title?.rendered || '',
+			};
 		},
 		[ videoId ],
 	);
 
-	// Update video attributes when media is loaded
+	// Fetch product display details dynamically (never saved to attributes).
+	const [ productData, setProductData ] = useState( { name: '', price: '', image: '' } );
+
 	useEffect( () => {
-		if ( videoMedia ) {
-			const thumbnail =
-				videoMedia?.meta?.rtgodam_media_video_thumbnail ||
-				videoMedia?.media_details?.sizes?.thumbnail?.source_url ||
-				videoMedia?.media_details?.sizes?.medium?.source_url ||
-				'';
-
-			setAttributes( {
-				videoUrl: videoMedia.source_url || '',
-				videoThumbnail: thumbnail,
-				videoTitle: videoMedia.title?.rendered || '',
-			} );
+		if ( ! productId ) {
+			setProductData( { name: '', price: '', image: '' } );
+			return;
 		}
-	}, [ videoMedia, setAttributes ] );
 
-	// Handle video selection
+		apiFetch( {
+			path: `/wc/store/v1/products/${ productId }`,
+		} )
+			.then( ( product ) => {
+				setProductData( {
+					name: product.name || '',
+					price: product.prices?.price
+						? `${ product.prices.currency_symbol || '$' }${ ( parseInt( product.prices.price, 10 ) / 100 ).toFixed( 2 ) }`
+						: '',
+					image: product.images?.[ 0 ]?.src || product.images?.[ 0 ]?.thumbnail || '',
+				} );
+			} )
+			.catch( () => {
+				setProductData( { name: '', price: '', image: '' } );
+			} );
+	}, [ productId ] );
+
+	const productName = productData.name;
+	const productPrice = productData.price;
+	const productImage = productData.image;
+
+	// Handle video selection — only persist the ID.
 	const onSelectVideo = ( media ) => {
 		if ( ! media || ! media.id ) {
 			return;
 		}
-
-		const thumbnail =
-			media?.meta?.rtgodam_media_video_thumbnail ||
-			media?.image?.src ||
-			media?.icon ||
-			'';
-
-		setAttributes( {
-			videoId: media.id,
-			videoUrl: media.url || '',
-			videoThumbnail: thumbnail,
-			videoTitle: media.title || '',
-		} );
+		setAttributes( { videoId: media.id } );
 	};
 
 	// Product search with debounce
@@ -172,20 +176,9 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		return () => clearTimeout( timeoutId );
 	}, [ isProductModalOpen ] );
 
-	// Handle product selection
+	// Handle product selection — only persist the ID.
 	const onSelectProduct = ( product ) => {
-		setAttributes( {
-			productId: product.id,
-			productName: product.name,
-			productPrice: product.prices?.price
-				? `${ product.prices.currency_symbol || '$' }${ ( parseInt( product.prices.price, 10 ) / 100 ).toFixed( 2 ) }`
-				: product.price || '',
-			productImage:
-				product.images?.[ 0 ]?.src ||
-				product.images?.[ 0 ]?.thumbnail ||
-				product.thumbnail ||
-				'',
-		} );
+		setAttributes( { productId: product.id } );
 		setIsProductModalOpen( false );
 		setProductSearchQuery( '' );
 		setSearchResults( [] );
@@ -193,12 +186,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 
 	// Clear product
 	const onClearProduct = () => {
-		setAttributes( {
-			productId: 0,
-			productName: '',
-			productPrice: '',
-			productImage: '',
-		} );
+		setAttributes( { productId: 0 } );
 	};
 
 	const blockProps = useBlockProps( {


### PR DESCRIPTION
This pull request refactors the `godam-video-product-gallery-item` block to simplify its data management and improve maintainability. The main change is that video and product display details are now dynamically derived at runtime rather than being stored in block attributes. Only the IDs for videos and products are persisted, ensuring that display data always reflects the latest state.

**Attribute and Data Management Simplification:**
- Removed the following attributes from `block.json`: `videoUrl`, `videoThumbnail`, `videoTitle`, `productName`, `productPrice`, and `productImage`. Now, only `videoId` and `productId` are stored.
- Updated the `Edit` component to derive `videoThumbnail`, `videoTitle`, `productName`, `productPrice`, and `productImage` dynamically using selectors and API calls, instead of persisting them as attributes.

**Event Handling Updates:**
- Changed the video and product selection handlers to only persist the respective IDs (`videoId`, `productId`) and not any display data. [[1]](diffhunk://#diff-67b3c0bddd4dc6204764aa4a32552c7f390cef10c6ed2c7149362857ebf02391L73-R122) [[2]](diffhunk://#diff-67b3c0bddd4dc6204764aa4a32552c7f390cef10c6ed2c7149362857ebf02391L175-R189)
- Updated the product clearing logic to reset only the `productId` attribute, removing unnecessary resets of display data.

**Component Simplification:**
- Refactored the attribute destructuring in the `Edit` component to only use `videoId` and `productId`, reflecting the new attribute structure.