### PR TITLE
Scope hidden class styles to player and layer selectors

### DIFF
--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -76,7 +76,8 @@
 	color: initial;
 }
 
-.hidden {
+.video-js .hidden,
+.easydam-layer.hidden {
 	display: none !important;
 }
 

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -66,7 +66,8 @@
 	container-name: easydam-layer-container;
 }
 
-.hidden {
+.video-js .hidden,
+.easydam-layer.hidden {
 	display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- Replace global .hidden selector usage in player styles with scoped selectors:
  - .video-js .hidden
  - .easydam-layer.hidden
- Apply the same fix in both source style files for consistency.

## Why
- Prevents unintended global side effects from .hidden.
- Ensures hiding behavior applies only to intended player/layer contexts.