### PR TITLE
fix: Gallery Carousel scroll on iOS

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -421,12 +421,14 @@
 	inset: 0;
 	background: rgba(15, 18, 12, 0.7);
 	opacity: 0;
+	visibility: hidden;
 	pointer-events: none;
 	transition: opacity 0.2s ease;
 	z-index: 999998;
 
 	&.is-active {
 		opacity: 1;
+		visibility: visible;
 		pointer-events: auto;
 	}
 }
@@ -442,12 +444,14 @@
 	overflow: hidden;
 	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
 	opacity: 0;
+	visibility: hidden;
 	pointer-events: none;
 	transition: opacity 0.2s ease, transform 0.2s ease;
 	z-index: 999999;
 
 	&.is-active {
 		opacity: 1;
+		visibility: visible;
 		transform: translate(-50%, -50%) scale(1);
 		pointer-events: auto;
 	}


### PR DESCRIPTION
This pull request improves the visibility handling of modal overlays and dialogs in the `godam-gallery-v2` block's styles. The changes ensure that hidden elements are not only transparent but also removed from the accessibility tree and user interactions, and are properly shown when active.

**Modal and overlay visibility improvements:**

* Added `visibility: hidden;` to modal overlay and dialog styles to ensure hidden elements are not focusable or accessible, and set `visibility: visible;` when the `.is-active` class is present to properly display them. [[1]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR424-R431) [[2]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR447-R454)

## Recording

https://github.com/user-attachments/assets/8cfdcca1-5e2d-4a44-bc89-50bc946d6bbf

