### PR TITLE
fix: Use godam-for-woo slug

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -950,14 +950,14 @@ class RTGODAM_Transcoder_Admin {
 		}
 
 		printf(
-			'<div class="notice notice-info is-dismissible rtgodam-woo-promo-notice"><p>%s</p></div>',
+			'<div class="notice notice-info is-dismissible rtgodam-for-woo-promo-notice"><p>%s</p></div>',
 			wp_kses_post( $message )
 		);
 
 		// Inline script to persist dismissal via AJAX.
 		?>
 		<script>
-			jQuery( document ).on( 'click', '.rtgodam-woo-promo-notice .notice-dismiss', function() {
+			jQuery( document ).on( 'click', '.rtgodam-for-woo-promo-notice .notice-dismiss', function() {
 				jQuery.post( ajaxurl, {
 					action: 'rtgodam_dismiss_woo_promo_notice',
 					nonce: '<?php echo esc_js( wp_create_nonce( 'dismiss_woo_promo_notice' ) ); ?>'

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -95,7 +95,7 @@ $godam_show_share_btn = ! empty( $attributes['showShareButton'] );
 $godam_disable_subtitles_and_transcript = isset( $attributes['godam_context'] ) &&
 	in_array(
 		$attributes['godam_context'],
-		array( 'godam-video-product-gallery', 'godam-woo-product-page-reels' ),
+		array( 'godam-video-product-gallery', 'godam-for-woo-product-page-reels' ),
 		true
 	);
 

--- a/languages/godam.pot
+++ b/languages/godam.pot
@@ -4274,7 +4274,7 @@ msgstr ""
 #: pages/video-editor/components/appearance/Appearance.js:271
 #: pages/video-editor/components/cta/ImageCTA.js:146
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:81
-msgid "Only Image file is allowed"
+msgid "Only Image files are allowed"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:89

--- a/pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx
@@ -50,7 +50,7 @@ const BrandImageSelector = ( { mediaSettings, handleSettingChange } ) => {
 			 * This handles the case for the uploader tab of WordPress media library.
 			 */
 			if ( attachment.type !== 'image' ) {
-				showNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				showNotice( __( 'Only Image files are allowed', 'godam' ), 'error' );
 				return;
 			}
 

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -63,7 +63,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 			 * This handles the case for the uploader tab of WordPress media library.
 			 */
 			if ( attachment.type !== 'image' ) {
-				showNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				showNotice( __( 'Only Image files are allowed', 'godam' ), 'error' );
 				return;
 			}
 

--- a/pages/video-editor/components/appearance/Appearance.js
+++ b/pages/video-editor/components/appearance/Appearance.js
@@ -196,7 +196,7 @@ const Appearance = () => {
 			 * This handles the case for the uploader tab of WordPress media library.
 			 */
 			if ( attachment?.type !== 'image' ) {
-				showCustomPlayNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				showCustomPlayNotice( __( 'Only Image files are allowed', 'godam' ), 'error' );
 				return;
 			}
 
@@ -268,7 +268,7 @@ const Appearance = () => {
 			 * This handles the case for the uploader tab of WordPress media library.
 			 */
 			if ( attachment?.type !== 'image' ) {
-				showCustomBrandNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				showCustomBrandNotice( __( 'Only Image files are allowed', 'godam' ), 'error' );
 				return;
 			}
 

--- a/pages/video-editor/components/cta/ImageCTA.js
+++ b/pages/video-editor/components/cta/ImageCTA.js
@@ -143,7 +143,7 @@ const ImageCTA = ( { layerID } ) => {
 			 * This handles the case for the uploader tab of WordPress media library.
 			 */
 			if ( attachment.type !== 'image' ) {
-				showNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				showNotice( __( 'Only Image files are allowed', 'godam' ), 'error' );
 				return;
 			}
 

--- a/pages/video-editor/components/hotspot/FontAwesomeIconPicker.js
+++ b/pages/video-editor/components/hotspot/FontAwesomeIconPicker.js
@@ -78,7 +78,7 @@ const FontAwesomeIconPicker = ( { hotspot, disabled = false, index, hotspots, up
 
 			// Check if the selected file is an image
 			if ( attachment.type !== 'image' ) {
-				showNotice( __( 'Only Image file is allowed', 'godam' ), 'error' );
+				showNotice( __( 'Only Image files are allowed', 'godam' ), 'error' );
 				return;
 			}
 


### PR DESCRIPTION
This pull request makes minor updates to class and context names related to WooCommerce integration to ensure consistency across the codebase.

- Consistency improvements for WooCommerce integration:
  * Changed the CSS class name in the admin notice from `rtgodam-woo-promo-notice` to `rtgodam-for-woo-promo-notice` and updated the corresponding jQuery selector in `class-rtgodam-transcoder-admin.php`.
  * Updated the context string from `godam-woo-product-page-reels` to `godam-for-woo-product-page-reels` in `godam-player.php`.