### PR TITLE
fix: WebP + Blur thumbnail optimization

### DIFF
--- a/admin/class-rtgodam-retranscodemedia.php
+++ b/admin/class-rtgodam-retranscodemedia.php
@@ -646,6 +646,12 @@ class RTGODAM_RetranscodeMedia {
 
 		if ( ! empty( $primary_remote_thumbnail_url ) ) {
 			do_action( 'rtgodam_primary_remote_thumbnail_set', $media_id, $primary_remote_thumbnail_url );
+
+			// Sync placeholder thumbnail for the newly set primary thumbnail.
+			$godam_placeholder_map = get_post_meta( $media_id, 'rtgodam_media_placeholder_thumbnails', true );
+			if ( is_array( $godam_placeholder_map ) && isset( $godam_placeholder_map[ $primary_remote_thumbnail_url ] ) ) {
+				update_post_meta( $media_id, 'rtgodam_media_video_placeholder_thumbnail', $godam_placeholder_map[ $primary_remote_thumbnail_url ] );
+			}
 		}
 	}
 

--- a/admin/class-rtgodam-retranscodemedia.php
+++ b/admin/class-rtgodam-retranscodemedia.php
@@ -651,6 +651,8 @@ class RTGODAM_RetranscodeMedia {
 			$godam_placeholder_map = get_post_meta( $media_id, 'rtgodam_media_placeholder_thumbnails', true );
 			if ( is_array( $godam_placeholder_map ) && isset( $godam_placeholder_map[ $primary_remote_thumbnail_url ] ) ) {
 				update_post_meta( $media_id, 'rtgodam_media_video_placeholder_thumbnail', $godam_placeholder_map[ $primary_remote_thumbnail_url ] );
+			} else {
+				delete_post_meta( $media_id, 'rtgodam_media_video_placeholder_thumbnail' );
 			}
 		}
 	}

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -678,6 +678,17 @@ class RTGODAM_Transcoder_Handler {
 			$first_thumbnail_url = $thumbnail_urls[0];
 		}
 
+		// Build placeholder thumbnail URLs if the transcoder provides them.
+		$placeholder_urls = array();
+		if ( ! empty( $post_thumbs_array['placeholder_thumbnail'] ) && is_array( $post_thumbs_array['placeholder_thumbnail'] ) ) {
+			foreach ( $post_thumbs_array['placeholder_thumbnail'] as $placeholder_url ) {
+				$sanitized_placeholder = esc_url_raw( $placeholder_url );
+				if ( ! empty( $sanitized_placeholder ) ) {
+					$placeholder_urls[] = $sanitized_placeholder;
+				}
+			}
+		}
+
 		if ( class_exists( 'RTMediaModel' ) ) {
 			$model    = new RTMediaModel();
 			$media    = $model->get( array( 'media_id' => $post_id ) );
@@ -695,6 +706,11 @@ class RTGODAM_Transcoder_Handler {
 
 		update_post_meta( $post_id, 'rtgodam_media_source', $post_thumbs_array['job_for'] );
 		update_post_meta( $post_id, 'rtgodam_media_thumbnails', $thumbnail_urls );
+
+		// Store thumbnail → placeholder mapping when both parallel arrays are present and match.
+		if ( ! empty( $placeholder_urls ) && count( $placeholder_urls ) === count( $thumbnail_urls ) ) {
+			update_post_meta( $post_id, 'rtgodam_media_placeholder_thumbnails', array_combine( $thumbnail_urls, $placeholder_urls ) );
+		}
 
 		do_action( 'rtgodam_transcoded_thumbnails_added', $post_id );
 
@@ -715,6 +731,10 @@ class RTGODAM_Transcoder_Handler {
 			// If the current selected thumbnail is NOT one of the custom uploaded thumbnails, overwrite it.
 			if ( empty( $current_thumbnail ) || ! in_array( $current_thumbnail, $custom_thumbnails, true ) ) {
 				update_post_meta( $post_id, 'rtgodam_media_video_thumbnail', $first_thumbnail_url );
+				// Also sync the placeholder for the newly set primary thumbnail.
+				if ( ! empty( $placeholder_urls ) ) {
+					update_post_meta( $post_id, 'rtgodam_media_video_placeholder_thumbnail', $placeholder_urls[0] );
+				}
 			}
 
 			/**

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -672,30 +672,33 @@ class RTGODAM_Transcoder_Handler {
 		$post_thumbs_array = maybe_unserialize( $post_thumbs );
 
 		$thumbnail_urls      = array();
+		$placeholder_map     = array();
 		$first_thumbnail_url = false;
 
-		foreach ( $post_thumbs_array['thumbnail'] as $thumbnail_url ) {
-				$sanitized_url = esc_url_raw( $thumbnail_url );
+		$raw_thumbnails   = $post_thumbs_array['thumbnail'];
+		$raw_placeholders = ! empty( $post_thumbs_array['placeholder_thumbnail'] ) && is_array( $post_thumbs_array['placeholder_thumbnail'] )
+			? $post_thumbs_array['placeholder_thumbnail']
+			: array();
+
+		// Iterate both parallel arrays by the same raw index so positions stay aligned.
+		foreach ( $raw_thumbnails as $idx => $thumbnail_url ) {
+			$sanitized_url = esc_url_raw( $thumbnail_url );
 			if ( empty( $sanitized_url ) ) {
 				continue;
 			}
 
-				$thumbnail_urls[] = $sanitized_url;
+			$thumbnail_urls[] = $sanitized_url;
+
+			if ( isset( $raw_placeholders[ $idx ] ) ) {
+				$sanitized_placeholder = esc_url_raw( $raw_placeholders[ $idx ] );
+				if ( ! empty( $sanitized_placeholder ) ) {
+					$placeholder_map[ $sanitized_url ] = $sanitized_placeholder;
+				}
+			}
 		}
 
 		if ( ! empty( $thumbnail_urls ) ) {
 			$first_thumbnail_url = $thumbnail_urls[0];
-		}
-
-		// Build placeholder thumbnail URLs if the transcoder provides them.
-		$placeholder_urls = array();
-		if ( ! empty( $post_thumbs_array['placeholder_thumbnail'] ) && is_array( $post_thumbs_array['placeholder_thumbnail'] ) ) {
-			foreach ( $post_thumbs_array['placeholder_thumbnail'] as $placeholder_url ) {
-				$sanitized_placeholder = esc_url_raw( $placeholder_url );
-				if ( ! empty( $sanitized_placeholder ) ) {
-					$placeholder_urls[] = $sanitized_placeholder;
-				}
-			}
 		}
 
 		$media_id = null;
@@ -720,9 +723,11 @@ class RTGODAM_Transcoder_Handler {
 		update_post_meta( $post_id, 'rtgodam_media_source', $post_thumbs_array['job_for'] );
 		update_post_meta( $post_id, 'rtgodam_media_thumbnails', $thumbnail_urls );
 
-		// Store thumbnail → placeholder mapping when both parallel arrays are present and match.
-		if ( ! empty( $placeholder_urls ) && count( $placeholder_urls ) === count( $thumbnail_urls ) ) {
-			update_post_meta( $post_id, 'rtgodam_media_placeholder_thumbnails', array_combine( $thumbnail_urls, $placeholder_urls ) );
+		// Store thumbnail → placeholder mapping, or clear stale meta when no valid placeholders.
+		if ( ! empty( $placeholder_map ) ) {
+			update_post_meta( $post_id, 'rtgodam_media_placeholder_thumbnails', $placeholder_map );
+		} else {
+			delete_post_meta( $post_id, 'rtgodam_media_placeholder_thumbnails' );
 		}
 
 		do_action( 'rtgodam_transcoded_thumbnails_added', $post_id );
@@ -744,9 +749,11 @@ class RTGODAM_Transcoder_Handler {
 			// If the current selected thumbnail is NOT one of the custom uploaded thumbnails, overwrite it.
 			if ( empty( $current_thumbnail ) || ! in_array( $current_thumbnail, $custom_thumbnails, true ) ) {
 				update_post_meta( $post_id, 'rtgodam_media_video_thumbnail', $first_thumbnail_url );
-				// Also sync the placeholder for the newly set primary thumbnail.
-				if ( ! empty( $placeholder_urls ) ) {
-					update_post_meta( $post_id, 'rtgodam_media_video_placeholder_thumbnail', $placeholder_urls[0] );
+				// Sync placeholder for the newly set primary thumbnail using the verified map.
+				if ( isset( $placeholder_map[ $first_thumbnail_url ] ) ) {
+					update_post_meta( $post_id, 'rtgodam_media_video_placeholder_thumbnail', $placeholder_map[ $first_thumbnail_url ] );
+				} else {
+					delete_post_meta( $post_id, 'rtgodam_media_video_placeholder_thumbnail' );
 				}
 			}
 

--- a/admin/class-rtgodam-transcoder-handler.php
+++ b/admin/class-rtgodam-transcoder-handler.php
@@ -48,6 +48,15 @@ class RTGODAM_Transcoder_Handler {
 	public $uploaded = array();
 
 	/**
+	 * The author of the rtMedia item being processed.
+	 *
+	 * @since    1.0.0
+	 * @access   public
+	 * @var      int|null    $media_author    rtMedia media author ID.
+	 */
+	public $media_author = null;
+
+	/**
 	 * The api key of transcoding service subscription.
 	 *
 	 * @since    1.0.0
@@ -689,15 +698,19 @@ class RTGODAM_Transcoder_Handler {
 			}
 		}
 
+		$media_id = null;
 		if ( class_exists( 'RTMediaModel' ) ) {
-			$model    = new RTMediaModel();
-			$media    = $model->get( array( 'media_id' => $post_id ) );
-			$media_id = $media[0]->id;
+			$model = new RTMediaModel();
+			$media = $model->get( array( 'media_id' => $post_id ) );
 
-			$this->media_author             = $media[0]->media_author;
-			$this->uploaded['context']      = $media[0]->context;
-			$this->uploaded['context_id']   = $media[0]->context_id;
-			$this->uploaded['media_author'] = $media[0]->media_author;
+			if ( ! empty( $media ) && isset( $media[0] ) ) {
+				$media_id = $media[0]->id;
+
+				$this->media_author             = $media[0]->media_author;
+				$this->uploaded['context']      = $media[0]->context;
+				$this->uploaded['context_id']   = $media[0]->context_id;
+				$this->uploaded['media_author'] = $media[0]->media_author;
+			}
 		}
 
 		// rtMedia support.
@@ -719,7 +732,7 @@ class RTGODAM_Transcoder_Handler {
 			// rtMedia support.
 			update_post_meta( $post_id, '_rt_media_video_thumbnail', $first_thumbnail_url );
 
-			if ( class_exists( 'RTMediaModel' ) ) {
+			if ( class_exists( 'RTMediaModel' ) && ! empty( $media_id ) ) {
 				$model->update( array( 'cover_art' => $first_thumbnail_url ), array( 'media_id' => $post_id ) );
 				update_activity_after_thumb_set( $media_id );
 			}

--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -57,72 +57,77 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 				'callback'            => array( $this, 'handle_callback' ),
 				'permission_callback' => array( $this, 'verify_callback_permission' ),
 				'args'                => array(
-					'job_id'           => array(
+					'job_id'                => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'job_type'         => array(
+					'job_type'              => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'job_for'          => array(
+					'job_for'               => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'format'           => array(
+					'format'                => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'download_url'     => array(
+					'download_url'          => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'esc_url_raw',
 					),
-					'file_name'        => array(
+					'file_name'             => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'thumb_count'      => array(
+					'thumb_count'           => array(
 						'required'          => false,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 					),
-					'status'           => array(
+					'status'                => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'file_status'      => array(
+					'file_status'           => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'files'            => array(
+					'files'                 => array(
 						'required'          => false,
 						'type'              => 'array',
 						'sanitize_callback' => array( $this, 'sanitize_array_of_urls' ),
 					),
-					'thumbnail'        => array(
+					'thumbnail'             => array(
 						'required'          => false,
 						'type'              => 'array',
 						'sanitize_callback' => array( $this, 'sanitize_array_of_urls' ),
 					),
-					'error_msg'        => array(
+					'placeholder_thumbnail' => array(
+						'required'          => false,
+						'type'              => 'array',
+						'sanitize_callback' => array( $this, 'sanitize_array_of_urls' ),
+					),
+					'error_msg'             => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'job_manager_form' => array(
+					'job_manager_form'      => array(
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'api_key'          => array(
+					'api_key'               => array(
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',

--- a/assets/src/css/godam-player-wrapper.scss
+++ b/assets/src/css/godam-player-wrapper.scss
@@ -8,7 +8,7 @@
 	}
 
 	.godam-player-poster-image {
-		position:absolute;
+		position: absolute;
 		aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9);
 		width: 100%;
 		height: auto;
@@ -16,12 +16,6 @@
 		object-fit: contain;
 		background-color: #000;
 	}
-}
-
-.godam-animate-video-loading {
-	position: relative;
-	animation: godam_pulse_animation 2s cubic-bezier(.4, 0, .6, 1) infinite;
-	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9);
 
 	.animate-play-btn {
 		width: 50px;
@@ -55,6 +49,10 @@
 	}
 }
 
+.godam-animate-video-loading {
+	animation: godam_pulse_animation 2s cubic-bezier(.4, 0, .6, 1) infinite;
+}
+
 .easydam-video-container {
 
 	&.loading {
@@ -78,13 +76,13 @@
 		animation: godam_blur_pulse 2.5s infinite;
 		background-color: #fff;
 		z-index: 1;
+		pointer-events: none;
 	}
 
 	.godam-player-poster-image {
 		opacity: 0;
 		transition: opacity 250ms ease-in-out;
-		position: relative; // ensure poster renders above ::before shimmer
-		z-index: 2;
+		z-index: 2; // render above ::before shimmer; base absolute positioning preserved
 	}
 
 	&.loaded {

--- a/assets/src/css/godam-player-wrapper.scss
+++ b/assets/src/css/godam-player-wrapper.scss
@@ -1,5 +1,7 @@
 
 .godam-video-placeholder {
+	position: relative;
+	aspect-ratio: var(--rtgodam-video-aspect-ratio, 16 / 9);
 
 	&.hidden {
 		display: none !important;
@@ -57,6 +59,60 @@
 
 	&.loading {
 		display: none;
+	}
+}
+
+// Blur-up LQIP loading: placeholder background fades to full-quality poster.
+// Matches the Web Dev Simplified technique: tiny blurred bg-image → pulse shimmer → full img fades in.
+.godam-blurred-img {
+	background-repeat: no-repeat;
+	background-size: cover;
+	background-position: center;
+
+	// Pulse shimmer overlay shown while the full-quality poster is downloading.
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		opacity: 0;
+		animation: godam_blur_pulse 2.5s infinite;
+		background-color: #fff;
+		z-index: 1;
+	}
+
+	.godam-player-poster-image {
+		opacity: 0;
+		transition: opacity 250ms ease-in-out;
+		position: relative; // ensure poster renders above ::before shimmer
+		z-index: 2;
+	}
+
+	&.loaded {
+
+		.godam-player-poster-image {
+			opacity: 1;
+		}
+
+		// Stop shimmer once the full image has arrived.
+		&::before {
+			animation: none;
+			content: none;
+		}
+	}
+}
+
+@keyframes godam_blur_pulse {
+
+	0% {
+		opacity: 0;
+	}
+
+	50% {
+		opacity: 0.15;
+	}
+
+	100% {
+		opacity: 0;
 	}
 }
 

--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -88,6 +88,13 @@ export default class PlayerManager {
 	 */
 	initBlurUpPlaceholders() {
 		document.querySelectorAll( '.godam-blurred-img' ).forEach( ( div ) => {
+			// Skip already-initialized placeholders to prevent duplicate listeners
+			// when multiple PlayerManager instances run (e.g. Elementor, FluentForms).
+			if ( div.dataset.godamBlurInit === '1' ) {
+				return;
+			}
+			div.dataset.godamBlurInit = '1';
+
 			const img = div.querySelector( '.godam-player-poster-image' );
 			if ( ! img ) {
 				return;
@@ -101,8 +108,8 @@ export default class PlayerManager {
 			if ( img.complete && img.naturalWidth > 0 ) {
 				markLoaded();
 			} else {
-				img.addEventListener( 'load', markLoaded );
-				img.addEventListener( 'error', markError );
+				img.addEventListener( 'load', markLoaded, { once: true } );
+				img.addEventListener( 'error', markError, { once: true } );
 			}
 		} );
 	}

--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -76,6 +76,35 @@ export default class PlayerManager {
 		this.initializeGlobalKeyboardHandler();
 		this.initializeAutoplayOnView();
 		this.initEngagement = engagement();
+		this.initBlurUpPlaceholders();
+	}
+
+	/**
+	 * Initialize blur-up LQIP placeholders.
+	 *
+	 * For each .godam-blurred-img div, listen for the inner full-quality
+	 * poster image to finish loading, then add the 'loaded' class so CSS
+	 * fades it in over the blurry background placeholder.
+	 */
+	initBlurUpPlaceholders() {
+		document.querySelectorAll( '.godam-blurred-img' ).forEach( ( div ) => {
+			const img = div.querySelector( '.godam-player-poster-image' );
+			if ( ! img ) {
+				return;
+			}
+			const markLoaded = () => div.classList.add( 'loaded' );
+			const markError = () => {
+				// On error, remove the blurry background so nothing is broken.
+				div.style.backgroundImage = '';
+				div.classList.add( 'loaded' );
+			};
+			if ( img.complete && img.naturalWidth > 0 ) {
+				markLoaded();
+			} else {
+				img.addEventListener( 'load', markLoaded );
+				img.addEventListener( 'error', markError );
+			}
+		} );
 	}
 
 	/**

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -830,11 +830,16 @@ class Media_Library extends Base {
 
 			if ( ! empty( $frappe_placeholder_map ) ) {
 				update_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', $frappe_placeholder_map );
-				// Set placeholder for the currently active/selected thumbnail.
-				$active_thumb_url = ! empty( $body->message->thumbnail_url ) ? $body->message->thumbnail_url : '';
-				if ( ! empty( $active_thumb_url ) && isset( $frappe_placeholder_map[ $active_thumb_url ] ) ) {
-					update_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail', $frappe_placeholder_map[ $active_thumb_url ] );
-				}
+			} else {
+				delete_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails' );
+			}
+
+			// Always sync the active placeholder thumbnail; clear it when there's no mapping.
+			$active_thumb_url = ! empty( $body->message->thumbnail_url ) ? $body->message->thumbnail_url : '';
+			if ( ! empty( $active_thumb_url ) && ! empty( $frappe_placeholder_map ) && isset( $frappe_placeholder_map[ $active_thumb_url ] ) ) {
+				update_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail', $frappe_placeholder_map[ $active_thumb_url ] );
+			} else {
+				delete_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail' );
 			}
 		}
 
@@ -916,8 +921,17 @@ class Media_Library extends Base {
 
 		$data['customThumbnails'] = $custom_thumbnails;
 
-		$godam_placeholder_map         = get_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', true );
-		$data['placeholderThumbnails'] = is_array( $godam_placeholder_map ) ? $godam_placeholder_map : array();
+		$godam_placeholder_map = get_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', true );
+		if ( is_array( $godam_placeholder_map ) ) {
+			$normalized_placeholder_map = array();
+			foreach ( $godam_placeholder_map as $placeholder_key => $placeholder_value ) {
+				$normalized_key                                = is_string( $placeholder_key ) ? rtgodam_convert_to_https_url( $placeholder_key ) : $placeholder_key;
+				$normalized_placeholder_map[ $normalized_key ] = is_string( $placeholder_value ) ? rtgodam_convert_to_https_url( $placeholder_value ) : $placeholder_value;
+			}
+			$data['placeholderThumbnails'] = $normalized_placeholder_map;
+		} else {
+			$data['placeholderThumbnails'] = array();
+		}
 
 		return rest_ensure_response(
 			array(

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -85,15 +85,20 @@ class Media_Library extends Base {
 						return current_user_can( 'edit_posts' );
 					},
 					'args'                => array(
-						'attachment_id' => array(
+						'attachment_id'             => array(
 							'required'    => true,
 							'type'        => 'integer',
 							'description' => __( 'Attachment ID to set video thumbnail for.', 'godam' ),
 						),
-						'thumbnail_url' => array(
+						'thumbnail_url'             => array(
 							'required'    => true,
 							'type'        => 'string',
 							'description' => __( 'Attachment URL to set as the thumbnail.', 'godam' ),
+						),
+						'placeholder_thumbnail_url' => array(
+							'required'    => false,
+							'type'        => 'string',
+							'description' => __( 'Placeholder (low-quality blur-up) thumbnail URL for this thumbnail.', 'godam' ),
 						),
 					),
 				),
@@ -805,17 +810,31 @@ class Media_Library extends Base {
 				return new \WP_Error( 'thumbnails_not_found', __( 'No thumbnails found.', 'godam' ), array( 'status' => 204 ) );
 			}
 
-			// Extract thumbnail URLs from objects.
-			$thumbnail_array = array();
+			// Extract thumbnail URLs and placeholder mapping from Frappe response objects.
+			$thumbnail_array        = array();
+			$frappe_placeholder_map = array();
 			foreach ( $body->message->thumbnails as $thumb_obj ) {
 				if ( isset( $thumb_obj->thumbnail_url ) ) {
-					$thumbnail_array[] = $thumb_obj->thumbnail_url;
+					$thumb_url         = $thumb_obj->thumbnail_url;
+					$thumbnail_array[] = $thumb_url;
+					if ( ! empty( $thumb_obj->placeholder_thumbnail ) ) {
+						$frappe_placeholder_map[ $thumb_url ] = $thumb_obj->placeholder_thumbnail;
+					}
 				}
 			}
 
 			$thumbnail_array = array_values( array_unique( $thumbnail_array ) );
 			if ( ! empty( $thumbnail_array ) ) {
 				update_post_meta( $attachment_id, 'rtgodam_media_thumbnails', $thumbnail_array );
+			}
+
+			if ( ! empty( $frappe_placeholder_map ) ) {
+				update_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', $frappe_placeholder_map );
+				// Set placeholder for the currently active/selected thumbnail.
+				$active_thumb_url = ! empty( $body->message->thumbnail_url ) ? $body->message->thumbnail_url : '';
+				if ( ! empty( $active_thumb_url ) && isset( $frappe_placeholder_map[ $active_thumb_url ] ) ) {
+					update_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail', $frappe_placeholder_map[ $active_thumb_url ] );
+				}
 			}
 		}
 
@@ -896,6 +915,9 @@ class Media_Library extends Base {
 		$data['thumbnails'] = $thumbnail_array;
 
 		$data['customThumbnails'] = $custom_thumbnails;
+
+		$godam_placeholder_map         = get_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', true );
+		$data['placeholderThumbnails'] = is_array( $godam_placeholder_map ) ? $godam_placeholder_map : array();
 
 		return rest_ensure_response(
 			array(
@@ -1029,8 +1051,9 @@ class Media_Library extends Base {
 	 * @return \WP_REST_Response
 	 */
 	public function set_video_thumbnail( $request ) {
-		$attachment_id = $request->get_param( 'attachment_id' );
-		$thumbnail_url = $request->get_param( 'thumbnail_url' );
+		$attachment_id             = $request->get_param( 'attachment_id' );
+		$thumbnail_url             = $request->get_param( 'thumbnail_url' );
+		$placeholder_thumbnail_url = $request->get_param( 'placeholder_thumbnail_url' );
 
 		// Check if attachment is of type video.
 		$mime_type = get_post_mime_type( $attachment_id );
@@ -1044,8 +1067,33 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_thumbnail_url', __( 'Invalid thumbnail URL.', 'godam' ), array( 'status' => 400 ) );
 		}
 
+		// Validate optional placeholder URL if provided.
+		if ( ! empty( $placeholder_thumbnail_url ) && ! filter_var( $placeholder_thumbnail_url, FILTER_VALIDATE_URL ) ) {
+			return new \WP_Error( 'invalid_placeholder_thumbnail_url', __( 'Invalid placeholder thumbnail URL.', 'godam' ), array( 'status' => 400 ) );
+		}
+
 		// Update the video thumbnail.
 		update_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', $thumbnail_url );
+
+		// If a placeholder URL was explicitly supplied, store it and update the map.
+		if ( ! empty( $placeholder_thumbnail_url ) ) {
+			$godam_placeholder_map = get_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', true );
+			if ( ! is_array( $godam_placeholder_map ) ) {
+				$godam_placeholder_map = array();
+			}
+			$godam_placeholder_map[ $thumbnail_url ] = esc_url_raw( $placeholder_thumbnail_url );
+			update_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', $godam_placeholder_map );
+			update_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail', esc_url_raw( $placeholder_thumbnail_url ) );
+		} else {
+			// Sync the placeholder thumbnail based on the new selection from the existing map.
+			$godam_placeholder_map = get_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', true );
+			if ( is_array( $godam_placeholder_map ) && isset( $godam_placeholder_map[ $thumbnail_url ] ) ) {
+				update_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail', esc_url_raw( $godam_placeholder_map[ $thumbnail_url ] ) );
+			} else {
+				// Custom/uploaded thumbnails have no placeholder – clear it.
+				delete_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail' );
+			}
+		}
 
 		return rest_ensure_response(
 			array(

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -323,7 +323,25 @@ $godam_global_video_share = isset( $godam_settings['video']['enable_global_video
 
 $godam_video_poster = empty( $godam_poster ) ? $godam_poster_image : $godam_poster;
 
-// Build the video setup options for data-setup.
+// Resolve the blur-up placeholder thumbnail.
+// For block-editor poster overrides, look up the mapping directly.
+// For auto-selected thumbnails, use the pre-synced single meta key.
+// Supports both normal WP media and virtual GoDAM media.
+$godam_placeholder_thumbnail = '';
+$godam_placeholder_lookup_id = is_numeric( $godam_attachment_id )
+	? intval( $godam_attachment_id )
+	: ( is_numeric( $godam_original_id ) ? intval( $godam_original_id ) : 0 );
+
+if ( $godam_placeholder_lookup_id > 0 ) {
+	if ( ! empty( $godam_poster ) ) {
+		$godam_placeholder_map = get_post_meta( $godam_placeholder_lookup_id, 'rtgodam_media_placeholder_thumbnails', true );
+		if ( is_array( $godam_placeholder_map ) && isset( $godam_placeholder_map[ $godam_poster ] ) ) {
+			$godam_placeholder_thumbnail = esc_url( $godam_placeholder_map[ $godam_poster ] );
+		}
+	} else {
+		$godam_placeholder_thumbnail = esc_url( get_post_meta( $godam_placeholder_lookup_id, 'rtgodam_media_video_placeholder_thumbnail', true ) );
+	}
+}
 $godam_video_setup = array(
 	'controls'    => $godam_controls,
 	'autoplay'    => $godam_autoplay,
@@ -548,13 +566,32 @@ if ( $godam_should_preload_poster ) {
 					</div>
 				<?php endif; ?>
 
-				<div class="godam-video-placeholder godam-animate-video-loading <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>">
+				<?php if ( ! empty( $godam_video_poster ) && ! empty( $godam_placeholder_thumbnail ) ) : ?>
+				<div
+					class="godam-video-placeholder godam-blurred-img <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>"
+					style="background-image: url('<?php echo esc_url( $godam_placeholder_thumbnail ); ?>')"
+				>
 					<div class="animate-play-btn">
 						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
 							<path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"/>
 						</svg>
 					</div>
-					<?php if ( ! empty( $godam_video_poster ) ) : ?>
+					<img
+						class="godam-player-poster-image"
+						src="<?php echo esc_url( $godam_video_poster ); ?>"
+						loading="lazy"
+						fetchpriority="low"
+						aria-hidden="true"
+						alt="<?php echo esc_attr( $godam_attachment_title ); ?>"
+					/>
+				</div>
+				<?php elseif ( ! empty( $godam_video_poster ) ) : ?>
+				<div class="godam-video-placeholder <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>">
+					<div class="animate-play-btn">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
+							<path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"/>
+						</svg>
+					</div>
 					<img
 						class="godam-player-poster-image"
 						src="<?php echo esc_url( $godam_video_poster ); ?>"
@@ -562,8 +599,16 @@ if ( $godam_should_preload_poster ) {
 						aria-hidden="true"
 						alt="<?php echo esc_attr( $godam_attachment_title ); ?>"
 					/>
-					<?php endif; ?>
 				</div>
+				<?php else : ?>
+				<div class="godam-video-placeholder godam-animate-video-loading <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>">
+					<div class="animate-play-btn">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-play-fill" viewBox="0 0 16 16">
+							<path d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"/>
+						</svg>
+					</div>
+				</div>
+				<?php endif; ?>
 
 				<div class="easydam-video-container loading <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>" >
 					<?php if ( isset( $godam_hover_select ) && 'shadow-overlay' === $godam_hover_select ) : ?>


### PR DESCRIPTION
This pull request implements support for low-quality image placeholders (LQIP) for video poster thumbnails, enabling a "blur-up" effect for faster and smoother perceived loading in the GoDAM player. It introduces new REST API fields and meta keys to handle placeholder thumbnails, updates backend logic to manage their mapping, and enhances the player frontend with CSS and JS for the blur-up transition.

**Backend: Placeholder Thumbnail Support**

* Added support for storing and retrieving placeholder (LQIP) thumbnails alongside each poster thumbnail, including new REST API fields (`placeholder_thumbnail` and `placeholder_thumbnail_url`) and meta keys (`rtgodam_media_placeholder_thumbnails`, `rtgodam_media_video_placeholder_thumbnail`). This ensures that for every main thumbnail, a corresponding placeholder can be managed and synced. [[1]](diffhunk://#diff-4f7d5e41b95ad49276b75df0eccbc9295818361e0ad9f8949e6d7f5d7e079868R681-R691) [[2]](diffhunk://#diff-4f7d5e41b95ad49276b75df0eccbc9295818361e0ad9f8949e6d7f5d7e079868R710-R714) [[3]](diffhunk://#diff-2c8260c84a22b264dd8ccfd5d58e5306e47db95a97a82118b0d72176c3b2baf2R115-R119) [[4]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R98-R102) [[5]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104L808-R838) [[6]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R919-R921) [[7]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R1056) [[8]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R1070-R1097) [[9]](diffhunk://#diff-0d4b5d9fe699dc8791e18e5ba3ea3c125885c17e6c1ff6815ee718e53481e7afR649-R654)
* Enhanced logic for setting and syncing placeholder thumbnails when the primary thumbnail is changed, including for custom and auto-selected thumbnails. [[1]](diffhunk://#diff-4f7d5e41b95ad49276b75df0eccbc9295818361e0ad9f8949e6d7f5d7e079868R734-R737) [[2]](diffhunk://#diff-0d4b5d9fe699dc8791e18e5ba3ea3c125885c17e6c1ff6815ee718e53481e7afR649-R654) [[3]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R1070-R1097)
* Updated REST API responses to include placeholder thumbnail mappings, and added validation for placeholder URLs. [[1]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R919-R921) [[2]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R1070-R1097)

**Frontend: Blur-Up LQIP Integration**

* Updated the player template (`godam-player.php`) to resolve and render the correct placeholder thumbnail for each video, supporting both block-editor overrides and auto-selected thumbnails. [[1]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aL326-R344) [[2]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aL551-R611)
* Added new CSS (`godam-player-wrapper.scss`) for the blur-up effect, including a shimmer animation and smooth fade-in of the full-quality poster image. [[1]](diffhunk://#diff-9067d83d44cde2c650e1e05d06c4d708d444e422dd8391121c64c3c1fb23da73R3-R4) [[2]](diffhunk://#diff-9067d83d44cde2c650e1e05d06c4d708d444e422dd8391121c64c3c1fb23da73R65-R118)
* Introduced JavaScript logic to handle the blur-up transition, detecting when the full poster image loads and triggering the CSS class switch for the effect.

These changes collectively improve the initial loading experience of video posters by displaying a fast-loading blurred placeholder before the full image appears, making the player feel more responsive and visually polished.

## 60% reduction in thumbnail size (conversion to WebP)
<img width="1433" height="786" alt="Screenshot 2026-04-21 at 4 58 14 PM" src="https://github.com/user-attachments/assets/2512cc05-5cbd-43a4-9393-5f736d990bc5" />

## Performance Improvements

### ~5kB placeholder thumbnails load first, then ~50kB thumbnails load. (both WebP)

<img width="1419" height="565" alt="Screenshot 2026-04-21 at 7 15 55 PM" src="https://github.com/user-attachments/assets/a76fd0c6-e870-4148-b593-d2941fd522b6" />

### Mobile - Before Optimization:

<img width="617" height="194" alt="Screenshot 2026-04-21 at 7 18 54 PM" src="https://github.com/user-attachments/assets/cc0bebe8-a627-4772-befa-9ada5a916989" />

### Mobile - After Optimization:

<img width="572" height="184" alt="Screenshot 2026-04-21 at 7 19 48 PM" src="https://github.com/user-attachments/assets/54a591c1-fb54-4a13-8e08-c83a2c733d3d" />

### Desktop - Before Optimization:

<img width="597" height="189" alt="Screenshot 2026-04-21 at 7 20 33 PM" src="https://github.com/user-attachments/assets/1b382a05-c9fd-4f41-9389-c5a573f6e851" />

### Desktop - After Optimization:

<img width="555" height="188" alt="Screenshot 2026-04-21 at 7 21 36 PM" src="https://github.com/user-attachments/assets/69158dbe-ee95-4cae-8378-2b080a1e04c0" />

## Recording


https://github.com/user-attachments/assets/d9f1fe68-0e01-4176-b1c2-8ccee237bf64


