### PR TITLE
Fix - QA Issues

### DIFF
--- a/assets/src/blocks/godam-player/editor.scss
+++ b/assets/src/blocks/godam-player/editor.scss
@@ -189,36 +189,44 @@
 		&.godam-thumbnail-custom-block-tile {
 			cursor: default;
 
-			.godam-thumbnail-delete-btn {
-				position: absolute;
-				top: 3px;
-				right: 3px;
-				width: 16px;
-				height: 16px;
-				padding: 0;
-				background: rgba(0, 0, 0, 0.55);
-				color: #fff;
-				border: none;
-				border-radius: 50%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				cursor: pointer;
-				font-size: 10px;
-				line-height: 1;
-				z-index: 2;
-				transition: background 0.1s ease;
-
-				&:hover {
-					background: #cc1818;
-				}
-			}
-
 			/* When selected, push checkmark to bottom-right so it doesn't overlap the delete btn */
 			&.is-selected::after {
 				bottom: 3px;
 				right: 3px;
 				top: auto;
+			}
+		}
+	}
+
+	/* Wrapper for the custom-uploaded tile — provides the positioning context for the X button */
+	.godam-thumbnail-custom-block-wrapper {
+		position: relative;
+		flex: 0 0 auto;
+		width: 72px;
+		height: 48px;
+
+		.godam-thumbnail-delete-btn {
+			position: absolute;
+			top: 4px;
+			right: 4px;
+			width: 16px;
+			height: 16px;
+			padding: 0;
+			background: rgba(0, 0, 0, 0.55);
+			color: #fff;
+			border: none;
+			border-radius: 50%;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			cursor: pointer;
+			font-size: 10px;
+			line-height: 1;
+			z-index: 2;
+			transition: background 0.1s ease;
+
+			&:hover {
+				background: #cc1818;
 			}
 		}
 	}

--- a/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
@@ -15,7 +15,6 @@ import { __ } from '@wordpress/i18n';
 import { hasAPIKey } from '../../../utils';
 
 const VideoEngagement = ( { handleSettingChange } ) => {
-	const enableGlobalEngagement = useSelector( ( state ) => state.mediaSettings.video.enable_global_video_engagement );
 	const enableGlobalShare = useSelector( ( state ) => state.mediaSettings.video.enable_global_video_share );
 
 	return (
@@ -26,20 +25,6 @@ const VideoEngagement = ( { handleSettingChange } ) => {
 			>
 				<PanelBody>
 					<div className="flex flex-col gap-2 opacity-90 relative">
-						<ToggleControl
-							__nextHasNoMarginBottom
-							className="godam-toggle"
-							label={ __( 'Enable video engagement globally', 'godam' ) }
-							checked={ enableGlobalEngagement }
-							onChange={ ( value ) => {
-								handleSettingChange( 'enable_global_video_engagement', value );
-							} }
-							disabled={ ! hasAPIKey }
-							help={ __(
-								'If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel.',
-								'godam',
-							) }
-						/>
 						<ToggleControl
 							__nextHasNoMarginBottom
 							className="godam-toggle"

--- a/pages/godam/redux/slice/media-settings.js
+++ b/pages/godam/redux/slice/media-settings.js
@@ -56,16 +56,13 @@ const mediaSettingsSlice = createSlice( {
 	initialState,
 	reducers: {
 		// Sets the entire media settings (validates allowed keys)
+		// Used only for initialization from API data — must NOT set isChanged = true.
 		setMediaSettings: ( state, action ) => {
 			Object.keys( action.payload ).forEach( ( category ) => {
 				if ( state[ category ] ) {
 					Object.keys( action.payload[ category ] ).forEach( ( key ) => {
 						if ( key in state[ category ] ) {
-							// Check if the value is actually different
-							if ( state[ category ][ key ] !== action.payload[ category ][ key ] ) {
-								state[ category ][ key ] = action.payload[ category ][ key ];
-								state.isChanged = true; // Mark as changed
-							}
+							state[ category ][ key ] = action.payload[ category ][ key ];
 						}
 					} );
 				}


### PR DESCRIPTION
This pull request makes improvements to the styling and logic for custom video thumbnail tiles and video engagement settings in the Godam player editor. The main focus is on refining the user interface for custom-uploaded thumbnails and cleaning up unused code in the video engagement settings panel.

**Styling and UI Improvements:**

* Added a `.godam-thumbnail-custom-block-wrapper` class to provide relative positioning context for custom-uploaded thumbnail tiles, ensuring the delete (X) button is positioned correctly. The delete button's position was also adjusted slightly for better alignment.
* Moved the checkmark indicator for selected custom thumbnail tiles to the bottom-right corner, preventing overlap with the delete button.
* Removed redundant or misplaced CSS for the checkmark indicator to avoid duplication and ensure correct styling

**Code Cleanup and Logic Adjustments:**

* Removed the unused `enableGlobalEngagement` selector and its associated toggle control from the `VideoEngagement` component, simplifying the settings UI. [[1]](diffhunk://#diff-bc5d8c011dc32e2237d2a4b734a2f968280e24fb3f9132d95ec8c78f8562c175L18) [[2]](diffhunk://#diff-bc5d8c011dc32e2237d2a4b734a2f968280e24fb3f9132d95ec8c78f8562c175L29-L42)
* Clarified the comment in the `setMediaSettings` reducer to indicate it should only be used for initialization from API data, and ensured it does not set the `isChanged` flag to `true` during this process.

## Screenshots

### Engagements global toggle removed
<img width="1127" height="521" alt="Screenshot 2026-04-23 at 6 50 14 PM" src="https://github.com/user-attachments/assets/bb265bf3-2fa2-407f-b032-f67d44bf7c6f" />

### Custom thumbnail delete button
<img width="1470" height="956" alt="Screenshot 2026-04-23 at 6 53 51 PM" src="https://github.com/user-attachments/assets/06420e83-8ce9-474e-bbdb-e12bececcaef" />

### Source of unsaved changes comparison in redux
<img width="539" height="79" alt="Screenshot 2026-04-23 at 7 19 31 PM" src="https://github.com/user-attachments/assets/ce932cf7-d0e1-40aa-95c1-2e1c366b535f" />
