### PR TITLE
fix: remove unnecessary parameter from update_option for new attachments

### DIFF
--- a/admin/class-rtgodam-transcoder-rest-routes.php
+++ b/admin/class-rtgodam-transcoder-rest-routes.php
@@ -299,7 +299,7 @@ class RTGODAM_Transcoder_Rest_Routes extends WP_REST_Controller {
 
 							if ( ! empty( $latest_attachment ) && $latest_attachment['attachment_id'] === $attachment_id ) {
 								$latest_attachment['transcoding_status'] = 'success';
-								update_option( 'rtgodam_new_attachment', $latest_attachment, '', true );
+								update_option( 'rtgodam_new_attachment', $latest_attachment, true );
 							}
 						} else {
 							$this->rtgodam_transcoder_handler->add_transcoded_files( $post_array['files'], $attachment_id, $job_for );

--- a/inc/classes/class-media-tracker.php
+++ b/inc/classes/class-media-tracker.php
@@ -50,7 +50,7 @@ class Media_Tracker {
 		);
 
 		// Check if the attachment is a video.
-		update_option( 'rtgodam_new_attachment', $attachment_data, '', true );
+		update_option( 'rtgodam_new_attachment', $attachment_data, true );
 
 		// Trigger cache invalidation for attachment counts in folders.
 		do_action( 'godam_attachment_added', $attachment_id );
@@ -101,7 +101,7 @@ class Media_Tracker {
 			}
 
 			$attachment_data['transcoding_status'] = $transcoding_status;
-			update_option( 'rtgodam_new_attachment', $attachment_data, '', true );
+			update_option( 'rtgodam_new_attachment', $attachment_data, true );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This pull request updates the way the `update_option` function is called for the `rtgodam_new_attachment` option throughout the codebase. The main change is the removal of an unnecessary empty string argument, aligning the function usage with WordPress standards and improving code clarity.

**Refactoring of `update_option` usage:**

* Replaced `update_option( 'rtgodam_new_attachment', $data, '', true )` with `update_option( 'rtgodam_new_attachment', $data, true )` in three locations:
  - In `class-rtgodam-transcoder-rest-routes.php` within the `handle_callback` method
  - In `class-media-tracker.php` within the `track_new_attachment` method
  - In `class-media-tracker.php` within the `check_new_attachment_transcoding_status` method

## Issue

https://github.com/rtCamp/godam/issues/1904