### PR TITLE
Fix:GoDAM blocks & features performance issues

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -346,7 +346,7 @@ if ( 'query' === $gallery_mode ) {
 						>
 							<div class="godam-gallery-v2__query-thumb">
 								<?php if ( ! empty( $item['thumbnail'] ) ) : ?>
-									<img src="<?php echo esc_url( $item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $item['title'] ); ?>" loading="lazy" />
+									<img src="<?php echo esc_url( $item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $item['title'] ); ?>" loading="lazy" fetchpriority="high" />
 								<?php else : ?>
 									<span><?php esc_html_e( 'GoDAM Video', 'godam' ); ?></span>
 								<?php endif; ?>
@@ -400,6 +400,7 @@ if ( 'query' === $gallery_mode ) {
 										alt="<?php echo esc_attr( $item['title'] ); ?>"
 										class="godam-gallery-v2-item__thumbnail"
 										loading="lazy"
+										fetchpriority="high"
 									/>
 								<?php else : ?>
 									<div class="godam-gallery-v2-item__placeholder">

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -42,7 +42,7 @@
 		},
 		"preload": {
 			"type": "string",
-			"default": "auto"
+			"default": "metadata"
 		},
 		"blob": {
 			"type": "string",

--- a/assets/src/js/godam-player/managers/transcriptManager.js
+++ b/assets/src/js/godam-player/managers/transcriptManager.js
@@ -52,6 +52,10 @@ export default class TranscriptManager {
 			return;
 		}
 
+		if ( this.video.dataset.disableTranscript === 'true' ) {
+			return;
+		}
+
 		// Check if captions/subtitles are enabled in the player configuration
 		if ( ! this.isCaptionsEnabled() ) {
 			return;

--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -29,6 +29,8 @@ export default class GodamVideoPlayer {
 		this.isDisplayingLayers = isDisplayingLayers;
 		this.currentPlayerVideoInstanceId = video.dataset.instanceId;
 		this.player = null;
+		this.metadataPreloadObserver = null;
+		this.deferMetadataPreloadUntilInView = false;
 
 		// Initialize managers
 		this.configManager = new ConfigurationManager( video );
@@ -156,6 +158,8 @@ export default class GodamVideoPlayer {
 			this.player = videojs( this.video, this.configManager.videoSetupControls );
 		}
 
+		this.setupDeferredMetadataPreload();
+
 		// Initialize ads manager (async - loads plugins dynamically)
 		this.adsManager = new AdsManager( this.player, this.configManager );
 		this.adsManager?.setupAdsIntegration().catch( ( error ) => {
@@ -165,6 +169,70 @@ export default class GodamVideoPlayer {
 
 		this.setupAspectRatio();
 		this.setupPlayerReady();
+	}
+
+	/**
+	 * Defer metadata loading until the player is at least 10% visible
+	 * when preload is explicitly disabled.
+	 */
+	setupDeferredMetadataPreload() {
+		const preload = this.configManager.videoSetupControls?.preload;
+
+		if ( preload !== 'none' ) {
+			this.deferMetadataPreloadUntilInView = false;
+			return;
+		}
+
+		this.deferMetadataPreloadUntilInView = true;
+
+		if ( ! ( 'IntersectionObserver' in window ) ) {
+			this.preloadVideoMetadata();
+			return;
+		}
+
+		this.metadataPreloadObserver = new IntersectionObserver(
+			( entries ) => {
+				entries.forEach( ( entry ) => {
+					if ( entry.intersectionRatio >= 0.1 ) {
+						this.preloadVideoMetadata();
+					}
+				} );
+			},
+			{
+				root: null,
+				rootMargin: '0px',
+				threshold: 0.1,
+			},
+		);
+
+		this.metadataPreloadObserver.observe( this.video );
+		this.player.one( 'dispose', () => this.cleanupMetadataPreloadObserver() );
+	}
+
+	/**
+	 * Upgrade preload mode to metadata and start loading video metadata.
+	 */
+	preloadVideoMetadata() {
+		if ( ! this.deferMetadataPreloadUntilInView ) {
+			return;
+		}
+
+		this.deferMetadataPreloadUntilInView = false;
+		this.cleanupMetadataPreloadObserver();
+
+		this.player.preload( 'metadata' );
+		this.video.setAttribute( 'preload', 'metadata' );
+		this.player.load();
+	}
+
+	/**
+	 * Disconnect the metadata preload observer when it is no longer needed.
+	 */
+	cleanupMetadataPreloadObserver() {
+		if ( this.metadataPreloadObserver ) {
+			this.metadataPreloadObserver.disconnect();
+			this.metadataPreloadObserver = null;
+		}
 	}
 
 	/**
@@ -590,6 +658,14 @@ export default class GodamVideoPlayer {
 	 * Setup quality selector button in control bar.
 	 */
 	setupQualitySelector() {
+		if ( this.deferMetadataPreloadUntilInView ) {
+			this.player.one( 'loadedmetadata', () => this.renderQualitySelectorButton() );
+			if ( ! this.hasQualitySelectorButton() ) {
+				this.eventsManager.onQualityLevelsAvailable( () => this.renderQualitySelectorButton() );
+			}
+			return;
+		}
+
 		// Force load. Required.
 		if ( this.player.readyState() === 0 ) {
 			this.player.load();

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -458,11 +458,7 @@ $godam_custom_css_properties = array(
 );
 
 if ( ! empty( $godam_aspect_ratio ) ) {
-	if ( isset( $attributes['godam_context'] ) && 'godam-woo-product-page-reels' === $attributes['godam_context'] ) {
-		$godam_custom_css_properties['--rtgodam-video-aspect-ratio'] = '16/9';
-	} else {
-		$godam_custom_css_properties['--rtgodam-video-aspect-ratio'] = str_replace( ':', '/', $godam_aspect_ratio );
-	}
+	$godam_custom_css_properties['--rtgodam-video-aspect-ratio'] = str_replace( ':', '/', $godam_aspect_ratio );
 }
 
 if ( ! empty( $godam_computed_max_width ) ) {

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -92,6 +92,13 @@ $godam_hover_select   = isset( $attributes['hoverSelect'] ) ? $attributes['hover
 $godam_caption        = ! empty( $attributes['caption'] ) ? esc_html( $attributes['caption'] ) : '';
 $godam_tracks         = ! empty( $attributes['tracks'] ) ? $attributes['tracks'] : array();
 $godam_show_share_btn = ! empty( $attributes['showShareButton'] );
+// Determine if subtitles and transcript should be disabled based on the context (e.g., product gallery or reels contexts not require them).
+$godam_disable_subtitles_and_transcript = isset( $attributes['godam_context'] ) &&
+	in_array(
+		$attributes['godam_context'],
+		array( 'godam-video-product-gallery', 'godam-woo-product-page-reels' ),
+		true
+	);
 
 // Resolve the attachment ID (could be WordPress or virtual media).
 $godam_attachment_id = '';
@@ -603,20 +610,23 @@ if ( $godam_should_preload_poster ) {
 						data-instance-id="<?php echo esc_attr( $godam_instance_id ); ?>"
 						data-controls="<?php echo esc_attr( $godam_video_setup ); ?>"
 						data-job_id="<?php echo esc_attr( $godam_job_id ); ?>"
-						data-global_ads_settings="<?php echo esc_attr( $godam_ads_settings ); ?>"
-						data-hover-select="<?php echo esc_attr( $godam_hover_select ); ?>"
-						data-video-title="<?php echo esc_attr( $godam_attachment_title ); ?>"
-						data-autoplay-on-view="<?php echo esc_attr( $godam_autoplay ? 'true' : 'false' ); ?>"
-					>
-						<?php
+							data-global_ads_settings="<?php echo esc_attr( $godam_ads_settings ); ?>"
+							data-hover-select="<?php echo esc_attr( $godam_hover_select ); ?>"
+							data-video-title="<?php echo esc_attr( $godam_attachment_title ); ?>"
+							data-autoplay-on-view="<?php echo esc_attr( $godam_autoplay ? 'true' : 'false' ); ?>"
+							data-disable-transcript="<?php echo esc_attr( $godam_disable_subtitles_and_transcript ? 'true' : 'false' ); ?>"
+						>
+							<?php
 
-						$godam_display_caption = ( ! isset( $godam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) ) ||
-							( isset( $godam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) && $godam_meta_data['videoConfig']['controlBar']['subsCapsButton'] );
+							$godam_display_caption = ! $godam_disable_subtitles_and_transcript && (
+								( ! isset( $godam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) ) ||
+								( isset( $godam_meta_data['videoConfig']['controlBar']['subsCapsButton'] ) && $godam_meta_data['videoConfig']['controlBar']['subsCapsButton'] )
+							);
 
-						if ( $godam_display_caption ) {
-							foreach ( $godam_tracks as $godam_track ) :
-								if ( ! empty( $godam_track['src'] ) && ! empty( $godam_track['kind'] ) ) :
-									?>
+							if ( $godam_display_caption ) {
+								foreach ( $godam_tracks as $godam_track ) :
+									if ( ! empty( $godam_track['src'] ) && ! empty( $godam_track['kind'] ) ) :
+										?>
 									<track
 										src="<?php echo esc_url( $godam_track['src'] ); ?>"
 										kind="<?php echo esc_attr( $godam_track['kind'] ); ?>"
@@ -625,11 +635,11 @@ if ( $godam_should_preload_poster ) {
 										echo ! empty( $godam_track['label'] ) ? sprintf( 'label="%s"', esc_attr( $godam_track['label'] ) ) : '';
 										?>
 									/>
-									<?php
-								endif;
-							endforeach;
-						}
-						?>
+										<?php
+									endif;
+								endforeach;
+							}
+							?>
 					</video>
 					<!-- Add this to target godam uppy modal inside video. -->
 					<div id="uppy-godam-video-modal-container"></div>

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -566,6 +566,7 @@ if ( $godam_should_preload_poster ) {
 						class="godam-player-poster-image"
 						src="<?php echo esc_url( $godam_video_poster ); ?>"
 						fetchpriority="high"
+						loading="lazy"
 						aria-hidden="true"
 						alt="<?php echo esc_attr( $godam_attachment_title ); ?>"
 					/>

--- a/integrations/woocommerce/assets/js/single-product-story/product-reels-carousel.js
+++ b/integrations/woocommerce/assets/js/single-product-story/product-reels-carousel.js
@@ -6,7 +6,8 @@
  * 2. Sequential autoplay – videos play one after another in order.
  * 3. Click / tap to jump sequence to a specific video.
  * 4. Swipe detection on touch devices to switch the active video.
- * 5. IntersectionObserver gates autoplay to only run when the carousel is ≥ 50 % visible in the viewport.
+ * 5. IntersectionObserver gates autoplay to only run when the carousel
+ * container is visible in the viewport.
  */
 ( function() {
 	'use strict';
@@ -31,6 +32,7 @@
 		// ── State ─────────────────────────────────────────────
 		let sequenceIndex = 0; // index of the video currently playing in sequence
 		let galleryVisible = false; // true when carousel is in viewport
+		let hasEnteredViewport = false; // true after the carousel container first enters viewport
 
 		// ── Helpers ───────────────────────────────────────────
 
@@ -126,9 +128,16 @@
 
 		/**
 		 * Start (or resume) the sequential playback at `sequenceIndex`.
+		 *
+		 * @param {Object}  [options={}]                 Optional sequence start options.
+		 * @param {boolean} [options.fromViewport=false] Whether the start was triggered by viewport entry.
 		 */
-		function startSequence() {
-			if ( ! galleryVisible ) {
+		function startSequence( { fromViewport = false } = {} ) {
+			if ( fromViewport ) {
+				hasEnteredViewport = true;
+			}
+
+			if ( ! galleryVisible || ! hasEnteredViewport ) {
 				return;
 			}
 
@@ -236,11 +245,11 @@
 			( entries ) => {
 				entries.forEach( ( entry ) => {
 					const wasVisible = galleryVisible;
-					galleryVisible = entry.isIntersecting;
+					galleryVisible = entry.isIntersecting && entry.intersectionRatio >= VISIBILITY_THRESHOLD;
 
 					if ( galleryVisible && ! wasVisible ) {
-						// Carousel scrolled into view → start sequence.
-						startSequence();
+						// Carousel container scrolled into view → start sequence.
+						startSequence( { fromViewport: true } );
 					} else if ( ! galleryVisible && wasVisible ) {
 						// Carousel scrolled out of view → pause everything.
 						pauseAll();
@@ -250,7 +259,7 @@
 			{ threshold: VISIBILITY_THRESHOLD },
 		);
 
-		visibilityObserver.observe( gallery );
+		visibilityObserver.observe( container );
 
 		// ── Arrow navigation ──────────────────────────────────
 

--- a/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
+++ b/integrations/woocommerce/blocks/godam-video-product-gallery/render.php
@@ -200,7 +200,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 						// Render the video using the godam_video shortcode.
 						echo do_shortcode(
 							sprintf(
-								'[godam_video id="%d" muted="true" loop="false" autoplay="%s" controls="true" aspect_ratio="%s" godam_context="godam-video-product-gallery" showShareButton="1"]',
+								'[godam_video id="%d" muted="true" loop="false" autoplay="%s" controls="true" aspect_ratio="%s" godam_context="godam-video-product-gallery" preload="none"]',
 								$item['videoId'],
 								'false',
 								esc_attr( $view_ratio )

--- a/integrations/woocommerce/classes/class-wc-featured-video-gallery.php
+++ b/integrations/woocommerce/classes/class-wc-featured-video-gallery.php
@@ -402,7 +402,7 @@ class WC_Featured_Video_Gallery {
 
 			// Shortcode.
 			$shortcode_html = do_shortcode(
-				"[godam_video id='{$attachment_id}' muted='true' loop='true' autoplay='true' controls='false' aspect_ratio='responsive' godam_context='godam-featured-video-gallery']"
+				"[godam_video id='{$attachment_id}' muted='true' loop='true' autoplay='true' controls='false' aspect_ratio='responsive' godam_context='godam-featured-video-gallery' preload='none']"
 			);
 
 			return sprintf(

--- a/integrations/woocommerce/classes/class-wc-product-video-gallery.php
+++ b/integrations/woocommerce/classes/class-wc-product-video-gallery.php
@@ -554,7 +554,7 @@ class WC_Product_Video_Gallery {
 
 			$videos_html .= '<div class="rtgodam-product-video-gallery__item">';
 			$videos_html .= '<div class="godam-gallery-video-wrapper">';
-			$videos_html .= do_shortcode( "[godam_video id='{$attachment_id}' autoplay={$autoplay} muted=true loop=false controls=true aspect_ratio='9:16' godam_context='godam-woo-product-page-reels']" );
+			$videos_html .= do_shortcode( "[godam_video id='{$attachment_id}' autoplay={$autoplay} muted=true loop=false controls=true aspect_ratio='9:16' godam_context='godam-woo-product-page-reels' preload='none']" );
 			$videos_html .= '</div>';
 			$videos_html .= '</div>';
 

--- a/integrations/woocommerce/classes/class-wc-product-video-gallery.php
+++ b/integrations/woocommerce/classes/class-wc-product-video-gallery.php
@@ -546,19 +546,12 @@ class WC_Product_Video_Gallery {
 		$videos_html  = '<div class="rtgodam-product-video-gallery">';
 		$videos_html .= '<div class="rtgodam-product-video-gallery__container">';
 
-		$is_first_video = true;
-
 		foreach ( $rtgodam_product_video_gallery_ids as $attachment_id ) {
-
-			$autoplay = $is_first_video ? 'true' : 'false';
-
 			$videos_html .= '<div class="rtgodam-product-video-gallery__item">';
 			$videos_html .= '<div class="godam-gallery-video-wrapper">';
-			$videos_html .= do_shortcode( "[godam_video id='{$attachment_id}' autoplay={$autoplay} muted=true loop=false controls=true aspect_ratio='9:16' godam_context='godam-woo-product-page-reels' preload='none']" );
+			$videos_html .= do_shortcode( "[godam_video id='{$attachment_id}' muted=true loop=false controls=true aspect_ratio='9:16' godam_context='godam-woo-product-page-reels' preload='none']" );
 			$videos_html .= '</div>';
 			$videos_html .= '</div>';
-
-			$is_first_video = false;
 		}
 
 		$videos_html .= '</div>';


### PR DESCRIPTION
Fixes: #https://github.com/rtCamp/godam-core/issues/738

Done Performance Optimization for 
- GoDAM Video Block
- GoDAM Video Gallery Block
- GoDAM Video Product Gallery Block
- WooCommerce product page features 
  - Product Reels
  - Product Gallery inline videos

**Main Optimization:** Improve the GoDAM video block and shortcode video loading strategy for preload="none". Preload none will improve the Core Web Vitals score, and auto-preload video once its enter in the viewport will improve the video performance from the user perspective.

This pull request introduces several improvements to video loading performance and accessibility, especially for product galleries and reels, while also refining the behavior of subtitles and transcripts in specific contexts. The main changes include deferred video metadata loading, context-aware disabling of subtitles/transcripts, and improved image loading strategies. Below are the most important updates grouped by theme:

**Performance and Loading Optimization**

* Added deferred metadata loading for videos with `preload="none"` using an `IntersectionObserver` in `GodamVideoPlayer`. Metadata is only loaded when the video is at least 10% visible, improving initial page load performance for product galleries and reels. (`assets/src/js/godam-player/videoPlayer.js`) [[1]](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398R32-R33) [[2]](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398R161-R162) [[3]](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398R174-R237) [[4]](diffhunk://#diff-9de8b1ceb38dc381f89c07ae025567054ac8a66fff887ec1374f6ef244542398R661-R668)
* Changed the default `preload` value for the player to `'metadata'` (was `'auto'`), and explicitly set `preload="none"` for product gallery and reels videos to ensure deferred loading applies in these contexts. (`assets/src/blocks/godam-player/block.json`, `integrations/woocommerce/blocks/godam-video-product-gallery/render.php`, `integrations/woocommerce/classes/class-wc-featured-video-gallery.php`, `integrations/woocommerce/classes/class-wc-product-video-gallery.php`) [[1]](diffhunk://#diff-0452960eaa8ba8724cc49af281678ab3c7d21abd9ed841f2362d9aa0e7b14d3dL45-R45) [[2]](diffhunk://#diff-94dc82df6f0f10e04a7f54b4dc7eda48a53313fcbc11d1a621e9b82ff1809df9L203-R203) [[3]](diffhunk://#diff-23a18cd16b718617c103afe30ed46af0d02756ee456007bcd34cea56aa6f1ecdL405-R405) [[4]](diffhunk://#diff-964c147dec46168a75578ddc50b868873a205627e400ec8853aa2b2c337858bfL549-L561)

**Subtitles and Transcript Accessibility**

* Subtitles and transcripts are now automatically disabled for videos rendered in product gallery or reels contexts, both in the PHP template and in the frontend JS manager. This prevents unnecessary UI elements and improves user experience in these contexts. (`inc/templates/godam-player.php`, `assets/src/js/godam-player/managers/transcriptManager.js`) [[1]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aR95-R101) [[2]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aR614-R621) [[3]](diffhunk://#diff-a3a87123d40597c4f65fe9c634350327d5b603390d78d24fb38e8a6f9e117052R55-R58)

**Image and Poster Loading Improvements**

* Gallery and poster images now use both `loading="lazy"` and `fetchpriority="high"` for better loading prioritization and performance. (`assets/src/blocks/godam-gallery-v2/render.php`, `inc/templates/godam-player.php`) [[1]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L349-R349) [[2]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9R403) [[3]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aR565)

**Product Reels Carousel Visibility Logic**

* Improved the IntersectionObserver logic in the product reels carousel to only start autoplay when the container is visible in the viewport (not just partially visible), and now tracks whether the carousel has entered the viewport for the first time. (`integrations/woocommerce/assets/js/single-product-story/product-reels-carousel.js`) [[1]](diffhunk://#diff-8b5b2a1a3eb3a9ff09b8a114f89fd1e4f009141b1827169fa41ea1c83fbe2b72L9-R10) [[2]](diffhunk://#diff-8b5b2a1a3eb3a9ff09b8a114f89fd1e4f009141b1827169fa41ea1c83fbe2b72R35) [[3]](diffhunk://#diff-8b5b2a1a3eb3a9ff09b8a114f89fd1e4f009141b1827169fa41ea1c83fbe2b72R131-R140) [[4]](diffhunk://#diff-8b5b2a1a3eb3a9ff09b8a114f89fd1e4f009141b1827169fa41ea1c83fbe2b72L239-R252) [[5]](diffhunk://#diff-8b5b2a1a3eb3a9ff09b8a114f89fd1e4f009141b1827169fa41ea1c83fbe2b72L253-R262)

**CSS and Aspect Ratio Handling**

* Simplified aspect ratio CSS logic for reels by removing the special case for `godam-woo-product-page-reels`, ensuring consistent aspect ratio handling. (`inc/templates/godam-player.php`)