### PR TITLE
Fix integration toggle notice rendering and persistence

### DIFF
--- a/inc/classes/rest-api/class-addon-toggle.php
+++ b/inc/classes/rest-api/class-addon-toggle.php
@@ -120,7 +120,14 @@ class Addon_Toggle extends Base {
 			ob_end_clean();
 
 			if ( is_wp_error( $result ) ) {
-				return $result;
+				$error_data = $result->get_error_data();
+				$status     = ( is_array( $error_data ) && isset( $error_data['status'] ) ) ? (int) $error_data['status'] : 400;
+
+				return new \WP_Error(
+					'addon_activation_failed',
+					wp_strip_all_tags( (string) $result->get_error_message() ),
+					array( 'status' => $status )
+				);
 			}
 
 			return rest_ensure_response(

--- a/inc/classes/rest-api/class-addon-toggle.php
+++ b/inc/classes/rest-api/class-addon-toggle.php
@@ -121,7 +121,7 @@ class Addon_Toggle extends Base {
 
 			if ( is_wp_error( $result ) ) {
 				$error_data = $result->get_error_data();
-				$status     = ( is_array( $error_data ) && isset( $error_data['status'] ) ) ? (int) $error_data['status'] : 400;
+				$status     = ( is_array( $error_data ) && isset( $error_data['status'] ) ) ? (int) $error_data['status'] : 500;
 
 				return new \WP_Error(
 					'addon_activation_failed',

--- a/inc/classes/rest-api/class-addon-toggle.php
+++ b/inc/classes/rest-api/class-addon-toggle.php
@@ -125,7 +125,7 @@ class Addon_Toggle extends Base {
 
 				return new \WP_Error(
 					'addon_activation_failed',
-					wp_strip_all_tags( (string) $result->get_error_message() ),
+					wp_kses_post( (string) $result->get_error_message() ),
 					array( 'status' => $status )
 				);
 			}

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
@@ -210,11 +210,12 @@ const IntegrationSettings = () => {
 		<>
 			{ notice.isVisible && (
 				<Notice
-					className="mb-4"
+					className="mb-4 godam-notice-message"
 					status={ notice.status }
 					onRemove={ () => setNotice( { ...notice, isVisible: false } ) }
+					// dangerouslySetInnerHTML={ { __html: notice.message } }
 				>
-					{ notice.message }
+					<div dangerouslySetInnerHTML={ { __html: notice.message } } />
 				</Notice>
 			) }
 

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
@@ -66,11 +66,18 @@ const IntegrationSettings = () => {
 	const [ installError, setInstallError ] = useState( null );
 
 	useEffect( () => {
-		const persistedNotice = window.sessionStorage?.getItem( TOGGLE_SUCCESS_NOTICE_KEY );
+		try {
+			const persistedNotice = window.sessionStorage?.getItem( TOGGLE_SUCCESS_NOTICE_KEY );
 
-		if ( persistedNotice ) {
-			showNotice( persistedNotice, 'success' );
-			window.sessionStorage?.removeItem( TOGGLE_SUCCESS_NOTICE_KEY );
+			if ( persistedNotice ) {
+				setNotice( { message: persistedNotice, status: 'success', isVisible: true } );
+				if ( window.scrollY > 0 ) {
+					scrollToTop();
+				}
+				window.sessionStorage?.removeItem( TOGGLE_SUCCESS_NOTICE_KEY );
+			}
+		} catch ( error ) {
+			// Ignore storage access issues (e.g. blocked/disabled sessionStorage).
 		}
 	}, [] );
 
@@ -97,10 +104,14 @@ const IntegrationSettings = () => {
 				} );
 
 				if ( response?.status === 'success' ) {
-					window.sessionStorage?.setItem(
-						TOGGLE_SUCCESS_NOTICE_KEY,
-						response?.message || __( 'Integration status updated successfully.', 'godam' ),
-					);
+					try {
+						window.sessionStorage?.setItem(
+							TOGGLE_SUCCESS_NOTICE_KEY,
+							response?.message || __( 'Integration status updated successfully.', 'godam' ),
+						);
+					} catch ( error ) {
+						// Ignore storage write issues; notice just will not persist across reload.
+					}
 					window.location.reload();
 				}
 			} catch ( error ) {

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
@@ -46,6 +46,8 @@ import integrationTabs from './integration-tabs.js';
 const getExtendedSettings = ( tabName ) =>
 	window.godamIntegrationComponents?.[ tabName ] || null;
 
+const TOGGLE_SUCCESS_NOTICE_KEY = 'godam_integration_toggle_notice';
+
 const IntegrationSettings = () => {
 	const tabs = integrationTabs;
 
@@ -62,6 +64,15 @@ const IntegrationSettings = () => {
 	const [ togglingPlugin, setTogglingPlugin ] = useState( null );
 	const [ installingPlugin, setInstallingPlugin ] = useState( null );
 	const [ installError, setInstallError ] = useState( null );
+
+	useEffect( () => {
+		const persistedNotice = window.sessionStorage?.getItem( TOGGLE_SUCCESS_NOTICE_KEY );
+
+		if ( persistedNotice ) {
+			showNotice( persistedNotice, 'success' );
+			window.sessionStorage?.removeItem( TOGGLE_SUCCESS_NOTICE_KEY );
+		}
+	}, [] );
 
 	// Function to show a notice message
 	const showNotice = ( message, status = 'success' ) => {
@@ -86,6 +97,10 @@ const IntegrationSettings = () => {
 				} );
 
 				if ( response?.status === 'success' ) {
+					window.sessionStorage?.setItem(
+						TOGGLE_SUCCESS_NOTICE_KEY,
+						response?.message || __( 'Integration status updated successfully.', 'godam' ),
+					);
 					window.location.reload();
 				}
 			} catch ( error ) {

--- a/pages/godam/index.scss
+++ b/pages/godam/index.scss
@@ -443,6 +443,13 @@ $settings-page-breakpoint: 782px;
 		}
 	}
 
+	/* GoDAM notice message */
+	.godam-notice-message {
+		a {
+			text-decoration: underline;
+		}
+	}
+
 	/* Animation */
 	@keyframes godamFadeSlide {
 		from {


### PR DESCRIPTION
## Summary: 
Fixes broken notice behavior in Integrations Settings when toggling add-on activation.
## Problem:

- WordPress activation errors could include HTML and appeared as raw tags in GoDAM notices.
- Success notices were not visible because the page reloaded immediately after toggle.

## Changes:

- Sanitized activation WP_Error messages in inc/classes/rest-api/class-addon-toggle.php.
- Persisted success notice across reload using sessionStorage in pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx.

## Why:

- Keeps error messages readable and safe.
- Preserves existing reload flow while showing user feedback.

## Validation:

- Two intended files committed.
- Assets rebuilt after UI change.
- No syntax errors in edited files.

## Screenshot

<img width="1469" height="828" alt="Screenshot 2026-06-02 at 2 01 48 PM" src="https://github.com/user-attachments/assets/6038b7a3-bdb7-49da-a92b-046f29c695b5" />

## Fixes

rtCamp/godam-for-woo#73