### PR TITLE
chore: Rename GoDAM blocks

### DIFF
--- a/assets/src/blocks/godam-audio/block.json
+++ b/assets/src/blocks/godam-audio/block.json
@@ -2,10 +2,10 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "godam/audio",
-	"title": "GoDAM Audio",
+	"title": "Audio",
 	"category": "media",
 	"description": "Embed a GoDAM audio player.",
-	"keywords": [ "music", "sound", "podcast", "recording" ],
+	"keywords": [ "music", "sound", "podcast", "recording", "godam" ],
 	"textdomain": "godam",
 	"attributes": {
 		"blob": {

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -122,7 +122,7 @@ function AudioEdit( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
 					onError={ onUploadError }
-					labels={ { title: __( 'GoDAM Audio', 'godam' ) } }
+					labels={ { title: __( 'Audio', 'godam' ) } }
 				/>
 			</div>
 		);

--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "godam/gallery-v2",
-	"title": "GoDAM Video Gallery",
+	"title": "Video Gallery",
 	"category": "media",
 	"description": "Create a handpicked or query-based GoDAM video gallery.",
 	"keywords": [ "video", "gallery", "grid", "godam" ],

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -820,7 +820,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 											{ video.thumbnail ? (
 												<img src={ video.thumbnail } alt={ video.title } />
 											) : (
-												<span>{ __( 'GoDAM Video', 'godam' ) }</span>
+														<span>{ __( 'Video', 'godam' ) }</span>
 											) }
 										</div>
 										{ showTitle && (

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -820,7 +820,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 											{ video.thumbnail ? (
 												<img src={ video.thumbnail } alt={ video.title } />
 											) : (
-														<span>{ __( 'Video', 'godam' ) }</span>
+												<span>{ __( 'Video', 'godam' ) }</span>
 											) }
 										</div>
 										{ showTitle && (

--- a/assets/src/blocks/godam-gallery-v2/render.php
+++ b/assets/src/blocks/godam-gallery-v2/render.php
@@ -345,7 +345,7 @@ if ( 'query' === $godam_gallery_mode ) {
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
 									<img src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" class="godam-gallery-v2__thumbnail" <?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?> />
 								<?php else : ?>
-									<span><?php esc_html_e( 'GoDAM Video', 'godam' ); ?></span>
+									<span><?php esc_html_e( 'Video', 'godam' ); ?></span>
 								<?php endif; ?>
 							</div>
 							<?php if ( $godam_show_title ) : ?>
@@ -401,7 +401,7 @@ if ( 'query' === $godam_gallery_mode ) {
 									/>
 								<?php else : ?>
 									<div class="godam-gallery-v2-item__placeholder">
-										<span><?php esc_html_e( 'GoDAM Video', 'godam' ); ?></span>
+										<span><?php esc_html_e( 'Video', 'godam' ); ?></span>
 									</div>
 								<?php endif; ?>
 								<div class="godam-gallery-v2-item__play-icon" aria-hidden="true">

--- a/assets/src/blocks/godam-pdf/block.json
+++ b/assets/src/blocks/godam-pdf/block.json
@@ -2,10 +2,10 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "godam/pdf",
-	"title": "GoDAM PDF",
+	"title": "Document",
 	"category": "media",
 	"description": "Embed a PDF file with preview.",
-	"keywords": [ "document", "pdf", "file", "preview" ],
+	"keywords": [ "document", "pdf", "file", "preview", "godam" ],
 	"textdomain": "godam",
 	"attributes": {
 		"blob": {

--- a/assets/src/blocks/godam-pdf/edit.js
+++ b/assets/src/blocks/godam-pdf/edit.js
@@ -109,7 +109,7 @@ function PdfEdit( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
 					onError={ onUploadError }
-					labels={ { title: __( 'GoDAM PDF', 'godam' ) } }
+					labels={ { title: __( 'Document', 'godam' ) } }
 				/>
 			</div>
 		);

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -6,7 +6,7 @@
 	"category": "media",
 	"description": "Embed a video from your media library or upload a new one.",
 	"keywords": [ "movie", "video", "player", "godam" ],
-	"textdomain": "transcoder",
+	"textdomain": "godam",
 	"attributes": {
 		"autoplay": {
 			"type": "boolean",

--- a/assets/src/blocks/godam-player/block.json
+++ b/assets/src/blocks/godam-player/block.json
@@ -2,10 +2,10 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "godam/video",
-	"title": "GoDAM Video",
+	"title": "Video",
 	"category": "media",
 	"description": "Embed a video from your media library or upload a new one.",
-	"keywords": [ "movie", "video", "player" ],
+	"keywords": [ "movie", "video", "player", "godam" ],
 	"textdomain": "transcoder",
 	"attributes": {
 		"autoplay": {

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -899,7 +899,7 @@ function VideoEdit( {
 					<div { ...blockProps }>
 						<div className="godam-editor-video-placeholder">
 							<span className="godam-editor-video-label">
-							{ __( 'Video', 'godam' ) }
+								{ __( 'Video', 'godam' ) }
 							</span>
 						</div>
 					</div>

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -641,7 +641,7 @@ function VideoEdit( {
 					className="block-editor-media-placeholder"
 					withIllustration={ ! isSingleSelected }
 					icon={ icon }
-					label={ __( 'GoDAM video', 'godam' ) }
+					label={ __( 'Video', 'godam' ) }
 					instructions={ __(
 						'Drag and drop a video, upload, or choose from your library.',
 						'godam',
@@ -899,7 +899,7 @@ function VideoEdit( {
 					<div { ...blockProps }>
 						<div className="godam-editor-video-placeholder">
 							<span className="godam-editor-video-label">
-								{ __( 'GoDAM Video', 'godam' ) }
+							{ __( 'Video', 'godam' ) }
 							</span>
 						</div>
 					</div>

--- a/assets/src/blocks/godam-player/editor.scss
+++ b/assets/src/blocks/godam-player/editor.scss
@@ -1,5 +1,5 @@
 /**
- * GoDAM Video Block - Editor styles
+ * Video Block - Editor styles
  * These styles ensure the block works correctly in the editor,
  * including in flex layouts (Row/Stack).
  */

--- a/assets/src/blocks/godam-player/index.js
+++ b/assets/src/blocks/godam-player/index.js
@@ -21,7 +21,7 @@ import icon from '../../images/godam-video-filled.svg';
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
 registerBlockType( 'godam/video', {
-	icon: <img src={ icon } alt="GoDAM Video Block icon" />,
+	icon: <img src={ icon } alt="Video Block icon" />,
 	usesContext: [ 'queryId' ],
 	/**
 	 * @see ./edit.js

--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -10,7 +10,7 @@
 @use './variables';
 
 /**
- * GoDAM Video Block - Main wrapper styles
+ * Video Block - Main wrapper styles
  * These styles ensure the block works correctly in all layout contexts,
  * including flex layouts (Row, Stack) and standard layouts (Group, Columns).
  */

--- a/pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js
+++ b/pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js
@@ -25,7 +25,7 @@ const integrationTabs = [
 			<>
 				{ __( 'WooCommerce', 'godam' ) }
 				<span className="godam-pro-badge">
-					{ __( 'Pro', 'godam' ) }
+					{ __( 'Beta', 'godam' ) }
 				</span>
 			</>
 		),


### PR DESCRIPTION
This pull request updates the naming and labeling of several GoDAM blocks to use more generic and user-friendly titles in the UI, while also ensuring the keyword "godam" is included for better discoverability. Additionally, it updates some UI labels and comments for clarity and consistency. The most important changes are grouped below:

**Block Title and Label Updates:**

* Changed block titles in `block.json` files from "GoDAM Audio", "GoDAM Video", and "GoDAM PDF" to "Audio", "Video", and "Document" respectively, and updated corresponding UI labels to match in their respective editor components (`edit.js`). This affects the audio, video, and PDF blocks. [[1]](diffhunk://#diff-df5daa52ef28247ba44331fe095c201054c298941471aea43ef3f86177d87e49L5-R8) [[2]](diffhunk://#diff-0452960eaa8ba8724cc49af281678ab3c7d21abd9ed841f2362d9aa0e7b14d3dL5-R8) [[3]](diffhunk://#diff-d716ec33795dc7c2806dd2816c998ae9fd5ef52acf2216dc644653669ba04d1cL5-R8) [[4]](diffhunk://#diff-f6b2e4d63567e93a73ddd90e3545ff9bcc28f9ff25365c16e3faaf3738605cb3L125-R125) [[5]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L644-R644) [[6]](diffhunk://#diff-6642f42562e371f51671c93932e8273003174d796f629690559dfdbada0ed116L112-R112)
* Updated the video gallery block title from "GoDAM Video Gallery" to "Video Gallery" in `block.json`.

**UI and Placeholder Text Consistency:**

* Changed placeholder and alt text in video and gallery blocks from "GoDAM Video" to "Video" for a more streamlined user experience, both in editor and frontend render files. [[1]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L823-R823) [[2]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L348-R348) [[3]](diffhunk://#diff-ecd0e7f5ef3ab65e1616a6d69838a1b1c8084015d20f6a03a1a4bed038b047b9L404-R404) [[4]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L902-R902) [[5]](diffhunk://#diff-7481b339281fe6b7b621bc806c8af78cf22576337394d76d0fff11e22268d64bL24-R24)
* Updated editor and style file comments to remove "GoDAM" from block names, making them more generic. [[1]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdL2-R2) [[2]](diffhunk://#diff-89e92fdab13aad2dda8bfe013f74d8961d1e5fad2e34d617cd41a3d29c67c9caL13-R13)

**Keyword Improvements:**

* Added "godam" to the `keywords` array in the `block.json` files for audio, video, and PDF blocks to improve block searchability in the editor. [[1]](diffhunk://#diff-df5daa52ef28247ba44331fe095c201054c298941471aea43ef3f86177d87e49L5-R8) [[2]](diffhunk://#diff-0452960eaa8ba8724cc49af281678ab3c7d21abd9ed841f2362d9aa0e7b14d3dL5-R8) [[3]](diffhunk://#diff-d716ec33795dc7c2806dd2816c998ae9fd5ef52acf2216dc644653669ba04d1cL5-R8)

**UI Badge Label Update:**

* Changed the WooCommerce integration badge from "Pro" to "Beta" in the integrations settings tab for clarity on feature status.


## Screenshots
<img width="777" height="337" alt="Screenshot 2026-05-05 at 4 11 08 PM" src="https://github.com/user-attachments/assets/9e676b66-79ab-47b1-811c-0a23ece3b4b2" />