### PR TITLE
fix: Woo functionality based on API key Verification Failed or Expired

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -856,6 +856,22 @@ class RTGODAM_Transcoder_Admin {
 			return;
 		}
 
+		// rtgodam_get_api_key_status() only reads the persistent DB status option
+		// ('rtgodam-api-key-status') which can NEVER contain 'verification_failed'
+		// because that state is transient and not persistable. The actual runtime
+		// status — including transient 'verification_failed' — is stored in the
+		// 'rtgodam_user_data' option by rtgodam_get_user_data(). Read from there
+		// so we don't show a false "expired" banner when the server is temporarily
+		// unreachable.
+		$cached_user_data = get_option( 'rtgodam_user_data', array() );
+		$runtime_status   = isset( $cached_user_data['api_key_status'] )
+			? $cached_user_data['api_key_status']
+			: rtgodam_get_api_key_status();
+
+		if ( \RTGODAM\Inc\Enums\Api_Key_Status::VERIFICATION_FAILED === $runtime_status ) {
+			return;
+		}
+
 		$pricing_url = add_query_arg(
 			array(
 				'utm_campaign' => 'expired-key',

--- a/pages/video-editor/VideoJSPlayer.js
+++ b/pages/video-editor/VideoJSPlayer.js
@@ -52,6 +52,8 @@ const layerTypes = [
 		icon: thumbsUp,
 		type: 'poll',
 	},
+	// Merge add-on layer types registered via PHP filters (e.g. WooCommerce).
+	...( window.godamVideoEditorConfig?.layerOptions || [] ),
 ];
 
 export const VideoJS = ( props ) => {
@@ -681,7 +683,13 @@ const Slider = ( props ) => {
 							>
 								<div className="layer-indicator--container">
 									<div className={ `icon ${ layer.id === currentLayerID ? 'active' : '' }` }>
-										<Icon icon={ layerTypes.find( ( type ) => type.type === layer.type )?.icon } />
+										{ ( () => {
+											const layerType = layerTypes.find( ( type ) => type.type === layer.type );
+											if ( layerType?.iconUrl ) {
+												return <img src={ layerType.iconUrl } alt={ layerType.title } className="layer-indicator__addon-icon" />;
+											}
+											return <Icon icon={ layerType?.icon } />;
+										} )() }
 										<div>
 											{ layer?.type?.toUpperCase() }
 											{

--- a/pages/video-editor/components/SidebarLayers.js
+++ b/pages/video-editor/components/SidebarLayers.js
@@ -290,10 +290,13 @@ const SidebarLayers = ( { currentTime, onSelectLayer, onPauseVideo, duration } )
 									addWarning = true;
 								}
 
+								// Disable the button when the required plugin/feature is inactive
+								// (e.g. form plugin not installed, or WooCommerce layer API key missing/expired).
+								const isLayerDisabled = ( formType && ! formType.isActive ) || layerData?.isActive === false;
+
 								return (
 									<Tooltip
 										key={ layer.id }
-										className="w-full flex justify-between items-center px-2 py-3 border rounded-md mb-2 hover:bg-gray-50 cursor-pointer"
 										text={ tooltipMessage }
 										placement="right"
 									>
@@ -304,6 +307,7 @@ const SidebarLayers = ( { currentTime, onSelectLayer, onPauseVideo, duration } )
 													dispatch( setCurrentLayer( layer ) );
 													onSelectLayer( layer.displayTime );
 												} }
+												disabled={ isLayerDisabled }
 											>
 												<div className="flex items-center gap-2">
 													{

--- a/pages/video-editor/style.scss
+++ b/pages/video-editor/style.scss
@@ -246,6 +246,16 @@
 				}
 			}
 
+			// Add-on layer icon (e.g. WooCommerce) rendered as <img>.
+			// Matches the intrinsic 24x24 size of the WordPress <Icon> SVG component.
+			.layer-indicator__addon-icon {
+				width: 20px;
+				height: 20px;
+				display: block;
+				flex-shrink: 0;
+				margin: 2px;
+			}
+
 			.info {
 				position: absolute;
 				bottom: -3rem;


### PR DESCRIPTION
This pull request introduces improvements to the video editor's extensibility and user experience, especially around add-on layers (such as WooCommerce) and API key status handling. The changes enable dynamic registration and display of new layer types, enhance the UI to support custom icons, and prevent user confusion by accurately reflecting API key verification status.

**Extensibility and Add-on Layer Support:**
- [`pages/video-editor/VideoJSPlayer.js`](diffhunk://#diff-d66614721b5b1d1c13154c450dc6e6b0ca0a3f19799534b21821bc136bf7814fR55-R56): Allows dynamic registration of add-on layer types via the global `window.godamVideoEditorConfig.layerOptions`, enabling external plugins to inject new layer types.
- [`pages/video-editor/VideoJSPlayer.js`](diffhunk://#diff-d66614721b5b1d1c13154c450dc6e6b0ca0a3f19799534b21821bc136bf7814fL684-R692): Updates the layer indicator to display either a custom icon image (`iconUrl`) for add-on layers or the default SVG icon, improving visual support for third-party integrations.
- [`pages/video-editor/style.scss`](diffhunk://#diff-33d6e8ebfa5a268f64e39c0fc0fe905060a30bf13f22f72a8228f848ced12223R249-R258): Adds styling for add-on layer icons rendered as images, ensuring consistent sizing and alignment with existing icons.

**Layer Activation and UI Controls:**
- [`pages/video-editor/components/SidebarLayers.js`](diffhunk://#diff-8567e4b458d3df4bafa9fb3490146685f7f3d2687d73109d0f7a4843bbb0eae1R293-L296): Disables layer controls in the sidebar when required plugins or features are inactive (e.g., missing/expired API keys for add-on layers), preventing user actions that would fail [[1]](diffhunk://#diff-8567e4b458d3df4bafa9fb3490146685f7f3d2687d73109d0f7a4843bbb0eae1R293-L296) [[2]](diffhunk://#diff-8567e4b458d3df4bafa9fb3490146685f7f3d2687d73109d0f7a4843bbb0eae1R310).

**API Key Status Handling:**
- [`admin/class-rtgodam-transcoder-admin.php`](diffhunk://#diff-bba9a8790490fbd0993b7d9a8c4774a21fc0934049d7431e92595d67dd4dea49R859-R874): Improves the logic for showing the expired API key notice by checking the runtime status from `rtgodam_user_data` instead of the persistent status, ensuring that transient verification failures (such as temporary server issues) do not incorrectly trigger the notice.

## Recording

https://github.com/user-attachments/assets/1622ccfe-2259-4384-b5c8-4daa0f92e203
