### PR TITLE
Feat/video seo hooks

### DIFF
--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -111,7 +111,7 @@ class Seo {
 		 * `godam/video-product-gallery` (Shoppable Video) blocks and return
 		 * the resulting VideoObject SEO entries.
 		 *
-		 * @since 1.11.0
+		 * @since n.e.x.t
 		 *
 		 * @param array  $extra_schemas Array of extra SEO data arrays (initially empty).
 		 * @param string $content       The post content.
@@ -128,7 +128,7 @@ class Seo {
 		 * video attachments from `godam/video-product-gallery` blocks, which
 		 * are not parsed by the core `extract_video_seo_schema_from_block()`.
 		 *
-		 * @since 1.11.0
+		 * @since n.e.x.t
 		 *
 		 * @param int[]  $extra_attachments Array of extra attachment IDs (initially empty).
 		 * @param string $content           The post content.
@@ -144,7 +144,7 @@ class Seo {
 			 * Allows add-ons (e.g. WooCommerce integration) to enrich each video's
 			 * cached SEO data with additional information such as product details.
 			 *
-			 * @since 1.10.0
+			 * @since n.e.x.t
 			 *
 			 * @param array $video_seo_schema Array of video SEO data arrays.
 			 * @param int   $post_ID          The post ID being saved.
@@ -161,7 +161,7 @@ class Seo {
 			 * Add-ons can use this to perform additional save-time operations,
 			 * such as storing reverse-lookup meta for gallery block product IDs.
 			 *
-			 * @since 1.11.0
+			 * @since n.e.x.t
 			 *
 			 * @param int   $post_ID          The post ID.
 			 * @param array $video_seo_schema The saved schema array.
@@ -175,7 +175,7 @@ class Seo {
 			/**
 			 * Fired after video SEO schema is cleared from a post.
 			 *
-			 * @since 1.11.0
+			 * @since n.e.x.t
 			 *
 			 * @param int $post_ID The post ID.
 			 */
@@ -441,7 +441,7 @@ class Seo {
 			 * Allows add-ons to modify or extend a single VideoObject schema,
 			 * e.g. by adding an associatedProduct for WooCommerce integration.
 			 *
-			 * @since 1.10.0
+			 * @since n.e.x.t
 			 *
 			 * @param array $schema  The VideoObject schema array.
 			 * @param array $video   The raw cached video SEO data.
@@ -467,7 +467,7 @@ class Seo {
 		 * the raw cached data (including `_source` markers) without an extra
 		 * `get_post_meta()` call.
 		 *
-		 * @since 1.10.0
+		 * @since n.e.x.t
 		 *
 		 * @param array $output_schemas  Array of schema arrays (VideoObject entries).
 		 * @param int   $post_id         The current post ID.

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -724,6 +724,9 @@ class Seo {
 	 * @param array $attachments Array of attachment IDs used in the post.
 	 */
 	private function update_attachment_post_mapping( $post_id, $attachments ) {
+		// Normalize: cast to positive integers and discard zeroes/non-numeric values.
+		$attachments = array_values( array_unique( array_filter( array_map( 'absint', $attachments ) ) ) );
+
 		// Get current attachments this post was using.
 		$previous_attachments = get_post_meta( $post_id, self::POST_ATTACHMENTS_META_KEY, true );
 		$previous_attachments = is_array( $previous_attachments ) ? $previous_attachments : array();

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -632,10 +632,16 @@ class Seo {
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY, $video_seo_schema );
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY, time() );
 			$this->update_attachment_post_mapping( $post_ID, array_unique( $attachments_used ) );
+
+			/** This action is documented in inc/classes/class-seo.php */
+			do_action( 'godam_video_seo_schema_saved', $post_ID, $video_seo_schema );
 		} else {
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY );
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY );
 			$this->update_attachment_post_mapping( $post_ID, array() );
+
+			/** This action is documented in inc/classes/class-seo.php */
+			do_action( 'godam_video_seo_schema_cleared', $post_ID );
 		}
 	}
 

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -47,14 +47,15 @@ class Seo {
 	}
 
 	/**
-	 * Save SEO schema data from 'godam/video' and 'godam/video-product-gallery' blocks as post meta.
+	 * Save SEO schema data from 'godam/video' blocks as post meta.
 	 *
 	 * This function parses the Gutenberg block content of the post and extracts
-	 * any `seo` attribute from blocks of type `godam/video`. It also extracts
-	 * video/product data from `godam/video-product-gallery` (Shoppable Video) blocks.
-	 * The extracted data is then saved in the post meta under the key
-	 * `godam_video_seo_schema`, along with a timestamp in
-	 * `godam_video_seo_schema_updated`.
+	 * any `seo` attribute from blocks of type `godam/video`. The extracted data
+	 * is then saved in the post meta under the key `godam_video_seo_schema`,
+	 * along with a timestamp in `godam_video_seo_schema_updated`.
+	 *
+	 * Add-ons can contribute additional schemas via the
+	 * `godam_video_seo_extra_block_schemas` filter.
 	 *
 	 * Also handles WPBakery shortcodes in the same post.
 	 *
@@ -83,11 +84,10 @@ class Seo {
 		$video_seo_schema = array();
 		$attachments_used = array();
 
-		// Parse Gutenberg blocks if content contains godam/video or godam/video-product-gallery blocks.
-		$has_video_block   = ! empty( $content ) && strpos( $content, '<!-- wp:godam/video' ) !== false;
-		$has_gallery_block = ! empty( $content ) && strpos( $content, '<!-- wp:godam/video-product-gallery ' ) !== false;
+		// Parse Gutenberg blocks if content contains godam/video blocks.
+		$has_video_block = ! empty( $content ) && strpos( $content, '<!-- wp:godam/video' ) !== false;
 
-		if ( $has_video_block || $has_gallery_block ) {
+		if ( $has_video_block ) {
 			$blocks = parse_blocks( $content );
 
 			foreach ( $blocks as $block ) {
@@ -103,6 +103,22 @@ class Seo {
 			$video_seo_schema = array_merge( $video_seo_schema, $result['schemas'] );
 			$attachments_used = array_merge( $attachments_used, $result['attachments'] );
 		}
+
+		/**
+		 * Filter to let add-ons contribute extra block-based video SEO schemas.
+		 *
+		 * For example, the GoDAM for WooCommerce add-on uses this to parse
+		 * `godam/video-product-gallery` (Shoppable Video) blocks and return
+		 * the resulting VideoObject SEO entries.
+		 *
+		 * @since 1.11.0
+		 *
+		 * @param array  $extra_schemas Array of extra SEO data arrays (initially empty).
+		 * @param string $content       The post content.
+		 * @param int    $post_ID       The post ID.
+		 */
+		$extra_schemas    = apply_filters( 'godam_video_seo_extra_block_schemas', array(), $content, $post_ID );
+		$video_seo_schema = array_merge( $video_seo_schema, $extra_schemas );
 
 		if ( ! empty( $video_seo_schema ) ) {
 			/**
@@ -122,18 +138,31 @@ class Seo {
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY, time() );
 			$this->update_attachment_post_mapping( $post_ID, array_unique( $attachments_used ) );
 
-			// Track VPG product IDs for reverse lookup when products are updated.
-			$vpg_product_ids = $this->extract_vpg_product_ids( $video_seo_schema );
-			if ( ! empty( $vpg_product_ids ) ) {
-				update_post_meta( $post_ID, '_godam_vpg_product_ids', $vpg_product_ids );
-			} else {
-				delete_post_meta( $post_ID, '_godam_vpg_product_ids' );
-			}
+			/**
+			 * Fired after video SEO schema is saved as post meta.
+			 *
+			 * Add-ons can use this to perform additional save-time operations,
+			 * such as storing reverse-lookup meta for gallery block product IDs.
+			 *
+			 * @since 1.11.0
+			 *
+			 * @param int   $post_ID          The post ID.
+			 * @param array $video_seo_schema The saved schema array.
+			 */
+			do_action( 'godam_video_seo_schema_saved', $post_ID, $video_seo_schema );
 		} else {
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY );
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY );
-			delete_post_meta( $post_ID, '_godam_vpg_product_ids' );
 			$this->update_attachment_post_mapping( $post_ID, array() );
+
+			/**
+			 * Fired after video SEO schema is cleared from a post.
+			 *
+			 * @since 1.11.0
+			 *
+			 * @param int $post_ID The post ID.
+			 */
+			do_action( 'godam_video_seo_schema_cleared', $post_ID );
 		}
 	}
 
@@ -171,11 +200,6 @@ class Seo {
 				// Fallback to block SEO if no attachment ID.
 				$schemas[] = $block['attrs']['seo'];
 			}
-		} elseif ( isset( $block['blockName'] ) && 'godam/video-product-gallery' === $block['blockName'] ) {
-			// Extract SEO data from Shoppable Video gallery block.
-			$result      = $this->extract_seo_from_video_product_gallery( $block, $track_attachments );
-			$schemas     = array_merge( $schemas, $track_attachments ? $result['schemas'] : $result );
-			$attachments = $track_attachments ? array_merge( $attachments, $result['attachments'] ) : $attachments;
 		}
 
 		if ( ! empty( $block['innerBlocks'] ) ) {
@@ -187,78 +211,6 @@ class Seo {
 				} else {
 					$schemas = array_merge( $schemas, $result );
 				}
-			}
-		}
-
-		if ( $track_attachments ) {
-			return array(
-				'schemas'     => $schemas,
-				'attachments' => $attachments,
-			);
-		}
-
-		return $schemas;
-	}
-
-	/**
-	 * Extract SEO data from a Shoppable Video (video-product-gallery) block.
-	 *
-	 * Iterates inner `godam/video-product-gallery-item` blocks to extract video
-	 * attachment metadata and associated product IDs. Each gallery item produces
-	 * a VideoObject SEO entry tagged with `_source => vpg` and `_vpg_product_ids`
-	 * so the WooCommerce add-on can enrich them with product data at save-time.
-	 *
-	 * @since 1.11.0
-	 *
-	 * @param array $block             Parsed block data for the gallery.
-	 * @param bool  $track_attachments Whether to track attachment IDs.
-	 * @return array Contains 'schemas' and 'attachments' arrays when tracking, otherwise just schemas.
-	 */
-	private function extract_seo_from_video_product_gallery( $block, $track_attachments = false ) {
-		$schemas     = array();
-		$attachments = array();
-
-		if ( empty( $block['innerBlocks'] ) ) {
-			return $track_attachments ? array(
-				'schemas'     => $schemas,
-				'attachments' => $attachments,
-			) : $schemas;
-		}
-
-		$position = 0;
-
-		foreach ( $block['innerBlocks'] as $inner_block ) {
-			if ( ! isset( $inner_block['blockName'] ) || 'godam/video-product-gallery-item' !== $inner_block['blockName'] ) {
-				continue;
-			}
-
-			$video_id   = isset( $inner_block['attrs']['videoId'] ) ? absint( $inner_block['attrs']['videoId'] ) : 0;
-			$product_id = isset( $inner_block['attrs']['productId'] ) ? absint( $inner_block['attrs']['productId'] ) : 0;
-
-			if ( ! $video_id ) {
-				continue;
-			}
-
-			$media_seo = $this->get_seo_from_attachment( $video_id );
-
-			if ( empty( $media_seo ) ) {
-				continue;
-			}
-
-			++$position;
-
-			// Tag with gallery source and product IDs for WooCommerce enrichment.
-			$media_seo['_source']       = 'vpg';
-			$media_seo['_vpg_position'] = $position;
-
-			if ( $product_id ) {
-				$media_seo['_vpg_product_ids'] = array( $product_id );
-			}
-
-			$schemas[] = $media_seo;
-
-			if ( $track_attachments ) {
-				$attachments[] = $video_id;
 			}
 		}
 
@@ -414,17 +366,33 @@ class Seo {
 			return;
 		}
 
-		$standalone_schemas = array();
-		$vpg_schemas        = array();
-		$seen_content_urls  = array();
+		$output_schemas    = array();
+		$seen_content_urls = array();
+
+		// Build a set of contentUrls claimed by VPG (Shoppable Video) entries.
+		// When the same video appears in both a godam/video block and a VPG block,
+		// the VPG version takes priority (it carries product data via the add-on).
+		$vpg_content_urls = array();
+		foreach ( $cached_schemas as $video ) {
+			if ( ! empty( $video['_source'] ) && 'vpg' === $video['_source'] && ! empty( $video['contentUrl'] ) ) {
+				$vpg_content_urls[ $video['contentUrl'] ] = true;
+			}
+		}
 
 		foreach ( $cached_schemas as $video ) {
 			if ( ! is_array( $video ) || empty( $video['headline'] ) ) {
 				continue;
 			}
 
-			// Deduplicate by contentUrl (same video in both godam/video and gallery).
 			$content_url = ! empty( $video['contentUrl'] ) ? $video['contentUrl'] : '';
+			$is_vpg      = ! empty( $video['_source'] ) && 'vpg' === $video['_source'];
+
+			// Skip standalone entries whose video already exists in a VPG block.
+			if ( ! $is_vpg && $content_url && isset( $vpg_content_urls[ $content_url ] ) ) {
+				continue;
+			}
+
+			// Deduplicate by contentUrl within the same context.
 			if ( $content_url && isset( $seen_content_urls[ $content_url ] ) ) {
 				continue;
 			}
@@ -464,40 +432,7 @@ class Seo {
 			 */
 			$schema = apply_filters( 'godam_video_seo_schema', $schema, $video, $post_id );
 
-			// Group gallery-sourced schemas for ItemList output.
-			if ( ! empty( $video['_source'] ) && 'vpg' === $video['_source'] ) {
-				$position = ! empty( $video['_vpg_position'] ) ? (int) $video['_vpg_position'] : count( $vpg_schemas ) + 1;
-
-				$vpg_schemas[] = array(
-					'@type'    => 'ListItem',
-					'position' => $position,
-					'item'     => $schema,
-				);
-			} else {
-				$standalone_schemas[] = $schema;
-			}
-		}
-
-		$output_schemas = array();
-
-		// Add standalone VideoObject schemas.
-		foreach ( $standalone_schemas as $schema ) {
 			$output_schemas[] = $schema;
-		}
-
-		// Wrap gallery schemas in an ItemList for carousel-eligible rich results.
-		if ( ! empty( $vpg_schemas ) ) {
-			// Remove @context from individual items — it's set on the ItemList.
-			foreach ( $vpg_schemas as &$list_item ) {
-				unset( $list_item['item']['@context'] );
-			}
-			unset( $list_item );
-
-			$output_schemas[] = array(
-				'@context'        => 'https://schema.org',
-				'@type'           => 'ItemList',
-				'itemListElement' => $vpg_schemas,
-			);
 		}
 
 		if ( empty( $output_schemas ) ) {
@@ -507,14 +442,21 @@ class Seo {
 		/**
 		 * Filter the complete array of video SEO schemas before JSON-LD output.
 		 *
-		 * Allows add-ons to add, remove, or reorder schema entries.
+		 * Allows add-ons to add, remove, reorder, or group schema entries —
+		 * for example, the GoDAM for WooCommerce add-on uses this to wrap
+		 * Shoppable Video schemas in an ItemList for carousel rich results.
+		 *
+		 * A third argument `$cached_schemas` is passed so add-ons can inspect
+		 * the raw cached data (including `_source` markers) without an extra
+		 * `get_post_meta()` call.
 		 *
 		 * @since 1.10.0
 		 *
-		 * @param array $output_schemas Array of schema arrays (VideoObject and/or ItemList).
-		 * @param int   $post_id        The current post ID.
+		 * @param array $output_schemas  Array of schema arrays (VideoObject entries).
+		 * @param int   $post_id         The current post ID.
+		 * @param array $cached_schemas  Raw cached SEO data from post meta.
 		 */
-		$output_schemas = apply_filters( 'godam_video_seo_schemas', $output_schemas, $post_id );
+		$output_schemas = apply_filters( 'godam_video_seo_schemas', $output_schemas, $post_id, $cached_schemas );
 
 		if ( empty( $output_schemas ) ) {
 			return;
@@ -743,26 +685,6 @@ class Seo {
 		}
 
 		return $seo_data;
-	}
-
-	/**
-	 * Extract unique product IDs from VPG-sourced schema entries.
-	 *
-	 * @since 1.11.0
-	 *
-	 * @param array $video_seo_schemas Array of cached video SEO data.
-	 * @return array Unique product IDs from gallery block entries.
-	 */
-	private function extract_vpg_product_ids( $video_seo_schemas ) {
-		$product_ids = array();
-
-		foreach ( $video_seo_schemas as $video ) {
-			if ( ! empty( $video['_vpg_product_ids'] ) && is_array( $video['_vpg_product_ids'] ) ) {
-				$product_ids = array_merge( $product_ids, $video['_vpg_product_ids'] );
-			}
-		}
-
-		return array_values( array_unique( array_map( 'absint', $product_ids ) ) );
 	}
 
 	/**

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -120,6 +120,23 @@ class Seo {
 		$extra_schemas    = apply_filters( 'godam_video_seo_extra_block_schemas', array(), $content, $post_ID );
 		$video_seo_schema = array_merge( $video_seo_schema, $extra_schemas );
 
+		/**
+		 * Filter to let add-ons contribute extra attachment IDs for the
+		 * attachment ↔ post mapping used by `edit_attachment` SEO resync.
+		 *
+		 * For example, the GoDAM for WooCommerce add-on uses this to register
+		 * video attachments from `godam/video-product-gallery` blocks, which
+		 * are not parsed by the core `extract_video_seo_schema_from_block()`.
+		 *
+		 * @since 1.11.0
+		 *
+		 * @param int[]  $extra_attachments Array of extra attachment IDs (initially empty).
+		 * @param string $content           The post content.
+		 * @param int    $post_ID           The post ID.
+		 */
+		$extra_attachments = apply_filters( 'godam_video_seo_extra_block_attachments', array(), $content, $post_ID );
+		$attachments_used  = array_merge( $attachments_used, $extra_attachments );
+
 		if ( ! empty( $video_seo_schema ) ) {
 			/**
 			 * Filter the video SEO schema data before it is cached as post meta.

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -117,8 +117,10 @@ class Seo {
 		 * @param string $content       The post content.
 		 * @param int    $post_ID       The post ID.
 		 */
-		$extra_schemas    = apply_filters( 'godam_video_seo_extra_block_schemas', array(), $content, $post_ID );
-		$video_seo_schema = array_merge( $video_seo_schema, $extra_schemas );
+		$extra_schemas = apply_filters( 'godam_video_seo_extra_block_schemas', array(), $content, $post_ID );
+		if ( is_array( $extra_schemas ) ) {
+			$video_seo_schema = array_merge( $video_seo_schema, $extra_schemas );
+		}
 
 		/**
 		 * Filter to let add-ons contribute extra attachment IDs for the
@@ -135,7 +137,9 @@ class Seo {
 		 * @param int    $post_ID           The post ID.
 		 */
 		$extra_attachments = apply_filters( 'godam_video_seo_extra_block_attachments', array(), $content, $post_ID );
-		$attachments_used  = array_merge( $attachments_used, $extra_attachments );
+		if ( is_array( $extra_attachments ) ) {
+			$attachments_used = array_merge( $attachments_used, $extra_attachments );
+		}
 
 		if ( ! empty( $video_seo_schema ) ) {
 			/**
@@ -400,7 +404,7 @@ class Seo {
 		// the VPG version takes priority (it carries product data via the add-on).
 		$vpg_content_urls = array();
 		foreach ( $cached_schemas as $video ) {
-			if ( ! empty( $video['_source'] ) && 'vpg' === $video['_source'] && ! empty( $video['contentUrl'] ) ) {
+			if ( ! empty( $video['_source'] ) && 'vpg' === $video['_source'] && ! empty( $video['contentUrl'] ) && is_string( $video['contentUrl'] ) ) {
 				$vpg_content_urls[ $video['contentUrl'] ] = true;
 			}
 		}
@@ -410,7 +414,7 @@ class Seo {
 				continue;
 			}
 
-			$content_url = ! empty( $video['contentUrl'] ) ? $video['contentUrl'] : '';
+			$content_url = ! empty( $video['contentUrl'] ) && is_string( $video['contentUrl'] ) ? $video['contentUrl'] : '';
 			$is_vpg      = ! empty( $video['_source'] ) && 'vpg' === $video['_source'];
 
 			// Skip standalone entries whose video already exists in a VPG block.

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -632,15 +632,11 @@ class Seo {
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY, $video_seo_schema );
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY, time() );
 			$this->update_attachment_post_mapping( $post_ID, array_unique( $attachments_used ) );
-
-			/** This action is documented in inc/classes/class-seo.php */
 			do_action( 'godam_video_seo_schema_saved', $post_ID, $video_seo_schema );
 		} else {
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY );
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY );
 			$this->update_attachment_post_mapping( $post_ID, array() );
-
-			/** This action is documented in inc/classes/class-seo.php */
 			do_action( 'godam_video_seo_schema_cleared', $post_ID );
 		}
 	}

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -100,6 +100,19 @@ class Seo {
 		}
 
 		if ( ! empty( $video_seo_schema ) ) {
+			/**
+			 * Filter the video SEO schema data before it is cached as post meta.
+			 *
+			 * Allows add-ons (e.g. WooCommerce integration) to enrich each video's
+			 * cached SEO data with additional information such as product details.
+			 *
+			 * @since 1.10.0
+			 *
+			 * @param array $video_seo_schema Array of video SEO data arrays.
+			 * @param int   $post_ID          The post ID being saved.
+			 */
+			$video_seo_schema = apply_filters( 'godam_video_seo_cache_data', $video_seo_schema, $post_ID );
+
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY, $video_seo_schema );
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY, time() );
 			$this->update_attachment_post_mapping( $post_ID, array_unique( $attachments_used ) );
@@ -335,8 +348,38 @@ class Seo {
 				$schema['duration'] = sanitize_text_field( $video['duration'] );
 			}
 
+			/**
+			 * Filter an individual video SEO schema entry before output.
+			 *
+			 * Allows add-ons to modify or extend a single VideoObject schema,
+			 * e.g. by adding an associatedProduct for WooCommerce integration.
+			 *
+			 * @since 1.10.0
+			 *
+			 * @param array $schema  The VideoObject schema array.
+			 * @param array $video   The raw cached video SEO data.
+			 * @param int   $post_id The current post ID.
+			 */
+			$schema = apply_filters( 'godam_video_seo_schema', $schema, $video, $post_id );
+
 			$schemas[] = $schema;
 		}
+
+		if ( empty( $schemas ) ) {
+			return;
+		}
+
+		/**
+		 * Filter the complete array of video SEO schemas before JSON-LD output.
+		 *
+		 * Allows add-ons to add, remove, or reorder schema entries.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param array $schemas Array of VideoObject schema arrays.
+		 * @param int   $post_id The current post ID.
+		 */
+		$schemas = apply_filters( 'godam_video_seo_schemas', $schemas, $post_id );
 
 		if ( empty( $schemas ) ) {
 			return;
@@ -476,6 +519,9 @@ class Seo {
 		$attachments_used = $result['attachments'];
 
 		if ( ! empty( $video_seo_schema ) ) {
+			/** This filter is documented in inc/classes/class-seo.php */
+			$video_seo_schema = apply_filters( 'godam_video_seo_cache_data', $video_seo_schema, $post_ID );
+
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY, $video_seo_schema );
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY, time() );
 			$this->update_attachment_post_mapping( $post_ID, array_unique( $attachments_used ) );

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -47,12 +47,14 @@ class Seo {
 	}
 
 	/**
-	 * Save SEO schema data from 'godam/video' blocks as post meta.
+	 * Save SEO schema data from 'godam/video' and 'godam/video-product-gallery' blocks as post meta.
 	 *
 	 * This function parses the Gutenberg block content of the post and extracts
-	 * any `seo` attribute from blocks of type `godam/video`. The extracted data is
-	 * then saved in the post meta under the key `godam_video_seo_schema`, along with
-	 * a timestamp in `godam_video_seo_schema_updated`.
+	 * any `seo` attribute from blocks of type `godam/video`. It also extracts
+	 * video/product data from `godam/video-product-gallery` (Shoppable Video) blocks.
+	 * The extracted data is then saved in the post meta under the key
+	 * `godam_video_seo_schema`, along with a timestamp in
+	 * `godam_video_seo_schema_updated`.
 	 *
 	 * Also handles WPBakery shortcodes in the same post.
 	 *
@@ -81,8 +83,11 @@ class Seo {
 		$video_seo_schema = array();
 		$attachments_used = array();
 
-		// Parse Gutenberg blocks if content contains them.
-		if ( ! empty( $content ) && strpos( $content, '<!-- wp:godam/video' ) !== false ) {
+		// Parse Gutenberg blocks if content contains godam/video or godam/video-product-gallery blocks.
+		$has_video_block   = ! empty( $content ) && strpos( $content, '<!-- wp:godam/video' ) !== false;
+		$has_gallery_block = ! empty( $content ) && strpos( $content, '<!-- wp:godam/video-product-gallery ' ) !== false;
+
+		if ( $has_video_block || $has_gallery_block ) {
 			$blocks = parse_blocks( $content );
 
 			foreach ( $blocks as $block ) {
@@ -116,9 +121,18 @@ class Seo {
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY, $video_seo_schema );
 			update_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY, time() );
 			$this->update_attachment_post_mapping( $post_ID, array_unique( $attachments_used ) );
+
+			// Track VPG product IDs for reverse lookup when products are updated.
+			$vpg_product_ids = $this->extract_vpg_product_ids( $video_seo_schema );
+			if ( ! empty( $vpg_product_ids ) ) {
+				update_post_meta( $post_ID, '_godam_vpg_product_ids', $vpg_product_ids );
+			} else {
+				delete_post_meta( $post_ID, '_godam_vpg_product_ids' );
+			}
 		} else {
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_META_KEY );
 			delete_post_meta( $post_ID, self::VIDEO_SEO_SCHEMA_UPDATED_META_KEY );
+			delete_post_meta( $post_ID, '_godam_vpg_product_ids' );
 			$this->update_attachment_post_mapping( $post_ID, array() );
 		}
 	}
@@ -157,6 +171,11 @@ class Seo {
 				// Fallback to block SEO if no attachment ID.
 				$schemas[] = $block['attrs']['seo'];
 			}
+		} elseif ( isset( $block['blockName'] ) && 'godam/video-product-gallery' === $block['blockName'] ) {
+			// Extract SEO data from Shoppable Video gallery block.
+			$result      = $this->extract_seo_from_video_product_gallery( $block, $track_attachments );
+			$schemas     = array_merge( $schemas, $track_attachments ? $result['schemas'] : $result );
+			$attachments = $track_attachments ? array_merge( $attachments, $result['attachments'] ) : $attachments;
 		}
 
 		if ( ! empty( $block['innerBlocks'] ) ) {
@@ -168,6 +187,78 @@ class Seo {
 				} else {
 					$schemas = array_merge( $schemas, $result );
 				}
+			}
+		}
+
+		if ( $track_attachments ) {
+			return array(
+				'schemas'     => $schemas,
+				'attachments' => $attachments,
+			);
+		}
+
+		return $schemas;
+	}
+
+	/**
+	 * Extract SEO data from a Shoppable Video (video-product-gallery) block.
+	 *
+	 * Iterates inner `godam/video-product-gallery-item` blocks to extract video
+	 * attachment metadata and associated product IDs. Each gallery item produces
+	 * a VideoObject SEO entry tagged with `_source => vpg` and `_vpg_product_ids`
+	 * so the WooCommerce add-on can enrich them with product data at save-time.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param array $block             Parsed block data for the gallery.
+	 * @param bool  $track_attachments Whether to track attachment IDs.
+	 * @return array Contains 'schemas' and 'attachments' arrays when tracking, otherwise just schemas.
+	 */
+	private function extract_seo_from_video_product_gallery( $block, $track_attachments = false ) {
+		$schemas     = array();
+		$attachments = array();
+
+		if ( empty( $block['innerBlocks'] ) ) {
+			return $track_attachments ? array(
+				'schemas'     => $schemas,
+				'attachments' => $attachments,
+			) : $schemas;
+		}
+
+		$position = 0;
+
+		foreach ( $block['innerBlocks'] as $inner_block ) {
+			if ( ! isset( $inner_block['blockName'] ) || 'godam/video-product-gallery-item' !== $inner_block['blockName'] ) {
+				continue;
+			}
+
+			$video_id   = isset( $inner_block['attrs']['videoId'] ) ? absint( $inner_block['attrs']['videoId'] ) : 0;
+			$product_id = isset( $inner_block['attrs']['productId'] ) ? absint( $inner_block['attrs']['productId'] ) : 0;
+
+			if ( ! $video_id ) {
+				continue;
+			}
+
+			$media_seo = $this->get_seo_from_attachment( $video_id );
+
+			if ( empty( $media_seo ) ) {
+				continue;
+			}
+
+			++$position;
+
+			// Tag with gallery source and product IDs for WooCommerce enrichment.
+			$media_seo['_source']       = 'vpg';
+			$media_seo['_vpg_position'] = $position;
+
+			if ( $product_id ) {
+				$media_seo['_vpg_product_ids'] = array( $product_id );
+			}
+
+			$schemas[] = $media_seo;
+
+			if ( $track_attachments ) {
+				$attachments[] = $video_id;
 			}
 		}
 
@@ -323,11 +414,22 @@ class Seo {
 			return;
 		}
 
-		$schemas = array();
+		$standalone_schemas = array();
+		$vpg_schemas        = array();
+		$seen_content_urls  = array();
 
 		foreach ( $cached_schemas as $video ) {
 			if ( ! is_array( $video ) || empty( $video['headline'] ) ) {
 				continue;
+			}
+
+			// Deduplicate by contentUrl (same video in both godam/video and gallery).
+			$content_url = ! empty( $video['contentUrl'] ) ? $video['contentUrl'] : '';
+			if ( $content_url && isset( $seen_content_urls[ $content_url ] ) ) {
+				continue;
+			}
+			if ( $content_url ) {
+				$seen_content_urls[ $content_url ] = true;
 			}
 
 			$schema = array(
@@ -362,10 +464,43 @@ class Seo {
 			 */
 			$schema = apply_filters( 'godam_video_seo_schema', $schema, $video, $post_id );
 
-			$schemas[] = $schema;
+			// Group gallery-sourced schemas for ItemList output.
+			if ( ! empty( $video['_source'] ) && 'vpg' === $video['_source'] ) {
+				$position = ! empty( $video['_vpg_position'] ) ? (int) $video['_vpg_position'] : count( $vpg_schemas ) + 1;
+
+				$vpg_schemas[] = array(
+					'@type'    => 'ListItem',
+					'position' => $position,
+					'item'     => $schema,
+				);
+			} else {
+				$standalone_schemas[] = $schema;
+			}
 		}
 
-		if ( empty( $schemas ) ) {
+		$output_schemas = array();
+
+		// Add standalone VideoObject schemas.
+		foreach ( $standalone_schemas as $schema ) {
+			$output_schemas[] = $schema;
+		}
+
+		// Wrap gallery schemas in an ItemList for carousel-eligible rich results.
+		if ( ! empty( $vpg_schemas ) ) {
+			// Remove @context from individual items — it's set on the ItemList.
+			foreach ( $vpg_schemas as &$list_item ) {
+				unset( $list_item['item']['@context'] );
+			}
+			unset( $list_item );
+
+			$output_schemas[] = array(
+				'@context'        => 'https://schema.org',
+				'@type'           => 'ItemList',
+				'itemListElement' => $vpg_schemas,
+			);
+		}
+
+		if ( empty( $output_schemas ) ) {
 			return;
 		}
 
@@ -376,18 +511,18 @@ class Seo {
 		 *
 		 * @since 1.10.0
 		 *
-		 * @param array $schemas Array of VideoObject schema arrays.
-		 * @param int   $post_id The current post ID.
+		 * @param array $output_schemas Array of schema arrays (VideoObject and/or ItemList).
+		 * @param int   $post_id        The current post ID.
 		 */
-		$schemas = apply_filters( 'godam_video_seo_schemas', $schemas, $post_id );
+		$output_schemas = apply_filters( 'godam_video_seo_schemas', $output_schemas, $post_id );
 
-		if ( empty( $schemas ) ) {
+		if ( empty( $output_schemas ) ) {
 			return;
 		}
 
-		// Output a single <script> with all VideoObject schemas.
+		// Output a single <script> with all schemas.
 		echo '<script type="application/ld+json">' . wp_json_encode(
-			count( $schemas ) === 1 ? $schemas[0] : $schemas,
+			count( $output_schemas ) === 1 ? $output_schemas[0] : $output_schemas,
 			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
 		) . '</script>';
 	}
@@ -608,6 +743,26 @@ class Seo {
 		}
 
 		return $seo_data;
+	}
+
+	/**
+	 * Extract unique product IDs from VPG-sourced schema entries.
+	 *
+	 * @since 1.11.0
+	 *
+	 * @param array $video_seo_schemas Array of cached video SEO data.
+	 * @return array Unique product IDs from gallery block entries.
+	 */
+	private function extract_vpg_product_ids( $video_seo_schemas ) {
+		$product_ids = array();
+
+		foreach ( $video_seo_schemas as $video ) {
+			if ( ! empty( $video['_vpg_product_ids'] ) && is_array( $video['_vpg_product_ids'] ) ) {
+				$product_ids = array_merge( $product_ids, $video['_vpg_product_ids'] );
+			}
+		}
+
+		return array_values( array_unique( array_map( 'absint', $product_ids ) ) );
 	}
 
 	/**

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -203,12 +203,21 @@ class Seo {
 
 			if ( $seo_override && isset( $block['attrs']['seo'] ) && ! empty( $block['attrs']['seo'] ) ) {
 				// Use overridden SEO from block attributes.
-				$schemas[] = $block['attrs']['seo'];
+				$seo_entry = $block['attrs']['seo'];
+
+				// Include attachment_id so add-ons can resolve the attachment
+				// on the first save (before _godam_seo_attachments exists).
+				if ( $attachment_id > 0 ) {
+					$seo_entry['attachment_id'] = $attachment_id;
+				}
+
+				$schemas[] = $seo_entry;
 			} elseif ( $attachment_id > 0 ) {
 				// Fetch SEO from media library attachment.
 				$media_seo = $this->get_seo_from_attachment( $attachment_id );
 				if ( ! empty( $media_seo ) ) {
-					$schemas[] = $media_seo;
+					$media_seo['attachment_id'] = $attachment_id;
+					$schemas[]                  = $media_seo;
 					if ( $track_attachments ) {
 						$attachments[] = $attachment_id;
 					}


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-for-woo/issues/60

This pull request enhances the SEO schema handling for video content by adding support for the `godam/video-product-gallery` (Shoppable Video) Gutenberg block, improving extensibility through new filters, and introducing better grouping and deduplication of video schema entries. These changes enable richer SEO data, WooCommerce integration, and improved structured data output for video galleries.

**Support for Shoppable Video (Video Product Gallery) blocks:**

- Added parsing and extraction of SEO schema data from `godam/video-product-gallery` blocks, including handling of associated product IDs for each video item within the gallery. This enables WooCommerce add-ons to enrich video schema with product information. [[1]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL50-R57) [[2]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL84-R90) [[3]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR174-R178) [[4]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR203-R274)

- Implemented the `extract_seo_from_video_product_gallery` method to process each gallery item, tag schema entries with source and product IDs, and support attachment tracking.

**Extensibility and integration improvements:**

- Introduced new filters (`godam_video_seo_cache_data`, `godam_video_seo_schema`, and `godam_video_seo_schemas`) to allow add-ons to modify cached schema data, individual schema entries, and the final output array. This provides hooks for integrations like WooCommerce to add product details or customize schema output. [[1]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR108-R135) [[2]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL338-R525) [[3]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR657-R659)

**Structured data output enhancements:**

- Grouped video schema entries by source, wrapping gallery-sourced videos in a `schema.org/ItemList` for carousel-eligible rich results, and deduplicated videos by `contentUrl` to avoid redundant schema entries. [[1]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL313-R434) [[2]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL338-R525)

**Product ID tracking:**

- Added logic to extract and store unique product IDs from video-product-gallery blocks in post meta (`_godam_vpg_product_ids`) for reverse lookup and update when products change. [[1]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR108-R135) [[2]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR748-R767)

These improvements make the SEO schema system more robust, extensible, and compatible with advanced video and e-commerce features.