### PR TITLE
fix: Analytics Type 2 Request Body

### DIFF
--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -111,7 +111,7 @@ export function getUserAgent( userAgent ) {
  * @param {Array}  [opts.videoIds]         Array of [videoId, jobId] pairs (type 1).
  * @param {Array}  [opts.ranges]           Played time-range pairs (type 2).
  * @param {number} [opts.videoLength]      Duration in seconds (type 2).
- * @return {Object} Ready-to-serialize request body.
+ * @return {{endpoint: (?string), body: (?Object)}} Object containing the analytics endpoint and the ready-to-serialize request body, or null values for both when no request should be sent.
  */
 export function buildAnalyticsRequestBody( {
 	type,

--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -182,7 +182,7 @@ export function buildAnalyticsRequestBody( {
 		is_page: isPage === '1',
 		is_archive: isArchive === '1',
 		post_type: postType,
-		post_id: parseInt( postId, 0 ),
+		post_id: parseInt( postId, 10 ) || 0,
 		post_title: postTitle,
 		categories,
 		tags,

--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -1,0 +1,204 @@
+/**
+ * Shared helpers for video analytics.
+ *
+ * Both the analytics plugin (async path) and the keepalive path
+ * (sendPlayerHeatmap) must send identical request bodies.  This module
+ * is the single source of truth for the request schema.
+ */
+
+/**
+ * Check if we should skip analytics tracking.
+ *
+ * @return {boolean} True if analytics should be skipped, false otherwise.
+ */
+export function shouldSkipAnalytics() {
+	const { isAdminPage } = window.videoAnalyticsParams || {};
+
+	if ( isAdminPage ) {
+		return true;
+	}
+
+	const urlParams = new URLSearchParams( window.location.search );
+	if ( urlParams.get( 'godam_page' ) === 'video-preview' ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Parse the browser's user-agent string into structured data.
+ *
+ * @param {string} userAgent - Raw navigator.userAgent string.
+ * @return {Object} Parsed data with userAgent, name, version, and platform.
+ */
+export function getUserAgent( userAgent ) {
+	const uAgent = userAgent;
+	let bname = 'Unknown';
+	let platform = 'Unknown';
+	let version = '';
+	let ub = '';
+
+	if ( /(linux)/i.test( uAgent ) ) {
+		platform = 'Linux';
+	} else if ( /(macintosh|mac os x)/i.test( uAgent ) ) {
+		platform = 'Macintosh';
+	} else if ( /(windows|win32)/i.test( uAgent ) ) {
+		platform = 'Windows';
+	}
+
+	if ( /(MSIE)/i.test( uAgent ) && ! /(Opera)/i.test( uAgent ) ) {
+		bname = 'Internet Explorer';
+		ub = 'MSIE';
+	} else if ( /(Firefox)/i.test( uAgent ) ) {
+		bname = 'Mozilla Firefox';
+		ub = 'Firefox';
+	} else if ( /(Chrome)/i.test( uAgent ) ) {
+		bname = 'Google Chrome';
+		ub = 'Chrome';
+	} else if ( /(Safari)/i.test( uAgent ) ) {
+		bname = 'Apple Safari';
+		ub = 'Safari';
+	} else if ( /(Opera)/i.test( uAgent ) ) {
+		bname = 'Opera';
+		ub = 'Opera';
+	} else if ( /(Netscape)/i.test( uAgent ) ) {
+		bname = 'Netscape';
+		ub = 'Netscape';
+	}
+
+	const known = [ 'Version', ub, 'other' ];
+	const pattern = new RegExp( '(?<browser>' + known.join( '|' ) + ')[/ ]+(?<version>[0-9.|a-zA-Z.]*)', 'g' );
+	const matches = uAgent.matchAll( pattern );
+	const matchArray = Array.from( matches );
+	const i = matchArray.length;
+
+	if ( i !== 1 ) {
+		if ( uAgent.lastIndexOf( 'Version' ) < uAgent.lastIndexOf( ub ) ) {
+			version = matchArray[ 0 ].groups.version;
+		} else {
+			version = matchArray[ 1 ].groups.version;
+		}
+	} else {
+		version = matchArray[ 0 ].groups.version;
+	}
+
+	if ( version === null || version === '' ) {
+		version = '?';
+	}
+
+	return {
+		userAgent: uAgent,
+		name: bname,
+		version,
+		platform,
+		pattern,
+	};
+}
+
+/**
+ * Build the canonical request body for the analytics endpoint.
+ *
+ * Every field that the microservice accepts is included so that both
+ * the async plugin path and the keepalive path produce identical payloads.
+ *
+ * @param {Object} opts
+ * @param {number} opts.type               Event type (1 = page load, 2 = heatmap, 3 = layer).
+ * @param {string} opts.userToken          Anonymous visitor ID (from analytics library).
+ * @param {number} [opts.visitorTimestamp] Epoch-ms timestamp; defaults to Date.now().
+ * @param {number} [opts.videoId]          Single video ID (type 2/3).
+ * @param {string} [opts.jobId]            Transcoding job ID.
+ * @param {Array}  [opts.videoIds]         Array of [videoId, jobId] pairs (type 1).
+ * @param {Array}  [opts.ranges]           Played time-range pairs (type 2).
+ * @param {number} [opts.videoLength]      Duration in seconds (type 2).
+ * @return {Object} Ready-to-serialize request body.
+ */
+export function buildAnalyticsRequestBody( {
+	type,
+	userToken = '',
+	visitorTimestamp,
+	videoId = 0,
+	jobId = '',
+	videoIds = [],
+	ranges = [],
+	videoLength = 0,
+} ) {
+	const {
+		endpoint,
+		token,
+		userId,
+		emailId,
+		locationIP,
+		isPost,
+		isPage,
+		isArchive,
+		postType,
+		postId,
+		postTitle,
+		categories,
+		tags,
+		author,
+	} = window.videoAnalyticsParams || {};
+
+	const campaignData = window.campaign_data || {};
+
+	// If the token is unverified or endpoint is missing, signal callers to bail
+	// by returning a null endpoint.
+	if ( ! endpoint || token === 'unverified' ) {
+		return { endpoint: null, body: null };
+	}
+
+	const ua = getUserAgent( window.navigator.userAgent );
+
+	const body = {
+		site_url: window.location.origin,
+		user_token: userToken,
+		wp_user_id: parseInt( userId, 10 ) || 0,
+		account_token: token || '',
+		email: emailId || '',
+		visitor_timestamp: visitorTimestamp || Date.now(),
+		visit_entry_action_url: window.location.href,
+		visit_entry_action_name: document.title,
+		referer_type: '',
+		referer_name: document.referrer || '',
+		referer_url: document.referrer || '',
+		referer_keyword: '',
+		campaign_keyword: campaignData.keyword || '',
+		campaign_medium: campaignData.medium || '',
+		campaign_name: campaignData.name || '',
+		campaign_source: campaignData.source || '',
+		campaign_content: campaignData.content || '',
+		campaign_token: campaignData.id || '',
+		config_token: ua.userAgent,
+		config_os: ua.platform,
+		config_browser_name: ua.name,
+		config_browser_version: ua.version,
+		config_resolution: window.innerWidth + 'x' + window.innerHeight,
+		location_browser_lang: navigator.language,
+		location_ip: locationIP || '',
+		config_cookie: navigator.cookieEnabled,
+		param_vars: '',
+		is_post: isPost === '1',
+		is_page: isPage === '1',
+		is_archive: isArchive === '1',
+		post_type: postType,
+		post_id: parseInt( postId, 0 ),
+		post_title: postTitle,
+		categories,
+		tags,
+		author,
+		type,
+		video_id: videoId ? parseInt( videoId, 10 ) : 0,
+		video_ids: type === 1 ? videoIds : [],
+		ranges,
+		video_length: videoLength || 0,
+	};
+
+	// Only include job_id when it has a value — an empty string triggers
+	// server-side validation that returns HTTP 400.
+	if ( jobId ) {
+		body.job_id = jobId;
+	}
+
+	return { endpoint, body };
+}

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -7,6 +7,7 @@ import { Analytics } from 'analytics';
  */
 import videoAnalyticsPlugin from './video-analytics-plugin';
 import GTMVideoTracker from './gtm-video-tracker';
+import { shouldSkipAnalytics, buildAnalyticsRequestBody } from './analytics-helpers';
 
 const analytics = Analytics( {
 	app: 'analytics-cdp-plugin',
@@ -283,6 +284,11 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 			return null;
 		}
 
+		// Skip the same conditions the analytics plugin does.
+		if ( shouldSkipAnalytics() ) {
+			return null;
+		}
+
 		const videoLength = Number( player.duration && player.duration() ) || 0;
 
 		/*
@@ -301,55 +307,18 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 		 *
 		 * Reference: https://fetch.spec.whatwg.org/#keep-alive-flag
 		 */
-		const {
-			endpoint,
-			token,
-			userId,
-			emailId,
-			locationIP,
-			isPost,
-			isPage,
-			isArchive,
-			postType,
-			postId,
-			postTitle,
-			categories,
-			tags,
-			author,
-		} = window.videoAnalyticsParams || {};
+		const { endpoint, body } = buildAnalyticsRequestBody( {
+			type: 2,
+			userToken: window.analytics?.user?.()?.anonymousId || '',
+			videoId: parseInt( videoId, 10 ),
+			jobId,
+			ranges,
+			videoLength,
+		} );
 
-		// Honour the same skip conditions as the analytics plugin itself.
-		if ( ! endpoint || token === 'unverified' ) {
+		if ( ! endpoint ) {
 			return null;
 		}
-
-		const requestBody = {
-			site_url: window.location.origin,
-			account_token: token || '',
-			wp_user_id: parseInt( userId, 10 ) || 0,
-			email: emailId || '',
-			visitor_timestamp: Date.now(),
-			visit_entry_action_url: window.location.href,
-			visit_entry_action_name: document.title,
-			referer_url: document.referrer || '',
-			referer_name: document.referrer || '',
-			location_ip: locationIP || '',
-			is_post: isPost === '1',
-			is_page: isPage === '1',
-			is_archive: isArchive === '1',
-			post_type: postType,
-			post_id: parseInt( postId, 0 ),
-			post_title: postTitle,
-			categories,
-			tags,
-			author,
-			type: 2,
-			video_id: parseInt( videoId, 10 ),
-			job_id: jobId,
-			video_ids: [],
-			ranges,
-			video_length: videoLength,
-		};
 
 		// keepalive: true guarantees the request outlives the page. We do NOT
 		// await — the browser handles delivery asynchronously at the network
@@ -357,7 +326,7 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 		fetch( endpoint + '/analytics/', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify( requestBody ),
+			body: JSON.stringify( body ),
 			keepalive: true,
 		} );
 

--- a/assets/src/js/godam-player/video-analytics-plugin.js
+++ b/assets/src/js/godam-player/video-analytics-plugin.js
@@ -1,127 +1,44 @@
-const {
-	userId,
-	emailId,
-	isPost,
-	isPage,
-	isArchive,
-	postType,
-	postId,
-	postTitle,
-	categories,
-	tags,
-	author,
-	endpoint,
-	locationIP,
-	token,
-	isAdminPage,
-} = window.videoAnalyticsParams || {};
-
 /**
- * Check if we should skip analytics tracking.
- *
- * @return {boolean} True if analytics should be skipped, false otherwise.
+ * Internal dependencies
  */
-function shouldSkipAnalytics() {
-	// Skip on admin pages
-	if ( isAdminPage ) {
-		return true;
-	}
-
-	// Skip on video preview pages
-	const urlParams = new URLSearchParams( window.location.search );
-	if ( urlParams.get( 'godam_page' ) === 'video-preview' ) {
-		return true;
-	}
-
-	return false;
-}
+import { shouldSkipAnalytics, buildAnalyticsRequestBody } from './analytics-helpers';
 
 const videoAnalyticsPlugin = () => {
 	return {
 		name: 'video-analytics-plugin',
 		track: async ( { payload } ) => {
-			// Skip analytics tracking on admin pages and video preview pages
 			if ( shouldSkipAnalytics() ) {
 				return;
 			}
 
-			let { properties, meta, anonymousId } = payload;
-
-			properties = {
-				...properties,
-				url: window.location.href,
-				title: document.title,
-				referrer: document.referrer || '', // Include referrer
-				width: window.innerWidth, // Screen width
-				height: window.innerHeight, // Screen height
-				campaign_data: window.campaign_data || {}, // Include campaign data if available
-			};
+			const { properties, meta, anonymousId } = payload;
 
 			try {
-				// Destructure the ranges array from properties
 				const { ranges = [], videoId, type, videoLength, videoIds, jobId } = properties;
 
-				if ( ! type || ( type === 1 && ( ! videoIds || videoIds.length === 0 ) ) || token === 'unverified' ) {
+				if ( ! type || ( type === 1 && ( ! videoIds || videoIds.length === 0 ) ) ) {
 					return;
 				}
 
-				const userAgentData = getUserAgent( window.navigator.userAgent );
-
-				const requestBody = {
-					site_url: window.location.origin,
-					user_token: anonymousId,
-					wp_user_id: parseInt( userId, 10 ) || 0,
-					account_token: token || '',
-					email: emailId || '',
-					visitor_timestamp: meta?.ts || Date.now(),
-					visit_entry_action_url: window.location.href,
-					visit_entry_action_name: document.title,
-					referer_type: '',
-					referer_name: properties.referrer,
-					referer_url: properties.referrer,
-					referer_keyword: '',
-					campaign_keyword: ( undefined !== window.campaign_data && undefined !== window.campaign_data.keyword ) ? window.campaign_data.keyword : '',
-					campaign_medium: ( undefined !== window.campaign_data && undefined !== window.campaign_data.medium ) ? window.campaign_data.medium : '',
-					campaign_name: ( undefined !== window.campaign_data && undefined !== window.campaign_data.name ) ? window.campaign_data.name : '',
-					campaign_source: ( undefined !== window.campaign_data && undefined !== window.campaign_data.source ) ? window.campaign_data.source : '',
-					campaign_content: ( undefined !== window.campaign_data && undefined !== window.campaign_data.content ) ? window.campaign_data.content : '',
-					campaign_token: ( undefined !== window.campaign_data && undefined !== window.campaign_data.id ) ? window.campaign_data.id : '',
-					config_token: userAgentData.userAgent,
-					config_os: userAgentData.platform,
-					config_browser_name: userAgentData.name,
-					config_browser_version: userAgentData.version,
-					config_resolution: properties.width + 'x' + properties.height,
-					location_browser_lang: navigator.language,
-					location_ip: locationIP || '',
-					config_cookie: navigator.cookieEnabled,
-					param_vars: '',
-					is_post: isPost === '1',
-					is_page: isPage === '1',
-					is_archive: isArchive === '1',
-					post_type: postType,
-					post_id: parseInt( postId, 0 ),
-					post_title: postTitle,
-					categories,
-					tags,
-					author,
+				const { endpoint, body } = buildAnalyticsRequestBody( {
 					type,
-					video_id: videoId ? parseInt( videoId, 0 ) : 0,
-					video_ids: type === 1 ? videoIds : [],
+					userToken: anonymousId,
+					visitorTimestamp: meta?.ts || Date.now(),
+					videoId,
+					jobId,
+					videoIds,
 					ranges,
-					video_length: videoLength || 0,
-				};
+					videoLength,
+				} );
 
-				if ( type === 2 && jobId ) {
-					requestBody.job_id = jobId;
+				if ( ! endpoint ) {
+					return;
 				}
 
-				// Iterate over each range and send a POST request for it
 				const response = await fetch( endpoint + '/analytics/', {
 					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify( requestBody ),
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify( body ),
 					keepalive: true,
 				} );
 
@@ -136,73 +53,5 @@ const videoAnalyticsPlugin = () => {
 		},
 	};
 };
-
-function getUserAgent( userAgent ) {
-	const uAgent = userAgent;
-	let bname = 'Unknown';
-	let platform = 'Unknown';
-	let version = '';
-	let ub = '';
-
-	// First get the platform
-	if ( /(linux)/i.test( uAgent ) ) {
-		platform = 'Linux';
-	} else if ( /(macintosh|mac os x)/i.test( uAgent ) ) {
-		platform = 'Macintosh';
-	} else if ( /(windows|win32)/i.test( uAgent ) ) {
-		platform = 'Windows';
-	}
-
-	// Next get the name of the useragent separately
-	if ( /(MSIE)/i.test( uAgent ) && ! /(Opera)/i.test( uAgent ) ) {
-		bname = 'Internet Explorer';
-		ub = 'MSIE';
-	} else if ( /(Firefox)/i.test( uAgent ) ) {
-		bname = 'Mozilla Firefox';
-		ub = 'Firefox';
-	} else if ( /(Chrome)/i.test( uAgent ) ) {
-		bname = 'Google Chrome';
-		ub = 'Chrome';
-	} else if ( /(Safari)/i.test( uAgent ) ) {
-		bname = 'Apple Safari';
-		ub = 'Safari';
-	} else if ( /(Opera)/i.test( uAgent ) ) {
-		bname = 'Opera';
-		ub = 'Opera';
-	} else if ( /(Netscape)/i.test( uAgent ) ) {
-		bname = 'Netscape';
-		ub = 'Netscape';
-	}
-
-	// Finally get the correct version number
-	const known = [ 'Version', ub, 'other' ];
-	const pattern = new RegExp( '(?<browser>' + known.join( '|' ) + ')[/ ]+(?<version>[0-9.|a-zA-Z.]*)', 'g' );
-	const matches = uAgent.matchAll( pattern );
-	const matchArray = Array.from( matches );
-	const i = matchArray.length;
-
-	if ( i !== 1 ) {
-		if ( uAgent.lastIndexOf( 'Version' ) < uAgent.lastIndexOf( ub ) ) {
-			version = matchArray[ 0 ].groups.version;
-		} else {
-			version = matchArray[ 1 ].groups.version;
-		}
-	} else {
-		version = matchArray[ 0 ].groups.version;
-	}
-
-	// Check if we have a version number
-	if ( version === null || version === '' ) {
-		version = '?';
-	}
-
-	return {
-		userAgent: uAgent,
-		name: bname,
-		version,
-		platform,
-		pattern,
-	};
-}
 
 export default videoAnalyticsPlugin;


### PR DESCRIPTION
This pull request refactors and centralizes the logic for video analytics request construction and analytics skip conditions in the Godam Player codebase. The main goal is to ensure that both the analytics plugin and the keepalive path use an identical, canonical request body and consistent skip logic, improving maintainability and reducing the risk of discrepancies.

**Centralization and Consistency Improvements:**

* Introduced a new shared module, `analytics-helpers.js`, which provides `shouldSkipAnalytics` and `buildAnalyticsRequestBody` functions to encapsulate analytics skip logic and request body construction for all analytics-related code paths.

**Refactoring of Analytics Plugin:**

* Updated `video-analytics-plugin.js` to use the shared helpers for skip logic and request body construction, removing duplicated code and in-module user agent parsing. This ensures analytics requests are built in a single, consistent way. [[1]](diffhunk://#diff-fdccdab500be3619b0c109442c9093428d78a687056b1bd5b6d1d8bdd6df39b9L1-R41) [[2]](diffhunk://#diff-fdccdab500be3619b0c109442c9093428d78a687056b1bd5b6d1d8bdd6df39b9L140-L207)

**Refactoring of Player Heatmap Analytics:**

* Modified the heatmap analytics sender in `analytics.js` to use the new shared helpers, ensuring the same skip logic and request schema as the main analytics plugin. [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR10) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR287-R291) [[3]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL304-R329)

These changes ensure that analytics tracking logic is DRY (Don't Repeat Yourself), easier to maintain, and less error-prone by consolidating critical logic into a single source of truth.

## Screenshots

### Before
<img width="780" height="549" alt="Screenshot 2026-05-12 at 7 57 27 PM" src="https://github.com/user-attachments/assets/fb158f80-2842-4871-8b8d-3ceae2277c1d" />

### After
<img width="961" height="672" alt="Screenshot 2026-05-12 at 7 57 35 PM" src="https://github.com/user-attachments/assets/7fbb2770-7012-4e53-985a-dc95909f2866" />
