### PR TITLE
fix: Add GoDAM Gallery context to hide mini cart

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -334,7 +334,7 @@ const { __ } = require( '@wordpress/i18n' );
 
 			this.currentIndex = index;
 			activeGallery = this;
-			this.modal.iframe.src = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }`;
+			this.modal.iframe.src = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1`;
 			this.modal.overlay.classList.add( 'is-active' );
 			this.modal.modal.classList.add( 'is-active' );
 			this.modal.closeButton.classList.add( 'is-active' );


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/1024
This pull request makes a small update to how video embeds are loaded in the Godam Gallery block. The change ensures that when a video is opened in the modal, the embed URL now includes an additional query parameter to indicate it is being loaded from the gallery.

- The video embed URL in `view.js` is updated to include `&godam_gallery=1` as a query parameter when setting the iframe source.

## Screenshots

<img width="924" height="766" alt="Screenshot 2026-04-23 at 12 47 06 PM" src="https://github.com/user-attachments/assets/f82d0e7d-8b1b-42e2-bd14-d9248b64c094" />
