### PR TITLE
Fix iOS autoplay issue 

### DIFF
--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -255,21 +255,28 @@ export default class PlayerManager {
 			return;
 		}
 
+		// Force muted state before attempting play for iOS compatibility
+		player.muted( true );
+
+		const attemptPlay = () => {
+			const playPromise = player.play();
+			if ( playPromise !== undefined ) {
+				playPromise.catch( ( error ) => {
+					// Autoplay was prevented (browser policy)
+					// eslint-disable-next-line no-console
+					console.debug( 'Autoplay blocked', error );
+				} );
+			}
+		};
+
 		// Wait for player to be ready
 		if ( player.readyState() >= 2 ) {
 			// Player has enough data to play
-			player.play().catch( ( error ) => {
-				// Autoplay was prevented (browser policy)
-				// eslint-disable-next-line no-console
-				console.warn( 'Autoplay prevented:', error );
-			} );
+			attemptPlay();
 		} else {
 			// Wait for loadeddata event
 			const playOnReady = () => {
-				player.play().catch( ( error ) => {
-					// eslint-disable-next-line no-console
-					console.warn( 'Autoplay prevented:', error );
-				} );
+				attemptPlay();
 				player.off( 'loadeddata', playOnReady );
 			};
 			player.on( 'loadeddata', playOnReady );

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -437,9 +437,9 @@ if ( $godam_placeholder_lookup_id > 0 ) {
 }
 $godam_video_setup = array(
 	'controls'    => $godam_controls,
-	'autoplay'    => $godam_autoplay,
+	'autoplay'    => $godam_autoplay ? 'muted' : false,
 	'loop'        => $godam_loop,
-	'muted'       => $godam_muted,
+	'muted'       => $godam_autoplay ? true : $godam_muted,
 	'preload'     => $godam_preload,
 	'poster'      => $godam_video_poster,
 	'fluid'       => true,

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -437,7 +437,7 @@ if ( $godam_placeholder_lookup_id > 0 ) {
 }
 $godam_video_setup = array(
 	'controls'    => $godam_controls,
-	'autoplay'    => $godam_autoplay ? 'muted' : false,
+	'autoplay'    => $godam_autoplay,
 	'loop'        => $godam_loop,
 	'muted'       => $godam_autoplay ? true : $godam_muted,
 	'preload'     => $godam_preload,

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -719,6 +719,13 @@ if ( empty( $godam_attachment_title ) ) {
 
 					<video
 						class="easydam-player video-js vjs-big-play-centered vjs-hidden"
+						<?php if ( $godam_autoplay || $godam_muted ) : ?>
+							muted
+						<?php endif; ?>
+						<?php if ( $godam_autoplay ) : ?>
+							autoplay
+						<?php endif; ?>
+						playsinline webkit-playsinline
 						data-options="<?php echo esc_attr( $godam_video_config ); ?>"
 						data-ad_tag_url="<?php echo ! $godam_woocommerce_context ? esc_url( $godam_ad_tag_url ) : ''; ?>"
 						data-id="<?php echo esc_attr( is_numeric( $godam_attachment_id ) ? $godam_attachment_id : $godam_original_id ); ?>"
@@ -732,7 +739,7 @@ if ( empty( $godam_attachment_title ) ) {
 							data-global_ads_settings="<?php echo esc_attr( $godam_ads_settings ); ?>"
 							data-hover-select="<?php echo esc_attr( $godam_hover_select ); ?>"
 							data-video-title="<?php echo esc_attr( $godam_attachment_title ); ?>"
-							data-autoplay-on-view="<?php echo esc_attr( $godam_autoplay ? 'true' : 'false' ); ?>"
+							data-autoplay-on-view="<?php echo esc_attr( ( $godam_autoplay && 'auto' !== $godam_preload ) ? 'true' : 'false' ); ?>"
 							data-disable-transcript="<?php echo esc_attr( $godam_disable_subtitles_and_transcript ? 'true' : 'false' ); ?>"
 						>
 							<?php


### PR DESCRIPTION
This pull request improves the autoplay and muted handling for the Godam video player, focusing on better compatibility with browser autoplay policies (especially on iOS) and more accurate player configuration. The main changes ensure that videos set to autoplay are always muted, update the way autoplay and muted attributes are set in both the backend and frontend, and refine the logic for when autoplay-on-view is enabled.

**Autoplay and Muted Handling Improvements:**

* The backend now sets the `autoplay` option to `'muted'` (instead of just `true`) and forces `muted: true` when autoplay is enabled, ensuring compliance with browser autoplay requirements. (`inc/templates/godam-player.php`)
* The `<video>` element now always includes the `muted` attribute if either autoplay or muted is enabled, and the `autoplay` attribute is only included if autoplay is enabled, ensuring the correct HTML attributes are present for browser compatibility. (`inc/templates/godam-player.php`)

**Frontend Player Logic Updates:**

* The player manager in JavaScript now always sets the player to muted before attempting to play, and centralizes the play logic to better handle autoplay restrictions, especially on iOS devices. (`assets/src/js/godam-player/managers/playerManager.js`)

**Autoplay-on-View Logic Refinement:**

* The `data-autoplay-on-view` attribute is now set to `true` only if autoplay is enabled and `preload` is not set to `'auto'`, preventing unwanted autoplay behavior when videos are preloaded. (`inc/templates/godam-player.php`)