### PR TITLE
feat: Implement blur-up placeholders for video thumbnails in gallery

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -41,32 +41,24 @@ if ( ! function_exists( 'godam_gallery_v2_get_thumbnail_url' ) ) {
 	 * @return string
 	 */
 	function godam_gallery_v2_get_thumbnail_url( $attachment_id ) {
-		$attachment_id = absint( $attachment_id );
+		$thumbnail_sources = rtgodam_get_video_thumbnail_sources( $attachment_id );
 
-		if ( ! $attachment_id ) {
-			return '';
-		}
+		return $thumbnail_sources['thumbnail'];
+	}
+}
 
-		$custom_thumbnail = get_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', true );
-		if ( ! empty( $custom_thumbnail ) ) {
-			return esc_url_raw( $custom_thumbnail );
-		}
+if ( ! function_exists( 'godam_gallery_v2_get_placeholder_thumbnail_url' ) ) {
 
-		$image = wp_get_attachment_image_url( $attachment_id, 'medium' );
-		if ( $image ) {
-			return $image;
-		}
+	/**
+	 * Resolve the placeholder thumbnail for a video attachment.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return string
+	 */
+	function godam_gallery_v2_get_placeholder_thumbnail_url( $attachment_id ) {
+		$thumbnail_sources = rtgodam_get_video_thumbnail_sources( $attachment_id );
 
-		$icon = wp_mime_type_icon( $attachment_id );
-		if ( $icon ) {
-			return $icon;
-		}
-
-		if ( defined( 'RTGODAM_URL' ) ) {
-			return trailingslashit( RTGODAM_URL ) . 'assets/src/images/video-thumbnail-default.png';
-		}
-
-		return '';
+		return $thumbnail_sources['placeholder'];
 	}
 }
 
@@ -201,10 +193,11 @@ if ( ! function_exists( 'godam_gallery_v2_get_video_data' ) ) {
 		}
 
 		return array(
-			'id'        => $attachment_id,
-			'title'     => get_the_title( $attachment_id ) ?: __( 'Untitled video', 'godam' ),
-			'date'      => godam_gallery_v2_format_display_date( $post->post_date ),
-			'thumbnail' => godam_gallery_v2_get_thumbnail_url( $attachment_id ),
+			'id'          => $attachment_id,
+			'title'       => get_the_title( $attachment_id ) ?: __( 'Untitled video', 'godam' ),
+			'date'        => godam_gallery_v2_format_display_date( $post->post_date ),
+			'thumbnail'   => godam_gallery_v2_get_thumbnail_url( $attachment_id ),
+			'placeholder' => godam_gallery_v2_get_placeholder_thumbnail_url( $attachment_id ),
 		);
 	}
 }
@@ -347,9 +340,9 @@ if ( 'query' === $godam_gallery_mode ) {
 							<?php /* translators: %s: video title. */ ?>
 							aria-label="<?php echo esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $godam_item['title'] ) ); ?>"
 						>
-							<div class="godam-gallery-v2__query-thumb">
+							<div class="godam-gallery-v2__query-thumb<?php echo ! empty( $godam_item['placeholder'] ) ? ' godam-gallery-blurred-img godam-blurred-img' : ''; ?>"<?php echo ! empty( $godam_item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $godam_item['placeholder'] ) . '\')"' : ''; ?>>
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
-									<img src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" <?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?> />
+									<img src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" class="godam-gallery-v2__thumbnail" <?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?> />
 								<?php else : ?>
 									<span><?php esc_html_e( 'GoDAM Video', 'godam' ); ?></span>
 								<?php endif; ?>
@@ -397,12 +390,12 @@ if ( 'query' === $godam_gallery_mode ) {
 							<?php /* translators: %s: video title. */ ?>
 							aria-label="<?php echo esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $godam_item['title'] ) ); ?>"
 						>
-							<div class="godam-gallery-v2-item__preview">
+							<div class="godam-gallery-v2-item__preview<?php echo ! empty( $godam_item['placeholder'] ) ? ' godam-gallery-blurred-img godam-blurred-img' : ''; ?>"<?php echo ! empty( $godam_item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $godam_item['placeholder'] ) . '\')"' : ''; ?>>
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
 									<img
 										src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>"
 										alt="<?php echo esc_attr( $godam_item['title'] ); ?>"
-										class="godam-gallery-v2-item__thumbnail"
+										class="godam-gallery-v2-item__thumbnail godam-gallery-v2__thumbnail"
 										<?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?>
 									/>
 								<?php else : ?>

--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -340,7 +340,7 @@ if ( 'query' === $godam_gallery_mode ) {
 							<?php /* translators: %s: video title. */ ?>
 							aria-label="<?php echo esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $godam_item['title'] ) ); ?>"
 						>
-							<div class="godam-gallery-v2__query-thumb<?php echo ! empty( $godam_item['placeholder'] ) ? ' godam-gallery-blurred-img godam-blurred-img' : ''; ?>"<?php echo ! empty( $godam_item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $godam_item['placeholder'] ) . '\')"' : ''; ?>>
+							<div class="godam-gallery-v2__query-thumb<?php echo ! empty( $godam_item['placeholder'] ) ? ' godam-gallery-blurred-img' : ''; ?>"<?php echo ! empty( $godam_item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $godam_item['placeholder'] ) . '\')"' : ''; ?>>
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
 									<img src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" class="godam-gallery-v2__thumbnail" <?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?> />
 								<?php else : ?>
@@ -390,7 +390,7 @@ if ( 'query' === $godam_gallery_mode ) {
 							<?php /* translators: %s: video title. */ ?>
 							aria-label="<?php echo esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $godam_item['title'] ) ); ?>"
 						>
-							<div class="godam-gallery-v2-item__preview<?php echo ! empty( $godam_item['placeholder'] ) ? ' godam-gallery-blurred-img godam-blurred-img' : ''; ?>"<?php echo ! empty( $godam_item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $godam_item['placeholder'] ) . '\')"' : ''; ?>>
+							<div class="godam-gallery-v2-item__preview<?php echo ! empty( $godam_item['placeholder'] ) ? ' godam-gallery-blurred-img' : ''; ?>"<?php echo ! empty( $godam_item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $godam_item['placeholder'] ) . '\')"' : ''; ?>>
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
 									<img
 										src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>"

--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -67,6 +67,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	position: relative;
 	color: #66705d;
 	font-weight: 600;
 
@@ -188,6 +189,7 @@
 		background: rgba(19, 25, 14, 0.62);
 		color: #fff;
 		pointer-events: none;
+		z-index: 2;
 
 		svg {
 			width: 24px;
@@ -229,6 +231,39 @@
 			margin-top: 6px;
 			font-size: 12px;
 			color: #66705d;
+		}
+	}
+}
+
+.godam-gallery-blurred-img {
+	background-repeat: no-repeat;
+	background-size: cover;
+	background-position: center;
+
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		opacity: 0;
+		animation: godam_gallery_v2_blur_pulse 2.5s infinite;
+		background-color: #fff;
+		pointer-events: none;
+	}
+
+	.godam-gallery-v2__thumbnail {
+		opacity: 0;
+		transition: opacity 250ms ease-in-out;
+	}
+
+	&.loaded {
+
+		.godam-gallery-v2__thumbnail {
+			opacity: 1;
+		}
+
+		&::before {
+			animation: none;
+			content: none;
 		}
 	}
 }
@@ -318,6 +353,21 @@
 .godam-gallery-v2__query-item--ratio-16-9 .godam-gallery-v2__query-thumb,
 .godam-gallery-v2-item--ratio-16-9 .godam-gallery-v2-item__preview {
 	aspect-ratio: 16 / 9;
+}
+
+@keyframes godam_gallery_v2_blur_pulse {
+
+	0% {
+		opacity: 0;
+	}
+
+	50% {
+		opacity: 0.15;
+	}
+
+	100% {
+		opacity: 0;
+	}
 }
 
 .godam-gallery-v2--handpicked,

--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -15,11 +15,10 @@ const { __ } = require( '@wordpress/i18n' );
 
 	function initBlurUpPlaceholders( root = document ) {
 		root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
-			if ( div.dataset.godamBlurInit === '1' ) {
+			if ( div.dataset.godamGalleryBlurInit === '1' ) {
 				return;
 			}
-
-			div.dataset.godamBlurInit = '1';
+			div.dataset.godamGalleryBlurInit = '1';
 
 			const img = div.querySelector( 'img' );
 			if ( ! img ) {

--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -13,6 +13,34 @@ const { __ } = require( '@wordpress/i18n' );
 	let activeGallery = null;
 	let sharedModal = null;
 
+	function initBlurUpPlaceholders( root = document ) {
+		root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
+			if ( div.dataset.godamBlurInit === '1' ) {
+				return;
+			}
+
+			div.dataset.godamBlurInit = '1';
+
+			const img = div.querySelector( 'img' );
+			if ( ! img ) {
+				return;
+			}
+
+			const markLoaded = () => div.classList.add( 'loaded' );
+			const markError = () => {
+				div.style.backgroundImage = '';
+				div.classList.add( 'loaded' );
+			};
+
+			if ( img.complete && img.naturalWidth > 0 ) {
+				markLoaded();
+			} else {
+				img.addEventListener( 'load', markLoaded, { once: true } );
+				img.addEventListener( 'error', markError, { once: true } );
+			}
+		} );
+	}
+
 	function handleModalKeydown( event ) {
 		if ( ! activeGallery ) {
 			return;
@@ -158,6 +186,7 @@ const { __ } = require( '@wordpress/i18n' );
 			this.items = [];
 
 			this.refreshItems();
+			initBlurUpPlaceholders( this.element );
 			this.bindEvents();
 			this.initInfiniteScroll();
 			this.updateLoadControls();
@@ -303,6 +332,7 @@ const { __ } = require( '@wordpress/i18n' );
 						const insertionTarget = this.loadMoreItem || this.sentinel;
 						this.queryList.insertBefore( template.content, insertionTarget );
 						this.currentOffset += newItems.length;
+						initBlurUpPlaceholders( this.element );
 					} else {
 						this.currentOffset = this.totalItems;
 					}

--- a/assets/src/css/godam-gallery.scss
+++ b/assets/src/css/godam-gallery.scss
@@ -125,6 +125,42 @@
 			aspect-ratio: 16/9;
 			overflow: hidden;
 			cursor: pointer;
+
+			.godam-gallery-blurred-img {
+				position: relative;
+				width: 100%;
+				height: 100%;
+				background-repeat: no-repeat;
+				background-size: cover;
+				background-position: center;
+
+				&::before {
+					content: "";
+					position: absolute;
+					inset: 0;
+					opacity: 0;
+					animation: godam_gallery_blur_pulse 2.5s infinite;
+					background-color: #fff;
+					pointer-events: none;
+				}
+
+				img {
+					opacity: 0;
+					transition: opacity 250ms ease-in-out;
+				}
+
+				&.loaded {
+
+					img {
+						opacity: 1;
+					}
+
+					&::before {
+						animation: none;
+						content: none;
+					}
+				}
+			}
 			
 			video,
 			img,
@@ -147,7 +183,7 @@
 				padding: 2px 6px;
 				border-radius: 4px;
 				line-height: 1;
-				z-index: 1;
+				z-index: 2;
 			}
 		}
 
@@ -415,6 +451,21 @@
 				background-color: rgba(0, 0, 0, 0.9);
 			}
 		}
+	}
+}
+
+@keyframes godam_gallery_blur_pulse {
+
+	0% {
+		opacity: 0;
+	}
+
+	50% {
+		opacity: 0.15;
+	}
+
+	100% {
+		opacity: 0;
 	}
 }
 

--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -7,6 +7,34 @@ import DOMPurify from 'isomorphic-dompurify';
 // Get the REST URL from localized data, fallback to hardcoded path.
 const galleryRestUrl = window.godamGalleryData?.restUrl || '/wp-json/godam/v1/gallery-shortcode';
 
+function initBlurUpPlaceholders( root = document ) {
+	root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
+		if ( div.dataset.godamBlurInit === '1' ) {
+			return;
+		}
+
+		div.dataset.godamBlurInit = '1';
+
+		const img = div.querySelector( 'img' );
+		if ( ! img ) {
+			return;
+		}
+
+		const markLoaded = () => div.classList.add( 'loaded' );
+		const markError = () => {
+			div.style.backgroundImage = '';
+			div.classList.add( 'loaded' );
+		};
+
+		if ( img.complete && img.naturalWidth > 0 ) {
+			markLoaded();
+		} else {
+			img.addEventListener( 'load', markLoaded, { once: true } );
+			img.addEventListener( 'error', markError, { once: true } );
+		}
+	} );
+}
+
 async function loadMoreVideos( gallery, offset, columns, orderby, order, totalVideos ) {
 	const loadCount = 3 * columns;
 	const spinnerContainer = document.querySelector( '.godam-spinner-container' );
@@ -41,6 +69,7 @@ async function loadMoreVideos( gallery, offset, columns, orderby, order, totalVi
 
 		if ( data.status === 'success' && data.html && data.html.trim() !== '' ) {
 			gallery.insertAdjacentHTML( 'beforeend', data.html );
+			initBlurUpPlaceholders( gallery );
 			const newOffset = offset + loadCount;
 
 			// Check if we've loaded all videos
@@ -66,6 +95,8 @@ async function loadMoreVideos( gallery, offset, columns, orderby, order, totalVi
 }
 
 document.addEventListener( 'DOMContentLoaded', function() {
+	initBlurUpPlaceholders();
+
 	// Get all galleries with infinite scroll enabled
 	document.querySelectorAll( '.godam-video-gallery[data-infinite-scroll="1"]' ).forEach( ( gallery ) => {
 		const offset = parseInt( gallery.getAttribute( 'data-offset' ), 10 );

--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -9,11 +9,10 @@ const galleryRestUrl = window.godamGalleryData?.restUrl || '/wp-json/godam/v1/ga
 
 function initBlurUpPlaceholders( root = document ) {
 	root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
-		if ( div.dataset.godamBlurInit === '1' ) {
+		if ( div.dataset.godamGalleryBlurInit === '1' ) {
 			return;
 		}
-
-		div.dataset.godamBlurInit = '1';
+		div.dataset.godamGalleryBlurInit = '1';
 
 		const img = div.querySelector( 'img' );
 		if ( ! img ) {

--- a/inc/classes/rest-api/class-dynamic-gallery.php
+++ b/inc/classes/rest-api/class-dynamic-gallery.php
@@ -396,7 +396,7 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 					echo '<div class="godam-video-item">';
 					echo '<div class="godam-video-thumbnail" data-video-id="' . esc_attr( $video_id ) . '" data-video-url="' . esc_url( $video_url ) . '">';
 					if ( ! empty( $thumbnail ) && ! empty( $placeholder_thumbnail ) ) {
-						echo '<div class="godam-gallery-blurred-img godam-blurred-img" style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')">';
+						echo '<div class="godam-gallery-blurred-img" style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')">';
 						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-thumbnail-image" />';
 						echo '</div>';
 					} elseif ( ! empty( $thumbnail ) ) {

--- a/inc/classes/rest-api/class-dynamic-gallery.php
+++ b/inc/classes/rest-api/class-dynamic-gallery.php
@@ -322,9 +322,9 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 				$video_slug  = get_post_field( 'post_name', $video_id );
 				$video_date  = apply_filters( 'rtgodam_dynamic_gallery_video_date', get_the_date( 'F j, Y', $video_id ), $video_id );
 	
-				$custom_thumbnail = get_post_meta( $video_id, 'rtgodam_media_video_thumbnail', true );
-				$fallback_thumb   = RTGODAM_URL . 'assets/src/images/video-thumbnail-default.png';
-				$thumbnail        = $custom_thumbnail ?: $fallback_thumb;
+				$thumbnail_data        = rtgodam_get_video_thumbnail_sources( $video_id );
+				$thumbnail             = $thumbnail_data['thumbnail'];
+				$placeholder_thumbnail = $thumbnail_data['placeholder'];
 	
 				$file_path = get_attached_file( $video_id );
 				$duration  = null;
@@ -374,10 +374,10 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 					echo '<div class="godam-gallery-v2__query-item godam-gallery-v2__query-item--ratio-' . esc_attr( $ratio_class ) . '">';
 					/* translators: %s: video title. */
 					echo '<button type="button" class="godam-gallery-v2__query-button" data-godam-gallery-v2-trigger="true" data-video-id="' . esc_attr( $video_id ) . '" aria-label="' . esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $video_title ) ) . '">';
-					echo '<div class="godam-gallery-v2__query-thumb">';
+					echo '<div class="godam-gallery-v2__query-thumb' . ( ! empty( $placeholder_thumbnail ) ? ' godam-gallery-blurred-img godam-blurred-img' : '' ) . '"' . ( ! empty( $placeholder_thumbnail ) ? ' style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')"' : '' ) . '>';
 					if ( ! empty( $thumbnail ) ) {
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $thumbnail_attributes is pre-sanitized via rtgodam_format_html_attributes(), and rtgodam_get_gallery_tile_image_attributes() returns pre-sanitized attributes.
-						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '"' . ( $thumbnail_attributes ? ' ' . $thumbnail_attributes : '' ) . ' />';
+						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-v2__thumbnail"' . ( $thumbnail_attributes ? ' ' . $thumbnail_attributes : '' ) . ' />';
 					} else {
 						echo '<span>' . esc_html__( 'GoDAM Video', 'godam' ) . '</span>';
 					}
@@ -395,7 +395,13 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 				} else {
 					echo '<div class="godam-video-item">';
 					echo '<div class="godam-video-thumbnail" data-video-id="' . esc_attr( $video_id ) . '" data-video-url="' . esc_url( $video_url ) . '">';
-					echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" />';
+					if ( ! empty( $thumbnail ) && ! empty( $placeholder_thumbnail ) ) {
+						echo '<div class="godam-gallery-blurred-img godam-blurred-img" style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')">';
+						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-thumbnail-image" />';
+						echo '</div>';
+					} elseif ( ! empty( $thumbnail ) ) {
+						echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-thumbnail-image" />';
+					}
 					if ( $duration ) {
 						echo '<span class="godam-video-duration">' . esc_html( $duration ) . '</span>';
 					}

--- a/inc/classes/shortcodes/class-godam-video-gallery.php
+++ b/inc/classes/shortcodes/class-godam-video-gallery.php
@@ -360,7 +360,7 @@ class GoDAM_Video_Gallery {
 				echo '<div class="godam-video-item">';
 				echo '<div class="godam-video-thumbnail" data-gallery-item-engagements="' . esc_attr( $item_engagements_enabled ? 'true' : 'false' ) . '" data-video-id="' . esc_attr( $video_id ) . '" data-video-url="' . esc_url( $video_url ) . '">';
 				if ( ! empty( $thumbnail ) && ! empty( $placeholder_thumbnail ) ) {
-					echo '<div class="godam-gallery-blurred-img godam-blurred-img" style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')">';
+					echo '<div class="godam-gallery-blurred-img" style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')">';
 					echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-thumbnail-image" />';
 					echo '</div>';
 				} elseif ( ! empty( $thumbnail ) ) {

--- a/inc/classes/shortcodes/class-godam-video-gallery.php
+++ b/inc/classes/shortcodes/class-godam-video-gallery.php
@@ -314,10 +314,9 @@ class GoDAM_Video_Gallery {
 				// Add filter for video date format.
 				$video_date = apply_filters( 'rtgodam_gallery_video_date', $video_date, $video_id );
 
-				$custom_thumbnail = get_post_meta( $video_id, 'rtgodam_media_video_thumbnail', true );
-				$fallback_thumb   = RTGODAM_URL . 'assets/src/images/video-thumbnail-default.png';
-
-				$thumbnail = $custom_thumbnail ?: $fallback_thumb;
+				$thumbnail_data        = rtgodam_get_video_thumbnail_sources( $video_id );
+				$thumbnail             = $thumbnail_data['thumbnail'];
+				$placeholder_thumbnail = $thumbnail_data['placeholder'];
 
 				// Get video duration using file path.
 				$file_path = get_attached_file( $video_id );
@@ -360,7 +359,13 @@ class GoDAM_Video_Gallery {
 
 				echo '<div class="godam-video-item">';
 				echo '<div class="godam-video-thumbnail" data-gallery-item-engagements="' . esc_attr( $item_engagements_enabled ? 'true' : 'false' ) . '" data-video-id="' . esc_attr( $video_id ) . '" data-video-url="' . esc_url( $video_url ) . '">';
-				echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" />';
+				if ( ! empty( $thumbnail ) && ! empty( $placeholder_thumbnail ) ) {
+					echo '<div class="godam-gallery-blurred-img godam-blurred-img" style="background-image: url(\'' . esc_url( $placeholder_thumbnail ) . '\')">';
+					echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-thumbnail-image" />';
+					echo '</div>';
+				} elseif ( ! empty( $thumbnail ) ) {
+					echo '<img src="' . esc_url( $thumbnail ) . '" alt="' . esc_attr( $video_title ) . '" class="godam-gallery-thumbnail-image" />';
+				}
 				if ( $duration ) {
 					echo '<span class="godam-video-duration">' . esc_html( $duration ) . '</span>';
 				}

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1557,6 +1557,87 @@ function rtgodam_get_gallery_tile_image_attributes( $performance_mode, $index = 
 }
 
 /**
+ * Resolve the selected video thumbnail and its matching blur-up placeholder.
+ *
+ * @since n.e.x.t
+ *
+ * @param int    $attachment_id Attachment ID.
+ * @param string $thumbnail_url Optional pre-resolved thumbnail URL.
+ * @return array<string, string>
+ */
+function rtgodam_get_video_thumbnail_sources( $attachment_id, $thumbnail_url = '' ) {
+	$attachment_id = absint( $attachment_id );
+
+	if ( ! $attachment_id ) {
+		return array(
+			'thumbnail'   => '',
+			'placeholder' => '',
+		);
+	}
+
+	$resolved_thumbnail   = '';
+	$resolved_placeholder = '';
+
+	if ( ! empty( $thumbnail_url ) && is_string( $thumbnail_url ) ) {
+		$resolved_thumbnail = esc_url_raw( rtgodam_convert_to_https_url( $thumbnail_url ) );
+	}
+
+	if ( empty( $resolved_thumbnail ) ) {
+		$custom_thumbnail = get_post_meta( $attachment_id, 'rtgodam_media_video_thumbnail', true );
+		if ( ! empty( $custom_thumbnail ) && is_string( $custom_thumbnail ) ) {
+			$resolved_thumbnail = esc_url_raw( rtgodam_convert_to_https_url( $custom_thumbnail ) );
+		}
+	}
+
+	if ( empty( $resolved_thumbnail ) ) {
+		$image = wp_get_attachment_image_url( $attachment_id, 'medium' );
+		if ( $image ) {
+			$resolved_thumbnail = esc_url_raw( $image );
+		}
+	}
+
+	if ( ! empty( $resolved_thumbnail ) ) {
+		$placeholder_map = get_post_meta( $attachment_id, 'rtgodam_media_placeholder_thumbnails', true );
+		if ( is_array( $placeholder_map ) ) {
+			$normalized_thumbnail = rtgodam_convert_to_https_url( $resolved_thumbnail );
+			foreach ( $placeholder_map as $thumbnail_key => $placeholder_url ) {
+				if ( empty( $thumbnail_key ) || empty( $placeholder_url ) ) {
+					continue;
+				}
+
+				if ( rtgodam_convert_to_https_url( (string) $thumbnail_key ) === $normalized_thumbnail ) {
+					$resolved_placeholder = esc_url_raw( rtgodam_convert_to_https_url( (string) $placeholder_url ) );
+					break;
+				}
+			}
+		}
+	}
+
+	if ( empty( $resolved_placeholder ) ) {
+		$single_placeholder = get_post_meta( $attachment_id, 'rtgodam_media_video_placeholder_thumbnail', true );
+		if ( ! empty( $single_placeholder ) && is_string( $single_placeholder ) ) {
+			$resolved_placeholder = esc_url_raw( rtgodam_convert_to_https_url( $single_placeholder ) );
+		}
+	}
+
+	if ( empty( $resolved_thumbnail ) ) {
+		$icon = wp_mime_type_icon( $attachment_id );
+		if ( $icon ) {
+			$resolved_thumbnail = esc_url_raw( $icon );
+		}
+	}
+
+	if ( empty( $resolved_thumbnail ) && defined( 'RTGODAM_URL' ) ) {
+		$resolved_thumbnail = trailingslashit( RTGODAM_URL ) . 'assets/src/images/video-thumbnail-default.png';
+	}
+
+	return array(
+		'thumbnail'   => $resolved_thumbnail,
+		'placeholder' => $resolved_placeholder,
+	);
+}
+
+/**
  * Format an associative array of HTML attributes into a string.
  *
  * @since n.e.x.t


### PR DESCRIPTION
This pull request introduces a "blur-up" placeholder effect for video thumbnails throughout the Godam Gallery, enhancing perceived performance and visual polish while thumbnails load. The update standardizes how thumbnails and their placeholders are resolved, updates rendering logic in both block and shortcode galleries, and adds the necessary JavaScript and CSS to support the new effect.

**Key changes include:**

### Thumbnail and Placeholder Resolution

* Added a new helper function `rtgodam_get_video_thumbnail_sources` to consistently resolve both the main thumbnail and its blur-up placeholder for a given video attachment. This function is now used throughout the codebase to ensure consistent logic and fallback handling.
* Updated PHP rendering logic in both block (`render.php`) and REST/shortcode galleries to use the new helper for thumbnail and placeholder resolution, and to output the placeholder as a blurred background behind the main thumbnail image. [[1]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L44-R61) [[2]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9R200) [[3]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL325-R327) [[4]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL377-R380) [[5]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL398-R404) [[6]](diffhunk://#diff-de9311fed0a3cfd870aaeb664c5043e3259ee52c672ab415193ea513a4a92c36L317-R319) [[7]](diffhunk://#diff-de9311fed0a3cfd870aaeb664c5043e3259ee52c672ab415193ea513a4a92c36L363-R368)

### Frontend Rendering and JavaScript

* Added logic to wrap thumbnails in a `div` with the `godam-gallery-blurred-img` class and set the placeholder as a background image, both in block and REST/shortcode output. The markup now supports a smooth transition from the blurred placeholder to the loaded thumbnail. [[1]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L350-R345) [[2]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L400-R398) [[3]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL377-R380) [[4]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL398-R404) [[5]](diffhunk://#diff-de9311fed0a3cfd870aaeb664c5043e3259ee52c672ab415193ea513a4a92c36L363-R368)
* Introduced a new `initBlurUpPlaceholders` JavaScript utility in both block and shortcode JS files to handle the transition from placeholder to loaded thumbnail, marking containers as `loaded` when the image is ready. This function is called on initial load and after dynamic content loads (e.g., infinite scroll, "Load More"). [[1]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354R16-R43) [[2]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354R189) [[3]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354R335) [[4]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798R10-R37) [[5]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798R72) [[6]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798R98-R99)

### Styling and Animation

* Added new SCSS/CSS for the `godam-gallery-blurred-img` class, including a blur-pulse animation while the thumbnail loads, and smooth opacity transitions for the image. Also included z-index adjustments for overlays and ensured proper positioning. [[1]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR70) [[2]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR192) [[3]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR238-R270) [[4]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR358-R372) [[5]](diffhunk://#diff-886f5e2d9d16ce1332754960568cffa9d0481ae1d89ab385dcdb9d58ff2dfd77R129-R164) [[6]](diffhunk://#diff-886f5e2d9d16ce1332754960568cffa9d0481ae1d89ab385dcdb9d58ff2dfd77L150-R186) [[7]](diffhunk://#diff-886f5e2d9d16ce1332754960568cffa9d0481ae1d89ab385dcdb9d58ff2dfd77R457-R471)

These changes collectively provide a visually appealing loading experience for video thumbnails, improve code maintainability by centralizing thumbnail logic, and ensure the effect works consistently across all gallery implementations.