### PR TITLE
fix: Preflight for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested up to: 6.9
 
 Requires PHP: 7.4
 
-Stable tag: 1.7.2
+Stable tag: 2.0.0
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 1.7.2
+ * Version: 2.0.0
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '1.7.2' );
+	define( 'RTGODAM_VERSION', '2.0.0' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -84,8 +84,13 @@ class Plugin {
 	 */
 	protected function __construct() {
 
-		// Run one-time migrations before loading plugin components.
-		Migrations_Runner::run();
+		// Always register persistent hooks (e.g. Action Scheduler callbacks)
+		// so queued async jobs can fire on any request.
+		Migrations_Runner::init();
+
+		// Trigger pending migrations only when the plugin version has changed
+		// (fresh install or update). No-ops on every other request.
+		Migrations_Runner::maybe_run();
 
 		// Load plugin classes.
 		Update::get_instance();

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -84,13 +84,8 @@ class Plugin {
 	 */
 	protected function __construct() {
 
-		// Always register persistent hooks (e.g. Action Scheduler callbacks)
-		// so queued async jobs can fire on any request.
+		// Register persistent migration hooks (includes admin_init trigger).
 		Migrations_Runner::init();
-
-		// Trigger pending migrations only when the plugin version has changed
-		// (fresh install or update). No-ops on every other request.
-		Migrations_Runner::maybe_run();
 
 		// Load plugin classes.
 		Update::get_instance();

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -123,6 +123,14 @@ class Gallery_V1_To_V2 {
 	 * @return void
 	 */
 	public static function run() {
+		// Non-cron, non-CLI requests must originate from an authenticated admin.
+		$is_cli  = defined( 'WP_CLI' ) && WP_CLI;
+		$is_cron = wp_doing_cron();
+
+		if ( ! $is_cron && ! $is_cli && ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
+
 		global $wpdb;
 
 		// Acquire a short-lived lock so concurrent requests on the same site

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -93,9 +93,9 @@ class Gallery_V1_To_V2 {
 	);
 
 	/**
-	 * Schedule the migration to run on `init` if it has not yet run.
+	 * Run the migration if it has not yet completed.
 	 *
-	 * Called by Runner::run() during plugin bootstrap.
+	 * Called by Runner::maybe_run() on admin_init when the plugin version has changed.
 	 *
 	 * @return void
 	 */

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -104,13 +104,10 @@ class Gallery_V1_To_V2 {
 			return;
 		}
 
-		// Only run during admin requests, WP-CLI, or cron. Bulk content writes
-		// must not be triggered by unauthenticated frontend page loads.
-		if ( ! is_admin() && ! wp_doing_cron() && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-			return;
-		}
-
-		add_action( 'init', array( static::class, 'run' ), 99 );
+		// Called from Runner::maybe_run() on admin_init — is_user_logged_in()
+		// and current_user_can() are guaranteed available. Call run() directly;
+		// no need to defer to a later hook.
+		self::run();
 	}
 
 	/**

--- a/inc/classes/migrations/class-godam-cpt-cleanup.php
+++ b/inc/classes/migrations/class-godam-cpt-cleanup.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * ## Lifecycle
  *
- * 1. `Runner::run()` calls `maybe_run()` on every plugin bootstrap.
+ * 1. `Runner::maybe_run()` calls `maybe_run()` when the plugin version has changed.
  * 2. `maybe_run()` bails immediately if the guard option is set, or if the
  *    current context is a frontend request.
  * 3. On the first qualifying request `run()` is scheduled on `init` priority 99.
@@ -93,18 +93,30 @@ class Godam_Cpt_Cleanup {
 	const AS_GROUP = 'godam-cpt-cleanup';
 
 	/**
+	 * Register the Action Scheduler batch callback.
+	 *
+	 * Must be called on every request so Action Scheduler can invoke
+	 * process_batch() for jobs that were queued on a previous request,
+	 * regardless of whether the migration is still pending.
+	 *
+	 * Called by Runner::init() during plugin bootstrap.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks(): void {
+		add_action( self::AS_HOOK, array( static::class, 'process_batch' ) );
+	}
+
+	/**
 	 * Register the AS batch callback and schedule the migration if needed.
 	 *
-	 * Called by Runner::run() on every plugin bootstrap. The AS hook is
-	 * registered unconditionally so Action Scheduler can fire it on any
-	 * request, even while a migration is already in progress.
+	 * Called by Runner::maybe_run() only when the plugin version has changed.
+	 * The AS hook is registered by register_hooks() unconditionally; this
+	 * method only decides whether to queue a new migration run.
 	 *
 	 * @return void
 	 */
 	public static function maybe_run() {
-		// Always register the batch callback so AS can fire it on any request.
-		add_action( self::AS_HOOK, array( static::class, 'process_batch' ) );
-
 		// 'processing' or 'done' — migration already started or complete.
 		if ( get_option( self::OPTION_KEY ) ) {
 			return;

--- a/inc/classes/migrations/class-godam-cpt-cleanup.php
+++ b/inc/classes/migrations/class-godam-cpt-cleanup.php
@@ -120,9 +120,6 @@ class Godam_Cpt_Cleanup {
 		if ( ! is_admin() && ! $is_cron && ! $is_cli ) {
 			return;
 		}
-		if ( ! $is_cron && ! $is_cli && ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) ) {
-			return;
-		}
 
 		add_action( 'init', array( static::class, 'run' ), 99 );
 	}
@@ -136,6 +133,16 @@ class Godam_Cpt_Cleanup {
 	 * @return void
 	 */
 	public static function run() {
+		// This runs on the 'init' hook, so is_user_logged_in() and current_user_can()
+		// are always available (pluggable.php fully loaded, auth cookies processed).
+		// Non-cron, non-CLI requests must come from an authenticated admin.
+		$is_cli  = defined( 'WP_CLI' ) && WP_CLI;
+		$is_cron = wp_doing_cron();
+
+		if ( ! $is_cron && ! $is_cli && ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
+
 		if ( ! self::acquire_lock() ) {
 			return;
 		}

--- a/inc/classes/migrations/class-godam-cpt-cleanup.php
+++ b/inc/classes/migrations/class-godam-cpt-cleanup.php
@@ -26,8 +26,8 @@ defined( 'ABSPATH' ) || exit;
  * ## Lifecycle
  *
  * 1. `Runner::maybe_run()` calls `maybe_run()` when the plugin version has changed.
- * 2. `maybe_run()` bails immediately if the guard option is set, or if the
- *    current context is a frontend request.
+ * 2. `maybe_run()` bails immediately if the guard option is set.
+ *    Context filtering (admin/CLI/cron) is handled by Runner::maybe_run().
  * 3. On the first qualifying request `run()` is scheduled on `init` priority 99.
  * 4. `run()` counts posts. If none exist, marks done immediately. Otherwise,
  *    writes `processing` to the guard option and queues the first AS batch job.
@@ -122,18 +122,10 @@ class Godam_Cpt_Cleanup {
 			return;
 		}
 
-		$is_cli  = defined( 'WP_CLI' ) && WP_CLI;
-		$is_cron = wp_doing_cron();
-
-		// Only trigger during authenticated admin requests, WP-CLI, or cron.
-		// is_admin() is also true for admin-ajax.php which can be hit without
-		// authentication, so non-cron/non-CLI requests require an explicit auth
-		// and capability check before scheduling a destructive migration.
-		if ( ! is_admin() && ! $is_cron && ! $is_cli ) {
-			return;
-		}
-
-		add_action( 'init', array( static::class, 'run' ), 99 );
+		// Called from Runner::maybe_run() on admin_init — is_user_logged_in()
+		// and current_user_can() are guaranteed available. Call run() directly;
+		// no need to defer to a later hook.
+		self::run();
 	}
 
 	/**

--- a/inc/classes/migrations/class-godam-cpt-cleanup.php
+++ b/inc/classes/migrations/class-godam-cpt-cleanup.php
@@ -25,10 +25,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * ## Lifecycle
  *
- * 1. `Runner::maybe_run()` calls `maybe_run()` when the plugin version has changed.
- * 2. `maybe_run()` bails immediately if the guard option is set.
- *    Context filtering (admin/CLI/cron) is handled by Runner::maybe_run().
- * 3. On the first qualifying request `run()` is scheduled on `init` priority 99.
+ * 1. `Runner::maybe_run()` (hooked to `admin_init`) calls `maybe_run()` when
+ *    the stored db version is behind the current plugin version.
+ * 2. `maybe_run()` bails immediately if the guard option is already set.
+ * 3. On the first qualifying admin page load, `maybe_run()` calls `run()` directly.
  * 4. `run()` counts posts. If none exist, marks done immediately. Otherwise,
  *    writes `processing` to the guard option and queues the first AS batch job.
  * 5. Each `process_batch()` job deletes up to BATCH_SIZE posts and, if posts
@@ -131,15 +131,15 @@ class Godam_Cpt_Cleanup {
 	/**
 	 * Entry point: count posts and queue the first Action Scheduler batch.
 	 *
-	 * Runs once on `init` (priority 99). A concurrency lock prevents two
-	 * simultaneous admin page loads from each queuing a batch.
+	 * Called directly from maybe_run() on admin_init. A concurrency lock prevents
+	 * two simultaneous admin page loads from each queuing a batch.
 	 *
 	 * @return void
 	 */
 	public static function run() {
-		// This runs on the 'init' hook, so is_user_logged_in() and current_user_can()
-		// are always available (pluggable.php fully loaded, auth cookies processed).
-		// Non-cron, non-CLI requests must come from an authenticated admin.
+		// Called from maybe_run() on admin_init — pluggable.php is fully loaded
+		// and auth cookies are processed, so is_user_logged_in() and
+		// current_user_can() are guaranteed available.
 		$is_cli  = defined( 'WP_CLI' ) && WP_CLI;
 		$is_cron = wp_doing_cron();
 

--- a/inc/classes/migrations/class-runner.php
+++ b/inc/classes/migrations/class-runner.php
@@ -14,10 +14,11 @@ defined( 'ABSPATH' ) || exit;
  *
  * ## Execution model
  *
- * Migrations are triggered only when the stored database version differs from
+ * Migrations are triggered only when the stored database version is lower than
  * the current plugin version — i.e. on fresh installs and after plugin updates.
- * All other requests return after a single option read with no per-migration
- * overhead.
+ * The runner iterates the version-keyed $migrations map and executes only the
+ * classes whose key version is newer than the stored version. All other requests
+ * return after a single option read with no per-migration overhead.
  *
  * ## Persistent hooks
  *
@@ -30,7 +31,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * 1. Create a migration class in this namespace with a static maybe_run().
  * 2. If it uses Action Scheduler, add a register_hooks() call inside init().
- * 3. Call its maybe_run() inside maybe_run() below.
+ * 3. Add it to the $migrations array below, keyed by the plugin version it ships in.
+ *    Multiple classes can share the same version key.
  *
  * ## Re-running migrations (e.g. for testing)
  *
@@ -43,12 +45,33 @@ class Runner {
 	/**
 	 * WordPress option key storing the plugin version migrations last ran against.
 	 *
-	 * Absent on fresh installs; updated to RTGODAM_VERSION after each migration
-	 * pass so subsequent requests skip the migration block entirely.
+	 * Absent on fresh installs; updated incrementally as each version's migrations
+	 * complete, then set to RTGODAM_VERSION at the end of a full pass.
 	 *
 	 * @var string
 	 */
 	const DB_VERSION_OPTION = 'rtgodam_db_version';
+
+	/**
+	 * Version-keyed migration map.
+	 *
+	 * Each key is the plugin version that introduced the migration(s).
+	 * Each value is an array of fully-qualified class names with a static
+	 * maybe_run() method. Entries must be ordered from oldest to newest version
+	 * so incremental updates are applied in the correct sequence.
+	 *
+	 * To add a new migration, append an entry for the version it ships in:
+	 *
+	 *   '1.8.0' => [ My_New_Migration::class ],
+	 *
+	 * @var array<string, class-string[]>
+	 */
+	private static $migrations = array(
+		'2.0.0' => array(
+			Gallery_V1_To_V2::class,
+			Godam_Cpt_Cleanup::class,
+		),
+	);
 
 	/**
 	 * Register persistent callbacks that must be present on every request.
@@ -57,35 +80,54 @@ class Runner {
 	 * can fire queued batch jobs on any request, independent of whether a
 	 * migration is currently pending.
 	 *
+	 * Also registers the migration trigger on admin_init, which fires on every
+	 * admin page load where is_admin() is guaranteed and auth functions are
+	 * available. The version compare gate ensures this is a single option read
+	 * on requests where no migrations are pending.
+	 *
 	 * @return void
 	 */
 	public static function init(): void {
 		Godam_Cpt_Cleanup::register_hooks();
+
+		// Trigger pending migrations on admin page loads after version changes.
+		add_action( 'admin_init', array( self::class, 'maybe_run' ) );
 	}
 
 	/**
 	 * Trigger pending migrations when the plugin version has changed.
 	 *
-	 * Compares the stored database version against RTGODAM_VERSION. When they
-	 * differ (fresh install or update), each migration's maybe_run() is invoked
-	 * and the stored version is advanced. On every subsequent request this method
-	 * exits after a single option read, adding negligible overhead.
+	 * Hooked to admin_init by Plugin::__construct(), mirroring RankMath's
+	 * pattern. admin_init fires on every admin page load so is_admin() is
+	 * guaranteed and auth functions (is_user_logged_in, current_user_can)
+	 * are available. The version compare is the sole gate — if stored version
+	 * equals current version, this is a single option read and returns.
 	 *
 	 * @return void
 	 */
 	public static function maybe_run(): void {
 		$installed_version = get_option( self::DB_VERSION_OPTION, '' );
-
 		if ( version_compare( $installed_version, RTGODAM_VERSION, '>=' ) ) {
 			return;
 		}
 
-		Gallery_V1_To_V2::maybe_run();
-		Godam_Cpt_Cleanup::maybe_run();
+		foreach ( self::$migrations as $version => $classes ) {
+			if ( version_compare( $installed_version, $version, '>=' ) ) {
+				continue;
+			}
 
-		// Advance the stored version so this block is skipped on subsequent
-		// requests. Individual migration guard options remain as idempotency
-		// safeguards and track per-migration completion state independently.
+			foreach ( $classes as $class ) {
+				$class::maybe_run();
+			}
+
+			// Advance the stored version after each batch so that if the
+			// request dies mid-pass, the next request resumes from here.
+			update_option( self::DB_VERSION_OPTION, $version, false );
+		}
+
+		// Final bump to the current plugin version so the outer guard short-
+		// circuits on all subsequent requests, even when no migration key
+		// matches the exact current version.
 		update_option( self::DB_VERSION_OPTION, RTGODAM_VERSION, false );
 	}
 }

--- a/inc/classes/migrations/class-runner.php
+++ b/inc/classes/migrations/class-runner.php
@@ -12,28 +12,80 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Coordinates all one-time content and database migrations.
  *
- * Each migration class must expose a static maybe_run() method that gates
- * itself behind a WordPress option so it only executes once per site.
+ * ## Execution model
  *
- * To add a future migration: instantiate it here and call ::maybe_run().
- * The order of calls determines execution order.
+ * Migrations are triggered only when the stored database version differs from
+ * the current plugin version — i.e. on fresh installs and after plugin updates.
+ * All other requests return after a single option read with no per-migration
+ * overhead.
  *
- * Re-running all migrations (e.g. for testing) requires deleting each
- * migration's guard option individually:
+ * ## Persistent hooks
+ *
+ * Some migrations (e.g. Godam_Cpt_Cleanup) use Action Scheduler for async
+ * batch processing. Their AS callbacks must be registered on every request so
+ * Action Scheduler can fire them even when no migration is pending. Runner::init()
+ * handles this unconditionally, separate from the version-gated trigger.
+ *
+ * ## Adding a future migration
+ *
+ * 1. Create a migration class in this namespace with a static maybe_run().
+ * 2. If it uses Action Scheduler, add a register_hooks() call inside init().
+ * 3. Call its maybe_run() inside maybe_run() below.
+ *
+ * ## Re-running migrations (e.g. for testing)
+ *
+ *   wp option delete rtgodam_db_version
  *   wp option delete rtgodam_gallery_v1_v2_migration_done
  *   wp option delete rtgodam_godam_cpt_cleanup_done
  */
 class Runner {
 
 	/**
-	 * Invoke every registered migration in sequence.
+	 * WordPress option key storing the plugin version migrations last ran against.
 	 *
-	 * Called once during plugin bootstrap (Plugin::__construct).
+	 * Absent on fresh installs; updated to RTGODAM_VERSION after each migration
+	 * pass so subsequent requests skip the migration block entirely.
+	 *
+	 * @var string
+	 */
+	const DB_VERSION_OPTION = 'rtgodam_db_version';
+
+	/**
+	 * Register persistent callbacks that must be present on every request.
+	 *
+	 * Called unconditionally during plugin bootstrap so that Action Scheduler
+	 * can fire queued batch jobs on any request, independent of whether a
+	 * migration is currently pending.
 	 *
 	 * @return void
 	 */
-	public static function run() {
+	public static function init(): void {
+		Godam_Cpt_Cleanup::register_hooks();
+	}
+
+	/**
+	 * Trigger pending migrations when the plugin version has changed.
+	 *
+	 * Compares the stored database version against RTGODAM_VERSION. When they
+	 * differ (fresh install or update), each migration's maybe_run() is invoked
+	 * and the stored version is advanced. On every subsequent request this method
+	 * exits after a single option read, adding negligible overhead.
+	 *
+	 * @return void
+	 */
+	public static function maybe_run(): void {
+		$installed_version = get_option( self::DB_VERSION_OPTION, '' );
+
+		if ( version_compare( $installed_version, RTGODAM_VERSION, '>=' ) ) {
+			return;
+		}
+
 		Gallery_V1_To_V2::maybe_run();
 		Godam_Cpt_Cleanup::maybe_run();
+
+		// Advance the stored version so this block is skipped on subsequent
+		// requests. Individual migration guard options remain as idempotency
+		// safeguards and track per-migration completion state independently.
+		update_option( self::DB_VERSION_OPTION, RTGODAM_VERSION, false );
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "1.7.2",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "1.7.2",
+			"version": "2.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "1.7.2",
+	"version": "2.0.0",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.7.2
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This pull request refactors the authentication and permission checks for running the Godam CPT cleanup migration. The main change is moving the check for authenticated admin users from the `maybe_run` method to the `run` method, ensuring the check is performed after WordPress has fully loaded authentication functions.

**Refactoring authentication and permission checks:**

* Moved the check for `is_user_logged_in()` and `current_user_can('manage_options')` from the `maybe_run` method to the `run` method in `class-godam-cpt-cleanup.php`, ensuring these checks run after WordPress has fully loaded pluggable functions. [[1]](diffhunk://#diff-436257bad28a0da97b35380d4d55c93ab661ea618f68fba57a9229ac1e411fe5L123-L125) [[2]](diffhunk://#diff-436257bad28a0da97b35380d4d55c93ab661ea618f68fba57a9229ac1e411fe5R136-R145)
* Added clarifying comments in the `run` method to explain why the permission check is performed there.