### PR TITLE
fix: Apply migration feedback

### DIFF
--- a/godam.php
+++ b/godam.php
@@ -159,6 +159,7 @@ function rtgodam_plugin_delete() {
 
 			delete_option( 'rtgodam_plugin_version' );
 			delete_option( 'rtgodam_show_whats_new' );
+			delete_transient( 'rtgodam_show_whats_new' ); // Stored as a transient in ≤1.7.2.
 			delete_option( 'rtgodam_user_data' );
 			delete_option( 'rtgodam-api-key' );
 			delete_option( 'rtgodam-api-key-stored' );
@@ -173,6 +174,7 @@ function rtgodam_plugin_delete() {
 		// For single site, delete options directly.
 		delete_option( 'rtgodam_plugin_version' );
 		delete_option( 'rtgodam_show_whats_new' );
+		delete_transient( 'rtgodam_show_whats_new' ); // Stored as a transient in ≤1.7.2.
 		delete_option( 'rtgodam_user_data' );
 		delete_option( 'rtgodam-api-key' );
 		delete_option( 'rtgodam-api-key-stored' );

--- a/inc/classes/migrations/class-gallery-v1-to-v2.php
+++ b/inc/classes/migrations/class-gallery-v1-to-v2.php
@@ -97,17 +97,27 @@ class Gallery_V1_To_V2 {
 	 *
 	 * Called by Runner::maybe_run() on admin_init when the plugin version has changed.
 	 *
-	 * @return void
+	 * Returns true when the migration is already done or was successfully started
+	 * so the runner can advance the stored DB version. Returns false when the
+	 * migration bailed before starting (e.g. insufficient capabilities), signalling
+	 * the runner to hold the DB version so the migration retries on the next
+	 * qualifying admin_init.
+	 *
+	 * @return bool True if migration is complete or in progress; false if it bailed.
 	 */
-	public static function maybe_run() {
+	public static function maybe_run(): bool {
 		if ( get_option( self::OPTION_KEY ) ) {
-			return;
+			return true; // Already done.
 		}
 
 		// Called from Runner::maybe_run() on admin_init — is_user_logged_in()
 		// and current_user_can() are guaranteed available. Call run() directly;
 		// no need to defer to a later hook.
 		self::run();
+
+		// If run() completed successfully it sets OPTION_KEY; if it bailed
+		// (e.g. cap check) the option is still absent.
+		return (bool) get_option( self::OPTION_KEY );
 	}
 
 	/**

--- a/inc/classes/migrations/class-godam-cpt-cleanup.php
+++ b/inc/classes/migrations/class-godam-cpt-cleanup.php
@@ -114,18 +114,27 @@ class Godam_Cpt_Cleanup {
 	 * The AS hook is registered by register_hooks() unconditionally; this
 	 * method only decides whether to queue a new migration run.
 	 *
-	 * @return void
+	 * Returns true when the migration is already started/done or was successfully
+	 * queued, so the runner can advance the stored DB version. Returns false when
+	 * the migration bailed before starting (e.g. insufficient capabilities),
+	 * signalling the runner to hold the DB version for a retry.
+	 *
+	 * @return bool True if migration is complete, in progress, or just queued; false if it bailed.
 	 */
-	public static function maybe_run() {
+	public static function maybe_run(): bool {
 		// 'processing' or 'done' — migration already started or complete.
 		if ( get_option( self::OPTION_KEY ) ) {
-			return;
+			return true; // Already started or done.
 		}
 
 		// Called from Runner::maybe_run() on admin_init — is_user_logged_in()
 		// and current_user_can() are guaranteed available. Call run() directly;
 		// no need to defer to a later hook.
 		self::run();
+
+		// If run() started the migration it sets OPTION_KEY to 'processing';
+		// if it bailed (e.g. cap check) the option is still absent.
+		return (bool) get_option( self::OPTION_KEY );
 	}
 
 	/**

--- a/inc/classes/migrations/class-runner.php
+++ b/inc/classes/migrations/class-runner.php
@@ -103,6 +103,12 @@ class Runner {
 	 * are available. The version compare is the sole gate — if stored version
 	 * equals current version, this is a single option read and returns.
 	 *
+	 * The runner only advances the stored DB version for a given version-batch
+	 * when every migration class in that batch returns true from maybe_run().
+	 * If any migration bails (e.g. the current user lacks manage_options), the
+	 * runner stops without bumping the stored version so the whole batch retries
+	 * on the next qualifying admin_init.
+	 *
 	 * @return void
 	 */
 	public static function maybe_run(): void {
@@ -116,8 +122,17 @@ class Runner {
 				continue;
 			}
 
+			$all_complete = true;
 			foreach ( $classes as $class ) {
-				$class::maybe_run();
+				if ( ! $class::maybe_run() ) {
+					$all_complete = false;
+				}
+			}
+
+			if ( ! $all_complete ) {
+				// At least one migration bailed — hold the stored version so
+				// the entire batch retries on the next qualifying admin_init.
+				return;
 			}
 
 			// Advance the stored version after each batch so that if the


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/1038

This pull request improves the reliability and clarity of the plugin's migration and cleanup processes. The main focus is on making the migration runner more robust by ensuring that database version updates only occur when all required migrations in a batch have completed successfully. Additionally, it enhances the cleanup logic for options and transients during plugin deletion.

**Migration runner and migration classes:**

* The migration runner (`Runner::maybe_run`) now only advances the stored database version if all migration classes in the current batch return `true` from their `maybe_run()` method, ensuring no partial migrations are marked as complete. If any migration bails (e.g., due to insufficient permissions), the batch is retried on the next eligible admin request. [[1]](diffhunk://#diff-56de9f73acfc428b5c51a2c677056ea081bfcf1ce93157798e24345370cbec79R106-R111) [[2]](diffhunk://#diff-56de9f73acfc428b5c51a2c677056ea081bfcf1ce93157798e24345370cbec79R125-R135)
* Both `Gallery_V1_To_V2::maybe_run()` and `Godam_CPT_Cleanup::maybe_run()` now return a boolean indicating whether the migration is complete or in progress (`true`) or if it bailed before starting (`false`). This allows the runner to make informed decisions about advancing the stored version. [[1]](diffhunk://#diff-38e45597cee6188fbe6d6932c4752695f0e4fb4917f68e655bf75df57d76a866L100-R120) [[2]](diffhunk://#diff-436257bad28a0da97b35380d4d55c93ab661ea618f68fba57a9229ac1e411fe5L117-R137)

**Plugin deletion cleanup:**

* The plugin deletion function now deletes the `rtgodam_show_whats_new` transient in addition to the option, ensuring complete cleanup of legacy data from versions ≤1.7.2. [[1]](diffhunk://#diff-11ad0cbfc6e1732b964b5298a09e2b1cd2df3efc7f60babe88d5d0e88d748916R162) [[2]](diffhunk://#diff-11ad0cbfc6e1732b964b5298a09e2b1cd2df3efc7f60babe88d5d0e88d748916R177)


## Recording

https://github.com/user-attachments/assets/230ba022-2554-4fa2-8981-a2e87977dc11

