### PR TITLE
fix: send type 2 heatmap reliably from GoDAM Video Gallery

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -13,6 +13,96 @@ const { __ } = require( '@wordpress/i18n' );
 	let activeGallery = null;
 	let sharedModal = null;
 
+	// Hard upper bound for how long we wait for an iframe to acknowledge an
+	// analytics flush request. The iframe processes the message synchronously
+	// and only needs to initiate a keepalive fetch, which is essentially
+	// instant — 50ms is a generous safety margin that stays imperceptible to
+	// the user closing or navigating the modal.
+	const FLUSH_ACK_TIMEOUT_MS = 50;
+
+	/**
+	 * Ask the embed iframe to send any pending type 2 (heatmap) analytics for
+	 * the video it is currently playing, then resolve once the iframe acks
+	 * (or the safety timeout elapses).
+	 *
+	 * iframes do not reliably fire pagehide / beforeunload when their src is
+	 * mutated — Safari in particular can drop those events on iframe-level
+	 * navigation. Without this explicit handshake, the type 2 heatmap fetch
+	 * that normally runs in those handlers is lost. We send a same-origin
+	 * postMessage that the analytics script inside the iframe handles by
+	 * issuing a synchronous keepalive fetch while its document is still alive.
+	 *
+	 * @param {HTMLIFrameElement} iframe Modal iframe currently hosting the embed.
+	 * @return {Promise<void>} Resolves after ack or timeout — never rejects.
+	 */
+	function flushIframeAnalytics( iframe ) {
+		return new Promise( ( resolve ) => {
+			if ( ! iframe || ! iframe.contentWindow ) {
+				resolve();
+				return;
+			}
+
+			// Nothing to flush if the iframe is empty or already on about:blank.
+			const currentSrc = iframe.src || '';
+			if ( ! currentSrc || currentSrc === 'about:blank' ) {
+				resolve();
+				return;
+			}
+
+			let targetOrigin;
+			try {
+				targetOrigin = new URL( currentSrc, window.location.origin ).origin;
+			} catch ( err ) {
+				resolve();
+				return;
+			}
+
+			// Cross-origin embeds cannot handle our message — bail rather than
+			// leak the request to an unrelated origin via postMessage('*').
+			if ( targetOrigin !== window.location.origin ) {
+				resolve();
+				return;
+			}
+
+			let settled = false;
+
+			const finish = () => {
+				if ( settled ) {
+					return;
+				}
+				settled = true;
+				window.removeEventListener( 'message', ackHandler );
+				clearTimeout( timeoutId );
+				resolve();
+			};
+
+			const ackHandler = ( event ) => {
+				if (
+					event.source === iframe.contentWindow &&
+					event.origin === targetOrigin &&
+					event.data?.type === 'godamFlushAnalyticsAck'
+				) {
+					finish();
+				}
+			};
+
+			window.addEventListener( 'message', ackHandler );
+			const timeoutId = setTimeout( finish, FLUSH_ACK_TIMEOUT_MS );
+
+			try {
+				iframe.contentWindow.postMessage(
+					{ type: 'godamFlushAnalytics' },
+					targetOrigin,
+				);
+			} catch ( err ) {
+				// postMessage can throw if the iframe document is already gone.
+				// In that case fall through to the timeout — there's nothing
+				// useful left to flush anyway.
+				finish();
+			}
+		} );
+	}
+
 	function initBlurUpPlaceholders( root = document ) {
 		root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
 			if ( div.dataset.godamGalleryBlurInit === '1' ) {
@@ -349,7 +439,7 @@ const { __ } = require( '@wordpress/i18n' );
 			}
 		}
 
-		openModalByIndex( index ) {
+		async openModalByIndex( index ) {
 			this.refreshItems();
 			const item = this.items[ index ];
 			const videoId = item?.dataset?.videoId;
@@ -364,6 +454,13 @@ const { __ } = require( '@wordpress/i18n' );
 
 			this.currentIndex = index;
 			activeGallery = this;
+
+			// When the modal is already showing a video, flush its analytics
+			// before reassigning iframe.src. The previous document's
+			// pagehide/beforeunload cannot be relied on for iframe-level
+			// navigation.
+			await flushIframeAnalytics( this.modal.iframe );
+
 			const engagementsParam = this.engagements === 'show' ? '&engagements=show' : '';
 			this.modal.iframe.src = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1${ engagementsParam }`;
 			this.modal.overlay.classList.add( 'is-active' );
@@ -391,13 +488,15 @@ const { __ } = require( '@wordpress/i18n' );
 			this.openModalByIndex( nextIndex );
 		}
 
-		closeModal() {
+		async closeModal() {
+			// Restore the visual state immediately so the modal closing feels
+			// responsive. The iframe teardown is deferred until after the
+			// analytics flush — a sub-50ms wait that the user does not see.
 			this.modal.overlay.classList.remove( 'is-active' );
 			this.modal.modal.classList.remove( 'is-active' );
 			this.modal.closeButton.classList.remove( 'is-active' );
 			this.modal.prevButton.classList.remove( 'is-active' );
 			this.modal.nextButton.classList.remove( 'is-active' );
-			this.modal.iframe.src = 'about:blank';
 			document.body.classList.remove( 'godam-gallery-v2-modal-open' );
 			this.currentIndex = -1;
 
@@ -409,6 +508,11 @@ const { __ } = require( '@wordpress/i18n' );
 				this.previouslyFocusedElement.focus();
 				this.previouslyFocusedElement = null;
 			}
+
+			// Flush analytics before navigating the iframe to about:blank so
+			// the heatmap fetch is initiated while the embed document is alive.
+			await flushIframeAnalytics( this.modal.iframe );
+			this.modal.iframe.src = 'about:blank';
 		}
 	}
 

--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -7,6 +7,89 @@ import DOMPurify from 'isomorphic-dompurify';
 // Get the REST URL from localized data, fallback to hardcoded path.
 const galleryRestUrl = window.godamGalleryData?.restUrl || '/wp-json/godam/v1/gallery-shortcode';
 
+// Hard upper bound for how long we wait for an iframe to acknowledge an
+// analytics flush request. The iframe processes the message synchronously and
+// only needs to initiate a keepalive fetch, so 50ms is a generous margin that
+// stays imperceptible to the user closing or navigating the modal.
+const GODAM_GALLERY_FLUSH_ACK_TIMEOUT_MS = 50;
+
+/**
+ * Ask the embed iframe to send any pending type 2 (heatmap) analytics for the
+ * video it is currently playing, then resolve once the iframe acks (or the
+ * safety timeout elapses).
+ *
+ * Required because the V1 gallery removes the modal (and its iframe) from the
+ * DOM on close, which suppresses pagehide / beforeunload — and even on src
+ * changes those events are not fired reliably for iframes across browsers.
+ * The analytics script inside the iframe listens for the postMessage and
+ * issues a synchronous keepalive fetch while its document is still alive.
+ *
+ * @param {HTMLIFrameElement} iframe Modal iframe currently hosting the embed.
+ * @return {Promise<void>} Resolves after ack or timeout — never rejects.
+ */
+function flushGalleryIframeAnalytics( iframe ) {
+	return new Promise( ( resolve ) => {
+		if ( ! iframe || ! iframe.contentWindow ) {
+			resolve();
+			return;
+		}
+
+		const currentSrc = iframe.src || '';
+		if ( ! currentSrc || currentSrc === 'about:blank' ) {
+			resolve();
+			return;
+		}
+
+		let targetOrigin;
+		try {
+			targetOrigin = new URL( currentSrc, window.location.origin ).origin;
+		} catch ( err ) {
+			resolve();
+			return;
+		}
+
+		// Skip cross-origin embeds — postMessage('*') would leak the request.
+		if ( targetOrigin !== window.location.origin ) {
+			resolve();
+			return;
+		}
+
+		let settled = false;
+
+		const finish = () => {
+			if ( settled ) {
+				return;
+			}
+			settled = true;
+			window.removeEventListener( 'message', ackHandler );
+			clearTimeout( timeoutId );
+			resolve();
+		};
+
+		const ackHandler = ( event ) => {
+			if (
+				event.source === iframe.contentWindow &&
+				event.origin === targetOrigin &&
+				event.data?.type === 'godamFlushAnalyticsAck'
+			) {
+				finish();
+			}
+		};
+
+		window.addEventListener( 'message', ackHandler );
+		const timeoutId = setTimeout( finish, GODAM_GALLERY_FLUSH_ACK_TIMEOUT_MS );
+
+		try {
+			iframe.contentWindow.postMessage(
+				{ type: 'godamFlushAnalytics' },
+				targetOrigin,
+			);
+		} catch ( err ) {
+			finish();
+		}
+	} );
+}
+
 function initBlurUpPlaceholders( root = document ) {
 	root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
 		if ( div.dataset.godamGalleryBlurInit === '1' ) {
@@ -256,8 +339,12 @@ document.addEventListener( 'click', function( e ) {
 				const animationClass = direction === 'next' ? 'slide-out-up' : 'slide-out-down';
 				modalBody.classList.add( animationClass );
 
-				// After animation, update iframe
-				setTimeout( () => {
+				// After animation, update iframe. Flush analytics from the
+				// outgoing video first so its heatmap is initiated while the
+				// embed document is still alive — iframe-level src changes
+				// don't reliably fire pagehide/beforeunload.
+				setTimeout( async () => {
+					await flushGalleryIframeAnalytics( _iframe );
 					_iframe.src = DOMPurify.sanitize( newVideoUrl );
 
 					modalBody.classList.remove( animationClass );
@@ -609,7 +696,7 @@ document.addEventListener( 'click', function( e ) {
 		document.addEventListener( 'keydown', handleEscape );
 
 		// Close modal function
-		const closeModal = () => {
+		const closeModal = async () => {
 			document.removeEventListener( 'wheel', handleScroll );
 			document.body.removeEventListener( 'touchstart', handleTouchStart );
 			document.body.removeEventListener( 'touchmove', handleTouchMove );
@@ -617,8 +704,19 @@ document.addEventListener( 'click', function( e ) {
 			window.removeEventListener( 'message', handlePostMessage );
 			document.removeEventListener( 'keydown', handleEscape );
 			iframe.removeEventListener( 'load', showModalContent );
-			modal.remove();
+
+			// Hide the modal and restore body scroll immediately so the close
+			// feels responsive. The DOM removal is deferred until after the
+			// analytics flush — a sub-50ms wait that the user does not see.
+			modal.style.display = 'none';
 			document.body.style.overflow = '';
+
+			// Flush analytics before removing the iframe from the DOM —
+			// DOM removal does not fire pagehide/beforeunload, so the type 2
+			// heatmap would otherwise be lost on every modal close.
+			await flushGalleryIframeAnalytics( iframe );
+
+			modal.remove();
 		};
 
 		// Close on X button click

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -237,9 +237,56 @@ if ( ! window.godamUnloadListenerBound ) {
 		}
 	};
 
+	/**
+	 * Explicit flush requested by a parent window (e.g. the GoDAM Video Gallery
+	 * modal before it navigates or removes the iframe).
+	 *
+	 * The browser's pagehide / beforeunload events are unreliable for iframes
+	 * whose src is being changed or whose containing element is being removed
+	 * from the DOM — Safari in particular can skip them, and DOM removal does
+	 * not fire them at all. The gallery sends this message synchronously before
+	 * tearing the iframe down so the type 2 heatmap is reliably dispatched via
+	 * the keepalive fetch path while the document still exists.
+	 *
+	 * @param {MessageEvent} event Cross-window message.
+	 */
+	const handleFlushRequest = ( event ) => {
+		// Only accept same-origin messages — the gallery iframe always loads
+		// video-embed.php from the same site that hosts the gallery block.
+		if ( event.origin !== window.location.origin ) {
+			return;
+		}
+
+		if ( event.data?.type !== 'godamFlushAnalytics' ) {
+			return;
+		}
+
+		window.godamTrackedPlayers.forEach( ( entry, playerInstance ) => {
+			const sent = sendPlayerHeatmap( playerInstance, entry.videoEl, entry.lastSentKey );
+			if ( sent ) {
+				// Stamp the ranges so a subsequent pagehide does not re-send.
+				entry.lastSentKey = sent;
+			}
+		} );
+
+		// Ack so the parent can stop waiting and proceed with the teardown
+		// that motivated the flush. Parent also has a timeout fallback.
+		if ( event.source && typeof event.source.postMessage === 'function' ) {
+			try {
+				event.source.postMessage(
+					{ type: 'godamFlushAnalyticsAck' },
+					event.origin,
+				);
+			} catch ( err ) {
+				// Best-effort — parent will fall back to its timeout.
+			}
+		}
+	};
+
 	window.addEventListener( 'beforeunload', handleUnload );
 	window.addEventListener( 'pagehide', handleUnload ); // For better mobile / bfcache support
 	document.addEventListener( 'visibilitychange', handleVisibilityHidden ); // Tab switch, minimize, screen lock
+	window.addEventListener( 'message', handleFlushRequest ); // Explicit flush from gallery parents
 }
 
 /**


### PR DESCRIPTION
## Summary

Type 2 (heatmap) analytics requests were not being sent when users closed or navigated through the GoDAM Video Gallery modal — affecting both the V1 (`[godam_video_gallery]`) shortcode and the V2 (`godam/gallery-v2`) block.

Both galleries host the player inside an iframe pointing at `video-embed.php`. The analytics script inside that iframe relies on the browser's `pagehide` / `beforeunload` events to flush the type 2 heatmap via a keepalive fetch when the iframe is torn down. Those events are not reliable for iframes:

- **V1 close** calls `modal.remove()`, which detaches the iframe from the DOM without firing `pagehide` or `beforeunload` at all → every modal close drops the heatmap.
- **V2** mutates `iframe.src` (to a new video URL on next/prev, or to `about:blank` on close). Browsers — Safari most consistently — frequently skip `pagehide` / `beforeunload` on iframe-level navigations → same drop reproduces.

## The fix

An explicit same-origin `postMessage` handshake driven by the gallery parents before the iframe is reused or removed.

**[`assets/src/js/godam-player/analytics.js`](https://github.com/rtCamp/godam/blob/fix/gallery-analytics-type-2/assets/src/js/godam-player/analytics.js)** — registers a new \`message\` listener that, on receiving \`{ type: 'godamFlushAnalytics' }\` from the same-origin parent:

- iterates \`window.godamTrackedPlayers\` and calls \`sendPlayerHeatmap\` for each (the same keepalive-fetch path the unload handlers use)
- stamps the per-player \`lastSentKey\` so a subsequent \`pagehide\` that does manage to fire will not re-send identical ranges
- posts a \`godamFlushAnalyticsAck\` back to the source window

**V2 (\`assets/src/blocks/godam-gallery-v2/view.js\`)** and **V1 (\`assets/src/js/godam-gallery.js\`)** gain a \`flushIframeAnalytics\` helper that sends the request and resolves on ack or a 50 ms safety timeout:

- V2 awaits it in \`openModalByIndex\` (before reassigning \`iframe.src\`) and in \`closeModal\` (before setting \`iframe.src = 'about:blank'\`)
- V1 awaits it in the \`updateModalVideo\` src change and in \`closeModal\` immediately before \`modal.remove()\`

Visual modal state (overlay / body classes, body scroll) is restored before the await so the close still feels instant.

Cross-origin embeds are skipped — \`postMessage('*')\` would leak the request, and the iframe analytics only listens for same-origin messages anyway, so a non-matching origin would never ack.

## Test plan

- [ ] **V2 close fires type 2**: Insert a GoDAM Video Gallery V2 block on a page, play a video for a few seconds, close the modal → confirm a POST to \`/analytics/\` with \`type: 2\` and the played ranges in the network tab.
- [ ] **V2 next/prev fires type 2 for previous video**: With multiple videos, play one, click next → confirm type 2 for the previous video before the new one loads.
- [ ] **V1 close fires type 2**: Use \`[godam_video_gallery]\` shortcode, play a video, close → confirm type 2 in network tab.
- [ ] **V1 next/prev fires type 2 for previous video**: Same as V2 but with the V1 shortcode gallery.
- [ ] **No duplicate type 2 on tab close**: Open modal, watch, then close the browser tab without closing the modal first → confirm type 2 fires once (explicit flush dedupes via \`lastSentKey\`, no double-send from pagehide).
- [ ] **No regression in non-iframe scenarios**: A standalone \`[godam_video]\` shortcode on a page → type 2 still fires on tab close / navigation (existing unload path untouched).
- [ ] **No visible delay on close**: Modal overlay disappears immediately when close button is clicked (the ≤ 50 ms iframe teardown is deferred and imperceptible).
- [ ] **Safari**: Repeat the V2 close and navigate tests in Safari — this is the browser where iframe-level \`pagehide\`/\`beforeunload\` is most unreliable, so it's the primary regression target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)