### PR TITLE
fix: GoDAM Tab for Woo + GoDAM Gallery

### DIFF
--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -13,6 +13,7 @@ import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { closeSmall, pencil, video as videoIcon } from '@wordpress/icons';
+import { useRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -53,6 +54,45 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 	const itemWidth = itemWidthMap[ itemWidthRaw ] || itemWidthMap.M;
 	const viewRatio = context[ 'godam/galleryV2/viewRatio' ] || '16:9';
 	const { removeBlock } = useDispatch( 'core/block-editor' );
+
+	// Ref to track the GoDAM virtual media ID from the most recent selection.
+	const pendingVirtualMediaId = useRef( null );
+
+	// Shared handler for both MediaUpload instances.
+	// Skips setAttributes for non-numeric GoDAM virtual IDs — the
+	// godam-virtual-attachment-created event provides the real WP ID.
+	const onSelectVideo = ( mediaItem ) => {
+		if ( ! mediaItem?.id ) {
+			return;
+		}
+		pendingVirtualMediaId.current = mediaItem.id;
+		const numericId = parseInt( mediaItem.id, 10 );
+		if ( numericId > 0 && String( numericId ) === String( mediaItem.id ) ) {
+			setAttributes( { videoId: numericId } );
+		}
+	};
+
+	// Listen for the GoDAM virtual attachment event and update videoId
+	// with the real WP attachment ID once it has been created.
+	useEffect( () => {
+		const handleVirtualAttachmentCreated = ( event ) => {
+			const { attachment, virtualMediaId } = event.detail || {};
+			if (
+				attachment?.id &&
+				pendingVirtualMediaId.current !== null &&
+				String( pendingVirtualMediaId.current ) === String( virtualMediaId )
+			) {
+				pendingVirtualMediaId.current = null;
+				setAttributes( { videoId: attachment.id } );
+			}
+		};
+
+		document.addEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+
+		return () => {
+			document.removeEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+		};
+	}, [ setAttributes ] );
 
 	const { media, hasResolvedMedia } = useSelect(
 		( select ) => {
@@ -99,11 +139,7 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 				<div className="godam-gallery-v2-item__preview-overlay">
 					<MediaUploadCheck>
 						<MediaUpload
-							onSelect={ ( mediaItem ) => {
-								if ( mediaItem?.id ) {
-									setAttributes( { videoId: mediaItem.id } );
-								}
-							} }
+							onSelect={ onSelectVideo }
 							allowedTypes={ [ 'video' ] }
 							value={ videoId }
 							render={ ( { open: openMediaModal } ) => (
@@ -156,11 +192,7 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 		<div { ...blockProps }>
 			<MediaUploadCheck>
 				<MediaUpload
-					onSelect={ ( mediaItem ) => {
-						if ( mediaItem?.id ) {
-							setAttributes( { videoId: mediaItem.id } );
-						}
-					} }
+					onSelect={ onSelectVideo }
 					allowedTypes={ [ 'video' ] }
 					value={ videoId }
 					render={ ( { open } ) => (

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -28,7 +28,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { columns, grid, listView, plus } from '@wordpress/icons';
 
 /**
@@ -202,7 +202,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const [ startDatePopoverOpen, setStartDatePopoverOpen ] = useState( false );
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
 	const [ dateError, setDateError ] = useState( '' );
-	const { insertBlocks } = useDispatch( blockEditorStore );
+	const { insertBlocks, updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	// Tracks {virtualId, blockClientId} pairs for GoDAM virtual insertions
+	// so the godam-virtual-attachment-created event can update the correct block.
+	const pendingVirtualInserts = useRef( [] );
 
 	const { mediaFolders, authors, queryPreviewVideos, wasJustInserted } = useSelect(
 		( select ) => {
@@ -356,16 +360,52 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				return;
 			}
 
-			insertBlocks(
-				createBlock( 'godam/gallery-v2-item', {
-					videoId: mediaItem.id,
-				} ),
-				undefined,
-				clientId,
-			);
+			const numericId = parseInt( mediaItem.id, 10 );
+			const isVirtual = ! ( numericId > 0 && String( numericId ) === String( mediaItem.id ) );
+
+			const newBlock = createBlock( 'godam/gallery-v2-item', {
+				videoId: isVirtual ? 0 : numericId,
+			} );
+
+			if ( isVirtual ) {
+				pendingVirtualInserts.current.push( {
+					virtualId: mediaItem.id,
+					blockClientId: newBlock.clientId,
+				} );
+			}
+
+			insertBlocks( newBlock, undefined, clientId );
 		},
 		[ clientId, insertBlocks ],
 	);
+
+	// When GoDAM creates a real WP attachment, find the pending child block
+	// and set its videoId to the actual attachment ID.
+	useEffect( () => {
+		const handleVirtualAttachmentCreated = ( event ) => {
+			const { attachment, virtualMediaId } = event.detail || {};
+			if ( ! attachment?.id || ! virtualMediaId ) {
+				return;
+			}
+
+			const idx = pendingVirtualInserts.current.findIndex(
+				( entry ) => String( entry.virtualId ) === String( virtualMediaId ),
+			);
+
+			if ( idx === -1 ) {
+				return;
+			}
+
+			const [ { blockClientId } ] = pendingVirtualInserts.current.splice( idx, 1 );
+			updateBlockAttributes( blockClientId, { videoId: attachment.id } );
+		};
+
+		document.addEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+
+		return () => {
+			document.removeEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+		};
+	}, [ updateBlockAttributes ] );
 
 	const renderVideoAppender = useCallback(
 		() => <AddVideoAppender onSelect={ insertHandpickedVideo } />,

--- a/integrations/woocommerce/assets/js/admin/wc-product-video-gallery.js
+++ b/integrations/woocommerce/assets/js/admin/wc-product-video-gallery.js
@@ -233,16 +233,8 @@ jQuery( document ).ready( function( $ ) {
 
 		$( '.godam-product-admin-video-spinner-overlay' ).show();
 
-		const thumbnail = ( attachment.meta && attachment.meta.rtgodam_media_video_thumbnail ) || RTGodamVideoGallery.defaultThumbnail;
+		const thumbnail = ( attachment.meta && attachment.meta.rtgodam_media_video_thumbnail ) || attachment.image?.src || RTGodamVideoGallery.defaultThumbnail;
 		const videoTitle = attachment.title || '';
-
-		const $addBtn = $( '<button>', {
-			type: 'button',
-			class: 'godam-add-product-button components-button godam-button is-compact is-tertiary wc-godam-product-admin',
-			'aria-label': __( 'Associate products with this video', 'godam' ),
-			text: __( '+ Add Products', 'godam' ),
-			'data-linked-products': '[]',
-		} );
 
 		const listItem = $( '<li>' ).append(
 			`<input type="hidden"
@@ -283,7 +275,9 @@ jQuery( document ).ready( function( $ ) {
 			} ),
 		);
 
-		listItem.append( $thumbWrapper ).append( $videoTitle ).append( $addBtn );
+		listItem.append( $thumbWrapper ).append( $videoTitle );
 		videoList.append( listItem );
+		updateAddButtonState();
+		$( '.godam-product-admin-video-spinner-overlay' ).hide();
 	} );
 } );

--- a/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery-item/edit.js
@@ -114,13 +114,54 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	const productPrice = productData.price;
 	const productImage = productData.image;
 
+	// Ref to track the GoDAM virtual media ID from the most recent selection.
+	// When a GoDAM-tab item is chosen, MediaUpload fires onSelect with the
+	// virtual (non-WP) ID before the real attachment is created. We capture
+	// that ID here so the godam-virtual-attachment-created handler can match it.
+	const pendingVirtualMediaId = useRef( null );
+
 	// Handle video selection — only persist the ID.
 	const onSelectVideo = ( media ) => {
 		if ( ! media || ! media.id ) {
 			return;
 		}
-		setAttributes( { videoId: media.id } );
+		// Always track the raw ID for virtual attachment matching.
+		pendingVirtualMediaId.current = media.id;
+
+		// Only immediately set the attribute for valid numeric WP attachment IDs.
+		// For GoDAM virtual IDs (non-numeric strings like "idcirqui0b"), skip the
+		// immediate setAttributes call to avoid a 404 on /wp/v2/media/<virtual-id>.
+		// The godam-virtual-attachment-created event will provide the real WP ID.
+		const numericId = parseInt( media.id, 10 );
+		if ( numericId > 0 && String( numericId ) === String( media.id ) ) {
+			setAttributes( { videoId: numericId } );
+		}
 	};
+
+	// Listen for the GoDAM virtual attachment event.
+	// When the user picks a video from the GoDAM tab, the real WordPress
+	// attachment is created asynchronously AFTER onSelectVideo fires.
+	// This effect waits for that creation and then corrects videoId to the
+	// real WP attachment ID.
+	useEffect( () => {
+		const handleVirtualAttachmentCreated = ( event ) => {
+			const { attachment, virtualMediaId } = event.detail || {};
+			if (
+				attachment?.id &&
+				pendingVirtualMediaId.current !== null &&
+				String( pendingVirtualMediaId.current ) === String( virtualMediaId )
+			) {
+				pendingVirtualMediaId.current = null;
+				setAttributes( { videoId: attachment.id } );
+			}
+		};
+
+		document.addEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+
+		return () => {
+			document.removeEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+		};
+	}, [ setAttributes ] );
 
 	// Product search with debounce
 	const searchProducts = useCallback(


### PR DESCRIPTION
This pull request improves the handling of video selection from the GoDAM media tab in the `Edit` component for the WooCommerce Godam Video Product Gallery block. It ensures that when a user selects a video from GoDAM (which uses virtual, non-WordPress IDs), the correct WordPress attachment ID is set only after the attachment is created asynchronously, preventing errors and mismatches.

**Improvements to GoDAM video selection handling:**

* Added a `pendingVirtualMediaId` ref to track the GoDAM virtual media ID during selection, enabling correct mapping when the real WordPress attachment is created.
* Modified the `onSelectVideo` handler to only immediately set the `videoId` attribute for valid numeric WordPress attachment IDs, deferring setting for GoDAM virtual IDs until the real attachment is available.
* Introduced a `useEffect` hook to listen for the `godam-virtual-attachment-created` event, updating the `videoId` attribute with the real WordPress attachment ID once it becomes available.

## Recordings


https://github.com/user-attachments/assets/7c29e533-cac5-47c2-9b64-96208f842561


https://github.com/user-attachments/assets/8b675798-fc6a-4f7a-aeb0-88b3387cd804

### Product Reels before:


https://github.com/user-attachments/assets/fee31e2d-1587-41f1-b228-224ff40063fc

<img width="304" height="470" alt="Screenshot 2026-04-21 at 2 27 23 PM" src="https://github.com/user-attachments/assets/75a76e63-69f3-4661-8cdf-64c0b645b829" />

### Product Reels after:


https://github.com/user-attachments/assets/1f293f5d-95ce-4598-843f-31037294a32d


### Product Gallery


https://github.com/user-attachments/assets/3db14597-1a6e-47e7-9afd-dc263bc42aee


