### PR TITLE
feat(analytics): add page_load_session_id + reel-pop attribution

### DIFF
--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -6,6 +6,11 @@
  * is the single source of truth for the request schema.
  */
 
+/**
+ * External dependencies
+ */
+import { v4 as uuidv4 } from 'uuid';
+
 // Module-scope cache. Generated once on first event, reused for the rest of
 // the page load. Every type=1/2/3/4 event from the same page load shares this
 // UUID so the microservice can dedup with uniqExact(page_load_session_id).
@@ -14,27 +19,12 @@ let _pageLoadSessionId = null;
 /**
  * Return a stable UUID v4 for this page load.
  *
- * Uses crypto.randomUUID() when available, falls back to
- * crypto.getRandomValues() so older browsers (e.g. mobile Safari < 15.4)
- * still produce a valid UUID v4.
- *
  * @return {string} UUID v4 (36 chars).
  */
 export function getPageLoadSessionId() {
-	if ( _pageLoadSessionId ) {
-		return _pageLoadSessionId;
+	if ( ! _pageLoadSessionId ) {
+		_pageLoadSessionId = uuidv4();
 	}
-
-	if ( window.crypto && typeof window.crypto.randomUUID === 'function' ) {
-		_pageLoadSessionId = window.crypto.randomUUID();
-		return _pageLoadSessionId;
-	}
-
-	const bytes = window.crypto.getRandomValues( new Uint8Array( 16 ) );
-	bytes[ 6 ] = ( bytes[ 6 ] & 0x0f ) | 0x40; // version 4
-	bytes[ 8 ] = ( bytes[ 8 ] & 0x3f ) | 0x80; // variant
-	const hex = Array.from( bytes, ( b ) => b.toString( 16 ).padStart( 2, '0' ) ).join( '' );
-	_pageLoadSessionId = `${ hex.slice( 0, 8 ) }-${ hex.slice( 8, 12 ) }-${ hex.slice( 12, 16 ) }-${ hex.slice( 16, 20 ) }-${ hex.slice( 20 ) }`;
 	return _pageLoadSessionId;
 }
 

--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -6,6 +6,60 @@
  * is the single source of truth for the request schema.
  */
 
+// Module-scope cache. Generated once on first event, reused for the rest of
+// the page load. Every type=1/2/3/4 event from the same page load shares this
+// UUID so the microservice can dedup with uniqExact(page_load_session_id).
+let _pageLoadSessionId = null;
+
+/**
+ * Return a stable UUID v4 for this page load.
+ *
+ * Uses crypto.randomUUID() when available, falls back to
+ * crypto.getRandomValues() so older browsers (e.g. mobile Safari < 15.4)
+ * still produce a valid UUID v4.
+ *
+ * @return {string} UUID v4 (36 chars).
+ */
+export function getPageLoadSessionId() {
+	if ( _pageLoadSessionId ) {
+		return _pageLoadSessionId;
+	}
+
+	if ( window.crypto && typeof window.crypto.randomUUID === 'function' ) {
+		_pageLoadSessionId = window.crypto.randomUUID();
+		return _pageLoadSessionId;
+	}
+
+	const bytes = window.crypto.getRandomValues( new Uint8Array( 16 ) );
+	bytes[ 6 ] = ( bytes[ 6 ] & 0x0f ) | 0x40; // version 4
+	bytes[ 8 ] = ( bytes[ 8 ] & 0x3f ) | 0x80; // variant
+	const hex = Array.from( bytes, ( b ) => b.toString( 16 ).padStart( 2, '0' ) ).join( '' );
+	_pageLoadSessionId = `${ hex.slice( 0, 8 ) }-${ hex.slice( 8, 12 ) }-${ hex.slice( 12, 16 ) }-${ hex.slice( 16, 20 ) }-${ hex.slice( 20 ) }`;
+	return _pageLoadSessionId;
+}
+
+/**
+ * Normalized browser name (e.g. "Google Chrome", "Apple Safari").
+ *
+ * Wraps getUserAgent so callers outside this module can produce the same
+ * config_browser_name string buildAnalyticsRequestBody emits — guarantees
+ * type=1/2/3 and reel-pop type=4 device buckets line up.
+ *
+ * @return {string} Browser name.
+ */
+export function getBrowserName() {
+	return getUserAgent( window.navigator.userAgent ).name;
+}
+
+/**
+ * Normalized OS / platform name (e.g. "Macintosh", "Windows", "Linux").
+ *
+ * @return {string} OS / platform name.
+ */
+export function getOSName() {
+	return getUserAgent( window.navigator.userAgent ).platform;
+}
+
 /**
  * Check if we should skip analytics tracking.
  *
@@ -111,6 +165,7 @@ export function getUserAgent( userAgent ) {
  * @param {Array}  [opts.videoIds]         Array of [videoId, jobId] pairs (type 1).
  * @param {Array}  [opts.ranges]           Played time-range pairs (type 2).
  * @param {number} [opts.videoLength]      Duration in seconds (type 2).
+ * @param {number} [opts.reelPopId]        Reel Pop CPT post ID (when event originates from a reel-pop modal).
  * @return {{ endpoint: string|null, body: Object|null }} Object with `endpoint` (the base
  * API URL) and `body` (the request payload). Both are `null` when the plugin token is
  * missing or unverified — callers must check `endpoint` before sending.
@@ -124,6 +179,7 @@ export function buildAnalyticsRequestBody( {
 	videoIds = [],
 	ranges = [],
 	videoLength = 0,
+	reelPopId = 0,
 } ) {
 	const {
 		endpoint,
@@ -194,6 +250,7 @@ export function buildAnalyticsRequestBody( {
 		video_ids: type === 1 ? videoIds : [],
 		ranges,
 		video_length: videoLength || 0,
+		page_load_session_id: getPageLoadSessionId(),
 	};
 
 	// Only include job_id when it has a value — an empty string triggers
@@ -202,5 +259,19 @@ export function buildAnalyticsRequestBody( {
 		body.job_id = jobId;
 	}
 
+	const reelPopIdInt = parseInt( reelPopId, 10 );
+	if ( reelPopIdInt > 0 ) {
+		body.reel_pop_id = reelPopIdInt;
+	}
+
 	return { endpoint, body };
 }
+
+// Expose helpers on a global namespace so sibling plugins (e.g. godam-for-woo)
+// that are bundled separately can reuse them without a shared import path.
+// Reusing these guarantees parity between type=1/2/3 and type=4 envelopes.
+window.GoDAM = window.GoDAM || {};
+window.GoDAM.getPageLoadSessionId = getPageLoadSessionId;
+window.GoDAM.getBrowserName = getBrowserName;
+window.GoDAM.getOSName = getOSName;
+window.GoDAM.shouldSkipAnalytics = shouldSkipAnalytics;

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -71,6 +71,7 @@ function collectPlayedRanges( player ) {
 	 * @param {Element|Document} [params.root]         - Root element to search for video elements. Defaults to document
 	 *
 	 * @param {boolean}          [params.sendPageLoad] - Whether to send a type 1 'page_load' event before the heatmap event. Defaults to true.
+	 * @param                    params.reelPopId
 	 * @return {boolean} Returns true if event was successfully tracked, false otherwise
 	 *
 	 * @description
@@ -90,7 +91,7 @@ function collectPlayedRanges( player ) {
 	 *
 	 * @since 1.4.2
 	 */
-	window.analytics.trackVideoEvent = ( { type, videoId, root, sendPageLoad = true } = {} ) => {
+	window.analytics.trackVideoEvent = ( { type, videoId, root, sendPageLoad = true, reelPopId = 0 } = {} ) => {
 		if ( ! type ) {
 			return false;
 		}
@@ -111,6 +112,14 @@ function collectPlayedRanges( player ) {
 				jobId = videoEl.getAttribute( 'data-job_id' ) || '';
 			}
 
+			// Fall back to the wrapper's own data-reel-pop-id when the caller
+			// didn't pass one explicitly. Lets reel-pop attribution travel with
+			// the DOM for callers that don't know about reel pops.
+			let rpId = parseInt( reelPopId, 10 ) || 0;
+			if ( ! rpId && videoEl ) {
+				rpId = parseInt( videoEl.getAttribute( 'data-reel-pop-id' ), 10 ) || 0;
+			}
+
 			vid = parseInt( vid, 10 ) || 0;
 			if ( ! vid ) {
 				return false;
@@ -120,7 +129,7 @@ function collectPlayedRanges( player ) {
 			// NOTE: This automatically sends a 'page_load' event before the heatmap event, for ease of use.
 			// This is intentional behavior but may cause duplicate type 1 events in some scenarios
 			if ( sendPageLoad ) {
-				window.analytics.track( 'page_load', { type: 1, videoIds: [ [ vid, jobId ] ] } );
+				window.analytics.track( 'page_load', { type: 1, videoIds: [ [ vid, jobId ] ], reelPopId: rpId } );
 			}
 
 			const player = getPlayer( videoEl );
@@ -141,6 +150,7 @@ function collectPlayedRanges( player ) {
 				jobId,
 				ranges,
 				videoLength,
+				reelPopId: rpId,
 			} );
 			return true;
 		}
@@ -155,8 +165,11 @@ if ( ! window.pageLoadEventTracked ) {
 	document.addEventListener( 'DOMContentLoaded', () => {
 		const videos = document.querySelectorAll( '.easydam-player.video-js' );
 
-		// Collect all video IDs and Job IDs
+		// Collect all video IDs and Job IDs. Skip wrappers that opted out of
+		// auto-instrumentation (e.g. reel-pop widget previews — those fire
+		// type=1 explicitly from inside the modal, never from the widget).
 		const videoInfo = Array.from( videos )
+			.filter( ( video ) => video.getAttribute( 'data-godam-no-auto-analytics' ) !== '1' )
 			.map( ( video ) => ( {
 				id: video.getAttribute( 'data-id' ),
 				jobId: video.getAttribute( 'data-job_id' ) || '',
@@ -291,6 +304,11 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 
 		const videoLength = Number( player.duration && player.duration() ) || 0;
 
+		// Pick up reel-pop attribution from the wrapper element when present,
+		// so the unload-flush heatmap correctly counts against the reel pop
+		// even though the godam SDK itself has no concept of reel pops.
+		const reelPopId = parseInt( video.getAttribute( 'data-reel-pop-id' ), 10 ) || 0;
+
 		/*
 		 * IMPORTANT: We bypass window.analytics.track() here intentionally.
 		 *
@@ -314,6 +332,7 @@ function sendPlayerHeatmap( player, video, skipIfKey = null ) {
 			jobId,
 			ranges,
 			videoLength,
+			reelPopId,
 		} );
 
 		if ( ! endpoint ) {
@@ -345,6 +364,15 @@ function setupPlayerAnalytics( player, video ) {
 	if ( player._godamAnalyticsSetup ) {
 		return;
 	}
+
+	// Skip wrappers that opted out of auto-instrumentation. Reel-pop widget
+	// previews use this so the SDK does not register them in
+	// godamTrackedPlayers — unload-flush would otherwise send type=2 for the
+	// muted preview that the user never engaged with through the modal.
+	if ( video && video.getAttribute && video.getAttribute( 'data-godam-no-auto-analytics' ) === '1' ) {
+		return;
+	}
+
 	player._godamAnalyticsSetup = true;
 	video.dataset.analyticsSetup = 'true'; // Keep for backwards compatibility
 

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -71,7 +71,7 @@ function collectPlayedRanges( player ) {
 	 * @param {Element|Document} [params.root]         - Root element to search for video elements. Defaults to document
 	 *
 	 * @param {boolean}          [params.sendPageLoad] - Whether to send a type 1 'page_load' event before the heatmap event. Defaults to true.
-	 * @param                    params.reelPopId
+	 * @param {number}           [params.reelPopId]    - Reel popup ID associated with the tracked video event. Defaults to 0.
 	 * @return {boolean} Returns true if event was successfully tracked, false otherwise
 	 *
 	 * @description

--- a/assets/src/js/godam-player/video-analytics-plugin.js
+++ b/assets/src/js/godam-player/video-analytics-plugin.js
@@ -14,7 +14,7 @@ const videoAnalyticsPlugin = () => {
 			const { properties, meta, anonymousId } = payload;
 
 			try {
-				const { ranges = [], videoId, type, videoLength, videoIds, jobId } = properties;
+				const { ranges = [], videoId, type, videoLength, videoIds, jobId, reelPopId } = properties;
 
 				if ( ! type || ( type === 1 && ( ! videoIds || videoIds.length === 0 ) ) ) {
 					return;
@@ -29,6 +29,7 @@ const videoAnalyticsPlugin = () => {
 					videoIds,
 					ranges,
 					videoLength,
+					reelPopId,
 				} );
 
 				if ( ! endpoint ) {

--- a/pages/dashboard/index.scss
+++ b/pages/dashboard/index.scss
@@ -71,6 +71,7 @@
 }
 
 .top-media-container {
+	margin-bottom: 1.5rem;
 
 	h2 {
 		font-weight: 600;


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Godam Player analytics system, focusing on enhanced session tracking, better support for Reel Pop attribution, and improved integration between plugins. The changes ensure more accurate analytics reporting, especially for events originating from Reel Pop modals, and provide mechanisms for sibling plugins to share helper functions. Additionally, auto-instrumentation can now be selectively disabled for certain video wrappers.

**Analytics Enhancements and Session Tracking:**

* Added a stable, page-load-scoped UUID v4 (`getPageLoadSessionId`) to all analytics events for deduplication and improved session tracking. This UUID is generated once per page load and reused for all relevant events. [[1]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R9-R62) [[2]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R253)
* Exposed analytics helper functions (`getPageLoadSessionId`, `getBrowserName`, `getOSName`, `shouldSkipAnalytics`) on the global `window.GoDAM` namespace, allowing sibling plugins to reuse them and ensure consistent event envelopes. [[1]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R9-R62) [[2]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R262-R277)

**Reel Pop Attribution Support:**

* Added support for passing and auto-detecting a `reelPopId` for analytics events, ensuring that events triggered from Reel Pop modals are correctly attributed. This includes updating function signatures, extracting the ID from DOM attributes, and sending it with both page load and heatmap events. [[1]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R168) [[2]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R182) [[3]](diffhunk://#diff-c69dbf7a77a01b23fb2088aa5eac3840ff9070efdd14fc94036718fdfc6d1786R262-R277) [[4]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR74) [[5]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL93-R94) [[6]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR115-R122) [[7]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL123-R132) [[8]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR153) [[9]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR307-R311) [[10]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR335) [[11]](diffhunk://#diff-fdccdab500be3619b0c109442c9093428d78a687056b1bd5b6d1d8bdd6df39b9L17-R17) [[12]](diffhunk://#diff-fdccdab500be3619b0c109442c9093428d78a687056b1bd5b6d1d8bdd6df39b9R32)

**Selective Auto-Instrumentation:**

* Implemented a way to skip auto-instrumentation for certain video wrappers by checking the `data-godam-no-auto-analytics` attribute. This prevents analytics events from being sent for muted previews or widgets that shouldn't be tracked automatically (e.g., Reel Pop widget previews). [[1]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dL158-R172) [[2]](diffhunk://#diff-725a972d57007a1beec49f90c0bc8295c5b681e437f343e6f55a29a4a855c42dR367-R375)

**Styling Update:**

* Added bottom margin to the `.top-media-container` in the dashboard for improved spacing.