### PR TITLE
chore: Update GoDAM version to 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested up to: 6.9
 
 Requires PHP: 7.4
 
-Stable tag: 1.8.0
+Stable tag: 1.9.0
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 1.8.0
+ * Version: 1.9.0
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '1.8.0' );
+	define( 'RTGODAM_VERSION', '1.9.0' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.8.0
+Stable tag: 1.9.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This pull request updates the plugin version from 1.8.0 to 1.9.0 throughout the codebase and documentation to reflect the new release. No other functional or code changes are included.

Version bump:

* Updated the version number to 1.9.0 in the plugin header in `godam.php`
* Updated the `RTGODAM_VERSION` constant to 1.9.0 in `godam.php`
* Updated the version in `package.json` to 1.9.0

Documentation updates:

* Updated the stable tag to 1.9.0 in `README.md`
* Updated the stable tag to 1.9.0 in `readme.txt`