### PR TITLE
fix: Send Analytics type 2 requests for Gallery iframe

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -15,31 +15,39 @@ const { __ } = require( '@wordpress/i18n' );
 
 	/*
 	 * Pull pending heatmap payloads out of the iframe and POST them from
-	 * THIS context, then close. Sending from the iframe right before
-	 * teardown gets cancelled by the browser; sending from here survives.
+	 * THIS context. Sending from the iframe right before teardown gets
+	 * cancelled by the browser; sending from here survives because the
+	 * parent window is not being destroyed. Caller is responsible for
+	 * tearing the iframe down after this returns.
+	 *
 	 * Same-origin direct call — no postMessage round-trip, fully synchronous.
-	 * Cross-origin or missing function: silently fall through to close.
+	 * Cross-origin or missing function: silently no-op.
+	 *
+	 * `keepalive: true` is defense-in-depth here, not the primary mechanism
+	 * (the parent isn't unloading). It only matters if the user closes the
+	 * entire tab during the close handler's brief window — in that case
+	 * keepalive lets the request still reach the wire.
 	 */
-	function flushIframeAnalytics( iframe, onDone ) {
+	function flushIframeAnalytics( iframe ) {
 		try {
 			const win = iframe?.contentWindow;
-			if ( win && typeof win.godamGalleryFlushPayloads === 'function' ) {
-				win.godamGalleryFlushPayloads().forEach( ( payload ) => {
-					if ( ! payload?.endpoint || ! payload?.body ) {
-						return;
-					}
-					fetch( `${ payload.endpoint }/analytics/`, {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify( payload.body ),
-						keepalive: true,
-					} ).catch( () => {} );
-				} );
+			if ( ! win || typeof win.godamGalleryFlushPayloads !== 'function' ) {
+				return;
 			}
+			win.godamGalleryFlushPayloads().forEach( ( payload ) => {
+				if ( ! payload?.endpoint || ! payload?.body ) {
+					return;
+				}
+				fetch( `${ payload.endpoint }/analytics/`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify( payload.body ),
+					keepalive: true,
+				} ).catch( () => {} );
+			} );
 		} catch ( e ) {
-			// Cross-origin access or function threw — fall through to close.
+			// Cross-origin access or function threw — silently no-op.
 		}
-		onDone();
 	}
 
 	function initBlurUpPlaceholders( root = document ) {
@@ -397,11 +405,10 @@ const { __ } = require( '@wordpress/i18n' );
 			const newIframeSrc = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1${ engagementsParam }`;
 
 			// Flush analytics from the previous video (navigation case) before
-			// the iframe navigates away. Same-document first-open is a no-op
-			// because flushIframeAnalytics short-circuits on empty/about:blank.
-			flushIframeAnalytics( this.modal.iframe, () => {
-				this.modal.iframe.src = newIframeSrc;
-			} );
+			// the iframe navigates away. First-open is a no-op because the
+			// iframe is empty/about:blank — godamGalleryFlushPayloads is undefined.
+			flushIframeAnalytics( this.modal.iframe );
+			this.modal.iframe.src = newIframeSrc;
 
 			this.modal.overlay.classList.add( 'is-active' );
 			this.modal.modal.classList.add( 'is-active' );
@@ -435,12 +442,11 @@ const { __ } = require( '@wordpress/i18n' );
 			this.modal.prevButton.classList.remove( 'is-active' );
 			this.modal.nextButton.classList.remove( 'is-active' );
 
-			// Ask the iframe for its pending heatmap payloads, fire them from
-			// here, then reset src. If we set src first the iframe is torn
+			// Ask the iframe for its pending heatmap payloads and fire them from
+			// here BEFORE resetting src. If we set src first the iframe is torn
 			// down and its in-flight analytics POST is cancelled by the browser.
-			flushIframeAnalytics( this.modal.iframe, () => {
-				this.modal.iframe.src = 'about:blank';
-			} );
+			flushIframeAnalytics( this.modal.iframe );
+			this.modal.iframe.src = 'about:blank';
 
 			document.body.classList.remove( 'godam-gallery-v2-modal-open' );
 			this.currentIndex = -1;

--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -13,6 +13,35 @@ const { __ } = require( '@wordpress/i18n' );
 	let activeGallery = null;
 	let sharedModal = null;
 
+	/*
+	 * Pull pending heatmap payloads out of the iframe and POST them from
+	 * THIS context, then close. Sending from the iframe right before
+	 * teardown gets cancelled by the browser; sending from here survives.
+	 * Same-origin direct call — no postMessage round-trip, fully synchronous.
+	 * Cross-origin or missing function: silently fall through to close.
+	 */
+	function flushIframeAnalytics( iframe, onDone ) {
+		try {
+			const win = iframe?.contentWindow;
+			if ( win && typeof win.godamGalleryFlushPayloads === 'function' ) {
+				win.godamGalleryFlushPayloads().forEach( ( payload ) => {
+					if ( ! payload?.endpoint || ! payload?.body ) {
+						return;
+					}
+					fetch( `${ payload.endpoint }/analytics/`, {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify( payload.body ),
+						keepalive: true,
+					} ).catch( () => {} );
+				} );
+			}
+		} catch ( e ) {
+			// Cross-origin access or function threw — fall through to close.
+		}
+		onDone();
+	}
+
 	function initBlurUpPlaceholders( root = document ) {
 		root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
 			if ( div.dataset.godamGalleryBlurInit === '1' ) {
@@ -365,7 +394,15 @@ const { __ } = require( '@wordpress/i18n' );
 			this.currentIndex = index;
 			activeGallery = this;
 			const engagementsParam = this.engagements === 'show' ? '&engagements=show' : '';
-			this.modal.iframe.src = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1${ engagementsParam }`;
+			const newIframeSrc = `${ this.embedBaseUrl }?godam_page=video-embed&id=${ encodeURIComponent( videoId ) }&godam_gallery=1${ engagementsParam }`;
+
+			// Flush analytics from the previous video (navigation case) before
+			// the iframe navigates away. Same-document first-open is a no-op
+			// because flushIframeAnalytics short-circuits on empty/about:blank.
+			flushIframeAnalytics( this.modal.iframe, () => {
+				this.modal.iframe.src = newIframeSrc;
+			} );
+
 			this.modal.overlay.classList.add( 'is-active' );
 			this.modal.modal.classList.add( 'is-active' );
 			this.modal.closeButton.classList.add( 'is-active' );
@@ -397,7 +434,14 @@ const { __ } = require( '@wordpress/i18n' );
 			this.modal.closeButton.classList.remove( 'is-active' );
 			this.modal.prevButton.classList.remove( 'is-active' );
 			this.modal.nextButton.classList.remove( 'is-active' );
-			this.modal.iframe.src = 'about:blank';
+
+			// Ask the iframe for its pending heatmap payloads, fire them from
+			// here, then reset src. If we set src first the iframe is torn
+			// down and its in-flight analytics POST is cancelled by the browser.
+			flushIframeAnalytics( this.modal.iframe, () => {
+				this.modal.iframe.src = 'about:blank';
+			} );
+
 			document.body.classList.remove( 'godam-gallery-v2-modal-open' );
 			this.currentIndex = -1;
 

--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -9,31 +9,39 @@ const galleryRestUrl = window.godamGalleryData?.restUrl || '/wp-json/godam/v1/ga
 
 /*
  * Pull pending heatmap payloads out of the iframe and POST them from
- * THIS context, then close. Sending from the iframe right before
- * teardown gets cancelled by the browser; sending from here survives.
+ * THIS context. Sending from the iframe right before teardown gets
+ * cancelled by the browser; sending from here survives because the
+ * parent window is not being destroyed. Caller is responsible for
+ * tearing the iframe down after this returns.
+ *
  * Same-origin direct call — no postMessage round-trip, fully synchronous.
- * Cross-origin or missing function: silently fall through to close.
+ * Cross-origin or missing function: silently no-op.
+ *
+ * `keepalive: true` is defense-in-depth here, not the primary mechanism
+ * (the parent isn't unloading). It only matters if the user closes the
+ * entire tab during the close handler's brief window — in that case
+ * keepalive lets the request still reach the wire.
  */
-function flushIframeAnalytics( iframe, onDone ) {
+function flushIframeAnalytics( iframe ) {
 	try {
 		const win = iframe?.contentWindow;
-		if ( win && typeof win.godamGalleryFlushPayloads === 'function' ) {
-			win.godamGalleryFlushPayloads().forEach( ( payload ) => {
-				if ( ! payload?.endpoint || ! payload?.body ) {
-					return;
-				}
-				fetch( `${ payload.endpoint }/analytics/`, {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify( payload.body ),
-					keepalive: true,
-				} ).catch( () => {} );
-			} );
+		if ( ! win || typeof win.godamGalleryFlushPayloads !== 'function' ) {
+			return;
 		}
+		win.godamGalleryFlushPayloads().forEach( ( payload ) => {
+			if ( ! payload?.endpoint || ! payload?.body ) {
+				return;
+			}
+			fetch( `${ payload.endpoint }/analytics/`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify( payload.body ),
+				keepalive: true,
+			} ).catch( () => {} );
+		} );
 	} catch ( e ) {
-		// Cross-origin access or function threw — fall through to close.
+		// Cross-origin access or function threw — silently no-op.
 	}
-	onDone();
 }
 
 function initBlurUpPlaceholders( root = document ) {
@@ -290,18 +298,17 @@ document.addEventListener( 'click', function( e ) {
 				// pagehide handler races the navigation and its keepalive POST
 				// gets cancelled by the browser.
 				setTimeout( () => {
-					flushIframeAnalytics( _iframe, () => {
-						_iframe.src = DOMPurify.sanitize( newVideoUrl );
+					flushIframeAnalytics( _iframe );
+					_iframe.src = DOMPurify.sanitize( newVideoUrl );
 
-						modalBody.classList.remove( animationClass );
-						const slideInClass = direction === 'next' ? 'slide-in-down' : 'slide-in-up';
-						modalBody.classList.add( slideInClass );
+					modalBody.classList.remove( animationClass );
+					const slideInClass = direction === 'next' ? 'slide-in-down' : 'slide-in-up';
+					modalBody.classList.add( slideInClass );
 
-						// Remove animation class after transition
-						setTimeout( () => {
-							modalBody.classList.remove( slideInClass );
-						}, 300 );
-					} );
+					// Remove animation class after transition
+					setTimeout( () => {
+						modalBody.classList.remove( slideInClass );
+					}, 300 );
 				}, 300 );
 			}
 		};
@@ -655,10 +662,9 @@ document.addEventListener( 'click', function( e ) {
 			// Flush analytics from the iframe BEFORE removing it. Removing the
 			// element synchronously cancels every in-flight request — including
 			// the keepalive heatmap POST from the iframe's pagehide handler.
-			flushIframeAnalytics( iframe, () => {
-				modal.remove();
-				document.body.style.overflow = '';
-			} );
+			flushIframeAnalytics( iframe );
+			modal.remove();
+			document.body.style.overflow = '';
 		};
 
 		// Close on X button click

--- a/assets/src/js/godam-gallery.js
+++ b/assets/src/js/godam-gallery.js
@@ -7,6 +7,35 @@ import DOMPurify from 'isomorphic-dompurify';
 // Get the REST URL from localized data, fallback to hardcoded path.
 const galleryRestUrl = window.godamGalleryData?.restUrl || '/wp-json/godam/v1/gallery-shortcode';
 
+/*
+ * Pull pending heatmap payloads out of the iframe and POST them from
+ * THIS context, then close. Sending from the iframe right before
+ * teardown gets cancelled by the browser; sending from here survives.
+ * Same-origin direct call — no postMessage round-trip, fully synchronous.
+ * Cross-origin or missing function: silently fall through to close.
+ */
+function flushIframeAnalytics( iframe, onDone ) {
+	try {
+		const win = iframe?.contentWindow;
+		if ( win && typeof win.godamGalleryFlushPayloads === 'function' ) {
+			win.godamGalleryFlushPayloads().forEach( ( payload ) => {
+				if ( ! payload?.endpoint || ! payload?.body ) {
+					return;
+				}
+				fetch( `${ payload.endpoint }/analytics/`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify( payload.body ),
+					keepalive: true,
+				} ).catch( () => {} );
+			} );
+		}
+	} catch ( e ) {
+		// Cross-origin access or function threw — fall through to close.
+	}
+	onDone();
+}
+
 function initBlurUpPlaceholders( root = document ) {
 	root.querySelectorAll( '.godam-gallery-blurred-img' ).forEach( ( div ) => {
 		if ( div.dataset.godamGalleryBlurInit === '1' ) {
@@ -256,18 +285,23 @@ document.addEventListener( 'click', function( e ) {
 				const animationClass = direction === 'next' ? 'slide-out-up' : 'slide-out-down';
 				modalBody.classList.add( animationClass );
 
-				// After animation, update iframe
+				// After animation, flush analytics for the outgoing video, THEN
+				// swap the iframe src. Without the flush, the previous page's
+				// pagehide handler races the navigation and its keepalive POST
+				// gets cancelled by the browser.
 				setTimeout( () => {
-					_iframe.src = DOMPurify.sanitize( newVideoUrl );
+					flushIframeAnalytics( _iframe, () => {
+						_iframe.src = DOMPurify.sanitize( newVideoUrl );
 
-					modalBody.classList.remove( animationClass );
-					const slideInClass = direction === 'next' ? 'slide-in-down' : 'slide-in-up';
-					modalBody.classList.add( slideInClass );
+						modalBody.classList.remove( animationClass );
+						const slideInClass = direction === 'next' ? 'slide-in-down' : 'slide-in-up';
+						modalBody.classList.add( slideInClass );
 
-					// Remove animation class after transition
-					setTimeout( () => {
-						modalBody.classList.remove( slideInClass );
-					}, 300 );
+						// Remove animation class after transition
+						setTimeout( () => {
+							modalBody.classList.remove( slideInClass );
+						}, 300 );
+					} );
 				}, 300 );
 			}
 		};
@@ -617,8 +651,14 @@ document.addEventListener( 'click', function( e ) {
 			window.removeEventListener( 'message', handlePostMessage );
 			document.removeEventListener( 'keydown', handleEscape );
 			iframe.removeEventListener( 'load', showModalContent );
-			modal.remove();
-			document.body.style.overflow = '';
+
+			// Flush analytics from the iframe BEFORE removing it. Removing the
+			// element synchronously cancels every in-flight request — including
+			// the keepalive heatmap POST from the iframe's pagehide handler.
+			flushIframeAnalytics( iframe, () => {
+				modal.remove();
+				document.body.style.overflow = '';
+			} );
 		};
 
 		// Close on X button click

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -206,6 +206,12 @@ if ( ! window.godamUnloadListenerBound ) {
 	 */
 	const handleUnload = () => {
 		window.godamTrackedPlayers.forEach( ( entry, playerInstance ) => {
+			// Parent gallery already POSTed this player's heatmap from its
+			// own context; skipping here avoids the duplicate (and the
+			// cancelled retry that the browser kills during iframe teardown).
+			if ( entry.flushedByGallery ) {
+				return;
+			}
 			// Pass lastSentKey so sendPlayerHeatmap skips if visibilitychange already
 			// sent these exact ranges (avoids double-send on tab close).
 			sendPlayerHeatmap( playerInstance, entry.videoEl, entry.lastSentKey );
@@ -226,6 +232,10 @@ if ( ! window.godamUnloadListenerBound ) {
 	const handleVisibilityHidden = () => {
 		if ( document.visibilityState === 'hidden' ) {
 			window.godamTrackedPlayers.forEach( ( entry, playerInstance ) => {
+				// Parent gallery has already claimed this player — skip.
+				if ( entry.flushedByGallery ) {
+					return;
+				}
 				const sent = sendPlayerHeatmap( playerInstance, entry.videoEl );
 				if ( sent ) {
 					// Stamp the ranges that were just sent so the unload handler
@@ -243,38 +253,36 @@ if ( ! window.godamUnloadListenerBound ) {
 }
 
 /**
- * Send heatmap data for a single player via a keepalive fetch.
+ * Build a heatmap analytics payload for a single player without sending it.
  *
- * Returns a string fingerprint of the ranges sent (used by the visibilitychange handler
- * to avoid re-sending identical data in the subsequent pagehide/beforeunload), or null
- * if nothing was sent.
+ * Split out from sendPlayerHeatmap so the same payload can be either:
+ * - fetched from this context (the normal unload/dispose path), or
+ * - handed to a parent window via postMessage (the gallery-modal-close path,
+ * where the iframe is about to be torn down and an in-context fetch would
+ * be cancelled by the browser).
  *
  * @param {Object}      player    - VideoJS player instance
  * @param {HTMLElement} video     - Video container element
- * @param {string|null} skipIfKey - If provided, skip sending when current ranges fingerprint matches this key.
- * @return {string|null} Fingerprint of sent ranges, or null if skipped.
+ * @param {string|null} skipIfKey - Skip when current ranges fingerprint matches this key.
+ * @return {{endpoint: string, body: Object, fingerprint: string}|null} - Payload data for the heatmap event, or null if no valid payload could be built or if skipped due to matching skipIfKey.
  */
-function sendPlayerHeatmap( player, video, skipIfKey = null ) {
+function buildHeatmapPayload( player, video, skipIfKey = null ) {
 	if ( ! player || ! video ) {
 		return null;
 	}
 
 	try {
-		// Double check player isn't disposed natively beforehand
 		if ( typeof player.isDisposed === 'function' && player.isDisposed() ) {
 			return null;
 		}
 
 		const ranges = collectPlayedRanges( player );
-
 		if ( ranges.length === 0 ) {
-			return null; // Nothing played — skip
+			return null;
 		}
 
-		const rangesKey = JSON.stringify( ranges );
-
-		// Skip if the caller already sent these exact ranges (visibilitychange → pagehide dedup).
-		if ( skipIfKey && rangesKey === skipIfKey ) {
+		const fingerprint = JSON.stringify( ranges );
+		if ( skipIfKey && fingerprint === skipIfKey ) {
 			return null;
 		}
 
@@ -284,29 +292,12 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 			return null;
 		}
 
-		// Skip the same conditions the analytics plugin does.
 		if ( shouldSkipAnalytics() ) {
 			return null;
 		}
 
 		const videoLength = Number( player.duration && player.duration() ) || 0;
 
-		/*
-		 * IMPORTANT: We bypass window.analytics.track() here intentionally.
-		 *
-		 * This function is called from beforeunload / pagehide / dispose handlers.
-		 * window.analytics.track() dispatches async work (Promises, microtasks).
-		 * The browser does NOT block page unload waiting for async work to settle —
-		 * the async chain can be silently abandoned mid-flight.
-		 *
-		 * The correct fix is to call fetch() with keepalive: true SYNCHRONOUSLY
-		 * inside the handler. The browser queues a keepalive request at the network
-		 * level and guarantees delivery even after the JS context is torn down.
-		 * This is the spec-compliant equivalent of navigator.sendBeacon() for POST
-		 * requests that need a JSON body.
-		 *
-		 * Reference: https://fetch.spec.whatwg.org/#keep-alive-flag
-		 */
 		const { endpoint, body } = buildAnalyticsRequestBody( {
 			type: 2,
 			userToken: window.analytics?.user?.()?.anonymousId || '',
@@ -320,21 +311,105 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 			return null;
 		}
 
-		// keepalive: true guarantees the request outlives the page. We do NOT
-		// await — the browser handles delivery asynchronously at the network
-		// layer, entirely outside our JS execution context.
-		fetch( endpoint + '/analytics/', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify( body ),
-			keepalive: true,
-		} );
-
-		return rangesKey; // Return fingerprint so caller can stamp it.
+		return { endpoint, body, fingerprint };
 	} catch ( e ) {
-		// Silently ignore — we are in an unload handler and cannot surface errors.
 		return null;
 	}
+}
+
+/**
+ * Send heatmap data for a single player via a keepalive fetch.
+ *
+ * Returns a string fingerprint of the ranges sent (used by the visibilitychange handler
+ * to avoid re-sending identical data in the subsequent pagehide/beforeunload), or null
+ * if nothing was sent.
+ *
+ * @param {Object}      player    - VideoJS player instance
+ * @param {HTMLElement} video     - Video container element
+ * @param {string|null} skipIfKey - If provided, skip sending when current ranges fingerprint matches this key.
+ * @return {string|null} Fingerprint of sent ranges, or null if skipped.
+ */
+function sendPlayerHeatmap( player, video, skipIfKey = null ) {
+	const payload = buildHeatmapPayload( player, video, skipIfKey );
+	if ( ! payload ) {
+		return null;
+	}
+
+	/*
+	 * IMPORTANT: We bypass window.analytics.track() here intentionally.
+	 *
+	 * This function is called from beforeunload / pagehide / dispose handlers.
+	 * window.analytics.track() dispatches async work (Promises, microtasks).
+	 * The browser does NOT block page unload waiting for async work to settle.
+	 *
+	 * keepalive: true queues the request at the network layer so it survives
+	 * top-level page unload. Note: keepalive does NOT survive iframe element
+	 * removal by the parent — that case is handled by the gallery's
+	 * `godamGalleryClose` postMessage flow below.
+	 *
+	 * Reference: https://fetch.spec.whatwg.org/#keep-alive-flag
+	 */
+	fetch( payload.endpoint + '/analytics/', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify( payload.body ),
+		keepalive: true,
+	} );
+
+	return payload.fingerprint;
+}
+
+/*
+ * Gallery-modal-close flush — exposed for the GoDAM gallery modal in the
+ * parent window. Returns the heatmap payloads the parent should POST from
+ * its own (not-being-destroyed) context before tearing this iframe down.
+ * Sending them from here would lose the request to the iframe-teardown
+ * cancel. Stamps each player's lastSentKey so the iframe's own pagehide /
+ * dispose handlers will dedupe and skip the same ranges later.
+ *
+ * Same-origin only. The parent calls `iframe.contentWindow.godamGalleryFlushPayloads()`
+ * directly; if the iframe is cross-origin the access throws SecurityError
+ * which the parent catches and falls through to its normal close path.
+ */
+// Only expose the gallery flush API when this script is running inside a
+// gallery iframe. The gallery embeds the video-embed page with
+// `?godam_gallery=1` in the iframe URL; on any other page (standalone embed,
+// admin preview, regular video on a post) the function is not defined and
+// `flushedByGallery` never gets set — so all non-gallery analytics paths
+// behave exactly as they did before this change.
+const isGalleryIframeContext = ( () => {
+	try {
+		return new URLSearchParams( window.location.search ).get( 'godam_gallery' ) === '1';
+	} catch ( e ) {
+		return false;
+	}
+} )();
+
+if ( isGalleryIframeContext ) {
+	window.godamGalleryFlushPayloads = function() {
+		const payloads = [];
+		if ( ! window.godamTrackedPlayers ) {
+			return payloads;
+		}
+		window.godamTrackedPlayers.forEach( ( entry, playerInstance ) => {
+			const payload = buildHeatmapPayload(
+				playerInstance,
+				entry.videoEl,
+				entry.lastSentKey,
+			);
+			if ( payload ) {
+				payloads.push( { endpoint: payload.endpoint, body: payload.body } );
+				entry.lastSentKey = payload.fingerprint;
+			}
+			// Parent gallery has taken responsibility for this player's type 2
+			// analytics. The iframe-side unload/visibility/dispose handlers must
+			// skip it from here on — sending again would double-count on the
+			// server, and the second attempt is the one the browser cancels
+			// during teardown anyway.
+			entry.flushedByGallery = true;
+		} );
+		return payloads;
+	};
 }
 
 function setupPlayerAnalytics( player, video ) {
@@ -363,8 +438,13 @@ function setupPlayerAnalytics( player, video ) {
 	// Send heatmap when player is unmounted/disposed (e.g. AJAX navigation)
 	player.on( 'dispose', () => {
 		if ( window.godamTrackedPlayers.has( player ) ) {
-			const { videoEl, lastSentKey } = window.godamTrackedPlayers.get( player );
-			sendPlayerHeatmap( player, videoEl, lastSentKey );
+			const entry = window.godamTrackedPlayers.get( player );
+			// Parent gallery already sent this player's heatmap from its
+			// own context — don't fire a second (cancelled) request as the
+			// iframe tears down.
+			if ( ! entry.flushedByGallery ) {
+				sendPlayerHeatmap( player, entry.videoEl, entry.lastSentKey );
+			}
 			window.godamTrackedPlayers.delete( player );
 		}
 	} );

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -345,7 +345,7 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 	 * keepalive: true queues the request at the network layer so it survives
 	 * top-level page unload. Note: keepalive does NOT survive iframe element
 	 * removal by the parent — that case is handled by the gallery's
-	 * `godamGalleryClose` postMessage flow below.
+	 * `godamGalleryFlushPayloads` direct-call flow below.
 	 *
 	 * Reference: https://fetch.spec.whatwg.org/#keep-alive-flag
 	 */
@@ -401,11 +401,14 @@ if ( isGalleryIframeContext ) {
 				payloads.push( { endpoint: payload.endpoint, body: payload.body } );
 				entry.lastSentKey = payload.fingerprint;
 			}
-			// Parent gallery has taken responsibility for this player's type 2
-			// analytics. The iframe-side unload/visibility/dispose handlers must
-			// skip it from here on — sending again would double-count on the
-			// server, and the second attempt is the one the browser cancels
-			// during teardown anyway.
+			// Set unconditionally — even when buildHeatmapPayload returned null.
+			// Every null-return represents "nothing to send right now" (no ranges,
+			// already-sent fingerprint, disposed, skip-analytics flag, etc.), so
+			// suppressing the iframe-side handlers is always safe here. Setting it
+			// only inside `if ( payload )` would be a regression: if more ranges
+			// accumulate between this call and iframe teardown, the iframe's own
+			// pagehide/dispose would fire and get cancelled by the teardown — the
+			// exact failure mode this whole flow exists to prevent.
 			entry.flushedByGallery = true;
 		} );
 		return payloads;


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam/issues/1882

This pull request introduces a robust mechanism to reliably send video heatmap analytics when navigating or closing Godam gallery modals, addressing browser behavior that cancels in-flight requests during iframe teardown. The changes ensure that analytics payloads are flushed from the parent context before iframes are removed or navigated, preventing data loss and double-counting. The implementation involves both the gallery modal code and the video analytics module, with careful coordination to avoid duplicate POSTs.

**Key changes:**

**Reliable analytics flushing from parent context**
- Added a `flushIframeAnalytics` function in both `assets/src/blocks/godam-gallery-v2/view.js` and `assets/src/js/godam-gallery.js` to extract pending heatmap analytics payloads from the iframe and POST them from the parent context before navigating away or removing the iframe. This avoids browser cancellation of requests sent from the iframe during teardown. [[1]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354R16-R44) [[2]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798R10-R38)
- Updated gallery modal navigation and close logic to call `flushIframeAnalytics` before changing the iframe `src` or removing the element, ensuring all analytics are sent reliably. [[1]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354L368-R405) [[2]](diffhunk://#diff-de1f478cccb95c2dd52b49018777e45068f5f3f5fa6bc88f5c345486b0c1f354R437-R444) [[3]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798L259-R293) [[4]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798R304) [[5]](diffhunk://#diff-e762d5dad902c67683d603d3d10e36e3f824f1cf1fc568643400c2406aee2798R654-R661)

**Analytics module refactor and coordination**
- Refactored the analytics module to split heatmap payload creation into a new `buildHeatmapPayload` function, allowing payloads to be generated without sending, and exposed a `godamGalleryFlushPayloads` API on gallery iframes for the parent to invoke. [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL246-R285) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL323-R412)
- Marked players as `flushedByGallery` when their analytics are handled by the parent, so iframe-side unload/visibility/dispose handlers skip sending again, preventing duplicate or cancelled POSTs. [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR209-R214) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR235-R238) [[3]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL366-R447)

**Other improvements**
- Improved inline documentation throughout the analytics code to clarify browser behaviors, API contracts, and rationale for the changes. [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL246-R285) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL323-R412)

These changes ensure accurate and reliable analytics reporting for Godam gallery video embeds, even during rapid navigation or modal closure.


## Recording

https://github.com/user-attachments/assets/e5fb13fe-bfc6-4463-9edd-ac0bee669091


