### PR TITLE
fix: Disable hover option when autoplay is enabled in VideoEdit component

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -397,6 +397,13 @@ function VideoEdit( {
 		}
 	}, [ id, src, attributes.seo, isVideoSelecting, setAttributes ] );
 
+	// When autoplay is enabled, hoverSelect is incompatible — reset it to 'none'.
+	useEffect( () => {
+		if ( autoplay && attributes.hoverSelect !== 'none' ) {
+			setAttributes( { hoverSelect: 'none' } );
+		}
+	}, [ autoplay ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	// Keep overridden SEO thumbnail synced with block poster.
 	useEffect( () => {
 		if ( ! attributes?.seoOverride || ! poster ) {
@@ -780,9 +787,12 @@ function VideoEdit( {
 									<SelectControl
 										__nextHasNoMarginBottom
 										label={ __( 'Hover Option', 'godam' ) }
-										help={ __( 'Choose the action to perform on video hover.', 'godam' ) }
+										help={ autoplay
+											? __( 'Hover option is disabled when autoplay is on.', 'godam' )
+											: __( 'Choose the action to perform on video hover.', 'godam' ) }
 										value={ attributes.hoverSelect || 'none' }
 										onChange={ ( value ) => setAttributes( { hoverSelect: value } ) }
+										disabled={ !! autoplay }
 										options={
 											[
 												{ label: __( 'None', 'godam' ), value: 'none' },

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -398,7 +398,17 @@ function VideoEdit( {
 	}, [ id, src, attributes.seo, isVideoSelecting, setAttributes ] );
 
 	// When autoplay is enabled, hoverSelect is incompatible — reset it to 'none'.
+	// Only apply this when autoplay is toggled on after mount so older content
+	// is not rewritten as a side effect of opening the editor.
+	const previousAutoplayRef = useRef( autoplay );
+
 	useEffect( () => {
+		const previousAutoplay = previousAutoplayRef.current;
+		if ( previousAutoplay === autoplay ) {
+			return;
+		}
+		previousAutoplayRef.current = autoplay;
+
 		if ( autoplay && attributes.hoverSelect !== 'none' ) {
 			setAttributes( { hoverSelect: 'none' } );
 		}

--- a/assets/src/js/godam-player/managers/hoverManager.js
+++ b/assets/src/js/godam-player/managers/hoverManager.js
@@ -42,6 +42,13 @@ class HoverManager {
 	 * Sets up event listeners for the appropriate behavior.
 	 */
 	init() {
+		// Hover behaviour is incompatible with autoplay – skip initialisation
+		// entirely so shortcodes/WPBakery/cached blocks with a stale hoverSelect
+		// value cannot start hover mode on an autoplay-enabled player.
+		if ( this.videoElement.dataset.autoplayOnView === 'true' || this.player.autoplay() ) {
+			return;
+		}
+
 		if ( this.hoverSelect === 'start-preview' ) {
 			this.setupPreview();
 		} else if ( this.hoverSelect === 'show-player-controls' ) {

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -81,12 +81,19 @@ $attributes = apply_filters(
 );
 
 // attributes.
-$godam_autoplay       = ! empty( $attributes['autoplay'] );
-$godam_controls       = isset( $attributes['controls'] ) ? $attributes['controls'] : true;
-$godam_loop           = ! empty( $attributes['loop'] );
-$godam_muted          = ! empty( $attributes['muted'] );
-$godam_poster         = ! empty( $attributes['poster'] ) ? esc_url( $attributes['poster'] ) : '';
-$godam_hover_select   = isset( $attributes['hoverSelect'] ) ? $attributes['hoverSelect'] : 'none';
+$godam_autoplay     = ! empty( $attributes['autoplay'] );
+$godam_controls     = isset( $attributes['controls'] ) ? $attributes['controls'] : true;
+$godam_loop         = ! empty( $attributes['loop'] );
+$godam_muted        = ! empty( $attributes['muted'] );
+$godam_poster       = ! empty( $attributes['poster'] ) ? esc_url( $attributes['poster'] ) : '';
+$godam_hover_select = isset( $attributes['hoverSelect'] ) ? $attributes['hoverSelect'] : 'none';
+
+// Autoplay and hover modes are mutually exclusive – reset hover to 'none' so
+// the frontend player never initialises hover behaviour on autoplay videos,
+// regardless of the stored block/shortcode attribute value.
+if ( $godam_autoplay ) {
+	$godam_hover_select = 'none';
+}
 $godam_caption        = ! empty( $attributes['caption'] ) ? esc_html( $attributes['caption'] ) : '';
 $godam_tracks         = ! empty( $attributes['tracks'] ) ? $attributes['tracks'] : array();
 $godam_show_share_btn = ! empty( $attributes['showShareButton'] );


### PR DESCRIPTION
Fixes: point no. 8 on [doc](https://docs.google.com/document/d/1KDpp3WxD6g8c0_J-p9SR5PzO148xZbgF3V97gyMmWOs/edit?tab=t.4pcof47k03in) 

This pull request improves the user experience in the `godam-player` block by ensuring that the hover option is properly managed when autoplay is enabled. Specifically, it prevents incompatible settings and clarifies the UI for users.

**Autoplay and Hover Option Handling:**

* Added a `useEffect` to automatically reset `hoverSelect` to `'none'` whenever `autoplay` is enabled, ensuring incompatible settings are not applied.
* Updated the `SelectControl` for the hover option to disable the control and display a contextual help message when `autoplay` is active, making the UI clearer and preventing user confusion.