### PR TITLE
Fix: godam video block aspect ratio for editor and frontend.

### DIFF
--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -149,6 +149,12 @@ function VideoEdit( {
 			return aspectRatio;
 		}
 
+		// Fallback to 16:9 while intrinsic dimensions are still loading, so the
+		// player reserves vertical space instead of collapsing to the controls.
+		if ( aspectRatio === 'responsive' ) {
+			return '16:9';
+		}
+
 		return '';
 	}, [ aspectRatio, videoWidth, videoHeight ] );
 
@@ -189,10 +195,15 @@ function VideoEdit( {
 
 	// Memoize video options to prevent unnecessary rerenders.
 	const videoOptions = useMemo( () => {
+		// In the editor, always preload at least metadata so `loadedmetadata`
+		// fires and we can capture intrinsic videoWidth/videoHeight/duration.
+		// The saved `preload` attribute still drives the frontend.
+		const editorPreload = preload === 'none' ? 'metadata' : preload;
+
 		const options = {
 			controls,
 			autoplay,
-			preload,
+			preload: editorPreload,
 			fluid: true,
 			playsinline: true,
 			flvjs: {

--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -175,6 +175,8 @@ const GoDAMMediaFrameShared = {
 						caption: data.caption,
 						description: data.description,
 						video_duration: data.video_duration || 0,
+						width: data.width || 0,
+						height: data.height || 0,
 					},
 				} );
 

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -120,6 +120,8 @@ class Media_Library_Ajax {
 			'hls_url'               => $item['transcoded_hls_path'] ?? '',
 			'mpd_url'               => $item['transcoded_file_path'] ?? '',
 			'video_duration'        => $video_duration ?? 0,
+			'width'                 => $item['width'] ?? 0,
+			'height'                => $item['height'] ?? 0,
 		);
 
 		// Set icon with fallback to default mime type icon for audio and PDF.

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1581,7 +1581,12 @@ class Media_Library extends Base {
 		}
 
 		// Validate MIME type against an allowed pattern to prevent stored XSS.
-		if ( ! preg_match( '/^(video|audio|image)\/[a-z0-9][a-z0-9!#$&\-^_.+]{0,126}$/i', $data['mime'] ) ) {
+		// Accepts video/*, audio/*, image/* plus the single PDF type — PDFs are
+		// handled by the 'pdf' branch below and otherwise can't form a virtual entry.
+		if (
+			! preg_match( '/^(video|audio|image)\/[a-z0-9][a-z0-9!#$&\-^_.+]{0,126}$/i', $data['mime'] )
+			&& 'application/pdf' !== strtolower( $data['mime'] )
+		) {
 			return new \WP_Error( 'invalid_mime', __( 'Invalid or disallowed MIME type.', 'godam' ), array( 'status' => 400 ) );
 		}
 

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1581,14 +1581,31 @@ class Media_Library extends Base {
 		}
 
 		// Validate MIME type against an allowed pattern to prevent stored XSS.
+		// The endpoint doesn't declare argument schemas, so guard against
+		// non-string payloads (array/object/number) before string operations —
+		// otherwise preg_match()/strtolower() raise a TypeError → 500.
+		if ( ! is_string( $data['mime'] ) ) {
+			return new \WP_Error( 'invalid_mime', __( 'Invalid or disallowed MIME type.', 'godam' ), array( 'status' => 400 ) );
+		}
+
+		// Normalize via sanitize_mime_type(): strips characters outside the RFC
+		// 2045 token set, lowercases, and returns '' for completely invalid input.
+		$mime = sanitize_mime_type( $data['mime'] );
+		if ( '' === $mime ) {
+			return new \WP_Error( 'invalid_mime', __( 'Invalid or disallowed MIME type.', 'godam' ), array( 'status' => 400 ) );
+		}
+
 		// Accepts video/*, audio/*, image/* plus the single PDF type — PDFs are
 		// handled by the 'pdf' branch below and otherwise can't form a virtual entry.
 		if (
-			! preg_match( '/^(video|audio|image)\/[a-z0-9][a-z0-9!#$&\-^_.+]{0,126}$/i', $data['mime'] )
-			&& 'application/pdf' !== strtolower( $data['mime'] )
+			! preg_match( '/^(video|audio|image)\/[a-z0-9][a-z0-9!#$&\-^_.+]{0,126}$/', $mime )
+			&& 'application/pdf' !== $mime
 		) {
 			return new \WP_Error( 'invalid_mime', __( 'Invalid or disallowed MIME type.', 'godam' ), array( 'status' => 400 ) );
 		}
+
+		// Use the normalized value for the rest of the handler.
+		$data['mime'] = $mime;
 
 		// Sanitize the GoDAM ID.
 		$godam_id = sanitize_text_field( $data['id'] );

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1688,6 +1688,15 @@ class Media_Library extends Base {
 				'filesize' => isset( $data['filesizeInBytes'] ) ? (int) $data['filesizeInBytes'] : 0,
 			);
 
+			// Persist intrinsic dimensions when GoDAM Central provides non-zero values
+			// so the editor can reserve aspect-ratio space without waiting for loadedmetadata.
+			$video_width  = isset( $data['width'] ) ? (int) $data['width'] : 0;
+			$video_height = isset( $data['height'] ) ? (int) $data['height'] : 0;
+			if ( $video_width > 0 && $video_height > 0 ) {
+				$wp_attachment_metadata['width']  = $video_width;
+				$wp_attachment_metadata['height'] = $video_height;
+			}
+
 			if ( ! empty( $video_duration_in_seconds ) ) {
 				update_post_meta( $attach_id, '_video_duration', $video_duration_in_seconds );
 				$wp_attachment_metadata['length']           = $video_duration_in_seconds;
@@ -1707,10 +1716,12 @@ class Media_Library extends Base {
 				'sizes'    => array(),
 			);
 
-			// Add width and height if available.
-			if ( ! empty( $data['width'] ) && ! empty( $data['height'] ) ) {
-				$wp_attachment_metadata['width']  = (int) $data['width'];
-				$wp_attachment_metadata['height'] = (int) $data['height'];
+			// Add width and height if available (non-zero).
+			$image_width  = isset( $data['width'] ) ? (int) $data['width'] : 0;
+			$image_height = isset( $data['height'] ) ? (int) $data['height'] : 0;
+			if ( $image_width > 0 && $image_height > 0 ) {
+				$wp_attachment_metadata['width']  = $image_width;
+				$wp_attachment_metadata['height'] = $image_height;
 			}
 
 			update_post_meta( $attach_id, '_wp_attachment_metadata', $wp_attachment_metadata );


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1891

This pull request improves the handling of media metadata—especially video and image dimensions—across the backend and editor, ensuring that intrinsic dimensions are preserved and used to optimize layout and rendering in the editor. It also refines MIME type validation to explicitly allow PDFs and ensures the editor preloads video metadata for a smoother editing experience.

**Media metadata handling:**

* The backend now persists intrinsic width and height for both videos and images when non-zero values are provided, allowing the editor to reserve the correct aspect-ratio space before media is fully loaded. (`inc/classes/rest-api/class-media-library.php`) [[1]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104R1696-R1704) [[2]](diffhunk://#diff-d4ded041aa285392c3c139cdcaf978a408d788a9dafb7ac96da3e56f69cf1104L1710-R1729)
* The backend includes `width` and `height` fields in the media item response, and these are now passed through to the editor. (`inc/classes/class-media-library-ajax.php`, `assets/src/js/media-library/views/godam-media-frame-shared.js`) [[1]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R123-R124) [[2]](diffhunk://#diff-a7878e67888eef229132a39357ea6378cbaf2c7cdc41b7b4bc69f4333e5fd9a4R178-R179)

**Editor experience improvements:**

* The editor uses a fallback aspect ratio of `16:9` while intrinsic dimensions are loading, preventing the video player from collapsing and improving layout stability. (`assets/src/blocks/godam-player/edit.js`)
* Video options in the editor are updated to always preload at least metadata, ensuring that intrinsic video properties are available as soon as possible. (`assets/src/blocks/godam-player/edit.js`)

**MIME type validation:**

* The backend now explicitly allows `application/pdf` in addition to standard video, audio, and image MIME types, improving compatibility with PDF uploads. (`inc/classes/rest-api/class-media-library.php`)

## Demo

https://github.com/user-attachments/assets/03d28297-21b0-4fd4-a699-8e9e033371c0

