### PR TITLE
fix: Skip Analytics tracking for Woo

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -265,6 +265,11 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 		return null;
 	}
 
+	// Honour the opt-out flag set by the PHP template (e.g. Woo Shoppable Video block).
+	if ( video.getAttribute( 'data-skip-analytics' ) === 'true' ) {
+		return null;
+	}
+
 	try {
 		// Double check player isn't disposed natively beforehand
 		if ( typeof player.isDisposed === 'function' && player.isDisposed() ) {
@@ -376,6 +381,11 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 }
 
 function setupPlayerAnalytics( player, video ) {
+	// Honour the opt-out flag set by the PHP template (e.g. Woo Shoppable Video block).
+	if ( video && video.getAttribute( 'data-skip-analytics' ) === 'true' ) {
+		return;
+	}
+
 	// Skip if already set up for this player instance.
 	// We use the player object rather than the DOM element because
 	// godamPlayerReady provides the raw <video> element, but playerAnalytics()
@@ -416,6 +426,11 @@ function playerAnalytics() {
 	const videos = document.querySelectorAll( '.easydam-player.video-js' );
 
 	videos.forEach( ( video ) => {
+		// Skip opted-out videos (e.g. Woo Shoppable Video block).
+		if ( video.getAttribute( 'data-skip-analytics' ) === 'true' ) {
+			return;
+		}
+
 		// Skip if player is still initializing
 		if ( video.dataset.videojsInitializing === 'true' ) {
 			return;

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -101,6 +101,11 @@ function collectPlayedRanges( player ) {
 
 			const videoEl = findVideoElementById( vid, root ) || ctx.querySelector( '.easydam-player.video-js, .video-js' );
 
+			// Skip analytics tracking if the video element has opted out.
+			if ( videoEl && videoEl.getAttribute( 'data-skip-analytics' ) === 'true' ) {
+				return false;
+			}
+
 			// If no videoId provided, automatically find the current video
 			if ( ! vid && videoEl ) {
 				vid = parseInt( videoEl.getAttribute( 'data-id' ), 10 ) || 0;
@@ -154,8 +159,10 @@ if ( ! window.pageLoadEventTracked ) {
 	document.addEventListener( 'DOMContentLoaded', () => {
 		const videos = document.querySelectorAll( '.easydam-player.video-js' );
 
-		// Collect all video IDs and Job IDs
+		// Collect all video IDs and Job IDs, excluding videos that have opted out of
+		// analytics tracking (e.g. Woo Shoppable Video block sets data-skip-analytics="true").
 		const videoInfo = Array.from( videos )
+			.filter( ( video ) => video.getAttribute( 'data-skip-analytics' ) !== 'true' )
 			.map( ( video ) => ( {
 				id: video.getAttribute( 'data-id' ),
 				jobId: video.getAttribute( 'data-job_id' ) || '',

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -99,6 +99,14 @@ $godam_disable_subtitles_and_transcript = isset( $attributes['godam_context'] ) 
 		true
 	);
 
+// Determine if analytics tracking should be skipped for this video instance.
+// Add-ons can opt-out by returning true from the filter; the context is also passed for convenience.
+$godam_skip_analytics = apply_filters(
+	'godam_skip_analytics',
+	false,
+	isset( $attributes['godam_context'] ) ? $attributes['godam_context'] : ''
+);
+
 // Resolve the attachment ID (could be WordPress or virtual media).
 $godam_attachment_id = '';
 
@@ -650,6 +658,10 @@ if ( empty( $godam_attachment_title ) ) {
 						data-instance-id="<?php echo esc_attr( $godam_instance_id ); ?>"
 						data-controls="<?php echo esc_attr( $godam_video_setup ); ?>"
 						data-job_id="<?php echo esc_attr( $godam_job_id ); ?>"
+						<?php
+						if ( $godam_skip_analytics ) :
+							?>
+							data-skip-analytics="true"<?php endif; ?>
 							data-global_ads_settings="<?php echo esc_attr( $godam_ads_settings ); ?>"
 							data-hover-select="<?php echo esc_attr( $godam_hover_select ); ?>"
 							data-video-title="<?php echo esc_attr( $godam_attachment_title ); ?>"

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -101,10 +101,13 @@ $godam_disable_subtitles_and_transcript = isset( $attributes['godam_context'] ) 
 
 // Determine if analytics tracking should be skipped for this video instance.
 // Add-ons can opt-out by returning true from the filter; the context is also passed for convenience.
-$godam_skip_analytics = apply_filters(
-	'godam_skip_analytics',
-	false,
-	isset( $attributes['godam_context'] ) ? $attributes['godam_context'] : ''
+// wp_validate_boolean() normalises the return value.
+$godam_skip_analytics = wp_validate_boolean(
+	apply_filters(
+		'godam_skip_analytics',
+		false,
+		isset( $attributes['godam_context'] ) ? $attributes['godam_context'] : ''
+	)
 );
 
 // Resolve the attachment ID (could be WordPress or virtual media).


### PR DESCRIPTION
This pull request introduces a mechanism to allow specific video elements to opt out of analytics tracking, improving flexibility for integrations such as the Woo Shoppable Video block. The changes ensure that both backend rendering and frontend analytics respect an opt-out flag.

Opt-out mechanism for analytics tracking:

* Added a WordPress filter (`godam_skip_analytics`) in `godam-player.php` to allow add-ons or custom logic to mark video instances that should skip analytics tracking.
* Updated the video player HTML markup to include a `data-skip-analytics="true"` attribute when analytics should be skipped, based on the filter's result.

Frontend analytics updates:

* Modified `collectPlayedRanges` in `analytics.js` to check for the `data-skip-analytics` attribute and skip analytics collection for opted-out videos.
* Updated the DOMContentLoaded handler in `analytics.js` to exclude videos with `data-skip-analytics="true"` from analytics initialization and tracking.


https://github.com/user-attachments/assets/4d76de02-3907-46ee-ad0c-0f8f6c0d0047

