### PR TITLE
Set  'eager' loading for videos with priority performance

### DIFF
--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1367,6 +1367,7 @@ function rtgodam_get_video_performance_settings( $attributes, $default_mode = 'b
 		'poster_attributes' => 'priority' === $mode
 			? array(
 				'fetchpriority' => 'high',
+				'loading'       => 'eager',
 			)
 			: array(
 				'loading' => 'lazy',


### PR DESCRIPTION
This pull request introduces a small update to the video performance settings in the `rtgodam_get_video_performance_settings` function. The change ensures that when the mode is set to `'priority'`, the video poster image will now load eagerly in addition to having a high fetch priority.

* Added the `'loading' => 'eager'` attribute to the `poster_attributes` array for priority mode in `rtgodam_get_video_performance_settings` in `inc/helpers/custom-functions.php`