### PR TITLE
Fix CSS reference for video product gallery block

### DIFF
--- a/integrations/woocommerce/blocks/godam-video-product-gallery/block.json
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/block.json
@@ -58,7 +58,7 @@
   },
   "editorScript": ["file:./index.js"],
   "render": "file:./render.php",
-  "style": ["file:./style-index.css", "godam-player-wc-reels-skin"],
+  "style": ["file:./style-index.css", "godam-player-reels-skin-css"],
   "editorStyle": ["file:./index.css"],
   "viewScript": ["wc-blocks-data-store","file:./view.js"]
 }


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/909

This pull request updates the `block.json` configuration for the Godam Video Product Gallery block in the WooCommerce integration. The main change is to the skin CSS used by the block.

Styling update:

* Changed the style dependency from `godam-player-wc-reels-skin` to `godam-player-reels-skin-css` in the `style` array of `block.json`, ensuring the correct skin stylesheet is loaded for the block.