### PR TITLE
Revert the GoDAM engagement features gated via "rtgodam_enable_engagement_feature" filter

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -78,7 +78,7 @@
 		},
 		"engagements": {
 			"type": "boolean",
-			"default": true
+			"default": false
 		}
 	},
 	"providesContext": {

--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -75,6 +75,10 @@
 		"performanceMode": {
 			"type": "string",
 			"default": "balanced"
+		},
+		"engagements": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"providesContext": {

--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -78,7 +78,7 @@
 		},
 		"engagements": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		}
 	},
 	"providesContext": {

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -207,7 +207,9 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		showTitle,
 		layout,
 		performanceMode,
+		engagements,
 	} = attributes;
+	const showEngagementSetting = window?.godamSettings?.enableGlobalVideoEngagement ?? false;
 	const [ startDatePopoverOpen, setStartDatePopoverOpen ] = useState( false );
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
 	const [ dateError, setDateError ] = useState( '' );
@@ -596,6 +598,16 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						checked={ !! showTitle }
 						onChange={ ( value ) => setAttributes( { showTitle: value } ) }
 					/>
+					{
+						showEngagementSetting && (
+							<ToggleControl
+								label={ __( 'Enable Likes & Comments', 'godam' ) }
+								checked={ !! engagements }
+								onChange={ ( value ) => setAttributes( { engagements: value } ) }
+								help={ __( 'Engagement will only be visible for transcoded videos', 'godam' ) }
+							/>
+						)
+					}
 					<SelectControl
 						label={ __( 'Performance', 'godam' ) }
 						value={ performanceMode || 'balanced' }

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -209,7 +209,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		performanceMode,
 		engagements,
 	} = attributes;
-	const showEngagementSetting = window?.godamSettings?.enableGlobalVideoEngagement ?? false;
+	const engagementFeatureEnabled = window?.godamSettings?.engagementFeatureEnabled ?? false;
+	const showEngagementSetting = engagementFeatureEnabled && ( window?.godamSettings?.enableGlobalVideoEngagement ?? false );
 	const [ startDatePopoverOpen, setStartDatePopoverOpen ] = useState( false );
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
 	const [ dateError, setDateError ] = useState( '' );

--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -254,7 +254,7 @@ $godam_wrapper_attributes = get_block_wrapper_attributes(
 		'data-layout'         => $godam_layout,
 		'data-ratio'          => $godam_view_ratio,
 		'data-embed-base-url' => home_url( '/' ),
-		'data-engagements'    => ! empty( $attributes['engagements'] ) ? 'show' : '',
+		'data-engagements'    => rtgodam_is_engagement_feature_enabled() && ! empty( $attributes['engagements'] ) ? 'show' : '',
 	)
 );
 

--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -254,6 +254,7 @@ $godam_wrapper_attributes = get_block_wrapper_attributes(
 		'data-layout'         => $godam_layout,
 		'data-ratio'          => $godam_view_ratio,
 		'data-embed-base-url' => home_url( '/' ),
+		'data-engagements'    => ! empty( $attributes['engagements'] ) ? 'show' : '',
 	)
 );
 

--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -163,6 +163,7 @@ const { __ } = require( '@wordpress/i18n' );
 			this.element = element;
 			this.mode = element.dataset.mode || 'handpicked';
 			this.embedBaseUrl = element.dataset.embedBaseUrl || '/';
+			this.engagements = element.dataset.engagements || '';
 			this.currentIndex = -1;
 			this.previouslyFocusedElement = null;
 			this.isLoading = false;
@@ -363,7 +364,8 @@ const { __ } = require( '@wordpress/i18n' );
 
 			this.currentIndex = index;
 			activeGallery = this;
-			this.modal.iframe.src = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1`;
+			const engagementsParam = this.engagements === 'show' ? '&engagements=show' : '';
+			this.modal.iframe.src = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1${ engagementsParam }`;
 			this.modal.overlay.classList.add( 'is-active' );
 			this.modal.modal.classList.add( 'is-active' );
 			this.modal.closeButton.classList.add( 'is-active' );

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -113,6 +113,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"engagements": {
+			"type": "boolean",
+			"default": false
+		},
 		"playerHeight": {
 			"type": "string",
 			"default": ""

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -45,7 +45,8 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 	const { autoplay, controls, loop, muted, preload, preloadPoster, performanceMode, showShareButton, engagements } =
 	attributes;
 	const showShareButtonSetting = window?.godamSettings?.enableGlobalVideoShare ?? false;
-	const showEngagementSetting = window?.godamSettings?.enableGlobalVideoEngagement ?? false;
+	const engagementFeatureEnabled = window?.godamSettings?.engagementFeatureEnabled ?? false;
+	const showEngagementSetting = engagementFeatureEnabled && ( window?.godamSettings?.enableGlobalVideoEngagement ?? false );
 
 	// Show a specific help for autoplay setting.
 	const getAutoplayHelp = useMemo( () => {

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -42,9 +42,10 @@ const resolveLegacyPerformanceMode = ( preload, preloadPoster ) => {
  * @return {WPElement} The video settings component.
  */
 const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false } ) => {
-	const { autoplay, controls, loop, muted, preload, preloadPoster, performanceMode, showShareButton } =
+	const { autoplay, controls, loop, muted, preload, preloadPoster, performanceMode, showShareButton, engagements } =
 	attributes;
 	const showShareButtonSetting = window?.godamSettings?.enableGlobalVideoShare ?? false;
+	const showEngagementSetting = window?.godamSettings?.enableGlobalVideoEngagement ?? false;
 
 	// Show a specific help for autoplay setting.
 	const getAutoplayHelp = useMemo( () => {
@@ -77,6 +78,7 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 			muted: toggleAttribute( 'muted' ),
 			controls: toggleAttribute( 'controls' ),
 			showShareButton: toggleAttribute( 'showShareButton' ),
+			engagements: toggleAttribute( 'engagements' ),
 		};
 	}, [ setAttributes ] );
 
@@ -152,6 +154,17 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 					help={ performanceHelpText[ selectedPerformanceMode ] }
 				/>
 			) }
+			{
+				showEngagementSetting && (
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Enable Likes & Comments', 'godam' ) }
+						onChange={ toggleFactory.engagements }
+						checked={ !! engagements }
+						help={ __( 'Engagement will only be visible for transcoded videos', 'godam' ) }
+					/>
+				)
+			}
 		</>
 	);
 };

--- a/assets/src/js/godam-video-embed.js
+++ b/assets/src/js/godam-video-embed.js
@@ -339,3 +339,92 @@ document.addEventListener( 'godamAllPlayersReady', () => {
 		}
 	} );
 } );
+
+/**
+ * Render CommentBox component on video embed page by default.
+ *
+ * @since 1.5.0
+ */
+document.addEventListener( 'DOMContentLoaded', function() {
+	const urlParams = new URLSearchParams( window.location.search );
+	const videoId = urlParams.get( 'id' );
+
+	if ( ! videoId ) {
+		return;
+	}
+
+	const videoIdNum = parseInt( videoId, 10 );
+	if ( ! videoIdNum || isNaN( videoIdNum ) ) {
+		return;
+	}
+
+	// Create and show loading overlay
+	const loadingOverlay = document.createElement( 'div' );
+	loadingOverlay.className = 'godam-video-embed-loading';
+	loadingOverlay.style.cssText = 'position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: #fff; z-index: 9999; display: flex; align-items: center; justify-content: center;';
+
+	// Create spinner element
+	const spinner = document.createElement( 'div' );
+	spinner.className = 'godam-video-embed-spinner';
+	loadingOverlay.appendChild( spinner );
+
+	document.body.appendChild( loadingOverlay );
+
+	// Function to hide loading overlay
+	const hideLoadingOverlay = () => {
+		if ( loadingOverlay && loadingOverlay.parentNode ) {
+			loadingOverlay.style.opacity = '0';
+			loadingOverlay.style.pointerEvents = 'none';
+			loadingOverlay.style.transition = 'opacity 0.3s ease-out';
+			setTimeout( () => {
+				loadingOverlay.remove();
+			}, 300 );
+		}
+	};
+
+	// Listen for the engagement store to be initialized.
+	document.addEventListener( 'godamEngagementStoreInitialized', renderCommentBox );
+
+	// Render the comment box.
+	function renderCommentBox() {
+		// Check WordPress dependencies
+		if ( typeof wp === 'undefined' || ! wp.data || ! wp.element?.createRoot ) {
+			return;
+		}
+
+		const storeName = 'godam-video-engagement';
+		const select = wp.data.select( storeName );
+		const dispatch = wp.data.dispatch( storeName );
+
+		if ( ! select || ! dispatch ) {
+			return;
+		}
+
+		// Find video element and get instance ID
+		const videoElement = document.querySelector( `.easydam-player.video-js[data-id="${ videoIdNum }"]` );
+		const videoInstanceId = videoElement?.getAttribute( 'data-instance-id' );
+
+		if ( ! videoInstanceId ) {
+			return;
+		}
+
+		// Get site URL
+		const siteUrl = window.location.origin;
+
+		// Determine if engagements should be shown
+		const embedElement = document.querySelector( '.godam-video-embed' );
+		const skipEngagements = embedElement?.getAttribute( 'data-show-engagements' ) !== 'true';
+
+		// Dispatch action to initiate comment modal
+		dispatch.initiateCommentModal(
+			videoIdNum.toString(),
+			siteUrl,
+			`engagement-${ videoInstanceId }`,
+			skipEngagements,
+			true,
+		);
+
+		// Hide loading overlay after modal is initiated
+		hideLoadingOverlay();
+	}
+} );

--- a/assets/src/js/godam-video-embed.js
+++ b/assets/src/js/godam-video-embed.js
@@ -347,6 +347,13 @@ document.addEventListener( 'godamAllPlayersReady', () => {
  */
 document.addEventListener( 'DOMContentLoaded', function() {
 	const urlParams = new URLSearchParams( window.location.search );
+
+	// Only run if engagements query parameter is enabled.
+	const engagementsParam = ( urlParams.get( 'engagements' ) || '' ).toLowerCase();
+	if ( ! [ '1', 'true', 'on', 'show' ].includes( engagementsParam ) ) {
+		return;
+	}
+
 	const videoId = urlParams.get( 'id' );
 
 	if ( ! videoId ) {

--- a/assets/src/js/godam-video-embed.js
+++ b/assets/src/js/godam-video-embed.js
@@ -346,13 +346,13 @@ document.addEventListener( 'godamAllPlayersReady', () => {
  * @since 1.5.0
  */
 document.addEventListener( 'DOMContentLoaded', function() {
-	const urlParams = new URLSearchParams( window.location.search );
+	const embedElement = document.querySelector( '.godam-video-embed' );
 
-	// Only run if engagements query parameter is enabled.
-	const engagementsParam = ( urlParams.get( 'engagements' ) || '' ).toLowerCase();
-	if ( ! [ '1', 'true', 'on', 'show' ].includes( engagementsParam ) ) {
+	if ( embedElement?.getAttribute( 'data-show-engagements' ) !== 'true' ) {
 		return;
 	}
+
+	const urlParams = new URLSearchParams( window.location.search );
 
 	const videoId = urlParams.get( 'id' );
 
@@ -419,7 +419,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		const siteUrl = window.location.origin;
 
 		// Determine if engagements should be shown
-		const embedElement = document.querySelector( '.godam-video-embed' );
 		const skipEngagements = embedElement?.getAttribute( 'data-show-engagements' ) !== 'true';
 
 		// Dispatch action to initiate comment modal

--- a/assets/src/js/godam-video-embed.js
+++ b/assets/src/js/godam-video-embed.js
@@ -368,7 +368,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	// Create and show loading overlay
 	const loadingOverlay = document.createElement( 'div' );
 	loadingOverlay.className = 'godam-video-embed-loading';
-	loadingOverlay.style.cssText = 'position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: #fff; z-index: 9999; display: flex; align-items: center; justify-content: center;';
 
 	// Create spinner element
 	const spinner = document.createElement( 'div' );
@@ -389,13 +388,21 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		}
 	};
 
-	// Listen for the engagement store to be initialized.
-	document.addEventListener( 'godamEngagementStoreInitialized', renderCommentBox );
+	// Fallback: remove the overlay after 10 s in case the engagement store
+	// event never fires or renderCommentBox() exits early.
+	const overlayFallbackTimer = setTimeout( hideLoadingOverlay, 10000 );
+
+	// Listen for the engagement store to be initialized (once only).
+	document.addEventListener( 'godamEngagementStoreInitialized', renderCommentBox, { once: true } );
 
 	// Render the comment box.
 	function renderCommentBox() {
+		// Always clear the fallback timer — we are now handling the overlay ourselves.
+		clearTimeout( overlayFallbackTimer );
+
 		// Check WordPress dependencies
 		if ( typeof wp === 'undefined' || ! wp.data || ! wp.element?.createRoot ) {
+			hideLoadingOverlay();
 			return;
 		}
 
@@ -404,6 +411,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		const dispatch = wp.data.dispatch( storeName );
 
 		if ( ! select || ! dispatch ) {
+			hideLoadingOverlay();
 			return;
 		}
 
@@ -412,6 +420,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		const videoInstanceId = videoElement?.getAttribute( 'data-instance-id' );
 
 		if ( ! videoInstanceId ) {
+			hideLoadingOverlay();
 			return;
 		}
 

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -386,6 +386,7 @@ class Assets {
 		$brand_image                    = $godam_settings['video_player']['brand_image'] ?? '';
 		$brand_color                    = $godam_settings['video_player']['brand_color'] ?? '';
 		$enable_gtm_tracking            = $godam_settings['general']['enable_gtm_tracking'] ?? false;
+		$engagement_feature_enabled     = rtgodam_is_engagement_feature_enabled();
 		$enable_global_video_engagement = $godam_settings['video']['enable_global_video_engagement'] ?? true;
 		$enable_global_share            = $godam_settings['video']['enable_global_video_share'] ?? true;
 
@@ -396,7 +397,8 @@ class Assets {
 			'apiBase'                     => RTGODAM_API_BASE,
 			'enableGTMTracking'           => $enable_gtm_tracking,
 			'videoPostSettings'           => get_option( 'rtgodam_video_post_settings', array() ),
-			'enableGlobalVideoEngagement' => $enable_global_video_engagement,
+			'engagementFeatureEnabled'    => $engagement_feature_enabled,
+			'enableGlobalVideoEngagement' => $engagement_feature_enabled ? $enable_global_video_engagement : false,
 			'enableGlobalVideoShare'      => $enable_global_share,
 
 		);

--- a/inc/classes/class-video-engagement.php
+++ b/inc/classes/class-video-engagement.php
@@ -149,6 +149,9 @@ class Video_Engagement {
 	 * @return bool True if engagements are enabled, otherwise false.
 	 */
 	public function check_if_engagements_enabled( $attachment_id, $attributes ) {
+		if ( ! rtgodam_is_engagement_feature_enabled() ) {
+			return false;
+		}
 
 		if ( empty( $attachment_id ) || ! isset( $attributes['engagements'] ) ) {
 			return false;

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -36,7 +36,7 @@ defined( 'ABSPATH' ) || exit;
  * | category        | (dropped)          | V2 query does not support category filter |
  * | tag             | (dropped)          | V2 query does not support tag filter      |
  * | search          | (dropped)          | V2 query does not support search filter   |
- * | engagements     | (dropped)          | V2 does not have engagement support       |
+ * | engagements     | engagements        | direct pass-through                       |
  * | openToNewPage   | (dropped)          | V2 does not have single-page linking      |
  */
 class Gallery_V1_To_V2 {
@@ -364,6 +364,7 @@ class Gallery_V1_To_V2 {
 			'customDateStart'   => '',
 			'customDateEnd'     => '',
 			'showTitle'         => true,
+			'engagements'       => true,
 		);
 
 		$diff = array();
@@ -412,6 +413,7 @@ class Gallery_V1_To_V2 {
 			'customDateStart',
 			'customDateEnd',
 			'showTitle',
+			'engagements',
 		);
 
 		foreach ( $passthrough as $key ) {
@@ -436,7 +438,7 @@ class Gallery_V1_To_V2 {
 
 		/*
 		 * Intentionally dropped (no equivalent in V2):
-		 * category, tag, search, engagements, openToNewPage, include.
+		 * category, tag, search, openToNewPage, include.
 		 */
 
 		return $v2;

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -364,7 +364,7 @@ class Gallery_V1_To_V2 {
 			'customDateStart'   => '',
 			'customDateEnd'     => '',
 			'showTitle'         => true,
-			'engagements'       => false,
+			'engagements'       => true,
 		);
 
 		$diff = array();

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -364,7 +364,7 @@ class Gallery_V1_To_V2 {
 			'customDateStart'   => '',
 			'customDateEnd'     => '',
 			'showTitle'         => true,
-			'engagements'       => true,
+			'engagements'       => false,
 		);
 
 		$diff = array();

--- a/inc/classes/rest-api/class-dynamic-gallery.php
+++ b/inc/classes/rest-api/class-dynamic-gallery.php
@@ -309,7 +309,7 @@ class Dynamic_Gallery extends Base {
 					data-date-range="' . esc_attr( $atts['date_range'] ?? '' ) . '"
 					data-custom-date-start="' . esc_attr( $atts['custom_date_start'] ?? '' ) . '"
 					data-custom-date-end="' . esc_attr( $atts['custom_date_end'] ?? '' ) . '"
-data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
+data-engagements="' . ( rtgodam_is_engagement_feature_enabled() && $atts['engagements'] ? '1' : '0' ) . '">';
 			}
 	
 			do_action( 'rtgodam_dynamic_gallery_before_output', $query, $atts );
@@ -340,7 +340,7 @@ data-engagements="' . ( $atts['engagements'] ? '1' : '0' ) . '">';
 				}
 
 				// Check if engagements are enabled for the video.
-				$engagements_enabled      = $atts['engagements'];
+				$engagements_enabled      = rtgodam_is_engagement_feature_enabled() && $atts['engagements'];
 				$item_engagements_enabled = false;
 				if ( $engagements_enabled ) {
 					// Check if engagements are enabled for the video is transcoded.

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -275,11 +275,20 @@ class GoDAM_Player {
 		);
 
 		// Handle boolean attributes passed as strings (do this before mapping).
-		$boolean_attributes = array( 'autoplay', 'controls', 'loop', 'muted', 'engagements', 'preview', 'showShareButton', 'show_share_button' );
+		$boolean_attributes = array( 'autoplay', 'controls', 'loop', 'muted', 'preview', 'showShareButton', 'show_share_button' );
 		foreach ( $boolean_attributes as $bool_attr ) {
 			if ( isset( $attributes[ $bool_attr ] ) ) {
 				$attributes[ $bool_attr ] = filter_var( $attributes[ $bool_attr ], FILTER_VALIDATE_BOOLEAN );
 			}
+		}
+
+		// Normalize 'engagements' separately: the embed page passes 'show' as a truthy value,
+		// which filter_var() would incorrectly map to false. Treat 'show' as true, then fall
+		// back to standard boolean parsing for all other string representations.
+		if ( isset( $attributes['engagements'] ) && is_string( $attributes['engagements'] ) ) {
+			$attributes['engagements'] = 'show' === $attributes['engagements']
+				? true
+				: filter_var( $attributes['engagements'], FILTER_VALIDATE_BOOLEAN );
 		}
 
 		// Map WPBakery format (lowercase_underscore) to camelCase for backward compatibility.

--- a/inc/classes/shortcodes/class-godam-video-gallery.php
+++ b/inc/classes/shortcodes/class-godam-video-gallery.php
@@ -296,7 +296,7 @@ class GoDAM_Video_Gallery {
 				data-date-range="' . esc_attr( $atts['date_range'] ) . '"
 				data-custom-date-start="' . esc_attr( $atts['custom_date_start'] ) . '"
 				data-custom-date-end="' . esc_attr( $atts['custom_date_end'] ) . '"
-				data-engagements="' . esc_attr( $atts['engagements'] ) . '"
+				data-engagements="' . esc_attr( rtgodam_is_engagement_feature_enabled() && $atts['engagements'] ? '1' : '0' ) . '"
 
 			>';
 			foreach ( $query->posts as $video ) {
@@ -334,7 +334,7 @@ class GoDAM_Video_Gallery {
 				}
 
 				// Check if engagements are enabled for the video.
-				$engagements_enabled      = $atts['engagements'];
+				$engagements_enabled      = rtgodam_is_engagement_feature_enabled() && $atts['engagements'];
 				$item_engagements_enabled = false;
 				if ( $engagements_enabled ) {
 					// Check if the video is transcoded when engagements are enabled.

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1149,6 +1149,30 @@ function rtgodam_get_post_id_by_meta_key_and_value( $key, $value ) {
 }
 
 /**
+ * Check whether the engagement feature is available in GoDAM.
+ *
+ * Returning true enables engagement settings and runtime behavior for
+ * GoDAM video, gallery, and embed experiences.
+ *
+ * @since 1.8.0
+ *
+ * @return bool Whether the engagement feature is enabled.
+ */
+function rtgodam_is_engagement_feature_enabled() {
+	/**
+	 * Filters whether the GoDAM engagement feature is enabled.
+	 *
+	 * Return true to enable engagement settings and functionality for GoDAM
+	 * videos, galleries, and embeds.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param bool $is_enabled Whether the engagement feature is enabled. Default false.
+	 */
+	return (bool) apply_filters( 'rtgodam_enable_engagement_feature', false );
+}
+
+/**
  * Generate HTML content for the video embed page.
  *
  * This function produces the HTML markup for embedding a single video.
@@ -1170,7 +1194,7 @@ function godam_embed_page_content( $video_id, $godam_context = '', $bg_color = '
 	$video_attachment = null;
 	$show_video       = false;
 	$video_id         = intval( $video_id );
-	$show_engagements = $show_engagements ? 'show' : '';
+	$show_engagements = rtgodam_is_engagement_feature_enabled() && $show_engagements ? 'show' : '';
 
 	if ( ! empty( $video_id ) ) {
 		$video_attachment = get_post( $video_id );

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1158,17 +1158,19 @@ function rtgodam_get_post_id_by_meta_key_and_value( $key, $value ) {
  * @param int    $video_id      The ID of the video attachment to embed.
  * @param string $godam_context Optional. The player context passed to the godam_video shortcode (e.g. 'video-only').
  * @param string $bg_color      Optional. Hex background color applied as --godam-video-bg-color CSS variable on the wrapper.
+ * @param bool   $show_engagements Optional. Whether to show engagements in the embed. Default false (no engagements shown).
  *
  * @since 1.5.0
  *
  * @return string The generated HTML content for the video embed page.
  */
-function godam_embed_page_content( $video_id, $godam_context = '', $bg_color = '' ) {
+function godam_embed_page_content( $video_id, $godam_context = '', $bg_color = '', $show_engagements = false ) {
 	ob_start();
 	// Check if video ID is provided and if video attachment exists.
 	$video_attachment = null;
 	$show_video       = false;
 	$video_id         = intval( $video_id );
+	$show_engagements = $show_engagements ? 'show' : '';
 
 	if ( ! empty( $video_id ) ) {
 		$video_attachment = get_post( $video_id );
@@ -1188,12 +1190,16 @@ function godam_embed_page_content( $video_id, $godam_context = '', $bg_color = '
 		if ( ! empty( $godam_context ) ) {
 			$godam_shortcode .= ' godam_context="' . esc_attr( $godam_context ) . '"';
 		}
+		if ( ! empty( $show_engagements ) ) {
+			$godam_shortcode .= ' engagements="' . esc_attr( $show_engagements ) . '"';
+		}
 		$godam_shortcode .= ']';
 
 		$godam_wrapper_style = ! empty( $bg_color ) ? '--godam-video-bg-color: ' . $bg_color . ';' : '';
 		?>
 		<div 
 			class="godam-video-embed" data-godam-context="<?php echo esc_attr( $godam_context ); ?>"
+			data-show-engagements="<?php echo esc_attr( $show_engagements ? 'true' : 'false' ); ?>"
 			style="<?php echo esc_attr( $godam_wrapper_style ); ?>"
 		>
 			<?php echo do_shortcode( $godam_shortcode ); ?>

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1191,10 +1191,10 @@ function rtgodam_is_engagement_feature_enabled() {
 function godam_embed_page_content( $video_id, $godam_context = '', $bg_color = '', $show_engagements = false ) {
 	ob_start();
 	// Check if video ID is provided and if video attachment exists.
-	$video_attachment = null;
-	$show_video       = false;
-	$video_id         = intval( $video_id );
-	$show_engagements = rtgodam_is_engagement_feature_enabled() && $show_engagements ? 'show' : '';
+	$video_attachment  = null;
+	$show_video        = false;
+	$video_id          = intval( $video_id );
+	$engagements_value = rtgodam_is_engagement_feature_enabled() && $show_engagements ? 'show' : '';
 
 	if ( ! empty( $video_id ) ) {
 		$video_attachment = get_post( $video_id );
@@ -1214,8 +1214,8 @@ function godam_embed_page_content( $video_id, $godam_context = '', $bg_color = '
 		if ( ! empty( $godam_context ) ) {
 			$godam_shortcode .= ' godam_context="' . esc_attr( $godam_context ) . '"';
 		}
-		if ( ! empty( $show_engagements ) ) {
-			$godam_shortcode .= ' engagements="' . esc_attr( $show_engagements ) . '"';
+		if ( ! empty( $engagements_value ) ) {
+			$godam_shortcode .= ' engagements="' . esc_attr( $engagements_value ) . '"';
 		}
 		$godam_shortcode .= ']';
 

--- a/inc/templates/video-embed.php
+++ b/inc/templates/video-embed.php
@@ -14,10 +14,12 @@ wp_enqueue_style( 'godam-video-embed-style' );
 wp_enqueue_script( 'godam-video-embed-script' );
 
 $godam_video_id         = isset( $_GET['id'] ) ? intval( wp_unslash( $_GET['id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
+$godam_video_transcoded = sanitize_text_field( (string) get_post_meta( $godam_video_id, 'rtgodam_transcoding_status', true ) );
 $godam_context          = isset( $_GET['godam_context'] ) ? sanitize_text_field( wp_unslash( $_GET['godam_context'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
 $godam_bg_color         = isset( $_GET['bg'] ) ? sanitize_hex_color( '#' . ltrim( wp_unslash( $_GET['bg'] ), '#' ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no nonce verification needed for this page.
 $godam_show_engagements = isset( $_GET['engagements'] ) ? sanitize_text_field( wp_unslash( $_GET['engagements'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
-$godam_show_engagements = rtgodam_is_engagement_feature_enabled() && in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
+$godam_show_engagements = rtgodam_is_engagement_feature_enabled() && rtgodam_is_api_key_valid() && 'transcoded' === $godam_video_transcoded && in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
+
 
 $godam_embed_content = godam_embed_page_content( $godam_video_id, $godam_context, $godam_bg_color, $godam_show_engagements );
 

--- a/inc/templates/video-embed.php
+++ b/inc/templates/video-embed.php
@@ -18,7 +18,7 @@ $godam_video_transcoded = sanitize_text_field( (string) get_post_meta( $godam_vi
 $godam_context          = isset( $_GET['godam_context'] ) ? sanitize_text_field( wp_unslash( $_GET['godam_context'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
 $godam_bg_color         = isset( $_GET['bg'] ) ? sanitize_hex_color( '#' . ltrim( wp_unslash( $_GET['bg'] ), '#' ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no nonce verification needed for this page.
 $godam_show_engagements = isset( $_GET['engagements'] ) ? sanitize_text_field( wp_unslash( $_GET['engagements'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
-$godam_show_engagements = rtgodam_is_engagement_feature_enabled() && rtgodam_is_api_key_valid() && 'transcoded' === $godam_video_transcoded && in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
+$godam_show_engagements = rtgodam_is_engagement_feature_enabled() && rtgodam_is_api_key_valid() && 'transcoded' === strtolower( $godam_video_transcoded ) && in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
 
 
 $godam_embed_content = godam_embed_page_content( $godam_video_id, $godam_context, $godam_bg_color, $godam_show_engagements );

--- a/inc/templates/video-embed.php
+++ b/inc/templates/video-embed.php
@@ -17,7 +17,7 @@ $godam_video_id         = isset( $_GET['id'] ) ? intval( wp_unslash( $_GET['id']
 $godam_context          = isset( $_GET['godam_context'] ) ? sanitize_text_field( wp_unslash( $_GET['godam_context'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
 $godam_bg_color         = isset( $_GET['bg'] ) ? sanitize_hex_color( '#' . ltrim( wp_unslash( $_GET['bg'] ), '#' ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no nonce verification needed for this page.
 $godam_show_engagements = isset( $_GET['engagements'] ) ? sanitize_text_field( wp_unslash( $_GET['engagements'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
-$godam_show_engagements = in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
+$godam_show_engagements = rtgodam_is_engagement_feature_enabled() && in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
 
 $godam_embed_content = godam_embed_page_content( $godam_video_id, $godam_context, $godam_bg_color, $godam_show_engagements );
 

--- a/inc/templates/video-embed.php
+++ b/inc/templates/video-embed.php
@@ -13,11 +13,13 @@ defined( 'ABSPATH' ) || exit;
 wp_enqueue_style( 'godam-video-embed-style' );
 wp_enqueue_script( 'godam-video-embed-script' );
 
-$godam_video_id = isset( $_GET['id'] ) ? intval( wp_unslash( $_GET['id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
-$godam_context  = isset( $_GET['godam_context'] ) ? sanitize_text_field( wp_unslash( $_GET['godam_context'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
-$godam_bg_color = isset( $_GET['bg'] ) ? sanitize_hex_color( '#' . ltrim( wp_unslash( $_GET['bg'] ), '#' ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no nonce verification needed for this page.
+$godam_video_id         = isset( $_GET['id'] ) ? intval( wp_unslash( $_GET['id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
+$godam_context          = isset( $_GET['godam_context'] ) ? sanitize_text_field( wp_unslash( $_GET['godam_context'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
+$godam_bg_color         = isset( $_GET['bg'] ) ? sanitize_hex_color( '#' . ltrim( wp_unslash( $_GET['bg'] ), '#' ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no nonce verification needed for this page.
+$godam_show_engagements = isset( $_GET['engagements'] ) ? sanitize_text_field( wp_unslash( $_GET['engagements'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no nonce verification needed for this page.
+$godam_show_engagements = in_array( strtolower( $godam_show_engagements ), array( '1', 'true', 'on', 'show' ), true );
 
-$godam_embed_content = godam_embed_page_content( $godam_video_id, $godam_context, $godam_bg_color );
+$godam_embed_content = godam_embed_page_content( $godam_video_id, $godam_context, $godam_bg_color, $godam_show_engagements );
 
 // translators: %s: video ID.
 $godam_page_title = empty( $godam_video_id ) ? __( 'Video Embed', 'godam' ) : sprintf( __( 'Video Embed: Attachment(%s)', 'godam' ), $godam_video_id );

--- a/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
@@ -17,6 +17,7 @@ import { hasAPIKey } from '../../../utils';
 const VideoEngagement = ( { handleSettingChange } ) => {
 	const enableGlobalEngagement = useSelector( ( state ) => state.mediaSettings.video.enable_global_video_engagement );
 	const enableGlobalShare = useSelector( ( state ) => state.mediaSettings.video.enable_global_video_share );
+	const engagementFeatureEnabled = window?.godamSettings?.engagementFeatureEnabled ?? false;
 
 	return (
 		<div className="relative">
@@ -26,20 +27,22 @@ const VideoEngagement = ( { handleSettingChange } ) => {
 			>
 				<PanelBody>
 					<div className="flex flex-col gap-2 opacity-90 relative">
-						<ToggleControl
-							__nextHasNoMarginBottom
-							className="godam-toggle"
-							label={ __( 'Enable video engagement globally', 'godam' ) }
-							checked={ enableGlobalEngagement }
-							onChange={ ( value ) => {
-								handleSettingChange( 'enable_global_video_engagement', value );
-							} }
-							disabled={ ! hasAPIKey }
-							help={ __(
-								'If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel.',
-								'godam',
-							) }
-						/>
+						{ engagementFeatureEnabled && (
+							<ToggleControl
+								__nextHasNoMarginBottom
+								className="godam-toggle"
+								label={ __( 'Enable video engagement globally', 'godam' ) }
+								checked={ enableGlobalEngagement }
+								onChange={ ( value ) => {
+									handleSettingChange( 'enable_global_video_engagement', value );
+								} }
+								disabled={ ! hasAPIKey }
+								help={ __(
+									'If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel.',
+									'godam',
+								) }
+							/>
+						) }
 						<ToggleControl
 							__nextHasNoMarginBottom
 							className="godam-toggle"

--- a/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { hasAPIKey } from '../../../utils';
 
 const VideoEngagement = ( { handleSettingChange } ) => {
+	const enableGlobalEngagement = useSelector( ( state ) => state.mediaSettings.video.enable_global_video_engagement );
 	const enableGlobalShare = useSelector( ( state ) => state.mediaSettings.video.enable_global_video_share );
 
 	return (
@@ -25,6 +26,20 @@ const VideoEngagement = ( { handleSettingChange } ) => {
 			>
 				<PanelBody>
 					<div className="flex flex-col gap-2 opacity-90 relative">
+						<ToggleControl
+							__nextHasNoMarginBottom
+							className="godam-toggle"
+							label={ __( 'Enable video engagement globally', 'godam' ) }
+							checked={ enableGlobalEngagement }
+							onChange={ ( value ) => {
+								handleSettingChange( 'enable_global_video_engagement', value );
+							} }
+							disabled={ ! hasAPIKey }
+							help={ __(
+								'If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel.',
+								'godam',
+							) }
+						/>
 						<ToggleControl
 							__nextHasNoMarginBottom
 							className="godam-toggle"


### PR DESCRIPTION
**Fixes:** [[Release] GoDAM Plugin v1.8.0 (rtCamp/godam-core#1038)](https://github.com/rtCamp/godam-core/issues/1038)

This pull request introduces the new engagement feature (likes & comments) for GoDAM videos and galleries, making it available as a toggle in both the editor and on the frontend, but only when the feature is enabled globally. The changes ensure that engagement controls and runtime behavior are only exposed if the engagement feature is enabled via a filter, and that the feature is only available for transcoded videos. The implementation includes updates across block attributes, editor controls, REST API, shortcodes, PHP helpers, and JavaScript, with careful handling of data attributes and settings propagation.

**Engagement Feature Enablement and Settings Propagation:**

* Added a global feature flag check via the new `rtgodam_is_engagement_feature_enabled()` helper, which determines if engagement options should be exposed throughout the system. This is now used in PHP, REST API, and JS to gate all engagement-related functionality. [[1]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1151-R1174) [[2]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dR389) [[3]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dL399-R401)
* Updated the global JS settings object to include `engagementFeatureEnabled`, and to only enable `enableGlobalVideoEngagement` if the feature is enabled.

**Editor and Block Attribute Updates:**

* Added `engagements` as a boolean attribute to both the Godam Gallery and Godam Player blocks, defaulting to `true` for galleries and `false` for players. [[1]](diffhunk://#diff-1bba1cbd20a66adc2eaef9e7c4aead7eebe45b0e6375b14169c5c875d7d63a49R78-R81) [[2]](diffhunk://#diff-0452960eaa8ba8724cc49af281678ab3c7d21abd9ed841f2362d9aa0e7b14d3dR116-R119)
* Introduced a toggle control for "Enable Likes & Comments" in the editor UI for both blocks, which only appears if the engagement feature is enabled globally. [[1]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R210-R213) [[2]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R602-R611) [[3]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cL45-R49) [[4]](diffhunk://#diff-da8e9c5db56f46907c50188af390d920ed08982cb6174c610e6b097e9eed2b8cR158-R168)

**Frontend Data Flow and Embed Handling:**

* Ensured that engagement enablement is passed as a data attribute (`data-engagements` or `data-show-engagements`) in galleries, shortcodes, and embed pages, and only set when the feature is enabled. [[1]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9R257) [[2]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL312-R312) [[3]](diffhunk://#diff-ff93ce1d751cfdecd260633d6f9c8cd542b57188ab5c95c5512c4f8ca99d40eeL343-R343) [[4]](diffhunk://#diff-de9311fed0a3cfd870aaeb664c5043e3259ee52c672ab415193ea513a4a92c36L299-R299) [[5]](diffhunk://#diff-de9311fed0a3cfd870aaeb664c5043e3259ee52c672ab415193ea513a4a92c36L337-R337) [[6]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1217-R1226) [[7]](diffhunk://#diff-614948c64a44011a93b26df44555361762cf72a835b1b8723ec2079f62f78d05R19-R22)
* Updated the gallery and player JS to read these attributes and append the correct `engagements` parameter to embed URLs, ensuring the engagement UI is only shown when allowed. [[1]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354R166) [[2]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354L366-R368)

**Embed Page and Engagement Modal Initialization:**

* Modified the embed page template and content generator to accept and propagate the engagement flag, and to set the appropriate data attribute for JS detection. [[1]](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27R1185-R1197) [[2]](diffhunk://#diff-614948c64a44011a93b26df44555361762cf72a835b1b8723ec2079f62f78d05R19-R22)
* Added JS logic to the embed page to automatically render the engagement modal (with a loading overlay) if engagements are enabled and the video is valid.

**Robustness and Backward Compatibility:**

* Improved the handling of boolean attributes for shortcodes, ensuring that string values like "show" are correctly interpreted as true for engagements.
* Updated backend checks for engagement enablement to always require the global feature flag to be true, preventing accidental exposure of the feature.

These changes collectively ensure that the engagement feature is robustly gated, consistently exposed in the UI, and only available when intended.