### PR TITLE
fix: Video element missing data-instance-id attribute

### DIFF
--- a/assets/src/js/godam-player/api/player.js
+++ b/assets/src/js/godam-player/api/player.js
@@ -64,7 +64,10 @@ class Player {
 
 		this.videoJs = videoJs;
 		this.video = video;
-		this.instanceId = video.dataset.instanceId;
+
+		// Check the element itself first, then fall back to descendants.
+		this.instanceId = video.dataset.instanceId ||
+			video.querySelector?.( '[data-instance-id]' )?.dataset?.instanceId;
 
 		// Validate instanceId exists
 		if ( ! this.instanceId ) {


### PR DESCRIPTION
This pull request improves the way the `Player` class retrieves the `instanceId` for a video element. The main change is to enhance robustness by checking for the `instanceId` both on the video element itself and among its descendants.

Initialization improvement:

* Updated the `Player` class in `assets/src/js/godam-player/api/player.js` to first attempt to read `instanceId` from the video element's dataset, and if not found, to search for a descendant element with the `data-instance-id` attribute. This ensures that `instanceId` is reliably obtained even if it's not set directly on the video element.

<img width="549" height="234" alt="Screenshot 2026-04-28 at 7 17 18 PM" src="https://github.com/user-attachments/assets/81022539-6f53-4213-9330-6a2c1d44f463" />
