### PR TITLE
Update: Admin notices as per Marketing

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -927,7 +927,7 @@ class RTGODAM_Transcoder_Admin {
 			// Case 4: Required active + valid key → link to integrations page.
 			$message = sprintf(
 				/* translators: 1: opening link tag, 2: closing link tag */
-				__( '<strong>GoDAM now supports WooCommerce!</strong> Head over to the %1$sIntegration Settings%2$s to get started.', 'godam' ),
+				__( '<strong>Shoppable video for WooCommerce is live!</strong> %1$sActivate%2$s to start selling directly from your videos.', 'godam' ),
 				'<a href="' . esc_url( $integrations_url ) . '">',
 				'</a>'
 			);
@@ -935,7 +935,7 @@ class RTGODAM_Transcoder_Admin {
 			// Case 2: WooCommerce not active + valid key → install/activate WooCommerce.
 			$message = sprintf(
 				/* translators: 1: opening link tag, 2: closing link tag */
-				__( '<strong>GoDAM now supports WooCommerce!</strong> %1$sInstall & activate WooCommerce%2$s to use our Woo integration.', 'godam' ),
+				__( '<strong>GoDAM now supports WooCommerce!</strong> %1$sInstall WooCommerce%2$s to start using shoppable videos with GoDAM.', 'godam' ),
 				'<a href="' . esc_url( $woo_plugin_url ) . '">',
 				'</a>'
 			);
@@ -943,7 +943,7 @@ class RTGODAM_Transcoder_Admin {
 			// Cases 1 & 3: No valid key → purchase.
 			$message = sprintf(
 				/* translators: 1: opening link tag, 2: closing link tag */
-				__( '<strong>GoDAM now supports WooCommerce!</strong> %1$sPurchase a plan%2$s to access our Woo integration.', 'godam' ),
+				__( '<strong>Add shoppable videos to your WooCommerce store!</strong> %1$sUpgrade your plan%2$s to unlock this feature.', 'godam' ),
 				'<a href="' . esc_url( $pricing_url ) . '" target="_blank" rel="noopener noreferrer">',
 				'</a>'
 			);

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx
@@ -11,9 +11,9 @@ import { sprintf, __ } from '@wordpress/i18n';
  * the toggle button handles activation/deactivation instead.
  *
  * States (add-on NOT installed):
- * 1. Required plugin NOT active + no API key  → "Purchase Now"
+ * 1. Required plugin NOT active + no API key  → "Upgrade Plan"
  * 2. Required plugin NOT active + valid key   → "Learn More"
- * 3. Required plugin active + no API key      → "Purchase Now"
+ * 3. Required plugin active + no API key      → "Upgrade Plan"
  * 4. Required plugin active + valid API key   → "Install {name}" (triggers install)
  *
  * If the add-on IS installed → returns null (no button).
@@ -86,7 +86,7 @@ const IntegrationActionButton = ( {
 		);
 	}
 
-	// 1 & 3. No valid API key (regardless of required plugin) → Purchase Now.
+	// 1 & 3. No valid API key (regardless of required plugin) → Upgrade Plan.
 	return (
 		<Button
 			variant="primary"
@@ -95,7 +95,7 @@ const IntegrationActionButton = ( {
 			target="_blank"
 			rel="noopener noreferrer"
 		>
-			{ __( 'Purchase Now', 'godam' ) }
+			{ __( 'Upgrade Plan', 'godam' ) }
 		</Button>
 	);
 };

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
@@ -269,7 +269,7 @@ const IntegrationSettings = () => {
 									</p>
 								) }
 
-								{ /* This will show when the Button Displays Purchase Now text */ }
+								{ /* This will show when the Button Displays Upgrade Plan text */ }
 								{ ! isInstalled && ! hasValidAPIKey && (
 									<p>
 										{ __( 'This is a Pro feature.', 'godam' ) }


### PR DESCRIPTION
## In the PR

- Update `GoDAM supports Woo now. (Link to Integration settings page).` with `Shoppable video for WooCommerce is live. Activate to start selling directly from your videos.`
- Update `GoDAM supports Woo. Purchase a plan to access our Woo integration. (Link to pricing page)` with `Add shoppable videos to your WooCommerce store. Upgrade your plan to unlock this feature.`
- Update `GoDAM now supports Woo. (Link to WooCommerce Plugin page)` with `GoDAM now supports Woo. Install WooCommerce to start using shoppable videos with GoDAM.`
- Update `Installation failed. Please download zip and install it like any other plugin.` with `Installation failed. Please download the ZIP file and install it manually.`
- Rename Purchase Plan Button to Upgrade Plan.