### PR TITLE
fix: Alignment issue on GoDAM blocks

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/editor.scss
+++ b/assets/src/blocks/godam-gallery-v2/editor.scss
@@ -1,5 +1,10 @@
 .godam-gallery-v2 {
-	width: 100%;
+	// Only apply 100% width when no block-level alignment is set.
+	// alignfull/alignwide rely on theme/editor CSS for their own width.
+	&:not(.alignfull):not(.alignwide) {
+		width: 100%;
+	}
+
 	padding: 16px;
 	background: #f8f9fa;
 	border: 1px dashed #ccc;

--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -2,7 +2,11 @@
 	--godam-gallery-item-width: 200px;
 	--godam-gallery-gap: 16px;
 
-	width: 100%;
+	// Only apply 100% width when no block-level alignment is set.
+	// alignfull/alignwide rely on theme CSS for their own width.
+	&:not(.alignfull):not(.alignwide) {
+		width: 100%;
+	}
 }
 
 .godam-gallery-v2__canvas {

--- a/assets/src/blocks/godam-player/editor.scss
+++ b/assets/src/blocks/godam-player/editor.scss
@@ -4,8 +4,13 @@
  * including in flex layouts (Row/Stack).
  */
 .wp-block-godam-video {
-	width: 100%;
 	min-width: 0; // Allow shrinking in flex layouts (Row/Stack)
+
+	// Only apply 100% width when no block-level alignment is set.
+	// alignfull/alignwide rely on editor CSS for their own width.
+	&:not(.alignfull):not(.alignwide) {
+		width: 100%;
+	}
 
 	// Ensure the figure takes full width
 	> figure {

--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -15,9 +15,14 @@
  * including flex layouts (Row, Stack) and standard layouts (Group, Columns).
  */
 .wp-block-godam-video {
-	width: 100%;
 	min-width: 0; // Allow shrinking in flex layouts (Row/Stack)
-	
+
+	// Only apply 100% width when no block-level alignment is set.
+	// alignfull/alignwide rely on theme CSS for their own width (e.g. 100vw + negative margins).
+	&:not(.alignfull):not(.alignwide) {
+		width: 100%;
+	}
+
 	// Ensure the figure takes full width
 	figure[id^="godam-player-container"] {
 		width: 100%;

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1752,9 +1752,14 @@ body.godam-share-modal-open {
  * including flex layouts (Row, Stack) and standard layouts (Group, Columns).
  */
 .wp-block-godam-video {
-	width: 100%;
 	min-width: 0; // Allow shrinking in flex layouts (Row/Stack)
-	
+
+	// Only apply 100% width when no block-level alignment is set.
+	// alignfull/alignwide rely on theme CSS for their own width (e.g. 100vw + negative margins).
+	&:not(.alignfull):not(.alignwide) {
+		width: 100%;
+	}
+
 	// Ensure the figure takes full width
 	figure[id^="godam-player-container"] {
 		width: 100%;


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/1024

This pull request improves how block-level alignment is handled for the `godam-gallery-v2` and `godam-player` blocks. The main change is to apply `width: 100%` only when the block does not have `alignfull` or `alignwide` classes, allowing theme and editor CSS to control the width for these special alignments. This prevents unintended width overrides and ensures better compatibility with theme styles.

**Block alignment handling improvements:**

* In `godam-gallery-v2` and `godam-player` editor and front-end styles (`editor.scss` and `style.scss`), `width: 100%` is now applied only when the block does not have `alignfull` or `alignwide` classes, preventing conflicts with theme or editor alignment styles. [[1]](diffhunk://#diff-3fbe485411a910b05202873b9e280e626ee3f9ca385d3d2192f1b5c96280906dR2-R7) [[2]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR5-R10) [[3]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdL7-R14) [[4]](diffhunk://#diff-89e92fdab13aad2dda8bfe013f74d8961d1e5fad2e34d617cd41a3d29c67c9caL18-R25) [[5]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L1755-R1762)

No other functional or structural changes were made.

## Recording
### Fix for Align wide and align full
https://app.godam.io/web/video/o85cvj8d8p

>[!NOTE]
> 1. Hard refresh and cache clear would be needed to see these changes reflected in development
> 2. Align left and align right are buggy on WordPress pages, even with normal image block:
<img width="1290" height="737" alt="Screenshot 2026-04-24 at 4 07 45 PM" src="https://github.com/user-attachments/assets/d0fd72d1-3e1d-44f7-a953-4b5dcaa006b6" />

