### PR TITLE
fix: Re-add Woo support after 1.8.0

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -43,13 +43,11 @@ class RTGODAM_Transcoder_Admin {
 			add_action( 'admin_notices', array( $this, 'posthog_tracking_notice' ) );
 			add_action( 'admin_notices', array( $this, 'api_key_status_notice' ) );
 			add_action( 'admin_notices', array( $this, 'expired_api_key_notice' ) );
-			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.InlineComment.InvalidEndChar -- GoDAM for Woo
-			// add_action( 'admin_notices', array( $this, 'woo_integration_promo_notice' ) );
+			add_action( 'admin_notices', array( $this, 'woo_integration_promo_notice' ) );
 			add_action( 'admin_init', array( $this, 'handle_posthog_tracking_action' ) );
 			add_action( 'admin_init', array( $this, 'handle_clear_godam_cache' ) );
 			add_action( 'wp_ajax_rtgodam_dismiss_free_plan_notice', array( $this, 'dismiss_free_plan_notice' ) );
-			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.InlineComment.InvalidEndChar -- GoDAM for Woo
-			// add_action( 'wp_ajax_rtgodam_dismiss_woo_promo_notice', array( $this, 'dismiss_woo_promo_notice' ) ); 
+			add_action( 'wp_ajax_rtgodam_dismiss_woo_promo_notice', array( $this, 'dismiss_woo_promo_notice' ) ); 
 		}
 	}
 

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -20,8 +20,7 @@ use RTGODAM\Inc\Video_Preview;
 use RTGODAM\Inc\Video_Embed;
 use RTGODAM\Inc\Video_Engagement;
 use RTGODAM\Inc\Update;
-// phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.InlineComment.InvalidEndChar -- GoDAM for Woo
-// use RTGODAM\Inc\Addons\Addon_Registry;
+use RTGODAM\Inc\Addons\Addon_Registry;
 
 use RTGODAM\Inc\Taxonomies\Media_Folders;
 
@@ -102,8 +101,7 @@ class Plugin {
 		Video_Preview::get_instance();
 		Video_Embed::get_instance();
 		Embed::get_instance();
-		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.InlineComment.InvalidEndChar -- GoDAM for Woo
-		// Addon_Registry::get_instance();
+		Addon_Registry::get_instance();
 
 		// Load shortcodes.
 		GoDAM_Player::get_instance();

--- a/pages/godam/App.js
+++ b/pages/godam/App.js
@@ -7,7 +7,7 @@ import { useDispatch } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { cog, video, alignJustify, close/*, blockDefault*/ } from '@wordpress/icons'; // blockDefault
+import { cog, video, alignJustify, close, blockDefault } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,7 +19,7 @@ import Skeleton from './components/Skeleton.jsx';
 import GodamHeader from './components/GoDAMHeader.jsx';
 import GoDAMFooter from './components/GoDAMFooter.jsx';
 import GeneralSettings from './components/tabs/GeneralSettings/GeneralSettings.jsx';
-// import IntegrationsSettings from './components/tabs/IntegrationsSettings/IntegrationsSettings.jsx'; // GoDAM for Woo
+import IntegrationsSettings from './components/tabs/IntegrationsSettings/IntegrationsSettings.jsx';
 import VideoSettings from './components/tabs/VideoSettings/VideoSettings.jsx';
 import VideoPlayer from './components/tabs/VideoPlayer/VideoPlayer.jsx';
 import AdsSettings from './components/tabs/AdsSettings/AdsSettings.jsx';
@@ -59,13 +59,12 @@ const TABS = [
 			<path d="M14 3a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zM2 2a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z" />
 		</svg>,
 	},
-	// GoDAM for Woo
-	// {
-	// 	id: 'integrations-settings',
-	// 	label: __( 'Integrations Settings', 'godam' ),
-	// 	component: IntegrationsSettings,
-	// 	icon: blockDefault,
-	// },
+	{
+		id: 'integrations-settings',
+		label: __( 'Integrations Settings', 'godam' ),
+		component: IntegrationsSettings,
+		icon: blockDefault,
+	},
 ];
 
 const App = () => {


### PR DESCRIPTION
This pull request re-enables the WooCommerce integration features in both the PHP backend and React frontend of the project. The changes restore previously commented-out code related to the Woo integration, making the relevant admin notices, actions, and UI components active again.

**Backend (PHP) changes:**

* **WooCommerce Integration Admin Notices and Actions:**
  - Re-enabled the `woo_integration_promo_notice` admin notice and its dismissal AJAX handler in the `RTGodam_Transcoder_Admin` class (`admin/class-rtgodam-transcoder-admin.php`).
* **Addon Registry Loading:**
  - Restored the import and initialization of `Addon_Registry` in the main plugin class, ensuring Woo integration addons are now loaded (`inc/classes/class-plugin.php`). [[1]](diffhunk://#diff-0beca18a469ce0ef11130f3a94b2f7f6997eecfa5f4f414442e163a0230e131cL23-R23) [[2]](diffhunk://#diff-0beca18a469ce0ef11130f3a94b2f7f6997eecfa5f4f414442e163a0230e131cL105-R104)

**Frontend (React) changes:**

* **Integrations Settings Tab:**
  - Re-enabled the import and usage of the `IntegrationsSettings` component, and added the "Integrations Settings" tab to the UI (`pages/godam/App.js`). [[1]](diffhunk://#diff-e9bc551c0e2cbad370b18f43dac0aa1d8b845ef44fd6fede0149080e73fdaf24L22-R22) [[2]](diffhunk://#diff-e9bc551c0e2cbad370b18f43dac0aa1d8b845ef44fd6fede0149080e73fdaf24L62-R67)
* **Icon Import:**
  - Restored the import of the `blockDefault` icon for use in the Integrations tab (`pages/godam/App.js`).

## Screenshot [if minimum GoDAM version is 1.8.0]
<img width="851" height="444" alt="Screenshot 2026-05-04 at 7 01 56 PM" src="https://github.com/user-attachments/assets/05b9b65b-f678-48b0-be8f-a629c045afb8" />
