### PR TITLE
Feat/further performance improvements

### DIFF
--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -28,6 +28,69 @@ class GoDAM_Player {
 		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ) );
 		add_action( 'wp_head', array( $this, 'godam_output_admin_player_css' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'godam_skin_styles_enqueue' ) );
+
+		// Invalidate video render cache when rtgodam_meta changes.
+		add_action( 'updated_post_meta', array( $this, 'invalidate_video_cache_on_meta_change' ), 10, 3 );
+		add_action( 'added_post_meta', array( $this, 'invalidate_video_cache_on_meta_change' ), 10, 3 );
+		add_action( 'deleted_post_meta', array( $this, 'invalidate_video_cache_on_meta_change' ), 10, 3 );
+
+		// Fallback: invalidate on attachment save/delete.
+		add_action( 'edit_attachment', array( $this, 'invalidate_video_cache_for_post' ) );
+		add_action( 'deleted_post', array( $this, 'invalidate_video_cache_for_post' ) );
+	}
+
+	/**
+	 * Return the work-cache index key for a given video post ID.
+	 *
+	 * @param int $post_id Post/attachment ID.
+	 * @return string
+	 */
+	public function get_video_cache_index_key( $post_id ) {
+		return 'work_cache_godam_meta_' . absint( $post_id );
+	}
+
+	/**
+	 * Invalidate the render cache for a video when its rtgodam_meta post meta changes.
+	 *
+	 * @param int    $meta_id    Meta entry ID (unused).
+	 * @param int    $object_id  Post ID the meta belongs to.
+	 * @param string $meta_key   Meta key being updated.
+	 */
+	public function invalidate_video_cache_on_meta_change( $meta_id, $object_id, $meta_key ) {
+		// Only invalidate for attachment posts (GoDAM videos are stored as attachments).
+		if ( 'attachment' !== get_post_type( $object_id ) ) {
+			return;
+		}
+
+		$watched_keys = array(
+			'rtgodam_meta',
+			'rtgodam_transcoded_url',
+			'rtgodam_hls_transcoded_url',
+			'rtgodam_media_video_thumbnail',
+			'rtgodam_transcript_path',
+		);
+
+		if ( ! in_array( $meta_key, $watched_keys, true ) ) {
+			return;
+		}
+
+		$this->invalidate_video_cache_for_post( $object_id );
+	}
+
+	/**
+	 * Clear all cached render output for a given post/video ID.
+	 *
+	 * Only acts on attachment post types to avoid unnecessary cache work on
+	 * unrelated post deletions/edits.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function invalidate_video_cache_for_post( $post_id ) {
+		if ( 'attachment' !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		rtgodam_work_cache_index_clear( $this->get_video_cache_index_key( $post_id ) );
 	}
 
 	/**
@@ -254,9 +317,51 @@ class GoDAM_Player {
 			wp_enqueue_style( $skins[ $selected_skin ] );
 		}
 
+		// Build a deterministic cache key from the attributes that affect rendered HTML.
+		$cache_key_attrs = array(
+			'id'              => $attributes['id'],
+			'autoplay'        => (int) $attributes['autoplay'],
+			'controls'        => (int) $attributes['controls'],
+			'loop'            => (int) $attributes['loop'],
+			'muted'           => (int) $attributes['muted'],
+			'performanceMode' => $attributes['performanceMode'],
+			'preload'         => $attributes['preload'],
+			'poster'          => $attributes['poster'],
+			'aspectratio'     => $attributes['aspectratio'],
+			'aspect_ratio'    => $attributes['aspect_ratio'],
+			'tracks'          => $attributes['tracks'],
+			'godam_context'   => $attributes['godam_context'],
+			'hoverSelect'     => $attributes['hoverSelect'],
+			'showShareButton' => (int) $attributes['showShareButton'],
+			'engagements'     => (int) $attributes['engagements'],
+			'preview'         => (int) $attributes['preview'],
+		);
+		$cache_key       = 'work_cache_godam_video_' . md5( wp_json_encode( $cache_key_attrs ) );
+
+		// Skip cache on preview or debug requests.
+		$skip_cache = ( isset( $_GET['preview'] ) || ( defined( 'WP_DEBUG' ) && WP_DEBUG && isset( $_GET['nocache'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( ! $skip_cache ) {
+			$cached_html = rtgodam_work_cache_get( $cache_key );
+			if ( false !== $cached_html ) {
+				return $cached_html;
+			}
+		}
+
 		ob_start();
 		require RTGODAM_PATH . 'inc/templates/godam-player.php';
 		$player_html = ob_get_clean();
+
+		// Cache and register against the video index for targeted invalidation.
+		if ( ! $skip_cache && $player_html ) {
+			rtgodam_work_cache_set( $cache_key, $player_html );
+
+			$post_id = absint( $attributes['id'] );
+			if ( $post_id ) {
+				rtgodam_work_cache_index_add( $this->get_video_cache_index_key( $post_id ), $cache_key );
+			}
+		}
+
 		return $player_html;
 	}
 }

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -42,6 +42,8 @@ class GoDAM_Player {
 	/**
 	 * Return the work-cache index key for a given video post ID.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @param int $post_id Post/attachment ID.
 	 * @return string
 	 */
@@ -51,6 +53,8 @@ class GoDAM_Player {
 
 	/**
 	 * Invalidate the render cache for a video when its rtgodam_meta post meta changes.
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @param int    $meta_id    Meta entry ID (unused).
 	 * @param int    $object_id  Post ID the meta belongs to.
@@ -84,6 +88,8 @@ class GoDAM_Player {
 	 *
 	 * Only acts on attachment post types to avoid unnecessary cache work on
 	 * unrelated post deletions/edits.
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @param int $post_id Post ID.
 	 */
@@ -217,6 +223,21 @@ class GoDAM_Player {
 
 	/**
 	 * Render the GoDAM player shortcode.
+	 *
+	 * HTML output is NOT cached here by design.  Caching the full rendered blob
+	 * would suppress per-request side effects that the template performs on every
+	 * call: adding wrapper CSS to wp_head, suppressing Gravity Forms autoscroll,
+	 * conditionally initialising the IMA SDK for ad-enabled videos, and generating
+	 * a unique per-render $godam_instance_id used in DOM IDs.
+	 *
+	 * Performance is instead improved at the data layer: the template bundles all
+	 * expensive attachment meta calls (rtgodam_meta, transcoded URLs, thumbnails,
+	 * etc.) into a single persistent cache entry (work_cache_godam_meta_{id}) that
+	 * is invalidated precisely when the underlying meta changes.  This avoids the
+	 * heavy DB work on warm requests while keeping HTML generation stateless and
+	 * side-effect-safe on every render.
+	 * 
+	 * @since n.e.x.t
 	 *
 	 * @param array $atts Shortcode attributes.
 	 * @return string HTML output of the player.

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -36,7 +36,7 @@ class GoDAM_Player {
 
 		// Fallback: invalidate on attachment save/delete.
 		add_action( 'edit_attachment', array( $this, 'invalidate_video_cache_for_post' ) );
-		add_action( 'deleted_post', array( $this, 'invalidate_video_cache_for_post' ) );
+		add_action( 'delete_attachment', array( $this, 'invalidate_video_cache_for_post' ) );
 	}
 
 	/**
@@ -67,6 +67,8 @@ class GoDAM_Player {
 			'rtgodam_transcoded_url',
 			'rtgodam_hls_transcoded_url',
 			'rtgodam_media_video_thumbnail',
+			'rtgodam_media_video_placeholder_thumbnail',
+			'rtgodam_media_placeholder_thumbnails',
 			'rtgodam_transcript_path',
 		);
 
@@ -317,51 +319,8 @@ class GoDAM_Player {
 			wp_enqueue_style( $skins[ $selected_skin ] );
 		}
 
-		// Build a deterministic cache key from the attributes that affect rendered HTML.
-		$cache_key_attrs = array(
-			'id'              => $attributes['id'],
-			'autoplay'        => (int) $attributes['autoplay'],
-			'controls'        => (int) $attributes['controls'],
-			'loop'            => (int) $attributes['loop'],
-			'muted'           => (int) $attributes['muted'],
-			'performanceMode' => $attributes['performanceMode'],
-			'preload'         => $attributes['preload'],
-			'poster'          => $attributes['poster'],
-			'aspectratio'     => $attributes['aspectratio'],
-			'aspect_ratio'    => $attributes['aspect_ratio'],
-			'tracks'          => $attributes['tracks'],
-			'godam_context'   => $attributes['godam_context'],
-			'hoverSelect'     => $attributes['hoverSelect'],
-			'showShareButton' => (int) $attributes['showShareButton'],
-			'engagements'     => (int) $attributes['engagements'],
-			'preview'         => (int) $attributes['preview'],
-		);
-		$cache_key       = 'work_cache_godam_video_' . md5( wp_json_encode( $cache_key_attrs ) );
-
-		// Skip cache on preview or debug requests.
-		$skip_cache = ( isset( $_GET['preview'] ) || ( defined( 'WP_DEBUG' ) && WP_DEBUG && isset( $_GET['nocache'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		if ( ! $skip_cache ) {
-			$cached_html = rtgodam_work_cache_get( $cache_key );
-			if ( false !== $cached_html ) {
-				return $cached_html;
-			}
-		}
-
 		ob_start();
 		require RTGODAM_PATH . 'inc/templates/godam-player.php';
-		$player_html = ob_get_clean();
-
-		// Cache and register against the video index for targeted invalidation.
-		if ( ! $skip_cache && $player_html ) {
-			rtgodam_work_cache_set( $cache_key, $player_html );
-
-			$post_id = absint( $attributes['id'] );
-			if ( $post_id ) {
-				rtgodam_work_cache_index_add( $this->get_video_cache_index_key( $post_id ), $cache_key );
-			}
-		}
-
-		return $player_html;
+		return ob_get_clean();
 	}
 }

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1313,7 +1313,8 @@ if ( ! defined( 'RTGODAM_WORK_CACHE_TTL' ) ) {
 /**
  * Retrieve a value from the work cache.
  *
- * Tries the WordPress object cache first, falls back to transients.
+ * Uses the WordPress object cache when an external cache is active,
+ * otherwise uses transients.
  *
  * @since n.e.x.t
  *
@@ -1323,9 +1324,8 @@ if ( ! defined( 'RTGODAM_WORK_CACHE_TTL' ) ) {
 function rtgodam_work_cache_get( $key ) {
 	$versioned_key = RTGODAM_WORK_CACHE_VERSION . '_' . $key;
 
-	$value = wp_cache_get( $versioned_key, RTGODAM_WORK_CACHE_GROUP );
-	if ( false !== $value ) {
-		return $value;
+	if ( wp_using_ext_object_cache() ) {
+		return wp_cache_get( $versioned_key, RTGODAM_WORK_CACHE_GROUP );
 	}
 
 	return get_transient( 'rtgodam_wc_' . md5( $versioned_key ) );
@@ -1334,8 +1334,8 @@ function rtgodam_work_cache_get( $key ) {
 /**
  * Store a value in the work cache.
  *
- * Writes to both the object cache and transients so the value is available
- * across processes even when persistent object caching is absent.
+ * Uses the WordPress object cache when an external cache is active,
+ * otherwise uses transients.
  *
  * @since n.e.x.t
  *
@@ -1346,13 +1346,19 @@ function rtgodam_work_cache_get( $key ) {
 function rtgodam_work_cache_set( $key, $value, $ttl = RTGODAM_WORK_CACHE_TTL ) {
 	$versioned_key = RTGODAM_WORK_CACHE_VERSION . '_' . $key;
 
-	// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- $ttl defaults to RTGODAM_WORK_CACHE_TTL (1800s) and callers must pass >= 300s.
-	wp_cache_set( $versioned_key, $value, RTGODAM_WORK_CACHE_GROUP, $ttl );
-	set_transient( 'rtgodam_wc_' . md5( $versioned_key ), $value, $ttl );
+	if ( wp_using_ext_object_cache() ) {
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- $ttl defaults to RTGODAM_WORK_CACHE_TTL (1800s) and callers must pass >= 300s.
+		wp_cache_set( $versioned_key, $value, RTGODAM_WORK_CACHE_GROUP, $ttl );
+	} else {
+		set_transient( 'rtgodam_wc_' . md5( $versioned_key ), $value, $ttl );
+	}
 }
 
 /**
  * Delete a single entry from the work cache.
+ *
+ * Clears both the dedicated object-cache entry and the transient key so
+ * stale data is removed even if the site's cache backend changed.
  *
  * @since n.e.x.t
  *

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1367,6 +1367,7 @@ function rtgodam_get_video_performance_settings( $attributes, $default_mode = 'b
 		'poster_attributes' => 'priority' === $mode
 			? array(
 				'fetchpriority' => 'high',
+				'loading'       => 'eager',
 			)
 			: array(
 				'loading' => 'lazy',
@@ -1395,6 +1396,7 @@ function rtgodam_get_gallery_tile_image_attributes( $performance_mode, $index = 
 	if ( $is_priority_tile ) {
 		return array(
 			'fetchpriority' => 'high',
+			'loading'       => 'eager',
 		);
 	}
 

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1511,7 +1511,6 @@ function rtgodam_get_video_performance_settings( $attributes, $default_mode = 'b
 		'poster_attributes' => 'priority' === $mode
 			? array(
 				'fetchpriority' => 'high',
-				'loading'       => 'eager',
 			)
 			: array(
 				'loading' => 'lazy',

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1291,6 +1291,112 @@ function godam_should_load_auth_detector_script( $screen ) {
 	return false;
 }
 
+// ---------------------------------------------------------------------------
+// Work-cache helpers
+// ---------------------------------------------------------------------------
+
+/** Cache group used across all work-cache entries. */
+define( 'RTGODAM_WORK_CACHE_GROUP', 'rtgodam_work_cache' );
+
+/** Cache version — bump to globally invalidate all work-cache entries. */
+define( 'RTGODAM_WORK_CACHE_VERSION', 'v1' );
+
+/** Default TTL (seconds) used as hard-expiry fallback: 30 minutes. */
+define( 'RTGODAM_WORK_CACHE_TTL', 30 * MINUTE_IN_SECONDS );
+
+/**
+ * Retrieve a value from the work cache.
+ *
+ * Tries the WordPress object cache first, falls back to transients.
+ *
+ * @param string $key Cache key (without version prefix).
+ * @return mixed|false Cached value or false on miss.
+ */
+function rtgodam_work_cache_get( $key ) {
+	$versioned_key = RTGODAM_WORK_CACHE_VERSION . '_' . $key;
+
+	$value = wp_cache_get( $versioned_key, RTGODAM_WORK_CACHE_GROUP );
+	if ( false !== $value ) {
+		return $value;
+	}
+
+	return get_transient( 'rtgodam_wc_' . md5( $versioned_key ) );
+}
+
+/**
+ * Store a value in the work cache.
+ *
+ * Writes to both the object cache and transients so the value is available
+ * across processes even when persistent object caching is absent.
+ *
+ * @param string $key   Cache key (without version prefix).
+ * @param mixed  $value Value to cache.
+ * @param int    $ttl   Time-to-live in seconds. Defaults to RTGODAM_WORK_CACHE_TTL.
+ */
+function rtgodam_work_cache_set( $key, $value, $ttl = RTGODAM_WORK_CACHE_TTL ) {
+	$versioned_key = RTGODAM_WORK_CACHE_VERSION . '_' . $key;
+
+	// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- $ttl defaults to RTGODAM_WORK_CACHE_TTL (1800s) and callers must pass >= 300s.
+	wp_cache_set( $versioned_key, $value, RTGODAM_WORK_CACHE_GROUP, $ttl );
+	set_transient( 'rtgodam_wc_' . md5( $versioned_key ), $value, $ttl );
+}
+
+/**
+ * Delete a single entry from the work cache.
+ *
+ * @param string $key Cache key (without version prefix).
+ */
+function rtgodam_work_cache_delete( $key ) {
+	$versioned_key = RTGODAM_WORK_CACHE_VERSION . '_' . $key;
+
+	wp_cache_delete( $versioned_key, RTGODAM_WORK_CACHE_GROUP );
+	delete_transient( 'rtgodam_wc_' . md5( $versioned_key ) );
+}
+
+/**
+ * Register a cache key under an index so it can be bulk-deleted later.
+ *
+ * The index itself is stored as a transient keyed by `$index_key`.
+ *
+ * @param string $index_key Human-readable index identifier (e.g. `work_cache_godam_meta_{post_id}`).
+ * @param string $cache_key The cache key to register.
+ */
+function rtgodam_work_cache_index_add( $index_key, $cache_key ) {
+	$members = get_option( 'rtgodam_wc_idx_' . md5( $index_key ), array() );
+
+	if ( ! in_array( $cache_key, $members, true ) ) {
+		$members[] = $cache_key;
+		update_option( 'rtgodam_wc_idx_' . md5( $index_key ), $members, false );
+	}
+}
+
+/**
+ * Return all cache keys registered under an index.
+ *
+ * @param string $index_key Index identifier.
+ * @return string[] List of registered cache keys.
+ */
+function rtgodam_work_cache_index_members( $index_key ) {
+	return (array) get_option( 'rtgodam_wc_idx_' . md5( $index_key ), array() );
+}
+
+/**
+ * Delete every cache key registered under an index and remove the index.
+ *
+ * @param string $index_key Index identifier.
+ */
+function rtgodam_work_cache_index_clear( $index_key ) {
+	$members = rtgodam_work_cache_index_members( $index_key );
+
+	foreach ( $members as $cache_key ) {
+		rtgodam_work_cache_delete( $cache_key );
+	}
+
+	delete_option( 'rtgodam_wc_idx_' . md5( $index_key ) );
+}
+
+// ---------------------------------------------------------------------------
+
 /**
  * Normalize a GoDAM video performance mode value.
  *

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1315,6 +1315,8 @@ if ( ! defined( 'RTGODAM_WORK_CACHE_TTL' ) ) {
  *
  * Tries the WordPress object cache first, falls back to transients.
  *
+ * @since n.e.x.t
+ *
  * @param string $key Cache key (without version prefix).
  * @return mixed|false Cached value or false on miss.
  */
@@ -1335,6 +1337,8 @@ function rtgodam_work_cache_get( $key ) {
  * Writes to both the object cache and transients so the value is available
  * across processes even when persistent object caching is absent.
  *
+ * @since n.e.x.t
+ *
  * @param string $key   Cache key (without version prefix).
  * @param mixed  $value Value to cache.
  * @param int    $ttl   Time-to-live in seconds. Defaults to RTGODAM_WORK_CACHE_TTL.
@@ -1349,6 +1353,8 @@ function rtgodam_work_cache_set( $key, $value, $ttl = RTGODAM_WORK_CACHE_TTL ) {
 
 /**
  * Delete a single entry from the work cache.
+ *
+ * @since n.e.x.t
  *
  * @param string $key Cache key (without version prefix).
  */
@@ -1371,6 +1377,8 @@ function rtgodam_work_cache_delete( $key ) {
  * refreshed so the index stays alive as long as any of its members could still
  * be cached.
  *
+ * @since n.e.x.t
+ *
  * @param string $index_key Human-readable index identifier (e.g. `work_cache_godam_meta_{post_id}`).
  * @param string $cache_key The cache key to register.
  */
@@ -1392,6 +1400,8 @@ function rtgodam_work_cache_index_add( $index_key, $cache_key ) {
  * Returns an empty array when the index transient has expired, which means
  * all previously registered cache entries have also naturally expired.
  *
+ * @since n.e.x.t
+ *
  * @param string $index_key Index identifier.
  * @return string[] List of registered cache keys.
  */
@@ -1402,6 +1412,8 @@ function rtgodam_work_cache_index_members( $index_key ) {
 
 /**
  * Delete every cache key registered under an index and remove the index transient.
+ *
+ * @since n.e.x.t
  *
  * @param string $index_key Index identifier.
  */
@@ -1419,6 +1431,8 @@ function rtgodam_work_cache_index_clear( $index_key ) {
 
 /**
  * Normalize a GoDAM video performance mode value.
+ *
+ * @since n.e.x.t
  *
  * @param string $mode     Candidate performance mode.
  * @param string $fallback Fallback mode when the candidate is invalid.
@@ -1438,6 +1452,8 @@ function rtgodam_normalize_video_performance_mode( $mode, $fallback = 'balanced'
 
 /**
  * Resolve the effective performance mode for a video from modern or legacy attributes.
+ *
+ * @since n.e.x.t
  *
  * @param array  $attributes Block or shortcode attributes.
  * @param string $default_mode Default performance mode when no stored value exists.
@@ -1477,6 +1493,8 @@ function rtgodam_resolve_video_performance_mode( $attributes, $default_mode = 'b
 /**
  * Resolve the final performance-driven render settings for a single video.
  *
+ * @since n.e.x.t
+ *
  * @param array  $attributes Block or shortcode attributes.
  * @param string $default_mode Default performance mode.
  *
@@ -1507,6 +1525,8 @@ function rtgodam_get_video_performance_settings( $attributes, $default_mode = 'b
  * Priority mode is intentionally capped to the leading tiles to avoid over-eager
  * image loading in multi-video layouts.
  *
+ * @since n.e.x.t
+ *
  * @param string $performance_mode Requested performance mode.
  * @param int    $index            Zero-based tile index.
  * @param int    $priority_cutoff  Number of leading tiles that may stay in priority mode.
@@ -1533,6 +1553,8 @@ function rtgodam_get_gallery_tile_image_attributes( $performance_mode, $index = 
 
 /**
  * Format an associative array of HTML attributes into a string.
+ *
+ * @since n.e.x.t
  *
  * @param array<string, scalar> $attributes Attributes to serialize.
  *

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1296,13 +1296,19 @@ function godam_should_load_auth_detector_script( $screen ) {
 // ---------------------------------------------------------------------------
 
 /** Cache group used across all work-cache entries. */
-define( 'RTGODAM_WORK_CACHE_GROUP', 'rtgodam_work_cache' );
+if ( ! defined( 'RTGODAM_WORK_CACHE_GROUP' ) ) {
+	define( 'RTGODAM_WORK_CACHE_GROUP', 'rtgodam_work_cache' );
+}
 
 /** Cache version — bump to globally invalidate all work-cache entries. */
-define( 'RTGODAM_WORK_CACHE_VERSION', 'v1' );
+if ( ! defined( 'RTGODAM_WORK_CACHE_VERSION' ) ) {
+	define( 'RTGODAM_WORK_CACHE_VERSION', 'v1' );
+}
 
 /** Default TTL (seconds) used as hard-expiry fallback: 30 minutes. */
-define( 'RTGODAM_WORK_CACHE_TTL', 30 * MINUTE_IN_SECONDS );
+if ( ! defined( 'RTGODAM_WORK_CACHE_TTL' ) ) {
+	define( 'RTGODAM_WORK_CACHE_TTL', 30 * MINUTE_IN_SECONDS );
+}
 
 /**
  * Retrieve a value from the work cache.
@@ -1356,32 +1362,46 @@ function rtgodam_work_cache_delete( $key ) {
 /**
  * Register a cache key under an index so it can be bulk-deleted later.
  *
- * The index itself is stored as a transient keyed by `$index_key`.
+ * The index is stored as a transient with a TTL aligned to the maximum
+ * render-cache TTL (RTGODAM_WORK_CACHE_TTL). This ensures stale keys are
+ * pruned naturally when the index expires rather than accumulating indefinitely
+ * in permanent options.
+ *
+ * If a key is already registered under the index the TTL of the transient is
+ * refreshed so the index stays alive as long as any of its members could still
+ * be cached.
  *
  * @param string $index_key Human-readable index identifier (e.g. `work_cache_godam_meta_{post_id}`).
  * @param string $cache_key The cache key to register.
  */
 function rtgodam_work_cache_index_add( $index_key, $cache_key ) {
-	$members = get_option( 'rtgodam_wc_idx_' . md5( $index_key ), array() );
+	$transient_name = 'rtgodam_wc_idx_' . md5( $index_key );
+	$members        = (array) get_transient( $transient_name );
 
 	if ( ! in_array( $cache_key, $members, true ) ) {
 		$members[] = $cache_key;
-		update_option( 'rtgodam_wc_idx_' . md5( $index_key ), $members, false );
 	}
+
+	// Always refresh the TTL so the index outlives the youngest member.
+	set_transient( $transient_name, $members, RTGODAM_WORK_CACHE_TTL );
 }
 
 /**
  * Return all cache keys registered under an index.
  *
+ * Returns an empty array when the index transient has expired, which means
+ * all previously registered cache entries have also naturally expired.
+ *
  * @param string $index_key Index identifier.
  * @return string[] List of registered cache keys.
  */
 function rtgodam_work_cache_index_members( $index_key ) {
-	return (array) get_option( 'rtgodam_wc_idx_' . md5( $index_key ), array() );
+	$members = get_transient( 'rtgodam_wc_idx_' . md5( $index_key ) );
+	return is_array( $members ) ? $members : array();
 }
 
 /**
- * Delete every cache key registered under an index and remove the index.
+ * Delete every cache key registered under an index and remove the index transient.
  *
  * @param string $index_key Index identifier.
  */
@@ -1392,7 +1412,7 @@ function rtgodam_work_cache_index_clear( $index_key ) {
 		rtgodam_work_cache_delete( $cache_key );
 	}
 
-	delete_option( 'rtgodam_wc_idx_' . md5( $index_key ) );
+	delete_transient( 'rtgodam_wc_idx_' . md5( $index_key ) );
 }
 
 // ---------------------------------------------------------------------------

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -117,23 +117,33 @@ $godam_is_virtual  = ! empty( $godam_attachment_id ) && ! is_numeric( $godam_att
 $godam_original_id = $godam_attachment_id;
 
 if ( $godam_is_virtual ) {
-	// Query the WordPress Media Library to find an attachment post that has
-	// a meta key `_godam_original_id` matching this virtual media ID.
-	$godam_query = new \WP_Query(
-		array(
-			'post_type'      => 'attachment',
-			'posts_per_page' => 1,
-			'post_status'    => 'any',
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required for finding attachment by GoDAM ID.
-			'meta_key'       => '_godam_original_id',
-			'meta_value'     => sanitize_text_field( $godam_attachment_id ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'fields'         => 'ids',
-		)
-	);
+	// Resolve virtual GoDAM ID → WordPress attachment ID.
+	// The WP_Query is expensive, so cache the mapping separately.
+	$godam_virtual_map_key = 'work_cache_godam_virtual_' . md5( $godam_attachment_id );
+	$godam_cached_wp_id    = function_exists( 'rtgodam_work_cache_get' )
+		? rtgodam_work_cache_get( $godam_virtual_map_key )
+		: false;
 
-	// If a matching media attachment exists, use its actual WordPress ID.
-	if ( $godam_query->have_posts() ) {
-		$godam_original_id = $godam_query->posts[0];
+	if ( false !== $godam_cached_wp_id ) {
+		$godam_original_id = $godam_cached_wp_id;
+	} else {
+		$godam_query = new \WP_Query(
+			array(
+				'post_type'      => 'attachment',
+				'posts_per_page' => 1,
+				'post_status'    => 'any',
+				'meta_key'       => '_godam_original_id',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Required for finding attachment by GoDAM ID.
+				'meta_value'     => sanitize_text_field( $godam_attachment_id ),
+				'fields'         => 'ids',
+			)
+		);
+		if ( $godam_query->have_posts() ) {
+			$godam_original_id = $godam_query->posts[0];
+		}
+		if ( function_exists( 'rtgodam_work_cache_set' ) ) {
+			rtgodam_work_cache_set( $godam_virtual_map_key, $godam_original_id );
+		}
 	}
 }
 
@@ -146,34 +156,77 @@ $godam_src                = ! empty( $attributes['src'] ) ? esc_url( $attributes
 $godam_transcoded_url     = ! empty( $attributes['transcoded_url'] ) ? esc_url( $attributes['transcoded_url'] ) : '';
 $godam_hls_transcoded_url = ! empty( $attributes['hls_transcoded_url'] ) ? esc_url( $attributes['hls_transcoded_url'] ) : '';
 
-// Retrieve 'rtgodam_meta' for the given attachment ID, defaulting to an empty array if not found.
-$godam_meta_data = $godam_attachment_id ? get_post_meta( $godam_attachment_id, 'rtgodam_meta', true ) : array();
-$godam_meta_data = is_array( $godam_meta_data ) ? $godam_meta_data : array();
+// ---------------------------------------------------------------------------
+// Attachment metadata cache
+// ---------------------------------------------------------------------------
+// All DB calls tied to the resolved numeric attachment ID are bundled into a
+// single cache entry (work_cache_godam_meta_{id}).  The invalidation hooks in
+// GoDAM_Player already clear this index whenever rtgodam_meta or the
+// transcoded-URL meta keys change on an attachment post.
+// ---------------------------------------------------------------------------
 
-if ( $godam_is_virtual ) {
-	$godam_meta_data = $godam_original_id ? get_post_meta( $godam_original_id, 'rtgodam_meta', true ) : array();
+// The resolved numeric WP attachment ID used as the cache key.
+$godam_numeric_id = 0;
+if ( $godam_is_virtual && is_numeric( $godam_original_id ) ) {
+	$godam_numeric_id = intval( $godam_original_id );
+} elseif ( ! $godam_is_virtual && is_numeric( $godam_attachment_id ) ) {
+	$godam_numeric_id = intval( $godam_attachment_id );
 }
+
+$godam_meta_cache_key  = $godam_numeric_id ? 'work_cache_godam_meta_' . $godam_numeric_id : '';
+$godam_attachment_data = ( $godam_meta_cache_key && function_exists( 'rtgodam_work_cache_get' ) )
+	? rtgodam_work_cache_get( $godam_meta_cache_key )
+	: false;
+
+if ( false === $godam_attachment_data && $godam_numeric_id ) {
+	// Cache miss — collect every DB/meta call for this attachment in one pass.
+	$_raw_transcoded_url     = rtgodam_get_transcoded_url_from_attachment( $godam_numeric_id );
+	$_raw_hls_transcoded_url = rtgodam_get_hls_transcoded_url_from_attachment( $godam_numeric_id );
+	$_raw_video_src          = wp_get_attachment_url( $godam_numeric_id );
+	$_raw_video_src_type     = get_post_mime_type( $godam_numeric_id );
+	$_raw_job_id             = '';
+	if ( ! empty( $_raw_transcoded_url ) ) {
+		$_raw_job_id = get_post_meta( $godam_numeric_id, 'rtgodam_transcoding_job_id', true );
+		if ( empty( $_raw_job_id ) ) {
+			$_raw_job_id = get_post_meta( $godam_numeric_id, '_godam_original_id', true );
+		}
+	}
+
+	$godam_attachment_data = array(
+		'meta_data'          => get_post_meta( $godam_numeric_id, 'rtgodam_meta', true ),
+		'poster_image'       => get_post_meta( $godam_numeric_id, 'rtgodam_media_video_thumbnail', true ),
+		'transcoded_url'     => $_raw_transcoded_url,
+		'hls_transcoded_url' => $_raw_hls_transcoded_url,
+		'video_src'          => $_raw_video_src,
+		'video_src_type'     => $_raw_video_src_type,
+		'job_id'             => $_raw_job_id,
+		'placeholder_map'    => get_post_meta( $godam_numeric_id, 'rtgodam_media_placeholder_thumbnails', true ),
+		'placeholder_single' => get_post_meta( $godam_numeric_id, 'rtgodam_media_video_placeholder_thumbnail', true ),
+		'attachment_meta'    => wp_get_attachment_metadata( $godam_numeric_id ),
+	);
+
+	if ( function_exists( 'rtgodam_work_cache_set' ) && function_exists( 'rtgodam_work_cache_index_add' ) ) {
+		rtgodam_work_cache_set( $godam_meta_cache_key, $godam_attachment_data );
+		rtgodam_work_cache_index_add( $godam_meta_cache_key, $godam_meta_cache_key );
+	}
+}
+
+// Unpack cached (or freshly fetched) attachment data into template variables.
+$godam_meta_data    = isset( $godam_attachment_data['meta_data'] ) && is_array( $godam_attachment_data['meta_data'] )
+	? $godam_attachment_data['meta_data']
+	: array();
+$godam_poster_image = ! empty( $godam_attachment_data['poster_image'] ) ? $godam_attachment_data['poster_image'] : '';
 
 // Resolve aspect ratio after we have all metadata loaded.
 if ( ! empty( $attributes['aspectRatio'] ) && 'responsive' === $attributes['aspectRatio'] ) {
 	if ( ! empty( $attributes['videoWidth'] ) && ! empty( $attributes['videoHeight'] ) ) {
 		// Use explicitly provided dimensions (from block attributes).
 		$godam_aspect_ratio = $attributes['videoWidth'] . ':' . $attributes['videoHeight'];
+	} elseif ( ! empty( $godam_attachment_data['attachment_meta']['width'] ) && ! empty( $godam_attachment_data['attachment_meta']['height'] ) ) {
+		$godam_aspect_ratio = intval( $godam_attachment_data['attachment_meta']['width'] ) . ':' . intval( $godam_attachment_data['attachment_meta']['height'] );
 	} else {
-		// Try to resolve from attachment metadata.
-		$godam_attachment_to_check = $godam_is_virtual && ! empty( $godam_original_id ) ? $godam_original_id : $godam_attachment_id;
-		if ( ! empty( $godam_attachment_to_check ) && is_numeric( $godam_attachment_to_check ) ) {
-			$godam_video_meta = wp_get_attachment_metadata( intval( $godam_attachment_to_check ) );
-			if ( ! empty( $godam_video_meta['width'] ) && ! empty( $godam_video_meta['height'] ) ) {
-				$godam_aspect_ratio = intval( $godam_video_meta['width'] ) . ':' . intval( $godam_video_meta['height'] );
-			} else {
-				// Fallback: let frontend JavaScript detect dimensions dynamically.
-				$godam_aspect_ratio = 'responsive';
-			}
-		} else {
-			// No attachment ID available - let frontend handle it.
-			$godam_aspect_ratio = 'responsive';
-		}
+		// Fallback: let frontend JavaScript detect dimensions dynamically.
+		$godam_aspect_ratio = 'responsive';
 	}
 } elseif ( ! empty( $attributes['aspectRatio'] ) && preg_match( '/^\d+:\d+$/', $attributes['aspectRatio'] ) ) {
 	// Use an explicitly set ratio like "16:9", "4:3", etc.
@@ -181,34 +234,30 @@ if ( ! empty( $attributes['aspectRatio'] ) && 'responsive' === $attributes['aspe
 } else {
 	$godam_aspect_ratio = '16:9';
 }
+
 // Extract control bar settings with a fallback to an empty array.
 $godam_control_bar_settings = $godam_meta_data['videoConfig']['controlBar'] ?? array();
 
-$godam_poster_image = get_post_meta( $godam_attachment_id, 'rtgodam_media_video_thumbnail', true );
-$godam_poster_image = ! empty( $godam_poster_image ) ? $godam_poster_image : '';
-
-$godam_job_id = '';
-
+$godam_job_id  = '';
 $godam_sources = array();
 
 if ( empty( $godam_attachment_id ) ) {
 	$godam_job_id = ! empty( $attributes['cmmId'] ) ? sanitize_text_field( $attributes['cmmId'] ) : '';
 } elseif ( $godam_is_virtual ) {
-	// For virtual media, the attachment_id is the GoDAM ID, which is the job_id.
+	// For virtual media the attachment_id is the GoDAM ID, which is the job_id.
 	$godam_job_id = $godam_attachment_id;
 }
 
 if ( ( empty( $godam_attachment_id ) || ( $godam_is_virtual && ! empty( $godam_original_id ) ) ) &&
-	! empty( $attributes['sources'] ) 
+	! empty( $attributes['sources'] )
 ) {
-	// If media is virtual media.
+	// Virtual media: sources supplied directly via attributes.
 	$godam_sources = $attributes['sources'];
 } elseif ( empty( $godam_attachment_id ) &&
 	! ( empty( $godam_src ) && empty( $godam_transcoded_url ) && empty( $godam_hls_transcoded_url ) )
 ) {
-	// in case of shortcode with src or transcoded_url or hls_transcoded_url attribute.
+	// Shortcode with explicit src / transcoded_url / hls_transcoded_url attributes.
 	$godam_sources = array();
-
 	if ( ! empty( $godam_hls_transcoded_url ) ) {
 		$godam_sources[] = array(
 			'src'  => $godam_hls_transcoded_url,
@@ -228,41 +277,30 @@ if ( ( empty( $godam_attachment_id ) || ( $godam_is_virtual && ! empty( $godam_o
 		);
 	}
 } else {
-
+	// Normal WP attachment — use cached transcoded/source URLs.
 	if ( $godam_is_virtual ) {
-		// For virtual media, we need to get the actual attachment ID first.
 		$godam_attachment_id = $godam_original_id;
 	}
 
-	$godam_transcoded_url     = $godam_attachment_id ? rtgodam_get_transcoded_url_from_attachment( $godam_attachment_id ) : '';
-	$godam_hls_transcoded_url = $godam_attachment_id ? rtgodam_get_hls_transcoded_url_from_attachment( $godam_attachment_id ) : '';
-	$godam_video_src          = $godam_attachment_id ? wp_get_attachment_url( $godam_attachment_id ) : '';
-	$godam_video_src_type     = $godam_attachment_id ? get_post_mime_type( $godam_attachment_id ) : '';
-	$godam_job_id             = '';
+	$godam_transcoded_url     = $godam_attachment_data['transcoded_url'] ?? '';
+	$godam_hls_transcoded_url = $godam_attachment_data['hls_transcoded_url'] ?? '';
+	$godam_video_src          = $godam_attachment_data['video_src'] ?? '';
+	$godam_video_src_type     = $godam_attachment_data['video_src_type'] ?? '';
+	$godam_job_id             = $godam_attachment_data['job_id'] ?? '';
 
-	if ( $godam_attachment_id && ! empty( $godam_transcoded_url ) ) {
-		$godam_job_id = get_post_meta( $godam_attachment_id, 'rtgodam_transcoding_job_id', true );
-
-		if ( empty( $godam_job_id ) ) {
-			$godam_job_id = get_post_meta( $godam_attachment_id, '_godam_original_id', true );
-		}
-	}
 	$godam_sources = array();
-
 	if ( ! empty( $godam_hls_transcoded_url ) ) {
 		$godam_sources[] = array(
 			'src'  => $godam_hls_transcoded_url,
 			'type' => 'application/x-mpegURL',
 		);
 	}
-
 	if ( ! empty( $godam_transcoded_url ) ) {
 		$godam_sources[] = array(
 			'src'  => $godam_transcoded_url,
 			'type' => 'application/dash+xml',
 		);
 	}
-
 	$godam_sources[] = array(
 		'src'  => $godam_video_src,
 		'type' => 'video/quicktime' === $godam_video_src_type ? 'video/mp4' : $godam_video_src_type,
@@ -357,12 +395,18 @@ $godam_placeholder_lookup_id = is_numeric( $godam_attachment_id )
 
 if ( $godam_placeholder_lookup_id > 0 ) {
 	if ( ! empty( $godam_poster ) ) {
-		$godam_placeholder_map = get_post_meta( $godam_placeholder_lookup_id, 'rtgodam_media_placeholder_thumbnails', true );
-		if ( is_array( $godam_placeholder_map ) && isset( $godam_placeholder_map[ $godam_poster ] ) ) {
+		// Use cached placeholder map (array of poster_url → placeholder_url).
+		$godam_placeholder_map = isset( $godam_attachment_data['placeholder_map'] ) && is_array( $godam_attachment_data['placeholder_map'] )
+			? $godam_attachment_data['placeholder_map']
+			: array();
+		if ( isset( $godam_placeholder_map[ $godam_poster ] ) ) {
 			$godam_placeholder_thumbnail = esc_url( $godam_placeholder_map[ $godam_poster ] );
 		}
 	} else {
-		$godam_placeholder_thumbnail = esc_url( get_post_meta( $godam_placeholder_lookup_id, 'rtgodam_media_video_placeholder_thumbnail', true ) );
+		// Use cached single-placeholder thumbnail.
+		$godam_placeholder_thumbnail = ! empty( $godam_attachment_data['placeholder_single'] )
+			? esc_url( $godam_attachment_data['placeholder_single'] )
+			: '';
 	}
 }
 $godam_video_setup = array(
@@ -468,7 +512,12 @@ if ( ! empty( $godam_ad_tag_url ) ) {
 	IMA_Assets::get_instance();
 }
 
-$godam_instance_id = 'video_' . bin2hex( random_bytes( 8 ) );
+// Allow callers that cache output (e.g. the shortcode renderer) to inject a
+// deterministic ID so cached HTML doesn't embed a random value. When no ID is
+// pre-set, fall back to a random one (non-cached / direct-require path).
+if ( ! isset( $godam_instance_id ) ) {
+	$godam_instance_id = 'video_' . bin2hex( random_bytes( 8 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+}
 
 // When a player height is set, derive max-width = height × (arW / arH), mirroring
 // the video-editor approach. This lets Video.js (fluid:true) fill the width and

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -140,9 +140,11 @@ if ( $godam_is_virtual ) {
 		);
 		if ( $godam_query->have_posts() ) {
 			$godam_original_id = $godam_query->posts[0];
-		}
-		if ( function_exists( 'rtgodam_work_cache_set' ) ) {
-			rtgodam_work_cache_set( $godam_virtual_map_key, $godam_original_id );
+			// Only cache a successful resolution — never cache a miss, so a
+			// newly-created attachment is resolvable on the very next request.
+			if ( function_exists( 'rtgodam_work_cache_set' ) ) {
+				rtgodam_work_cache_set( $godam_virtual_map_key, $godam_original_id );
+			}
 		}
 	}
 }
@@ -173,12 +175,19 @@ if ( $godam_is_virtual && is_numeric( $godam_original_id ) ) {
 	$godam_numeric_id = intval( $godam_attachment_id );
 }
 
+// Always start as an empty array — safe for all downstream ?? / isset() / empty() access.
+// A populated array means a cache hit; an empty array means miss or no numeric ID.
 $godam_meta_cache_key  = $godam_numeric_id ? 'work_cache_godam_meta_' . $godam_numeric_id : '';
-$godam_attachment_data = ( $godam_meta_cache_key && function_exists( 'rtgodam_work_cache_get' ) )
-	? rtgodam_work_cache_get( $godam_meta_cache_key )
-	: false;
+$godam_attachment_data = array();
 
-if ( false === $godam_attachment_data && $godam_numeric_id ) {
+if ( $godam_meta_cache_key && function_exists( 'rtgodam_work_cache_get' ) ) {
+	$godam_cached = rtgodam_work_cache_get( $godam_meta_cache_key );
+	if ( is_array( $godam_cached ) ) {
+		$godam_attachment_data = $godam_cached;
+	}
+}
+
+if ( empty( $godam_attachment_data ) && $godam_numeric_id ) {
 	// Cache miss — collect every DB/meta call for this attachment in one pass.
 	$_raw_transcoded_url     = rtgodam_get_transcoded_url_from_attachment( $godam_numeric_id );
 	$_raw_hls_transcoded_url = rtgodam_get_hls_transcoded_url_from_attachment( $godam_numeric_id );


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-core/issues/909

This pull request introduces a robust caching layer for GoDAM video attachment metadata, significantly improving performance by reducing redundant database queries. The cache is carefully invalidated whenever relevant attachment metadata changes, ensuring data consistency. Additionally, the player template and related helpers are updated to leverage this cache, optimizing both virtual and regular media lookups.

**Caching infrastructure and invalidation:**

* Adds a set of work-cache helper functions in `custom-functions.php` to store, retrieve, index, and bulk-clear cached data, using both object cache and transients for reliability.
* Implements precise cache invalidation in `class-godam-player.php` by hooking into post meta changes and attachment edits/deletes, ensuring that cached video metadata is always up-to-date.

**Player template and metadata usage:**

* Refactors `godam-player.php` to bundle all expensive attachment meta/database calls into a single cached entry per video, greatly improving render performance. The template now fetches all metadata (including transcoded URLs, thumbnails, and attachment meta) from this cache, with fallback logic for cache misses. [[1]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aL149-L211) [[2]](diffhunk://#diff-5167081b957cb76c4fb932a2978e980763218ae938e1a2422ae82a6cf36f2c1aL231-L265)
* Caches the mapping from virtual GoDAM IDs to WordPress attachment IDs to avoid repeated expensive queries, only caching successful resolutions to ensure new attachments are discoverable immediately.

**Documentation and code clarity:**

* Adds detailed documentation to the player shortcode render method and helper functions, clarifying the caching strategy and performance rationale. [[1]](diffhunk://#diff-f088ae9e674e2216e4e699ab4901aa7a473ca40d91c00421262b902272da8f21R227-R241) [[2]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1456-R1457) [[3]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1496-R1497) [[4]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1527-R1528) [[5]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1556-R1557)


These changes collectively make the GoDAM player more efficient and scalable, especially for sites with many videos or frequent attachment updates.

## Screenshots:

Performance score in the range of **72** to **77**
<img width="1470" height="731" alt="Screenshot 2026-04-27 at 4 18 00 PM" src="https://github.com/user-attachments/assets/decc677d-f920-4dc1-bb13-201cf06c9529" />

**Without persistent cache:** marginal improvement (same-request deduplication only).
**With persistent cache (Redis):** meaningful improvement — most meta DB calls are skipped entirely on warm requests. Eventually, increase the page load time by a few milliseconds.

**Before** 
<img width="1470" height="731" alt="Screenshot 2026-04-27 at 5 50 23 PM" src="https://github.com/user-attachments/assets/82cd4541-0b76-4d05-ba55-f0779eb3f294" />

**After**
<img width="1470" height="731" alt="Screenshot 2026-04-27 at 5 48 42 PM" src="https://github.com/user-attachments/assets/a55ebe51-6a67-4bb8-8dd9-da7e749096a3" />


