### PR TITLE
Fix/video gallery enhancement

### DIFF
--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -13,6 +13,7 @@ import {
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect, select as dataSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 import { closeSmall, pencil, video as videoIcon } from '@wordpress/icons';
 import { useRef, useEffect } from '@wordpress/element';
 
@@ -55,6 +56,7 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 	const itemWidth = itemWidthMap[ itemWidthRaw ] || itemWidthMap.M;
 	const viewRatio = context[ 'godam/galleryV2/viewRatio' ] || '16:9';
 	const { removeBlock } = useDispatch( 'core/block-editor' );
+	const { createNotice } = useDispatch( noticesStore );
 
 	// Ref to track the GoDAM virtual media ID from the most recent selection.
 	const pendingVirtualMediaId = useRef( null );
@@ -68,9 +70,17 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 		}
 		// Only allow video attachments.
 		if ( mediaItem.type && mediaItem.type !== 'video' ) {
+			createNotice( 'warning', __( 'Only video files can be added to the gallery.', 'godam' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
 			return;
 		}
 		if ( mediaItem.mime && ! mediaItem.mime.startsWith( 'video/' ) ) {
+			createNotice( 'warning', __( 'Only video files can be added to the gallery.', 'godam' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
 			return;
 		}
 		pendingVirtualMediaId.current = mediaItem.id;
@@ -84,6 +94,10 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 				( block ) => block.clientId !== clientId && block.attributes?.videoId === numericId,
 			);
 			if ( isDuplicate ) {
+				createNotice( 'warning', __( 'This video is already in the gallery.', 'godam' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
 				return;
 			}
 			setAttributes( { videoId: numericId } );

--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -8,9 +8,10 @@ import {
 	useBlockProps,
 	MediaUpload,
 	MediaUploadCheck,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, select as dataSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { closeSmall, pencil, video as videoIcon } from '@wordpress/icons';
 import { useRef, useEffect } from '@wordpress/element';
@@ -65,9 +66,26 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 		if ( ! mediaItem?.id ) {
 			return;
 		}
+		// Only allow video attachments.
+		if ( mediaItem.type && mediaItem.type !== 'video' ) {
+			return;
+		}
+		if ( mediaItem.mime && ! mediaItem.mime.startsWith( 'video/' ) ) {
+			return;
+		}
 		pendingVirtualMediaId.current = mediaItem.id;
 		const numericId = parseInt( mediaItem.id, 10 );
 		if ( numericId > 0 && String( numericId ) === String( mediaItem.id ) ) {
+			// Prevent selecting a video already used by a sibling.
+			const { getBlockRootClientId, getBlock } = dataSelect( blockEditorStore );
+			const parentClientId = getBlockRootClientId( clientId );
+			const parentBlock = getBlock( parentClientId );
+			const isDuplicate = ( parentBlock?.innerBlocks || [] ).some(
+				( block ) => block.clientId !== clientId && block.attributes?.videoId === numericId,
+			);
+			if ( isDuplicate ) {
+				return;
+			}
 			setAttributes( { videoId: numericId } );
 		}
 	};

--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -115,6 +115,22 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 				String( pendingVirtualMediaId.current ) === String( virtualMediaId )
 			) {
 				pendingVirtualMediaId.current = null;
+
+				// Prevent selecting a video already used by a sibling.
+				const { getBlockRootClientId, getBlock } = dataSelect( blockEditorStore );
+				const parentClientId = getBlockRootClientId( clientId );
+				const parentBlock = getBlock( parentClientId );
+				const isDuplicate = ( parentBlock?.innerBlocks || [] ).some(
+					( block ) => block.clientId !== clientId && block.attributes?.videoId === attachment.id,
+				);
+				if ( isDuplicate ) {
+					createNotice( 'warning', __( 'This video is already in the gallery.', 'godam' ), {
+						type: 'snackbar',
+						isDismissible: true,
+					} );
+					return;
+				}
+
 				setAttributes( { videoId: attachment.id } );
 			}
 		};
@@ -124,7 +140,7 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 		return () => {
 			document.removeEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
 		};
-	}, [ setAttributes ] );
+	}, [ clientId, setAttributes, createNotice ] );
 
 	const { media, hasResolvedMedia } = useSelect(
 		( select ) => {

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -26,7 +26,7 @@ import {
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	Button,
 } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, select as dataSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { columns, grid, listView, plus } from '@wordpress/icons';
@@ -172,6 +172,7 @@ const AddVideoAppender = ( { onSelect } ) => (
 	<MediaUploadCheck>
 		<MediaUpload
 			allowedTypes={ [ 'video' ] }
+			multiple
 			onSelect={ onSelect }
 			render={ ( { open } ) => (
 				<Button
@@ -367,26 +368,64 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	);
 
 	const insertHandpickedVideo = useCallback(
-		( mediaItem ) => {
-			if ( ! mediaItem?.id ) {
+		( mediaItemOrArray ) => {
+			const items = Array.isArray( mediaItemOrArray ) ? mediaItemOrArray : [ mediaItemOrArray ];
+			if ( ! items.length ) {
 				return;
 			}
 
-			const numericId = parseInt( mediaItem.id, 10 );
-			const isVirtual = ! ( numericId > 0 && String( numericId ) === String( mediaItem.id ) );
+			// Get existing video IDs from inner blocks to prevent duplicates.
+			const { getBlock } = dataSelect( blockEditorStore );
+			const parentBlock = getBlock( clientId );
+			const existingVideoIds = new Set(
+				( parentBlock?.innerBlocks || [] )
+					.map( ( block ) => block.attributes?.videoId )
+					.filter( Boolean ),
+			);
 
-			const newBlock = createBlock( 'godam/gallery-v2-item', {
-				videoId: isVirtual ? 0 : numericId,
+			const newBlocks = [];
+
+			items.forEach( ( mediaItem ) => {
+				if ( ! mediaItem?.id ) {
+					return;
+				}
+
+				// Only allow video attachments.
+				if ( mediaItem.type && mediaItem.type !== 'video' ) {
+					return;
+				}
+				if ( mediaItem.mime && ! mediaItem.mime.startsWith( 'video/' ) ) {
+					return;
+				}
+
+				const numericId = parseInt( mediaItem.id, 10 );
+				const isVirtual = ! ( numericId > 0 && String( numericId ) === String( mediaItem.id ) );
+
+				if ( ! isVirtual ) {
+					// Skip if this video is already in the gallery.
+					if ( existingVideoIds.has( numericId ) ) {
+						return;
+					}
+					existingVideoIds.add( numericId );
+				}
+
+				const newBlock = createBlock( 'godam/gallery-v2-item', {
+					videoId: isVirtual ? 0 : numericId,
+				} );
+
+				if ( isVirtual ) {
+					pendingVirtualInserts.current.push( {
+						virtualId: mediaItem.id,
+						blockClientId: newBlock.clientId,
+					} );
+				}
+
+				newBlocks.push( newBlock );
 			} );
 
-			if ( isVirtual ) {
-				pendingVirtualInserts.current.push( {
-					virtualId: mediaItem.id,
-					blockClientId: newBlock.clientId,
-				} );
+			if ( newBlocks.length > 0 ) {
+				insertBlocks( newBlocks, undefined, clientId );
 			}
-
-			insertBlocks( newBlock, undefined, clientId );
 		},
 		[ clientId, insertBlocks ],
 	);

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -216,7 +216,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const [ startDatePopoverOpen, setStartDatePopoverOpen ] = useState( false );
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
 	const [ dateError, setDateError ] = useState( '' );
-	const { insertBlocks, updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { insertBlocks, updateBlockAttributes, removeBlock } = useDispatch( blockEditorStore );
 	const { createNotice } = useDispatch( noticesStore );
 
 	// Tracks {virtualId, blockClientId} pairs for GoDAM virtual insertions
@@ -469,6 +469,22 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			}
 
 			const [ { blockClientId } ] = pendingVirtualInserts.current.splice( idx, 1 );
+
+			// Skip if this video already exists in another gallery item.
+			const { getBlock } = dataSelect( blockEditorStore );
+			const parentBlock = getBlock( clientId );
+			const isDuplicate = ( parentBlock?.innerBlocks || [] ).some(
+				( block ) => block.clientId !== blockClientId && block.attributes?.videoId === attachment.id,
+			);
+			if ( isDuplicate ) {
+				createNotice( 'warning', __( 'Duplicate videos were skipped.', 'godam' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+				removeBlock( blockClientId );
+				return;
+			}
+
 			updateBlockAttributes( blockClientId, { videoId: attachment.id } );
 		};
 
@@ -477,7 +493,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		return () => {
 			document.removeEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
 		};
-	}, [ updateBlockAttributes ] );
+	}, [ clientId, createNotice, removeBlock, updateBlockAttributes ] );
 
 	const renderVideoAppender = useCallback(
 		() => <AddVideoAppender onSelect={ insertHandpickedVideo } />,

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -28,6 +28,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect, select as dataSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { columns, grid, listView, plus } from '@wordpress/icons';
 
@@ -216,6 +217,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
 	const [ dateError, setDateError ] = useState( '' );
 	const { insertBlocks, updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { createNotice } = useDispatch( noticesStore );
 
 	// Tracks {virtualId, blockClientId} pairs for GoDAM virtual insertions
 	// so the godam-virtual-attachment-created event can update the correct block.
@@ -384,6 +386,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			);
 
 			const newBlocks = [];
+			let skippedNonVideo = false;
+			let skippedDuplicate = false;
 
 			items.forEach( ( mediaItem ) => {
 				if ( ! mediaItem?.id ) {
@@ -392,9 +396,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 				// Only allow video attachments.
 				if ( mediaItem.type && mediaItem.type !== 'video' ) {
+					skippedNonVideo = true;
 					return;
 				}
 				if ( mediaItem.mime && ! mediaItem.mime.startsWith( 'video/' ) ) {
+					skippedNonVideo = true;
 					return;
 				}
 
@@ -404,6 +410,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				if ( ! isVirtual ) {
 					// Skip if this video is already in the gallery.
 					if ( existingVideoIds.has( numericId ) ) {
+						skippedDuplicate = true;
 						return;
 					}
 					existingVideoIds.add( numericId );
@@ -423,11 +430,25 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				newBlocks.push( newBlock );
 			} );
 
+			if ( skippedNonVideo ) {
+				createNotice( 'warning', __( 'Only video files can be added to the gallery.', 'godam' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+			}
+
+			if ( skippedDuplicate ) {
+				createNotice( 'warning', __( 'Duplicate videos were skipped.', 'godam' ), {
+					type: 'snackbar',
+					isDismissible: true,
+				} );
+			}
+
 			if ( newBlocks.length > 0 ) {
 				insertBlocks( newBlocks, undefined, clientId );
 			}
 		},
-		[ clientId, insertBlocks ],
+		[ clientId, createNotice, insertBlocks ],
 	);
 
 	// When GoDAM creates a real WP attachment, find the pending child block

--- a/assets/src/blocks/godam-gallery-v2/editor.scss
+++ b/assets/src/blocks/godam-gallery-v2/editor.scss
@@ -23,6 +23,7 @@
 
 	.block-list-appender {
 		position: initial;
+		width: 100%;
 	}
 }
 


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-for-woo/issues/63


This pull request improves the user experience and data integrity of the GoDAM Gallery v2 block by enforcing video-only uploads, preventing duplicate videos in galleries, and enhancing feedback to users. The changes ensure that only valid video files can be added, provide clear warnings when invalid or duplicate files are selected, and support batch video uploads.

**Validation and User Feedback Enhancements:**

* Enforced that only video files (by type and MIME type) can be added to the gallery, displaying a warning notice if a non-video file is selected. [[1]](diffhunk://#diff-3324e9b9615fbf8655a587728572a291c97bd674f7d47f2f59269becf01daab6R71-R102) [[2]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L370-R418) [[3]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L389-R451)
* Added checks to prevent adding duplicate videos within the same gallery, warning the user if a duplicate is attempted. [[1]](diffhunk://#diff-3324e9b9615fbf8655a587728572a291c97bd674f7d47f2f59269becf01daab6R71-R102) [[2]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L370-R418) [[3]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L389-R451)

**Batch Upload and Block Handling:**

* Enabled multi-select for video uploads and updated logic to handle arrays of media items, including skipping and notifying about invalid or duplicate entries. [[1]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R176) [[2]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L370-R418) [[3]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L389-R451)

**Integration with WordPress Notices:**

* Integrated the WordPress notices system (`noticesStore`) to provide user feedback via snackbars for invalid file types and duplicate videos. [[1]](diffhunk://#diff-3324e9b9615fbf8655a587728572a291c97bd674f7d47f2f59269becf01daab6R11-R16) [[2]](diffhunk://#diff-3324e9b9615fbf8655a587728572a291c97bd674f7d47f2f59269becf01daab6R59) [[3]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8L29-R31) [[4]](diffhunk://#diff-c656cc1154e1ccddf78ed0c1b6ea9939c4a743960165a5d1b030a6bf2cc6d1a8R220)

**UI Improvement:**

* Adjusted the gallery appender's width to 100% for better alignment and usability in the editor.


## Demo

https://github.com/user-attachments/assets/0f76d985-cff0-4871-943b-237759457012

## Testing Instructions
**Note:** All changes are related to **Handpicked** mode.

- Check user can select and insert multiple videos into the video gallery block.
- Directly upload the non-video media into the selector and use it. The user will get a proper guide message in a toast.
- Test the single video replacement attachment functionality.
- It should not allow inserting the attachment that already exists in the same video gallery block.
- Only video media is allowed to be inserted.
- Delete the video attachments that are present in the video gallery, and then check the frontend without doing anything in the editor. It should not show the deleted videos in the video gallery.
