### PR TITLE
Enhance type 1 video page load tracking with viewport observation

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -35,6 +35,133 @@ function collectPlayedRanges( player ) {
 	return ranges;
 }
 
+/**
+ * Resolve the canonical video element used for analytics.
+ * Falls back to a descendant so callers can pass either the raw <video>
+ * element or a wrapping player container.
+ *
+ * @param {HTMLElement} video - Candidate video or wrapper element.
+ * @return {HTMLElement|null} The element carrying analytics data attributes.
+ */
+function resolveAnalyticsVideoElement( video ) {
+	if ( ! video ) {
+		return null;
+	}
+
+	if ( video.getAttribute?.( 'data-instance-id' ) ) {
+		return video;
+	}
+
+	return video.querySelector?.( '[data-instance-id]' ) || null;
+}
+
+/**
+ * Build analytics metadata for a single video instance.
+ *
+ * @param {HTMLElement} video - Candidate video or wrapper element.
+ * @return {{ videoEl: HTMLElement, instanceId: string, videoId: number, jobId: string }|null} Parsed analytics data.
+ */
+function getPageLoadVideoInfo( video ) {
+	const videoEl = resolveAnalyticsVideoElement( video );
+	const instanceId = videoEl?.getAttribute( 'data-instance-id' ) || '';
+	const videoId = parseInt( videoEl?.getAttribute( 'data-id' ), 10 ) || 0;
+
+	if ( ! videoEl || ! instanceId || ! videoId ) {
+		return null;
+	}
+
+	return {
+		videoEl,
+		instanceId,
+		videoId,
+		jobId: videoEl.getAttribute( 'data-job_id' ) || '',
+	};
+}
+
+// Keep instance tracking on window so repeat evaluations share one registry.
+window.godamTrackedPageLoadInstances = window.godamTrackedPageLoadInstances || new Set();
+window.godamObservedPageLoadVideos = window.godamObservedPageLoadVideos || new WeakSet();
+window.godamPageLoadObserver = window.godamPageLoadObserver || null;
+
+/**
+ * Send a type 1 page_load event for a single video instance exactly once.
+ * Deduplication is per data-instance-id so duplicate renders of the same
+ * underlying video each send independently, while re-entries do not.
+ *
+ * @param {HTMLElement} video - Candidate video or wrapper element.
+ * @return {boolean} True when an event was sent, false otherwise.
+ */
+function trackPageLoadForVideo( video ) {
+	const videoInfo = getPageLoadVideoInfo( video );
+
+	if ( ! videoInfo || ! window.analytics ) {
+		return false;
+	}
+
+	if ( window.godamTrackedPageLoadInstances.has( videoInfo.instanceId ) ) {
+		return false;
+	}
+
+	window.analytics.track( 'page_load', {
+		type: 1,
+		videoIds: [ [ videoInfo.videoId, videoInfo.jobId ] ],
+	} );
+
+	window.godamTrackedPageLoadInstances.add( videoInfo.instanceId );
+
+	return true;
+}
+
+/**
+ * Observe a video instance and send its page_load event the first time at
+ * least 10% of it is visible in the viewport.
+ *
+ * @param {HTMLElement} video - Candidate video or wrapper element.
+ */
+function observePageLoadForVideo( video ) {
+	const videoInfo = getPageLoadVideoInfo( video );
+
+	if ( ! videoInfo ) {
+		return;
+	}
+
+	if (
+		window.godamTrackedPageLoadInstances.has( videoInfo.instanceId ) ||
+		window.godamObservedPageLoadVideos.has( videoInfo.videoEl )
+	) {
+		return;
+	}
+
+	if ( ! ( 'IntersectionObserver' in window ) ) {
+		trackPageLoadForVideo( videoInfo.videoEl );
+		return;
+	}
+
+	if ( ! window.godamPageLoadObserver ) {
+		window.godamPageLoadObserver = new IntersectionObserver(
+			( entries, observer ) => {
+				entries.forEach( ( entry ) => {
+					if ( ! entry.isIntersecting || entry.intersectionRatio < 0.1 ) {
+						return;
+					}
+
+					trackPageLoadForVideo( entry.target );
+					observer.unobserve( entry.target );
+					window.godamObservedPageLoadVideos.delete( entry.target );
+				} );
+			},
+			{
+				root: null,
+				rootMargin: '0px',
+				threshold: 0.1,
+			},
+		);
+	}
+
+	window.godamObservedPageLoadVideos.add( videoInfo.videoEl );
+	window.godamPageLoadObserver.observe( videoInfo.videoEl );
+}
+
 // Generic video analytics helper
 ( function() {
 	function findVideoElementById( videoId, root ) {
@@ -77,11 +204,11 @@ function collectPlayedRanges( player ) {
 	 *
 	 * **IMPORTANT: Automatic Type 1 Event Behavior**
 	 * When type 2 (heatmap) is requested, this function automatically sends a type 1 'page_load' (Video Loaded)
-	 * event BEFORE sending the type 2 (Video Played) event, if sendPageLoad is true (default true). This behavior is intentional but may result
-	 * in duplicate type 1 events in certain scenarios:
+	 * event BEFORE sending the type 2 (Video Played) event, if sendPageLoad is true (default true). This behavior is intentional and now uses
+	 * the shared per-instance type 1 helper so viewport-triggered and type 2-triggered sends stay deduplicated:
 	 *
-	 * - Called during video switches: Will send type 2 for the old video
-	 * - Called when videos are closed: Will send type 2 for the closing video
+	 * - Called during video switches: Will send a type 1 fallback only if that video instance has not already been tracked
+	 * - Called when videos are closed: Will send a type 1 fallback only if that video instance has not already been tracked
 	 *
 	 * **Event Types:**
 	 * - Type 1: Video Loaded (automatically sent before type 2)
@@ -115,11 +242,11 @@ function collectPlayedRanges( player ) {
 				return false;
 			}
 
-			// Send type 1 first (for the current video) if sendPageLoad is true
-			// NOTE: This automatically sends a 'page_load' event before the heatmap event, for ease of use.
-			// This is intentional behavior but may cause duplicate type 1 events in some scenarios
+			// Send type 1 first (for the current video instance) if sendPageLoad is true.
+			// This reuses the shared page_load helper so viewport and heatmap paths
+			// follow the same per-instance deduplication rules.
 			if ( sendPageLoad ) {
-				window.analytics.track( 'page_load', { type: 1, videoIds: [ [ vid, jobId ] ] } );
+				trackPageLoadForVideo( videoEl );
 			}
 
 			const player = getPlayer( videoEl );
@@ -149,31 +276,19 @@ function collectPlayedRanges( player ) {
 }() );
 
 if ( ! window.pageLoadEventTracked ) {
-	window.pageLoadEventTracked = true; // Mark as tracked to avoid duplicate execution
+	window.pageLoadEventTracked = true; // Mark page_load tracking listeners as initialized.
 
 	document.addEventListener( 'DOMContentLoaded', () => {
 		const videos = document.querySelectorAll( '.easydam-player.video-js' );
 
-		// Collect all video IDs and Job IDs
-		const videoInfo = Array.from( videos )
-			.map( ( video ) => ( {
-				id: video.getAttribute( 'data-id' ),
-				jobId: video.getAttribute( 'data-job_id' ) || '',
-			} ) )
-			.filter( ( info ) => info.id !== null && info.id !== '' && ! isNaN( info.id ) )
-			.map( ( info ) => [ parseInt( info.id, 10 ), info.jobId ] );
-
-		// Send a single page_load request with all video ID and Job ID pairs
-		if ( window.analytics && videoInfo.length > 0 ) {
-			window.analytics.track( 'page_load', {
-				type: 1, // Enum: 1 = Page Load
-				videoIds: videoInfo, // Array of [video_id, job_id] pairs
-			} );
-		}
+		// Observe all current videos and send type 1 only when each individual
+		// player instance first enters the viewport.
+		videos.forEach( ( video ) => observePageLoadForVideo( video ) );
 
 		// Set up analytics for each player when it's ready
 		// This prevents double initialization issues during async plugin loading
 		document.addEventListener( 'godamPlayerReady', ( event ) => {
+			observePageLoadForVideo( event.detail.videoElement );
 			setupPlayerAnalytics( event.detail.player, event.detail.videoElement );
 		} );
 
@@ -369,6 +484,8 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 }
 
 function setupPlayerAnalytics( player, video ) {
+	observePageLoadForVideo( video );
+
 	// Skip if already set up for this player instance.
 	// We use the player object rather than the DOM element because
 	// godamPlayerReady provides the raw <video> element, but playerAnalytics()
@@ -386,13 +503,18 @@ function setupPlayerAnalytics( player, video ) {
 
 	// Initialize GTM tracker for this video
 	if ( typeof window.dataLayer !== 'undefined' && window.godamSettings?.enableGTMTracking ) {
-		const gtmTracker = new GTMVideoTracker( player, video );
 		// Store tracker reference for potential cleanup
-		video.gtmTracker = gtmTracker;
+		video.gtmTracker = new GTMVideoTracker( player, video );
 	}
 
 	// Send heatmap when player is unmounted/disposed (e.g. AJAX navigation)
 	player.on( 'dispose', () => {
+		const pageLoadVideo = resolveAnalyticsVideoElement( video );
+		if ( pageLoadVideo && window.godamPageLoadObserver ) {
+			window.godamPageLoadObserver.unobserve( pageLoadVideo );
+			window.godamObservedPageLoadVideos.delete( pageLoadVideo );
+		}
+
 		if ( window.godamTrackedPlayers.has( player ) ) {
 			const { videoEl, lastSentKey } = window.godamTrackedPlayers.get( player );
 			sendPlayerHeatmap( player, videoEl, lastSentKey );


### PR DESCRIPTION
**What changed**
- `type 1` is no longer sent as one bulk request on page load for all videos.
- It should now fire **per video instance**, **only the first time** that instance enters the viewport.


This pull request refactors and improves the video analytics tracking logic in `assets/src/js/godam-player/analytics.js`. The main focus is to ensure that "page_load" (type 1) analytics events are sent exactly once per video instance, triggered when the video enters the viewport, and to deduplicate these events across different code paths. The code now uses IntersectionObserver for more accurate event timing and centralizes the logic for identifying video instances.

Key improvements include:

**Per-Instance Page Load Analytics & Deduplication:**

* Introduced helper functions (`resolveAnalyticsVideoElement`, `getPageLoadVideoInfo`, `trackPageLoadForVideo`, `observePageLoadForVideo`) to reliably identify video instances and ensure "page_load" events are sent once per instance, either on viewport entry or as a fallback.
* Updated the documentation and logic in analytics event sending to clarify and enforce the new deduplication behavior for type 1 events, preventing duplicates from multiple triggers. [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL80-R211) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL118-R249)

**Event Triggering & Observer Usage:**

* Replaced the previous approach of sending a single "page_load" event for all videos on DOMContentLoaded with per-instance observation: each video now sends its event when it first becomes at least 10% visible in the viewport.
* On player setup and readiness, each video is registered with the observer to ensure consistent analytics even for dynamically loaded players.

**Cleanup & Resource Management:**

* On player disposal, the video instance is unobserved and removed from the observer's tracking set to prevent memory leaks and ensure correct analytics behavior.

## Recordings

### Gutenberg
https://app.godam.io/web/video/uf8ccm7ph1

### Product page
https://app.godam.io/web/video/88qirgv3mb

### Elementor
https://app.godam.io/web/video/uf6lufs4j3

### WPBakery + Gallery block analytics
https://app.godam.io/web/video/tt4l56nv4d

### Test: Type 2 requests with autoplay
Type 2 requests successfully not going when video is set to autoplay. This is because video only starts playing when it is in the viewport.
https://app.godam.io/web/video/6326fdottl


