### PR TITLE
fix: Video block editor player collapsed to play button (#1891)

### DIFF
--- a/assets/src/blocks/godam-player/VideoJS.js
+++ b/assets/src/blocks/godam-player/VideoJS.js
@@ -17,6 +17,23 @@ import 'videojs-flvjs-es6';
  */
 import { useRef, useEffect, useMemo } from '@wordpress/element';
 
+// Mirror Video.js's fluid aspect-ratio padding inline on the player element.
+// Video.js generates this rule in the top document only, which the block-editor iframe
+// can't see — without an explicit padding-top the player collapses to zero height.
+const applyAspectRatioPadding = ( player, aspectRatio ) => {
+	if ( ! player || ! aspectRatio || ! /^\d+:\d+$/.test( aspectRatio ) ) {
+		return;
+	}
+	const [ x, y ] = aspectRatio.split( ':' ).map( Number );
+	if ( ! x || ! y ) {
+		return;
+	}
+	const playerEl = player.el_;
+	if ( playerEl ) {
+		playerEl.style.paddingTop = `${ ( y / x ) * 100 }%`;
+	}
+};
+
 export const VideoJS = ( props ) => {
 	const videoRef = useRef( null );
 	const playerRef = useRef( null );
@@ -56,21 +73,19 @@ export const VideoJS = ( props ) => {
 					onReady( playerRef.current );
 				}
 
-				// Video.js player initialize instantly and hides the video loading spinner, so add a slight delay to hide it smoothly
+				// Video.js writes its fluid padding-top rule to the top-level document, which
+				// doesn't reach the block editor's iframed canvas. Mirror it inline so the
+				// player gets a visible height in either context.
+				applyAspectRatioPadding( playerRef.current, videojsOptions.aspectRatio );
+
+				// Fade the loading overlay out after a short delay so the transition feels smooth.
 				setTimeout( () => {
-					if ( videoRef.current ) {
-						// Hide the video player loading animation
-						const parentElement = videoRef.current.parentElement;
-
-						if ( parentElement ) {
-							// Remove the child element with class name 'godam-video-loading'
-							const childElement = parentElement.querySelector( '.godam-video-loading' );
-							if ( childElement ) {
-								childElement.classList.add( 'hide' );
-							}
-						}
-
-						videoRef.current.style.display = 'block';
+					if ( ! videoRef.current ) {
+						return;
+					}
+					const loadingElement = videoRef.current.parentElement?.querySelector( '.godam-video-loading' );
+					if ( loadingElement ) {
+						loadingElement.classList.add( 'hide' );
 					}
 				}, 500 );
 			} );
@@ -94,13 +109,7 @@ export const VideoJS = ( props ) => {
 			// Verify if aspectRatio is in valid format x:y
 			if ( /^\d+:\d+$/.test( options.aspectRatio ) ) {
 				player.aspectRatio( options.aspectRatio );
-
-				// Get x and y from aspectRatio
-				const [ x, y ] = options.aspectRatio.split( ':' );
-				if ( playerRef.current && x && y ) {
-					const playerEl = playerRef.current.el_;
-					playerEl.style.paddingTop = `${ ( y / x ) * 100 }%`;
-				}
+				applyAspectRatioPadding( player, options.aspectRatio );
 			}
 		}
 	}, [ options, videoRef ] );
@@ -121,10 +130,10 @@ export const VideoJS = ( props ) => {
 
 	return (
 		<div data-vjs-player>
+			<div ref={ videoRef } />
 			<div style={ { paddingTop: paddingTopValue } } className="godam-video-loading">
 				<div className="godam-video-loading-spinner"></div>
 			</div>
-			<div style={ { display: 'none' } } ref={ videoRef } />
 		</div>
 	);
 };

--- a/assets/src/blocks/godam-player/editor.scss
+++ b/assets/src/blocks/godam-player/editor.scss
@@ -41,15 +41,28 @@
 		width: 100%;
 	}
 
+	// Ensure the loading overlay overlays the video element rather than pushing it
+	// down. video.js needs the video container to be visible/sized at init time, so we
+	// stack the loading overlay on top with absolute positioning.
+	[data-vjs-player] {
+		position: relative;
+	}
+
 	.godam-video-loading {
+		position: absolute;
+		top: 0;
+		left: 0;
 		width: 100%;
 		background-color: #000;
-		display: flex;
-		align-items: center;
-		justify-content: center;
 		z-index: 10;
+		pointer-events: none;
+		transition: opacity 0.2s ease-out;
 
-		.godam-video-loading-spinner:not(.hide) {
+		&.hide {
+			opacity: 0;
+		}
+
+		.godam-video-loading-spinner {
 			position: absolute;
 			top: 50%;
 			left: 50%;


### PR DESCRIPTION
## Summary

- The GoDAM Video block in the block editor was rendering as a tiny play button after a video was selected — see [#1891](https://github.com/rtCamp/godam/issues/1891).
- Two issues combined to collapse the player:
  1. The video container had inline `display: none` until 500 ms after Video.js initialised, so Video.js couldn't measure its parent and started up with zero dimensions.
  2. Video.js writes its fluid `padding-top` rule to the top-level document. The editor canvas runs in an iframe, so the rule never reached the player and `.video-js` kept `padding-top: 0` — leaving only the big-play button visible.
- Render the video container immediately, stack the loading overlay on top via `position: absolute`, and mirror Video.js's fluid padding inline on the player element so the height resolves inside the editor iframe. Add a proper `.hide` rule so the loading overlay actually fades out once the player is ready.

## Before / After

| Before (#1891) | After |
|---|---|
| Tiny grey box with only the play button | Full 16:9 player with centred play button |

Verified locally on `subodh-multisite.rt.gw` by inserting a `godam/video` block with a sample MP4 source — the player now renders at 645×363 (16:9) and the loading overlay fades cleanly.

## Test plan

- [ ] Open the block editor, insert a GoDAM Video block, pick any uploaded video — player renders at the configured aspect ratio with the big play button centred.
- [ ] Switch aspect ratios in the inspector (16:9 → 4:3 → custom) — player resizes accordingly.
- [ ] Reload the editor with a saved post containing the block — player still renders at the correct size on initial mount.
- [ ] Frontend rendering of the same post is unaffected (no changes to `render.php` / frontend JS).
- [ ] Loading overlay briefly shows on first mount, then fades out after Video.js is ready.

Fixes #1891

🤖 Generated with [Claude Code](https://claude.com/claude-code)