### PR TITLE
feat: Reel Pop analytics — SDK page_load_session_id + Dashboard table

### DIFF
--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -153,6 +153,7 @@ export function buildAnalyticsRequestBody( {
 	videoIds = [],
 	ranges = [],
 	videoLength = 0,
+	reelPopId = 0,
 } ) {
 	const {
 		endpoint,
@@ -230,6 +231,12 @@ export function buildAnalyticsRequestBody( {
 	// server-side validation that returns HTTP 400.
 	if ( jobId ) {
 		body.job_id = jobId;
+	}
+
+	// Optional reel-pop attribution — only included when > 0 so non-Reel-Pop
+	// events stay at the same wire shape as before.
+	if ( reelPopId && parseInt( reelPopId, 10 ) > 0 ) {
+		body.reel_pop_id = parseInt( reelPopId, 10 );
 	}
 
 	return { endpoint, body };

--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -7,6 +7,35 @@
  */
 
 /**
+ * Per-page-load session ID — UUID v4, generated once on first call, reused for
+ * the rest of the page load. Lives on the analytics envelope so the microservice
+ * can dedup engagement counters with uniqExact(page_load_session_id), keeping
+ * derived rates (Engagement / Impressions etc.) bounded ≤ 100%.
+ *
+ * Uses crypto.randomUUID() where available, falling back to a hand-rolled v4
+ * via crypto.getRandomValues() for older browsers (e.g. mobile Safari < 15.4).
+ *
+ * @return {string} 36-char UUID v4 string.
+ */
+let _pageLoadSessionId = null;
+export function getPageLoadSessionId() {
+	if ( _pageLoadSessionId ) {
+		return _pageLoadSessionId;
+	}
+	if ( window.crypto?.randomUUID ) {
+		_pageLoadSessionId = window.crypto.randomUUID();
+		return _pageLoadSessionId;
+	}
+	// Fallback for older browsers.
+	const bytes = window.crypto.getRandomValues( new Uint8Array( 16 ) );
+	bytes[ 6 ] = ( bytes[ 6 ] & 0x0f ) | 0x40; // version 4
+	bytes[ 8 ] = ( bytes[ 8 ] & 0x3f ) | 0x80; // variant 10
+	const hex = Array.from( bytes, ( b ) => b.toString( 16 ).padStart( 2, '0' ) ).join( '' );
+	_pageLoadSessionId = `${ hex.slice( 0, 8 ) }-${ hex.slice( 8, 12 ) }-${ hex.slice( 12, 16 ) }-${ hex.slice( 16, 20 ) }-${ hex.slice( 20 ) }`;
+	return _pageLoadSessionId;
+}
+
+/**
  * Check if we should skip analytics tracking.
  *
  * @return {boolean} True if analytics should be skipped, false otherwise.

--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -184,6 +184,7 @@ export function buildAnalyticsRequestBody( {
 	const body = {
 		site_url: window.location.origin,
 		user_token: userToken,
+		page_load_session_id: getPageLoadSessionId(), // Per-page-load UUID v4 for dedup.
 		wp_user_id: parseInt( userId, 10 ) || 0,
 		account_token: token || '',
 		email: emailId || '',

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -315,6 +315,11 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 		 *
 		 * Reference: https://fetch.spec.whatwg.org/#keep-alive-flag
 		 */
+		// Forward reel-pop attribution when the surrounding plugin (e.g. godam-for-woo)
+		// tagged the <video> element. The SDK itself doesn't know what a Reel Pop is —
+		// this just opaquely propagates the attribute when present.
+		const reelPopId = parseInt( video.getAttribute( 'data-reel-pop-id' ), 10 ) || 0;
+
 		const { endpoint, body } = buildAnalyticsRequestBody( {
 			type: 2,
 			userToken: window.analytics?.user?.()?.anonymousId || '',
@@ -322,6 +327,7 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 			jobId,
 			ranges,
 			videoLength,
+			reelPopId,
 		} );
 
 		if ( ! endpoint ) {

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -90,7 +90,7 @@ function collectPlayedRanges( player ) {
 	 *
 	 * @since 1.4.2
 	 */
-	window.analytics.trackVideoEvent = ( { type, videoId, root, sendPageLoad = true } = {} ) => {
+	window.analytics.trackVideoEvent = ( { type, videoId, root, sendPageLoad = true, reelPopId = 0 } = {} ) => {
 		if ( ! type ) {
 			return false;
 		}
@@ -120,7 +120,11 @@ function collectPlayedRanges( player ) {
 			// NOTE: This automatically sends a 'page_load' event before the heatmap event, for ease of use.
 			// This is intentional behavior but may cause duplicate type 1 events in some scenarios
 			if ( sendPageLoad ) {
-				window.analytics.track( 'page_load', { type: 1, videoIds: [ [ vid, jobId ] ] } );
+				const pageLoadPayload = { type: 1, videoIds: [ [ vid, jobId ] ] };
+				if ( reelPopId > 0 ) {
+					pageLoadPayload.reel_pop_id = parseInt( reelPopId, 10 );
+				}
+				window.analytics.track( 'page_load', pageLoadPayload );
 			}
 
 			const player = getPlayer( videoEl );
@@ -135,13 +139,17 @@ function collectPlayedRanges( player ) {
 
 			const videoLength = Number( player.duration && player.duration() ) || 0;
 
-			window.analytics.track( 'video_heatmap', {
+			const heatmapPayload = {
 				type: 2,
 				videoId: vid,
 				jobId,
 				ranges,
 				videoLength,
-			} );
+			};
+			if ( reelPopId > 0 ) {
+				heatmapPayload.reel_pop_id = parseInt( reelPopId, 10 );
+			}
+			window.analytics.track( 'video_heatmap', heatmapPayload );
 			return true;
 		}
 

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -7,7 +7,7 @@ import { Analytics } from 'analytics';
  */
 import videoAnalyticsPlugin from './video-analytics-plugin';
 import GTMVideoTracker from './gtm-video-tracker';
-import { shouldSkipAnalytics, buildAnalyticsRequestBody } from './analytics-helpers';
+import { shouldSkipAnalytics, buildAnalyticsRequestBody, getUserAgent, getPageLoadSessionId } from './analytics-helpers';
 
 const analytics = Analytics( {
 	app: 'analytics-cdp-plugin',
@@ -16,6 +16,15 @@ const analytics = Analytics( {
 	],
 } );
 window.analytics = analytics;
+
+// Expose helpers that godam-for-woo (and other plugins) need to call so type=4
+// events produce identical normalized UA strings + share the per-page-load
+// session ID. window.analytics is the Analytics() library instance — keep our
+// helpers on a separate namespace to avoid collisions.
+window.RTGodamAnalyticsHelpers = {
+	getPageLoadSessionId,
+	getUserAgent,
+};
 
 /**
  * Collect all played time ranges from a VideoJS player instance.

--- a/assets/src/js/godam-player/video-analytics-plugin.js
+++ b/assets/src/js/godam-player/video-analytics-plugin.js
@@ -14,7 +14,7 @@ const videoAnalyticsPlugin = () => {
 			const { properties, meta, anonymousId } = payload;
 
 			try {
-				const { ranges = [], videoId, type, videoLength, videoIds, jobId } = properties;
+				const { ranges = [], videoId, type, videoLength, videoIds, jobId, reel_pop_id: reelPopId } = properties;
 
 				if ( ! type || ( type === 1 && ( ! videoIds || videoIds.length === 0 ) ) ) {
 					return;
@@ -29,6 +29,7 @@ const videoAnalyticsPlugin = () => {
 					videoIds,
 					ranges,
 					videoLength,
+					reelPopId,
 				} );
 
 				if ( ! endpoint ) {

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -37,6 +37,7 @@ use RTGODAM\Inc\REST_API\Media_Library;
 use RTGODAM\Inc\REST_API\Ads;
 use RTGODAM\Inc\REST_API\Transcoding;
 use RTGODAM\Inc\REST_API\Analytics;
+use RTGODAM\Inc\REST_API\Dashboard;
 use RTGODAM\Inc\REST_API\Polls;
 use RTGODAM\Inc\REST_API\Dynamic_Shortcode;
 use RTGODAM\Inc\REST_API\Dynamic_Gallery;
@@ -176,6 +177,7 @@ class Plugin {
 		Ads::get_instance();
 		Transcoding::get_instance();
 		Analytics::get_instance();
+		Dashboard::get_instance();
 		Deactivation::get_instance();
 		Polls::get_instance();
 		Dynamic_Shortcode::get_instance();

--- a/inc/classes/rest-api/class-dashboard.php
+++ b/inc/classes/rest-api/class-dashboard.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * REST API class for the GoDAM Dashboard — Reel Pops summary proxy.
+ *
+ * Proxies the godam-analytics `/reel-pops/summary` endpoint, injecting the
+ * site's API key + account token server-side so the browser never sees them.
+ * Enriches each row with the WordPress post title / thumbnail / edit URL so the
+ * React table can render a click-through to the Reel Pop editor.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\REST_API;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Class Dashboard.
+ */
+class Dashboard extends Base {
+
+	/**
+	 * REST route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'dashboard';
+
+	/**
+	 * Cache TTL for the upstream response (seconds).
+	 *
+	 * @var int
+	 */
+	const CACHE_TTL = 60;
+
+	/**
+	 * Register custom REST API routes for the Dashboard.
+	 *
+	 * @return array Array of registered REST API routes.
+	 */
+	public function get_rest_routes() {
+		return array(
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/reel-pops-summary',
+				'args'      => array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_reel_pops_summary' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+					'args'                => array(
+						'from' => array(
+							'required'          => false,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'to'   => array(
+							'required'          => false,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check — only site admins may view the cross-Reel-Pop summary.
+	 *
+	 * @return bool
+	 */
+	public function permission_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Fetch the cumulative Reel Pops summary from the godam-analytics
+	 * microservice and enrich each row with WP post metadata.
+	 *
+	 * @param WP_REST_Request $request REST API request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_reel_pops_summary( WP_REST_Request $request ) {
+		$endpoint      = defined( 'RTGODAM_ANALYTICS_BASE' ) ? RTGODAM_ANALYTICS_BASE : 'https://analytics.godam.io';
+		$api_key       = get_option( 'rtgodam-api-key', '' );
+		$account_token = get_option( 'rtgodam-account-token', 'unverified' );
+		$site_url      = home_url();
+		$from          = $request->get_param( 'from' );
+		$to            = $request->get_param( 'to' );
+
+		if ( empty( $api_key ) || empty( $account_token ) || 'unverified' === $account_token ) {
+			return new WP_Error(
+				'godam_unconfigured',
+				__( 'GoDAM API key not configured.', 'godam' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$cache_key = 'godam_rp_dashboard_summary_' . md5( $account_token . '|' . (string) $from . '|' . (string) $to );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return rest_ensure_response( $cached );
+		}
+
+		$query_args = array_filter(
+			array(
+				'account_token' => $account_token,
+				'site_url'      => $site_url,
+				'from'          => $from,
+				'to'            => $to,
+			)
+		);
+
+		$url = add_query_arg(
+			$query_args,
+			trailingslashit( $endpoint ) . 'reel-pops/summary'
+		);
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'headers' => array( 'X-API-Key' => $api_key ),
+				'timeout' => 5,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'godam_upstream',
+				$response->get_error_message(),
+				array( 'status' => 502 )
+			);
+		}
+
+		$status = wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status >= 400 || ! is_array( $body ) ) {
+			return new WP_Error(
+				'godam_upstream',
+				__( 'Failed to fetch Reel Pops summary.', 'godam' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		// Enrich each row with WP post title / thumbnail / edit URL so the React
+		// table can render a click-through. Drop rows whose post no longer exists
+		// or isn't published — ghost rows would just confuse the admin.
+		$enriched = array();
+		$rows     = isset( $body['reel_pops'] ) && is_array( $body['reel_pops'] ) ? $body['reel_pops'] : array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$reel_pop_id = isset( $row['reel_pop_id'] ) ? (int) $row['reel_pop_id'] : 0;
+			if ( $reel_pop_id <= 0 ) {
+				continue;
+			}
+			$post = get_post( $reel_pop_id );
+			if ( ! $post || 'publish' !== $post->post_status ) {
+				continue;
+			}
+			$thumbnail        = get_the_post_thumbnail_url( $reel_pop_id, 'thumbnail' );
+			$row['title']     = get_the_title( $post );
+			$row['thumbnail'] = $thumbnail ? $thumbnail : '';
+			$row['edit_url']  = admin_url( 'post.php?post=' . $reel_pop_id . '&action=edit' );
+			$enriched[]       = $row;
+		}
+
+		$body['reel_pops'] = $enriched;
+
+		set_transient( $cache_key, $body, self::CACHE_TTL );
+
+		return rest_ensure_response( $body );
+	}
+}

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -27,6 +27,7 @@ import chevronRight from '../../assets/src/images/chevron-right.svg';
 import NewYearSaleBanner from '../../assets/src/images/new-year-sale-2026.webp';
 import UpgradePlanDashboardBg from '../../assets/src/images/upgrade-plan-dashboard-bg.webp';
 import { formatNumber, formatWatchTime } from '../utils/formatters';
+import ReelPopsTable from './components/ReelPopsTable';
 
 const Dashboard = () => {
 	const [ topVideosPage, setTopVideosPage ] = useState( 1 );
@@ -512,6 +513,8 @@ const Dashboard = () => {
 						</div>
 					</div>
 				</div>
+
+				<ReelPopsTable />
 			</div>
 		</div>
 	);

--- a/pages/dashboard/components/ReelPopsTable.jsx
+++ b/pages/dashboard/components/ReelPopsTable.jsx
@@ -1,0 +1,186 @@
+/**
+ * Reel Pops cumulative table for the GoDAM Dashboard.
+ *
+ * Fetches /godam/v1/dashboard/reel-pops-summary once on mount and renders one
+ * row per Reel Pop with the four cumulative counters (Impressions, Engagement,
+ * Closure, Conversion). Each row links to the Reel Pop editor.
+ *
+ * Counters are unique page-load sessions (uniqExact(page_load_session_id) on
+ * the microservice), so derived rates are bounded ≤ 100%.
+ *
+ * @package GoDAM
+ */
+
+import React, { useEffect, useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatNumber } from '../../utils/formatters';
+import chevronLeft from '../../../assets/src/images/chevron-left.svg';
+import chevronRight from '../../../assets/src/images/chevron-right.svg';
+import DefaultThumbnail from '../../../assets/src/images/video-thumbnail-default.png';
+
+const PAGE_SIZE = 10;
+
+const ReelPopsTable = () => {
+	const [ rows, setRows ] = useState( null );
+	const [ error, setError ] = useState( null );
+	const [ page, setPage ] = useState( 1 );
+
+	useEffect( () => {
+		apiFetch( { path: '/godam/v1/dashboard/reel-pops-summary' } )
+			.then( ( data ) => setRows( Array.isArray( data?.reel_pops ) ? data.reel_pops : [] ) )
+			.catch( ( err ) => setError( err?.message || __( 'Failed to load Reel Pops summary.', 'godam' ) ) );
+	}, [] );
+
+	if ( error ) {
+		return (
+			<div className="top-media-container godam-reel-pops-table godam-reel-pops-table--error">
+				<div className="flex justify-between pt-4">
+					<h2>{ __( 'Reel Pops', 'godam' ) }</h2>
+				</div>
+				<p>{ error }</p>
+			</div>
+		);
+	}
+
+	if ( null === rows ) {
+		return (
+			<div className="top-media-container godam-reel-pops-table godam-reel-pops-table--loading">
+				<div className="flex justify-between pt-4">
+					<h2>{ __( 'Reel Pops', 'godam' ) }</h2>
+				</div>
+				<div className="table-container overflow-x-auto">
+					<div className="space-y-4 mt-3">
+						<div className="skeleton h-4 w-full"></div>
+						<div className="skeleton h-4 w-full"></div>
+						<div className="skeleton h-4 w-full"></div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	if ( rows.length === 0 ) {
+		return (
+			<div className="top-media-container godam-reel-pops-table godam-reel-pops-table--empty">
+				<div className="flex justify-between pt-4">
+					<h2>{ __( 'Reel Pops', 'godam' ) }</h2>
+				</div>
+				<div className="table-container overflow-x-auto">
+					<p className="text-center py-4 text-lg">
+						{ __( 'No Reel Pops yet.', 'godam' ) }
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const totalPages = Math.max( 1, Math.ceil( rows.length / PAGE_SIZE ) );
+	const safePage = Math.min( page, totalPages );
+	const start = ( safePage - 1 ) * PAGE_SIZE;
+	const visible = rows.slice( start, start + PAGE_SIZE );
+
+	return (
+		<div className="top-media-container godam-reel-pops-table">
+			<div className="flex justify-between pt-4">
+				<h2>{ __( 'Reel Pops', 'godam' ) }</h2>
+			</div>
+			<div className="table-container overflow-x-auto">
+				<table className="w-full">
+					<tbody>
+						<tr>
+							<th>{ __( 'Reel Pop', 'godam' ) }</th>
+							<th>{ __( 'Impressions', 'godam' ) }</th>
+							<th>{ __( 'Engagement', 'godam' ) }</th>
+							<th>{ __( 'Closure', 'godam' ) }</th>
+							<th>{ __( 'Conversion', 'godam' ) }</th>
+						</tr>
+						{ visible.map( ( row ) => (
+							<tr key={ row.reel_pop_id }>
+								<td>
+									<div className="video-info">
+										<a className="thumbnail-link" href={ row.edit_url }>
+											<img
+												src={ row.thumbnail || DefaultThumbnail }
+												alt={ row.title || __( 'Reel Pop thumbnail', 'godam' ) }
+											/>
+										</a>
+										<a className="title-link" href={ row.edit_url }>
+											<div className="w-full max-w-40 text-left flex-1">
+												<p className="font-semibold">
+													{ row.title || sprintf(
+														/* translators: %s is the Reel Pop ID. */
+														__( 'Reel Pop #%s', 'godam' ),
+														row.reel_pop_id,
+													) }
+												</p>
+											</div>
+										</a>
+									</div>
+								</td>
+								<td title={ ( row.impressions ?? 0 ).toLocaleString() }>
+									{ formatNumber( row.impressions ?? 0 ) }
+								</td>
+								<td title={ ( row.engagement ?? 0 ).toLocaleString() }>
+									{ formatNumber( row.engagement ?? 0 ) }
+								</td>
+								<td title={ ( row.closure ?? 0 ).toLocaleString() }>
+									{ formatNumber( row.closure ?? 0 ) }
+								</td>
+								<td title={ ( row.conversion ?? 0 ).toLocaleString() }>
+									{ formatNumber( row.conversion ?? 0 ) }
+								</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</div>
+			{ totalPages > 1 && (
+				<div className="flex items-center justify-between mt-4">
+					<p className="text-sm text-gray-500">
+						{
+							/* translators: %1$d is the current page number, %2$d is the total number of pages */
+							sprintf( __( 'Page %1$d of %2$d', 'godam' ), safePage, totalPages )
+						}
+					</p>
+					<div className="flex items-center gap-4">
+						<button
+							className="previous-btn flex items-center gap-1"
+							disabled={ safePage === 1 }
+							onClick={ () => setPage( ( prev ) => Math.max( prev - 1, 1 ) ) }
+						>
+							<img
+								src={ chevronLeft }
+								alt={ __( 'Previous', 'godam' ) }
+								className={ `w-4 h-4 chevron-icon ${ safePage === 1 ? 'icon-disabled' : '' }` }
+							/>
+							<span>{ __( 'Previous', 'godam' ) }</span>
+						</button>
+						<button
+							className="next-btn flex items-center gap-1"
+							disabled={ safePage >= totalPages }
+							onClick={ () => setPage( ( prev ) => prev + 1 ) }
+						>
+							<span>{ __( 'Next', 'godam' ) }</span>
+							<img
+								src={ chevronRight }
+								alt={ __( 'Next', 'godam' ) }
+								className={ `w-4 h-4 chevron-icon ${ safePage >= totalPages ? 'icon-disabled' : '' }` }
+							/>
+						</button>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default ReelPopsTable;


### PR DESCRIPTION
## Summary

Plugin-side counterpart to the already-merged godam-analytics PR #140. Adds a per-page-load UUID v4 (`page_load_session_id`) to every type=1/2/3 analytics envelope so the microservice can dedup engagement counters with `uniqExact(page_load_session_id)`, keeping derived rates (Engagement / Impressions etc.) bounded ≤ 100%. Exposes godam SDK helpers on `window.RTGodamAnalyticsHelpers` so godam-for-woo can emit identical normalized UA strings + share the per-page-load session ID for its type=4 (Reel Pop) events. Adds a new "Reel Pops" cumulative table to the GoDAM Dashboard backed by a server-side REST proxy that injects `X-API-Key` so the browser never sees the key.

## SDK changes (`assets/src/js/godam-player/`)

- `analytics-helpers.js`: new `getPageLoadSessionId()` (UUID v4 with crypto.randomUUID + hand-rolled fallback for mobile Safari < 15.4); added to `buildAnalyticsRequestBody` envelope.
- `analytics-helpers.js`: `buildAnalyticsRequestBody` now accepts optional `reelPopId` and only writes `reel_pop_id` to the body when > 0 — non-Reel-Pop events stay at the same wire shape.
- `analytics.js`: `trackVideoEvent` accepts optional `reelPopId` and propagates it onto both the auto type=1 `page_load` payload and the type=2 `video_heatmap` payload.
- `analytics.js`: `sendPlayerHeatmap` (the unload-flush keepalive path) reads `data-reel-pop-id` off the `<video>` element and forwards it on type=2 events. The SDK itself doesn't know what a Reel Pop is — this just opaquely propagates the attribute.
- `analytics.js`: exposes `window.RTGodamAnalyticsHelpers = { getPageLoadSessionId, getUserAgent }` so godam-for-woo (and future plugins) can call them without polluting `window.analytics` (which is the Analytics library instance).
- `video-analytics-plugin.js`: forwards `reel_pop_id` from `track()` properties into `buildAnalyticsRequestBody`.

## Dashboard changes

- New `inc/classes/rest-api/class-dashboard.php`: `GET /godam/v1/dashboard/reel-pops-summary` — proxies the microservice `/reel-pops/summary` endpoint with `X-API-Key` injected server-side, enriches each row with the WP post title / thumbnail / edit URL, drops rows whose post no longer exists or isn't published, caches the upstream response for 60 s.
- Registered the new class in `inc/classes/class-plugin.php::load_rest_api()`.
- New `pages/dashboard/components/ReelPopsTable.jsx`: single `apiFetch` on mount; renders one row per Reel Pop with Impressions / Engagement / Closure / Conversion counters; thumbnail + title click-through to the editor; matches the existing top-videos table styling and pagination pattern.
- Mounted `<ReelPopsTable />` in `Dashboard.js` below the existing top-videos table.

## Companion PRs

- Microservice (MERGED): https://github.com/rtCamp/godam-analytics/pull/140
- godam-for-woo (type=4 collector + per-Reel-Pop admin view): https://github.com/rtCamp/godam-for-woo/pull/93

## Test plan

- [x] `npm run build:prod` completes without errors.
- [x] Verified `page_load_session_id`, `RTGodamAnalyticsHelpers`, `reel_pop_id` strings appear in the minified `godam-player-analytics.min.js` bundle.
- [x] Verified `reel-pops-summary` + `reel_pop_id` strings appear in the minified `dashboard.min.js` bundle.
- [ ] Manual on test site `subodh-multisite.rt.gw`:
  - [ ] Confirm every video analytics POST body contains `page_load_session_id` (DevTools Network → request payload).
  - [ ] Confirm `window.RTGodamAnalyticsHelpers.getPageLoadSessionId()` returns the same UUID across multiple calls on one page load.
  - [ ] GoDAM Dashboard → confirm Reel Pops table renders (empty state if no Reel Pops yet, otherwise rows with counters + thumbnails).
  - [ ] Click a row → lands on the Reel Pop editor.
  - [ ] Confirm dashboard table data updates after the next APScheduler tick on the microservice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)