### PR TITLE
feat: Introduce performance mode settings for video and gallery blocks

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -71,6 +71,10 @@
 		"showTitle": {
 			"type": "boolean",
 			"default": true
+		},
+		"performanceMode": {
+			"type": "string",
+			"default": "balanced"
 		}
 	},
 	"providesContext": {

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -37,6 +37,14 @@ import { columns, grid, listView, plus } from '@wordpress/icons';
 import './editor.scss';
 
 const ALLOWED_BLOCKS = [ 'godam/gallery-v2-item' ];
+const performanceModeOptions = [
+	{ label: __( 'Balanced', 'godam' ), value: 'balanced' },
+	{ label: __( 'Priority', 'godam' ), value: 'priority' },
+];
+const performanceModeHelpText = {
+	balanced: __( 'Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it. Best for overall page performance.', 'godam' ),
+	priority: __( 'For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly - one or two per page.', 'godam' ),
+};
 
 const formatDisplayDate = ( dateString ) => {
 	if ( ! dateString ) {
@@ -198,6 +206,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		customDateEnd,
 		showTitle,
 		layout,
+		performanceMode,
 	} = attributes;
 	const [ startDatePopoverOpen, setStartDatePopoverOpen ] = useState( false );
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
@@ -586,6 +595,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						label={ __( 'Show Video Titles and Dates', 'godam' ) }
 						checked={ !! showTitle }
 						onChange={ ( value ) => setAttributes( { showTitle: value } ) }
+					/>
+					<SelectControl
+						label={ __( 'Performance', 'godam' ) }
+						value={ performanceMode || 'balanced' }
+						options={ performanceModeOptions }
+						help={ performanceModeHelpText[ performanceMode || 'balanced' ] }
+						onChange={ ( value ) => setAttributes( { performanceMode: value } ) }
 					/>
 				</PanelBody>
 

--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -222,6 +222,7 @@ $item_width_map      = array(
 );
 $item_width          = isset( $item_width_map[ $item_width_size ] ) ? $item_width_map[ $item_width_size ] : 200;
 $show_title          = ! isset( $attributes['showTitle'] ) || (bool) $attributes['showTitle'];
+$performance_mode    = rtgodam_resolve_video_performance_mode( $attributes, 'balanced' );
 $enable_more_items   = array_key_exists( 'enableMoreItems', $attributes ) ? ! empty( $attributes['enableMoreItems'] ) : false;
 $more_items_behavior = isset( $attributes['moreItemsBehavior'] ) ? sanitize_key( $attributes['moreItemsBehavior'] ) : '';
 
@@ -282,6 +283,7 @@ if ( 'query' === $gallery_mode ) {
 		'custom_date_end'   => $attributes['customDateEnd'] ?? '',
 		'gallery_variant'   => 'gallery-v2',
 		'view_ratio'        => $view_ratio,
+		'performance_mode'  => $performance_mode,
 	);
 	$query             = new WP_Query( godam_gallery_v2_build_query_args( $attributes, 1 ) );
 	$total_query_items = (int) $query->found_posts;
@@ -334,7 +336,8 @@ if ( 'query' === $gallery_mode ) {
 				data-view-ratio="<?php echo esc_attr( $view_ratio ); ?>"
 			>
 			<div class="godam-gallery-v2__query-list">
-				<?php foreach ( $items as $item ) : ?>
+				<?php foreach ( $items as $index => $item ) : ?>
+					<?php $thumbnail_attributes = rtgodam_format_html_attributes( rtgodam_get_gallery_tile_image_attributes( $performance_mode, $index ) ); ?>
 					<div class="<?php echo esc_attr( sprintf( 'godam-gallery-v2__query-item godam-gallery-v2__query-item--ratio-%s', $ratio_class ) ); ?>">
 						<button
 							type="button"
@@ -346,7 +349,7 @@ if ( 'query' === $gallery_mode ) {
 						>
 							<div class="godam-gallery-v2__query-thumb">
 								<?php if ( ! empty( $item['thumbnail'] ) ) : ?>
-									<img src="<?php echo esc_url( $item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $item['title'] ); ?>" loading="lazy" fetchpriority="high" />
+									<img src="<?php echo esc_url( $item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $item['title'] ); ?>" <?php echo $thumbnail_attributes ? wp_kses_data( $thumbnail_attributes ) : ''; ?> />
 								<?php else : ?>
 									<span><?php esc_html_e( 'GoDAM Video', 'godam' ); ?></span>
 								<?php endif; ?>
@@ -383,7 +386,8 @@ if ( 'query' === $gallery_mode ) {
 			</div>
 		<?php else : ?>
 			<div class="godam-gallery-v2__item-list">
-				<?php foreach ( $items as $item ) : ?>
+				<?php foreach ( $items as $index => $item ) : ?>
+					<?php $thumbnail_attributes = rtgodam_format_html_attributes( rtgodam_get_gallery_tile_image_attributes( $performance_mode, $index ) ); ?>
 					<div class="<?php echo esc_attr( sprintf( 'godam-gallery-v2-item godam-gallery-v2-item--%s godam-gallery-v2-item--ratio-%s', $layout, $ratio_class ) ); ?>">
 						<button
 							type="button"
@@ -399,8 +403,7 @@ if ( 'query' === $gallery_mode ) {
 										src="<?php echo esc_url( $item['thumbnail'] ); ?>"
 										alt="<?php echo esc_attr( $item['title'] ); ?>"
 										class="godam-gallery-v2-item__thumbnail"
-										loading="lazy"
-										fetchpriority="high"
+										<?php echo $thumbnail_attributes ? wp_kses_data( $thumbnail_attributes ) : ''; ?>
 									/>
 								<?php else : ?>
 									<div class="godam-gallery-v2-item__placeholder">

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -42,7 +42,11 @@
 		},
 		"preload": {
 			"type": "string",
-			"default": "metadata"
+			"default": "none"
+		},
+		"performanceMode": {
+			"type": "string",
+			"default": "balanced"
 		},
 		"blob": {
 			"type": "string",

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -1,16 +1,33 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { ToggleControl, SelectControl } from '@wordpress/components';
 import { useMemo, useCallback } from '@wordpress/element';
 
 const options = [
-	{ value: 'auto', label: __( 'Auto', 'godam' ) },
-	{ value: 'metadata', label: __( 'Metadata', 'godam' ) },
-	{ value: 'thumbnail', label: __( 'Preload Only Video Thumbnail', 'godam' ) },
-	{ value: 'none', label: _x( 'None', 'Preload value', 'godam' ) },
+	{ value: 'balanced', label: __( 'Balanced', 'godam' ) },
+	{ value: 'priority', label: __( 'Priority', 'godam' ) },
 ];
+
+const performanceHelpText = {
+	balanced: __( 'Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it. Best for overall page performance.', 'godam' ),
+	priority: __( 'For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly - one or two per page.', 'godam' ),
+};
+
+const resolveLegacyPerformanceMode = ( preload, preloadPoster ) => {
+	const normalizedPreload = typeof preload === 'string' ? preload.toLowerCase() : '';
+
+	if ( preloadPoster ) {
+		return 'priority';
+	}
+
+	if ( normalizedPreload === 'preload only video thumbnail' ) {
+		return 'priority';
+	}
+
+	return 'balanced';
+};
 
 /**
  * Video settings component.
@@ -25,7 +42,7 @@ const options = [
  * @return {WPElement} The video settings component.
  */
 const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false } ) => {
-	const { autoplay, controls, loop, muted, preload, preloadPoster, showShareButton } =
+	const { autoplay, controls, loop, muted, preload, preloadPoster, performanceMode, showShareButton } =
 	attributes;
 	const showShareButtonSetting = window?.godamSettings?.enableGlobalVideoShare ?? false;
 
@@ -63,26 +80,17 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 		};
 	}, [ setAttributes ] );
 
-	const selectedPreloadValue = useMemo( () => {
-		// Only report 'thumbnail' when the legacy preloadPoster flag is set
-		// AND preload is already 'none', so existing content with preloadPoster=true
-		// but a non-'none' preload value is not misrepresented in the UI.
-		if ( preloadPoster && ( ! preload || 'none' === preload ) ) {
-			return 'thumbnail';
-		}
+	const selectedPerformanceMode = useMemo(
+		() => performanceMode || resolveLegacyPerformanceMode( preload, preloadPoster ),
+		[ performanceMode, preload, preloadPoster ],
+	);
 
-		return preload || 'auto';
-	}, [ preload, preloadPoster ] );
-
-	const onChangePreload = useCallback( ( value ) => {
-		if ( 'thumbnail' === value ) {
-			// Keep video preload off while preloading only poster image.
-			setAttributes( { preload: 'none', preloadPoster: true } );
-
-			return;
-		}
-
-		setAttributes( { preload: value, preloadPoster: false } );
+	const onChangePerformanceMode = useCallback( ( value ) => {
+		setAttributes( {
+			performanceMode: value,
+			preload: value === 'priority' ? 'metadata' : 'none',
+			preloadPoster: false,
+		} );
 	}, [ setAttributes ] );
 
 	return (
@@ -136,12 +144,12 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 				<SelectControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
-					label={ __( 'Preload', 'godam' ) }
-					value={ selectedPreloadValue }
-					onChange={ onChangePreload }
+					label={ __( 'Performance', 'godam' ) }
+					value={ selectedPerformanceMode }
+					onChange={ onChangePerformanceMode }
 					options={ options }
 					hideCancelButton
-					help={ __( 'Choose how the video should preload.', 'godam' ) }
+					help={ performanceHelpText[ selectedPerformanceMode ] }
 				/>
 			) }
 		</>

--- a/inc/classes/class-update.php
+++ b/inc/classes/class-update.php
@@ -20,6 +20,13 @@ class Update {
 	use Singleton;
 
 	/**
+	 * Option flag used to show the post-update video performance notice once.
+	 *
+	 * @var string
+	 */
+	const VIDEO_PERFORMANCE_NOTICE_OPTION = 'rtgodam_show_video_performance_notice';
+
+	/**
 	 * Construct method.
 	 */
 	protected function __construct() {
@@ -31,6 +38,7 @@ class Update {
 	 */
 	protected function setup_hooks() {
 		add_action( 'admin_init', array( $this, 'rtgodam_update_plugin_version' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_render_video_performance_notice' ) );
 	}
 
 	/**
@@ -57,9 +65,35 @@ class Update {
 				update_option( 'rtgodam_show_whats_new', true );
 			}
 
+			update_option( self::VIDEO_PERFORMANCE_NOTICE_OPTION, true, false );
 			$this->rtgodam_reconcile_api_key_state();
 			update_option( 'rtgodam_plugin_version', $current_version );
 		}
+	}
+
+	/**
+	 * Render a one-time admin notice after the video performance controls change.
+	 *
+	 * @return void
+	 */
+	public function maybe_render_video_performance_notice() {
+		if ( ! current_user_can( 'manage_options' ) || ! get_option( self::VIDEO_PERFORMANCE_NOTICE_OPTION ) ) {
+			return;
+		}
+
+		delete_option( self::VIDEO_PERFORMANCE_NOTICE_OPTION );
+		?>
+		<div class="notice notice-info is-dismissible">
+			<p>
+				<?php
+				esc_html_e(
+					'GoDAM video performance settings have been simplified to Balanced and Priority modes. Please review any hero videos that should stay in Priority mode after this update.',
+					'godam'
+				);
+				?>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/inc/classes/rest-api/class-dynamic-gallery.php
+++ b/inc/classes/rest-api/class-dynamic-gallery.php
@@ -113,6 +113,10 @@ class Dynamic_Gallery extends Base {
 							'type'    => 'string',
 							'default' => '16:9',
 						),
+						'performance_mode'  => array(
+							'type'    => 'string',
+							'default' => 'balanced',
+						),
 					),
 				),
 			),
@@ -146,6 +150,7 @@ class Dynamic_Gallery extends Base {
 			'engagements'       => $request->get_param( 'engagements' ),
 			'gallery_variant'   => $request->get_param( 'gallery_variant' ),
 			'view_ratio'        => $request->get_param( 'view_ratio' ),
+			'performance_mode'  => $request->get_param( 'performance_mode' ),
 		);
 
 		// Add filter for dynamic gallery attributes.
@@ -278,11 +283,12 @@ class Dynamic_Gallery extends Base {
 		$query = new \WP_Query( $args );
 		ob_start();
 		if ( $query->have_posts() ) {
-			$total_videos    = $query->found_posts;
-			$shown_videos    = count( $query->posts );
-			$alignment_class = '';
-			$is_gallery_v2   = 'gallery-v2' === $atts['gallery_variant'];
-			$ratio_class     = str_replace( ':', '-', $atts['view_ratio'] ?? '16:9' );
+			$total_videos     = $query->found_posts;
+			$shown_videos     = count( $query->posts );
+			$alignment_class  = '';
+			$is_gallery_v2    = 'gallery-v2' === $atts['gallery_variant'];
+			$ratio_class      = str_replace( ':', '-', $atts['view_ratio'] ?? '16:9' );
+			$performance_mode = rtgodam_normalize_video_performance_mode( $atts['performance_mode'] ?? 'balanced' );
 	
 			if ( ! $is_gallery_v2 && intval( $atts['offset'] ) === 0 ) {
 				echo '<div class="godam-video-gallery layout-' . esc_attr( $atts['layout'] ) .
@@ -308,7 +314,7 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 	
 			do_action( 'rtgodam_dynamic_gallery_before_output', $query, $atts );
 	
-			foreach ( $query->posts as $video ) {
+			foreach ( $query->posts as $index => $video ) {
 				do_action( 'rtgodam_dynamic_gallery_before_video_item', $video, $atts );
 	
 				$video_id    = intval( $video->ID );
@@ -358,12 +364,20 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 				$video_url = add_query_arg( $query_args, $cpt_base_url );
 
 				if ( $is_gallery_v2 ) {
+					$thumbnail_attributes = rtgodam_format_html_attributes(
+						rtgodam_get_gallery_tile_image_attributes(
+							$performance_mode,
+							intval( $atts['offset'] ) + $index
+						)
+					);
+
 					echo '<div class="godam-gallery-v2__query-item godam-gallery-v2__query-item--ratio-' . esc_attr( $ratio_class ) . '">';
 					/* translators: %s: video title. */
 					echo '<button type="button" class="godam-gallery-v2__query-button" data-godam-gallery-v2-trigger="true" data-video-id="' . esc_attr( $video_id ) . '" aria-label="' . esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $video_title ) ) . '">';
 					echo '<div class="godam-gallery-v2__query-thumb">';
 					if ( ! empty( $thumbnail ) ) {
-						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" loading="lazy" />';
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $thumbnail_attributes is pre-sanitized via rtgodam_format_html_attributes(), and rtgodam_get_gallery_tile_image_attributes() returns pre-sanitized attributes.
+						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '"' . ( $thumbnail_attributes ? ' ' . $thumbnail_attributes : '' ) . ' />';
 					} else {
 						echo '<span>' . esc_html__( 'GoDAM Video', 'godam' ) . '</span>';
 					}

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -167,6 +167,8 @@ class GoDAM_Player {
 				'hoverSelect'       => 'none',
 				'hover_select'      => 'none', // WPBakery format (lowercase with underscore).
 				'poster'            => '',
+				'performanceMode'   => 'balanced',
+				'performance_mode'  => 'balanced',
 				'preload'           => 'metadata',
 				'src'               => '',
 				'sources'           => '',
@@ -204,6 +206,9 @@ class GoDAM_Player {
 		}
 		if ( isset( $attributes['show_share_button'] ) && '' !== $attributes['show_share_button'] && ( ! isset( $attributes['showShareButton'] ) || false === $attributes['showShareButton'] ) ) {
 			$attributes['showShareButton'] = $attributes['show_share_button'];
+		}
+		if ( isset( $attributes['performance_mode'] ) && '' !== $attributes['performance_mode'] && ( ! isset( $attributes['performanceMode'] ) || '' === $attributes['performanceMode'] ) ) {
+			$attributes['performanceMode'] = $attributes['performance_mode'];
 		}
 
 		// Get WPBakery Design Options CSS class if available.

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -207,7 +207,9 @@ class GoDAM_Player {
 		if ( isset( $attributes['show_share_button'] ) && '' !== $attributes['show_share_button'] && ( ! isset( $attributes['showShareButton'] ) || false === $attributes['showShareButton'] ) ) {
 			$attributes['showShareButton'] = $attributes['show_share_button'];
 		}
-		if ( isset( $attributes['performance_mode'] ) && '' !== $attributes['performance_mode'] && ( ! isset( $attributes['performanceMode'] ) || '' === $attributes['performanceMode'] ) ) {
+		$raw_has_performance_mode = is_array( $atts ) && array_key_exists( 'performance_mode', $atts );
+		$raw_has_performanceMode  = is_array( $atts ) && array_key_exists( 'performanceMode', $atts );
+		if ( $raw_has_performance_mode && ! $raw_has_performanceMode && isset( $attributes['performance_mode'] ) && '' !== $attributes['performance_mode'] ) {
 			$attributes['performanceMode'] = $attributes['performance_mode'];
 		}
 

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -207,9 +207,9 @@ class GoDAM_Player {
 		if ( isset( $attributes['show_share_button'] ) && '' !== $attributes['show_share_button'] && ( ! isset( $attributes['showShareButton'] ) || false === $attributes['showShareButton'] ) ) {
 			$attributes['showShareButton'] = $attributes['show_share_button'];
 		}
-		$raw_has_performance_mode = is_array( $atts ) && array_key_exists( 'performance_mode', $atts );
-		$raw_has_performanceMode  = is_array( $atts ) && array_key_exists( 'performanceMode', $atts );
-		if ( $raw_has_performance_mode && ! $raw_has_performanceMode && isset( $attributes['performance_mode'] ) && '' !== $attributes['performance_mode'] ) {
+		$raw_has_performance_mode            = is_array( $atts ) && array_key_exists( 'performance_mode', $atts );
+		$raw_has_performance_mode_camel_case = is_array( $atts ) && array_key_exists( 'performanceMode', $atts );
+		if ( $raw_has_performance_mode && ! $raw_has_performance_mode_camel_case && isset( $attributes['performance_mode'] ) && '' !== $attributes['performance_mode'] ) {
 			$attributes['performanceMode'] = $attributes['performance_mode'];
 		}
 

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1333,16 +1333,16 @@ function rtgodam_resolve_video_performance_mode( $attributes, $default_mode = 'b
 
 	$legacy_preload = isset( $attributes['preload'] ) ? strtolower( trim( (string) $attributes['preload'] ) ) : '';
 
-	if ( in_array( $legacy_preload, array( 'metadata', 'auto' ), true ) ) {
+	if ( in_array( $legacy_preload, array( 'metadata', 'auto', 'none' ), true ) ) {
+		return 'balanced';
+	}
+
+	if ( in_array( $legacy_preload, array( 'preload only video thumbnail' ), true ) ) {
 		return 'priority';
 	}
 
-	if ( in_array( $legacy_preload, array( 'none', 'preload only video thumbnail' ), true ) ) {
-		return 'balanced';
-	}
-
 	if ( ! empty( $attributes['preloadPoster'] ) ) {
-		return 'balanced';
+		return 'priority';
 	}
 
 	return rtgodam_normalize_video_performance_mode( '', $default_mode );

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1290,3 +1290,146 @@ function godam_should_load_auth_detector_script( $screen ) {
 
 	return false;
 }
+
+/**
+ * Normalize a GoDAM video performance mode value.
+ *
+ * @param string $mode     Candidate performance mode.
+ * @param string $fallback Fallback mode when the candidate is invalid.
+ *
+ * @return string
+ */
+function rtgodam_normalize_video_performance_mode( $mode, $fallback = 'balanced' ) {
+	$mode     = is_string( $mode ) ? sanitize_key( $mode ) : '';
+	$fallback = 'priority' === sanitize_key( $fallback ) ? 'priority' : 'balanced';
+
+	if ( in_array( $mode, array( 'balanced', 'priority' ), true ) ) {
+		return $mode;
+	}
+
+	return $fallback;
+}
+
+/**
+ * Resolve the effective performance mode for a video from modern or legacy attributes.
+ *
+ * @param array  $attributes Block or shortcode attributes.
+ * @param string $default_mode Default performance mode when no stored value exists.
+ *
+ * @return string
+ */
+function rtgodam_resolve_video_performance_mode( $attributes, $default_mode = 'balanced' ) {
+	if ( ! is_array( $attributes ) ) {
+		return rtgodam_normalize_video_performance_mode( '', $default_mode );
+	}
+
+	if ( ! empty( $attributes['performanceMode'] ) ) {
+		return rtgodam_normalize_video_performance_mode( $attributes['performanceMode'], $default_mode );
+	}
+
+	if ( ! empty( $attributes['performance_mode'] ) ) {
+		return rtgodam_normalize_video_performance_mode( $attributes['performance_mode'], $default_mode );
+	}
+
+	$legacy_preload = isset( $attributes['preload'] ) ? strtolower( trim( (string) $attributes['preload'] ) ) : '';
+
+	if ( in_array( $legacy_preload, array( 'metadata', 'auto' ), true ) ) {
+		return 'priority';
+	}
+
+	if ( in_array( $legacy_preload, array( 'none', 'preload only video thumbnail' ), true ) ) {
+		return 'balanced';
+	}
+
+	if ( ! empty( $attributes['preloadPoster'] ) ) {
+		return 'balanced';
+	}
+
+	return rtgodam_normalize_video_performance_mode( '', $default_mode );
+}
+
+/**
+ * Resolve the final performance-driven render settings for a single video.
+ *
+ * @param array  $attributes Block or shortcode attributes.
+ * @param string $default_mode Default performance mode.
+ *
+ * @return array<string, mixed>
+ */
+function rtgodam_get_video_performance_settings( $attributes, $default_mode = 'balanced' ) {
+	$mode = rtgodam_resolve_video_performance_mode( $attributes, $default_mode );
+
+	return array(
+		'mode'              => $mode,
+		'video_attributes'  => array(
+			'preload' => 'priority' === $mode ? 'metadata' : 'none',
+		),
+		'poster_attributes' => 'priority' === $mode
+			? array(
+				'fetchpriority' => 'high',
+			)
+			: array(
+				'loading' => 'lazy',
+			),
+	);
+}
+
+/**
+ * Resolve the render attributes for a gallery tile thumbnail.
+ *
+ * Priority mode is intentionally capped to the leading tiles to avoid over-eager
+ * image loading in multi-video layouts.
+ *
+ * @param string $performance_mode Requested performance mode.
+ * @param int    $index            Zero-based tile index.
+ * @param int    $priority_cutoff  Number of leading tiles that may stay in priority mode.
+ *
+ * @return array<string, string>
+ */
+function rtgodam_get_gallery_tile_image_attributes( $performance_mode, $index = 0, $priority_cutoff = 3 ) {
+	$performance_mode = rtgodam_normalize_video_performance_mode( $performance_mode );
+	$index            = max( 0, intval( $index ) );
+	$priority_cutoff  = max( 0, intval( $priority_cutoff ) );
+	$is_priority_tile = 'priority' === $performance_mode && $index < $priority_cutoff;
+
+	if ( $is_priority_tile ) {
+		return array(
+			'fetchpriority' => 'high',
+		);
+	}
+
+	return array(
+		'loading' => 'lazy',
+	);
+}
+
+/**
+ * Format an associative array of HTML attributes into a string.
+ *
+ * @param array<string, scalar> $attributes Attributes to serialize.
+ *
+ * @return string
+ */
+function rtgodam_format_html_attributes( $attributes ) {
+	if ( ! is_array( $attributes ) || empty( $attributes ) ) {
+		return '';
+	}
+
+	$formatted = array();
+
+	foreach ( $attributes as $name => $value ) {
+		if ( ! is_scalar( $value ) || '' === $value ) {
+			continue;
+		}
+
+		$name = strtolower( trim( (string) $name ) );
+
+		if ( ! preg_match( '/^[a-z_:][-a-z0-9_:.]*$/', $name ) ) {
+			continue;
+		}
+
+		$formatted[] = sprintf( '%s="%s"', $name, esc_attr( (string) $value ) );
+	}
+
+	return implode( ' ', $formatted );
+}

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -86,8 +86,6 @@ $godam_controls       = isset( $attributes['controls'] ) ? $attributes['controls
 $godam_loop           = ! empty( $attributes['loop'] );
 $godam_muted          = ! empty( $attributes['muted'] );
 $godam_poster         = ! empty( $attributes['poster'] ) ? esc_url( $attributes['poster'] ) : '';
-$godam_preload_poster = ! empty( $attributes['preloadPoster'] );
-$godam_preload        = ! empty( $attributes['preload'] ) ? esc_attr( $attributes['preload'] ) : 'auto';
 $godam_hover_select   = isset( $attributes['hoverSelect'] ) ? $attributes['hoverSelect'] : 'none';
 $godam_caption        = ! empty( $attributes['caption'] ) ? esc_html( $attributes['caption'] ) : '';
 $godam_tracks         = ! empty( $attributes['tracks'] ) ? $attributes['tracks'] : array();
@@ -318,6 +316,34 @@ $godam_ads_settings       = wp_json_encode( $godam_ads_settings );
 $godam_global_video_share = isset( $godam_settings['video']['enable_global_video_share'] ) ? $godam_settings['video']['enable_global_video_share'] : true;
 
 $godam_video_poster = empty( $godam_poster ) ? $godam_poster_image : $godam_poster;
+$godam_performance  = rtgodam_get_video_performance_settings( $attributes );
+
+/**
+ * Filter the final performance-resolved attributes used to render a GoDAM video block.
+ *
+ * This runs after legacy preload values are mapped to the new performance modes,
+ * and before the HTML attributes are printed.
+ *
+ * @param array $render_attributes {
+ *     Final resolved render attributes.
+ *
+ *     @type string $mode                  Balanced or priority.
+ *     @type array  $video_attributes      Attributes applied to the <video> element.
+ *     @type array  $poster_attributes     Attributes applied to the poster <img>.
+ * }
+ * @param array $attributes Original block or shortcode attributes.
+ */
+$godam_performance = apply_filters(
+	'godam_video_block_attributes',
+	$godam_performance,
+	$attributes
+);
+
+$godam_preload                  = isset( $godam_performance['video_attributes']['preload'] ) ? sanitize_text_field( $godam_performance['video_attributes']['preload'] ) : 'none';
+$godam_poster_render_attributes = isset( $godam_performance['poster_attributes'] ) && is_array( $godam_performance['poster_attributes'] )
+	? $godam_performance['poster_attributes']
+	: array();
+$godam_poster_attribute_string  = rtgodam_format_html_attributes( $godam_poster_render_attributes );
 
 // Resolve the blur-up placeholder thumbnail.
 // For block-editor poster overrides, look up the mapping directly.
@@ -527,18 +553,6 @@ if ( empty( $godam_attachment_title ) ) {
 	$godam_attachment_title = basename( get_attached_file( $godam_attachment_id ) );
 }
 
-$godam_should_preload_poster = $godam_preload_poster && ! empty( $godam_video_poster );
-
-// Preload poster image if enabled to improve performance, especially LCP.
-if ( $godam_should_preload_poster ) {
-	add_action(
-		'wp_head',
-		function () use ( $godam_video_poster ) {
-			printf( '<link rel="preload" as="image" fetchpriority="high" href="%s">', esc_url( $godam_video_poster ) );
-		}
-	);
-}
-
 ?>
 
 <?php if ( ! empty( $godam_sources ) ) : ?>
@@ -571,8 +585,7 @@ if ( $godam_should_preload_poster ) {
 					<img
 						class="godam-player-poster-image"
 						src="<?php echo esc_url( $godam_video_poster ); ?>"
-						loading="lazy"
-						fetchpriority="low"
+						<?php echo $godam_poster_attribute_string ? wp_kses_data( $godam_poster_attribute_string ) : ''; ?>
 						aria-hidden="true"
 						alt="<?php echo esc_attr( $godam_attachment_title ); ?>"
 					/>
@@ -587,8 +600,7 @@ if ( $godam_should_preload_poster ) {
 					<img
 						class="godam-player-poster-image"
 						src="<?php echo esc_url( $godam_video_poster ); ?>"
-						fetchpriority="high"
-						loading="lazy"
+						<?php echo $godam_poster_attribute_string ? wp_kses_data( $godam_poster_attribute_string ) : ''; ?>
 						aria-hidden="true"
 						alt="<?php echo esc_attr( $godam_attachment_title ); ?>"
 					/>
@@ -620,15 +632,6 @@ if ( $godam_should_preload_poster ) {
 						?>
 					<?php endif; ?>
 
-					<?php if ( $godam_should_preload_poster ) : ?>
-						<img
-							class="godam-poster-image"
-							src="<?php echo esc_url( $godam_video_poster ); ?>"
-							fetchpriority="high"
-							aria-hidden="true"
-							alt="<?php echo esc_attr( $godam_attachment_title ); ?>"
-						/>
-					<?php endif; ?>
 					<video
 						class="easydam-player video-js vjs-big-play-centered vjs-hidden"
 						data-options="<?php echo esc_attr( $godam_video_config ); ?>"

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -90,6 +90,7 @@ $godam_hover_select   = isset( $attributes['hoverSelect'] ) ? $attributes['hover
 $godam_caption        = ! empty( $attributes['caption'] ) ? esc_html( $attributes['caption'] ) : '';
 $godam_tracks         = ! empty( $attributes['tracks'] ) ? $attributes['tracks'] : array();
 $godam_show_share_btn = ! empty( $attributes['showShareButton'] );
+
 // Determine if subtitles and transcript should be disabled based on the context (e.g., product gallery or reels contexts not require them).
 $godam_disable_subtitles_and_transcript = isset( $attributes['godam_context'] ) &&
 	in_array(


### PR DESCRIPTION
Fixes: https://github.com/rtCamp/godam-core/issues/1029

- Added a new performanceMode attribute to both the godam-gallery-v2 and godam-player blocks, allowing users to select between balanced and priority modes.
- Updated the edit interface to include a SelectControl for performance mode selection with contextual help text.
- Enhanced rendering logic to apply performance settings when displaying video thumbnails, optimizing loading behavior based on the selected mode.
- Implemented a one-time admin notice to inform users about the new performance settings after updates.

This pull request introduces a new "Performance" mode setting for both the Godam Gallery v2 and Godam Player blocks, replacing the previous preload settings with more user-friendly "Balanced" and "Priority" modes. This change is reflected across block attributes, editor controls, REST API, shortcode handling, and server-side rendering. Additionally, a one-time admin notice will inform users of the updated performance controls.

**Performance Mode Controls and Attributes**

- Added a new `performanceMode` attribute (defaulting to `'balanced'`) to both `godam-gallery-v2` and `godam-player` blocks, replacing previous preload-related settings for a more intuitive experience. [[1]](diffhunk://#diff-1bba1cbd20a66adc2eaef9e7c4aead7eebe45b0e6375b14169c5c875d7d63a49R74-R77) [[2]](diffhunk://#diff-0452960eaa8ba8724cc49af281678ab3c7d21abd9ed841f2362d9aa0e7b14d3dL45-R49)
- Updated block editors to provide a "Performance" dropdown with "Balanced" and "Priority" options, along with contextual help text explaining each mode. [[1]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R40-R47) [[2]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R599-R605) [[3]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL4-R31) [[4]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL28-R45) [[5]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL139-R152)

**Server-Side and API Updates**

- Updated server-side rendering for galleries and players to use the new `performanceMode` attribute, including logic to apply appropriate image loading attributes and propagate the setting through REST API and shortcode interfaces. [[1]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9R225) [[2]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9R286) [[3]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L337-R340) [[4]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L349-R352) [[5]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L386-R390) [[6]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L402-R406) [[7]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeR116-R119) [[8]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeR153) [[9]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeR291) [[10]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL311-R317) [[11]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeR367-R380) [[12]](diffhunk://#diff-f088ae9e674e2216e4e699ab4901aa7a473ca40d91c00421262b902272da8f21R170-R171) [[13]](diffhunk://#diff-f088ae9e674e2216e4e699ab4901aa7a473ca40d91c00421262b902272da8f21R210-R212)

**User Experience and Migration**

- Added a one-time admin notice to inform site administrators about the new performance controls and recommend reviewing hero videos to ensure correct settings post-update. [[1]](diffhunk://#diff-6736258678e3cdd96790d80d7d55070e7946c39b7084f45838f019a48d6e0e38R22-R28) [[2]](diffhunk://#diff-6736258678e3cdd96790d80d7d55070e7946c39b7084f45838f019a48d6e0e38R41) [[3]](diffhunk://#diff-6736258678e3cdd96790d80d7d55070e7946c39b7084f45838f019a48d6e0e38R68-R98)

These changes streamline video loading performance options, making them easier for users to understand and configure, while ensuring backward compatibility and a smooth migration path.


## Screenshots

https://github.com/user-attachments/assets/37a355f5-01ff-495f-bc7b-7450f3e355ba

