### PR TITLE
Adding Test IDs

### DIFF
--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -115,16 +115,17 @@ function AudioEdit( {
 	if ( ! src && ! temporaryURL ) {
 		return (
 			<div { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					onSelect={ onSelectAudio }
-					accept="audio/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ attributes }
-					onError={ onUploadError }
-					labels={ { title: __( 'Audio', 'godam' ) } }
-					data-test-id="godam-audio-button-select"
-				/>
+				<div data-test-id="godam-audio-button-select">
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						onSelect={ onSelectAudio }
+						accept="audio/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ attributes }
+						onError={ onUploadError }
+						labels={ { title: __( 'Audio', 'godam' ) } }
+					/>
+				</div>
 			</div>
 		);
 	}
@@ -146,21 +147,23 @@ function AudioEdit( {
 			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'godam' ) } data-test-id="godam-audio-panel-settings">
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Autoplay', 'godam' ) }
-						onChange={ toggleAttribute( 'autoplay' ) }
-						checked={ autoplay }
-						help={ getAutoplayHelp }
-						data-test-id="godam-audio-control-autoplay"
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Loop', 'godam' ) }
-						onChange={ toggleAttribute( 'loop' ) }
-						checked={ loop }
-						data-test-id="godam-audio-control-loop"
-					/>
+					<div data-test-id="godam-audio-control-autoplay">
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Autoplay', 'godam' ) }
+							onChange={ toggleAttribute( 'autoplay' ) }
+							checked={ autoplay }
+							help={ getAutoplayHelp }
+						/>
+					</div>
+					<div data-test-id="godam-audio-control-loop">
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Loop', 'godam' ) }
+							onChange={ toggleAttribute( 'loop' ) }
+							checked={ loop }
+						/>
+					</div>
 					<SelectControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -114,7 +114,7 @@ function AudioEdit( {
 
 	if ( ! src && ! temporaryURL ) {
 		return (
-			<div { ...blockProps }>
+			<div { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectAudio }
@@ -123,6 +123,7 @@ function AudioEdit( {
 					value={ attributes }
 					onError={ onUploadError }
 					labels={ { title: __( 'Audio', 'godam' ) } }
+					data-test-id="godam-audio-button-select"
 				/>
 			</div>
 		);
@@ -144,24 +145,27 @@ function AudioEdit( {
 				</BlockControls>
 			) }
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'godam' ) }>
+				<PanelBody title={ __( 'Settings', 'godam' ) } data-test-id="godam-audio-panel-settings">
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Autoplay', 'godam' ) }
 						onChange={ toggleAttribute( 'autoplay' ) }
 						checked={ autoplay }
 						help={ getAutoplayHelp }
+						data-test-id="godam-audio-control-autoplay"
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Loop', 'godam' ) }
 						onChange={ toggleAttribute( 'loop' ) }
 						checked={ loop }
+						data-test-id="godam-audio-control-loop"
 					/>
 					<SelectControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 						label={ _x( 'Preload', 'noun; Audio block parameter', 'godam' ) }
+						data-test-id="godam-audio-control-preload"
 						value={ preload || '' }
 						// `undefined` is required for the preload attribute to be unset.
 						onChange={ ( value ) =>
@@ -181,7 +185,7 @@ function AudioEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<figure { ...blockProps }>
+			<figure { ...blockProps } data-test-id="godam-audio-canvas">
 				{ /*
 				Disable the audio tag if the block is not selected
 				so the user clicking on it won't play the

--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -273,8 +273,8 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 								</div>
 							) : (
 								<div className="godam-gallery-v2-item__copy">
-									<strong title={ videoTitle }>{ videoTitle }</strong>
-									{ videoDate && <span>{ videoDate }</span> }
+									<strong title={ videoTitle } data-test-id="godam-gallery-v2-item-element-title">{ videoTitle }</strong>
+									{ videoDate && <span data-test-id="godam-gallery-v2-item-element-date">{ videoDate }</span> }
 								</div>
 							) }
 						</div>

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -674,12 +674,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						<ToggleGroupControlOption label={ __( 'M', 'godam' ) } value="M" />
 						<ToggleGroupControlOption label={ __( 'L', 'godam' ) } value="L" />
 					</ToggleGroupControl>
-					<ToggleControl
-						label={ __( 'Show Video Titles and Dates', 'godam' ) }
-						data-test-id="godam-gallery-v2-control-show-title"
-						checked={ !! showTitle }
-						onChange={ ( value ) => setAttributes( { showTitle: value } ) }
-					/>
+					<div data-test-id="godam-gallery-v2-control-show-title">
+						<ToggleControl
+							label={ __( 'Show Video Titles and Dates', 'godam' ) }
+							checked={ !! showTitle }
+							onChange={ ( value ) => setAttributes( { showTitle: value } ) }
+						/>
+					</div>
 					{
 						showEngagementSetting && (
 							<ToggleControl
@@ -833,12 +834,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 								</div>
 							</div>
 						) }
-						<ToggleControl
-							label={ __( 'Enable More Items', 'godam' ) }
-							data-test-id="godam-gallery-v2-control-enable-more-items"
-							checked={ !! resolvedEnableMoreItems }
-							onChange={ ( value ) => updateMoreItemsSettings( value ) }
-						/>
+						<div data-test-id="godam-gallery-v2-control-enable-more-items">
+							<ToggleControl
+								label={ __( 'Enable More Items', 'godam' ) }
+								checked={ !! resolvedEnableMoreItems }
+								onChange={ ( value ) => updateMoreItemsSettings( value ) }
+							/>
+						</div>
 						{ resolvedEnableMoreItems && (
 							<SelectControl
 								label={ __( 'More Items Behavior', 'godam' ) }

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -589,11 +589,12 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Source', 'godam' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Source', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-source">
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'Gallery Source', 'godam' ) }
+						data-test-id="godam-gallery-v2-control-mode"
 						value={ mode }
 						onChange={ ( value ) => {
 							if ( value ) {
@@ -606,11 +607,12 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					</ToggleGroupControl>
 				</PanelBody>
 
-				<PanelBody title={ __( 'Gallery Settings', 'godam' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Gallery Settings', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-settings">
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'Layout', 'godam' ) }
+						data-test-id="godam-gallery-v2-control-layout"
 						value={ layout }
 						onChange={ ( value ) => {
 							if ( ! value ) {
@@ -649,6 +651,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'View Ratio', 'godam' ) }
+						data-test-id="godam-gallery-v2-control-view-ratio"
 						value={ viewRatio }
 						onChange={ ( value ) => value && setAttributes( { viewRatio: value } ) }
 					>
@@ -662,6 +665,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'Item Size', 'godam' ) }
+						data-test-id="godam-gallery-v2-control-item-width"
 						value={ itemWidth }
 						onChange={ ( value ) => value && setAttributes( { itemWidth: value } ) }
 						help={ __( 'Size of each gallery item.', 'godam' ) }
@@ -672,6 +676,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					</ToggleGroupControl>
 					<ToggleControl
 						label={ __( 'Show Video Titles and Dates', 'godam' ) }
+						data-test-id="godam-gallery-v2-control-show-title"
 						checked={ !! showTitle }
 						onChange={ ( value ) => setAttributes( { showTitle: value } ) }
 					/>
@@ -695,9 +700,10 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				</PanelBody>
 
 				{ mode === 'query' && (
-					<PanelBody title={ __( 'Query Settings', 'godam' ) } initialOpen={ true }>
+					<PanelBody title={ __( 'Query Settings', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-query">
 						<RangeControl
 							label={ __( 'Number of videos', 'godam' ) }
+							data-test-id="godam-gallery-v2-control-count"
 							value={ count }
 							onChange={ ( value ) => setAttributes( { count: value } ) }
 							min={ 1 }
@@ -829,6 +835,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						) }
 						<ToggleControl
 							label={ __( 'Enable More Items', 'godam' ) }
+							data-test-id="godam-gallery-v2-control-enable-more-items"
 							checked={ !! resolvedEnableMoreItems }
 							onChange={ ( value ) => updateMoreItemsSettings( value ) }
 						/>
@@ -853,11 +860,12 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				) }
 			</InspectorControls>
 
-			<div { ...blockProps }>
+			<div { ...blockProps } data-test-id="godam-gallery-v2-canvas">
 
 				{ mode === 'handpicked' && (
 					<div
 						className={ `godam-gallery-v2__canvas godam-gallery-v2__canvas--${ layout }` }
+						data-test-id="godam-gallery-v2-canvas-handpicked"
 					>
 						<InnerBlocks
 							allowedBlocks={ ALLOWED_BLOCKS }
@@ -870,6 +878,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				{ mode === 'query' && (
 					<div
 						className={ `godam-gallery-v2__canvas godam-gallery-v2__canvas--${ layout }` }
+						data-test-id="godam-gallery-v2-canvas-query"
 					>
 						{ queryPreviewVideos === null && (
 							<div className="godam-gallery-v2__state godam-gallery-v2__state--loading">
@@ -891,12 +900,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 									<div
 										className={ `godam-gallery-v2__query-item godam-gallery-v2__query-item--ratio-${ viewRatio.replace( ':', '-' ) }` }
 										key={ video.id }
+										data-test-id={ `godam-gallery-v2-element-query-item-${ video.id }` }
 									>
 										<div className="godam-gallery-v2__query-thumb">
 											{ video.thumbnail ? (
 												<img src={ video.thumbnail } alt={ video.title } />
 											) : (
-												<span>{ __( 'Video', 'godam' ) }</span>
+												<span data-test-id="godam-gallery-v2-element-thumbnail-fallback">{ __( 'Video', 'godam' ) }</span>
 											) }
 										</div>
 										{ showTitle && (

--- a/assets/src/blocks/godam-pdf/edit.js
+++ b/assets/src/blocks/godam-pdf/edit.js
@@ -101,7 +101,7 @@ function PdfEdit( {
 
 	if ( ! src && ! temporaryURL ) {
 		return (
-			<div { ...blockProps }>
+			<div { ...blockProps } data-test-id="godam-pdf-canvas-placeholder">
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
 					onSelect={ onSelectPdf }
@@ -110,6 +110,7 @@ function PdfEdit( {
 					value={ attributes }
 					onError={ onUploadError }
 					labels={ { title: __( 'Document', 'godam' ) } }
+					data-test-id="godam-pdf-button-select"
 				/>
 			</div>
 		);
@@ -131,10 +132,11 @@ function PdfEdit( {
 				</BlockControls>
 			) }
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'godam' ) }>
+				<PanelBody title={ __( 'Settings', 'godam' ) } data-test-id="godam-pdf-panel-settings">
 					<RangeControl
 						__nextHasNoMarginBottom
 						label={ __( 'Height (px)', 'godam' ) }
+						data-test-id="godam-pdf-control-height"
 						value={ height }
 						onChange={ ( value ) =>
 							setAttributes( { height: value } )
@@ -145,7 +147,7 @@ function PdfEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<figure { ...blockProps }>
+			<figure { ...blockProps } data-test-id="godam-pdf-canvas">
 				{ /*
 				Disable the embed if the block is not selected
 				so the user clicking on it won't interact with the PDF.

--- a/assets/src/blocks/godam-pdf/edit.js
+++ b/assets/src/blocks/godam-pdf/edit.js
@@ -102,16 +102,17 @@ function PdfEdit( {
 	if ( ! src && ! temporaryURL ) {
 		return (
 			<div { ...blockProps } data-test-id="godam-pdf-canvas-placeholder">
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					onSelect={ onSelectPdf }
-					accept="application/pdf"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ attributes }
-					onError={ onUploadError }
-					labels={ { title: __( 'Document', 'godam' ) } }
-					data-test-id="godam-pdf-button-select"
-				/>
+				<div data-test-id="godam-pdf-button-select">
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						onSelect={ onSelectPdf }
+						accept="application/pdf"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ attributes }
+						onError={ onUploadError }
+						labels={ { title: __( 'Document', 'godam' ) } }
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -98,44 +98,48 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 
 	return (
 		<>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Autoplay', 'godam' ) }
-				data-test-id="godam-video-control-autoplay"
-				onChange={ ( e ) => {
-					/**
-					 * When autoplay is enabled, mute the video.
-					 * This behaviour follows core/video block.
-					 */
-					toggleFactory.muted( e );
-					toggleFactory.autoplay( e );
-				} }
-				checked={ !! autoplay }
-				help={ getAutoplayHelp }
-			/>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Loop', 'godam' ) }
-				data-test-id="godam-video-control-loop"
-				onChange={ toggleFactory.loop }
-				checked={ !! loop }
-			/>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Muted', 'godam' ) }
-				data-test-id="godam-video-control-muted"
-				onChange={ toggleFactory.muted }
-				disabled={ autoplay }
-				checked={ !! muted }
-				help={ getMutedHelp }
-			/>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Playback controls', 'godam' ) }
-				data-test-id="godam-video-control-controls"
-				onChange={ toggleFactory.controls }
-				checked={ !! controls }
-			/>
+			<div data-test-id="godam-video-control-autoplay">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Autoplay', 'godam' ) }
+					onChange={ ( e ) => {
+						/**
+						 * When autoplay is enabled, mute the video.
+						 * This behaviour follows core/video block.
+						 */
+						toggleFactory.muted( e );
+						toggleFactory.autoplay( e );
+					} }
+					checked={ !! autoplay }
+					help={ getAutoplayHelp }
+				/>
+			</div>
+			<div data-test-id="godam-video-control-loop">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Loop', 'godam' ) }
+					onChange={ toggleFactory.loop }
+					checked={ !! loop }
+				/>
+			</div>
+			<div data-test-id="godam-video-control-muted">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Muted', 'godam' ) }
+					onChange={ toggleFactory.muted }
+					disabled={ autoplay }
+					checked={ !! muted }
+					help={ getMutedHelp }
+				/>
+			</div>
+			<div data-test-id="godam-video-control-controls">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Playback controls', 'godam' ) }
+					onChange={ toggleFactory.controls }
+					checked={ !! controls }
+				/>
+			</div>
 			{
 				showShareButtonSetting && (
 					<ToggleControl

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -101,6 +101,7 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Autoplay', 'godam' ) }
+				data-test-id="godam-video-control-autoplay"
 				onChange={ ( e ) => {
 					/**
 					 * When autoplay is enabled, mute the video.
@@ -115,12 +116,14 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Loop', 'godam' ) }
+				data-test-id="godam-video-control-loop"
 				onChange={ toggleFactory.loop }
 				checked={ !! loop }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Muted', 'godam' ) }
+				data-test-id="godam-video-control-muted"
 				onChange={ toggleFactory.muted }
 				disabled={ autoplay }
 				checked={ !! muted }
@@ -129,6 +132,7 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ __( 'Playback controls', 'godam' ) }
+				data-test-id="godam-video-control-controls"
 				onChange={ toggleFactory.controls }
 				checked={ !! controls }
 			/>
@@ -148,6 +152,7 @@ const VideoSettings = ( { setAttributes, attributes, isInsideQueryLoop = false }
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 					label={ __( 'Performance', 'godam' ) }
+					data-test-id="godam-video-control-performance"
 					value={ selectedPerformanceMode }
 					onChange={ onChangePerformanceMode }
 					options={ options }

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -679,7 +679,7 @@ function VideoEdit( {
 						onSelect={ onSelectVideo }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						render={ ( { open } ) => (
-							<Button onClick={ open } variant="primary">
+							<Button onClick={ open } variant="primary" data-test-id="godam-video-button-select-video">
 								{ __( 'Select Video', 'godam' ) }
 							</Button>
 						) }
@@ -763,6 +763,7 @@ function VideoEdit( {
 								label={ __( 'Edit Video', 'godam' ) }
 								href={ `${ window?.pluginInfo?.adminUrl || '/wp-admin/' }admin.php?page=rtgodam_video_editor&id=${ undefined !== id ? id : cmmId }` }
 								target="_blank"
+								data-test-id="godam-video-toolbar-edit"
 							/>
 						</ToolbarGroup>
 					) }
@@ -771,6 +772,7 @@ function VideoEdit( {
 							icon={ trendingUp }
 							label={ __( 'Video SEO', 'godam' ) }
 							onClick={ () => setIsSEOModelOpen( true ) }
+							data-test-id="godam-video-toolbar-seo"
 						>
 							{ __( 'SEO', 'godam' ) }
 						</ToolbarButton>
@@ -792,7 +794,7 @@ function VideoEdit( {
 				</BlockControls>
 			) }
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'godam' ) }>
+				<PanelBody title={ __( 'Settings', 'godam' ) } data-test-id="godam-video-panel-settings">
 					<VideoCommonSettings
 						setAttributes={ setAttributes }
 						attributes={ attributes }
@@ -808,6 +810,7 @@ function VideoEdit( {
 									<SelectControl
 										__nextHasNoMarginBottom
 										label={ __( 'Hover Option', 'godam' ) }
+										data-test-id="godam-video-control-hover-select"
 										help={ autoplay
 											? __( 'Hover option is disabled when autoplay is on.', 'godam' )
 											: __( 'Choose the action to perform on video hover.', 'godam' ) }
@@ -838,6 +841,7 @@ function VideoEdit( {
 									__nextHasNoMarginBottom
 								>
 									<SelectControl
+										data-test-id="godam-video-control-aspect-ratio"
 										value={ attributes.aspectRatio || 'responsive' }
 										options={ [
 											{ label: __( 'Original', 'godam' ), value: 'responsive' },
@@ -851,6 +855,7 @@ function VideoEdit( {
 								<UnitControl
 									__nextHasNoMarginBottom
 									label={ __( 'Height', 'godam' ) }
+									data-test-id="godam-video-control-player-height"
 									value={ playerHeight || '' }
 									onChange={ ( value ) => setAttributes( { playerHeight: value || '' } ) }
 									help={ __( 'Set the video height. Width is auto-calculated from the aspect ratio.', 'godam' ) }
@@ -875,18 +880,20 @@ function VideoEdit( {
 
 				{ /* Only show additional settings when not inside a Query Loop */ }
 				{ ! isInsideQueryLoop && (
-					<PanelBody title={ __( 'Overlay Blocks', 'godam' ) }>
+					<PanelBody title={ __( 'Overlay Blocks', 'godam' ) } data-test-id="godam-video-panel-overlay-blocks">
 						<ToggleControl
 							label={ __( 'Show overlay blocks', 'godam' ) }
 							checked={ showOverlay }
 							onChange={ ( value ) => setAttributes( { showOverlay: value } ) }
 							help={ __( 'Display blocks on top of the video player.', 'godam' ) }
+							data-test-id="godam-video-control-show-overlay"
 						/>
 
 						{ showOverlay && (
 							<>
 								<SelectControl
 									label={ __( 'Vertical alignment', 'godam' ) }
+									data-test-id="godam-video-control-vertical-alignment"
 									value={ verticalAlignment }
 									options={ [
 										{ label: __( 'Top', 'godam' ), value: 'top' },
@@ -899,6 +906,7 @@ function VideoEdit( {
 
 								<RangeControl
 									label={ __( 'Time range', 'godam' ) }
+									data-test-id="godam-video-control-overlay-time-range"
 									value={ overlayTimeRange }
 									onChange={ ( value ) => setAttributes( { overlayTimeRange: value } ) }
 									min={ 0 }
@@ -929,7 +937,7 @@ function VideoEdit( {
 				isInsideQueryLoop ? (
 					<div { ...blockProps }>
 						<div className="godam-editor-video-placeholder">
-							<span className="godam-editor-video-label">
+							<span className="godam-editor-video-label" data-test-id="godam-video-element-query-label">
 								{ __( 'Video', 'godam' ) }
 							</span>
 						</div>
@@ -943,11 +951,12 @@ function VideoEdit( {
 							setAttributes={ setAttributes }
 						/>
 
-						<figure { ...blockProps }>
+						<figure { ...blockProps } data-test-id="godam-video-canvas">
 							<div className="godam-video-wrapper">
 								{ showOverlay && (
 									<div
 										className={ `godam-video-overlay-container godam-overlay-alignment-${ verticalAlignment }` }
+										data-test-id="godam-video-canvas-overlay"
 									>
 										<InnerBlocks
 											allowedBlocks={ ALLOWED_BLOCKS }

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -881,13 +881,14 @@ function VideoEdit( {
 				{ /* Only show additional settings when not inside a Query Loop */ }
 				{ ! isInsideQueryLoop && (
 					<PanelBody title={ __( 'Overlay Blocks', 'godam' ) } data-test-id="godam-video-panel-overlay-blocks">
-						<ToggleControl
-							label={ __( 'Show overlay blocks', 'godam' ) }
-							checked={ showOverlay }
-							onChange={ ( value ) => setAttributes( { showOverlay: value } ) }
-							help={ __( 'Display blocks on top of the video player.', 'godam' ) }
-							data-test-id="godam-video-control-show-overlay"
-						/>
+						<div data-test-id="godam-video-control-show-overlay">
+							<ToggleControl
+								label={ __( 'Show overlay blocks', 'godam' ) }
+								checked={ showOverlay }
+								onChange={ ( value ) => setAttributes( { showOverlay: value } ) }
+								help={ __( 'Display blocks on top of the video player.', 'godam' ) }
+							/>
+						</div>
 
 						{ showOverlay && (
 							<>

--- a/assets/src/blocks/godam-video-duration/edit.js
+++ b/assets/src/blocks/godam-video-duration/edit.js
@@ -59,7 +59,7 @@ function Edit( { attributes, setAttributes } ) {
 			</InspectorControls>
 			<div { ...blockProps }>
 				<p className="godam-duration-preview">
-					<span>
+					<span data-test-id="godam-video-duration-element-preview">
 						{ durationOptions.find( ( option ) => option.value === durationFormat )?.placeholder || __( '00:00:00', 'godam' ) }
 					</span>
 				</p>

--- a/assets/src/blocks/godam-video-thumbnail/edit.js
+++ b/assets/src/blocks/godam-video-thumbnail/edit.js
@@ -36,7 +36,7 @@ function Edit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Thumbnail Settings', 'godam' ) }>
+				<PanelBody title={ __( 'Thumbnail Settings', 'godam' ) } data-test-id="godam-video-thumbnail-panel-settings">
 					<ToggleControl
 						label={ __( 'Show play button overlay', 'godam' ) }
 						checked={ showPlayButton }
@@ -45,6 +45,7 @@ function Edit( { attributes, setAttributes } ) {
 							? __( 'Play button will be displayed.', 'godam' )
 							: __( 'No play button will be displayed.', 'godam' )
 						}
+						data-test-id="godam-video-thumbnail-control-show-play-button"
 					/>
 					<ToggleControl
 						label={ __( 'Link to post', 'godam' ) }
@@ -54,6 +55,7 @@ function Edit( { attributes, setAttributes } ) {
 							? __( 'Thumbnail will link to the video page.', 'godam' )
 							: __( 'Thumbnail will not be linked.', 'godam' )
 						}
+						data-test-id="godam-video-thumbnail-control-link-to-video"
 					/>
 					{ linkToVideo && (
 						<ToggleControl
@@ -64,21 +66,22 @@ function Edit( { attributes, setAttributes } ) {
 								? __( 'Link will open in a new tab.', 'godam' )
 								: __( 'Link will open in the same tab.', 'godam' )
 							}
+							data-test-id="godam-video-thumbnail-control-open-in-new-tab"
 						/>
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<div { ...blockProps }>
+			<div { ...blockProps } data-test-id="godam-video-thumbnail-canvas">
 				<div className="godam-editor-video-thumbnail">
 
 					{ /* Placeholder text */ }
-					<span className="godam-editor-video-label">
+					<span className="godam-editor-video-label" data-test-id="godam-video-thumbnail-element-label">
 						{ __( 'GoDAM Video Thumbnail', 'godam' ) }
 					</span>
 
 					{ /* Play button overlay */ }
 					{ showPlayButton && (
-						<div className="godam-editor-video-play-button">
+						<div className="godam-editor-video-play-button" data-test-id="godam-video-thumbnail-element-play-button">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="60" height="60" aria-hidden="true" focusable="false">
 								<path d="M8 5v14l11-7z" fill="currentColor"></path>
 							</svg>

--- a/assets/src/blocks/godam-video-thumbnail/edit.js
+++ b/assets/src/blocks/godam-video-thumbnail/edit.js
@@ -37,37 +37,40 @@ function Edit( { attributes, setAttributes } ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Thumbnail Settings', 'godam' ) } data-test-id="godam-video-thumbnail-panel-settings">
-					<ToggleControl
-						label={ __( 'Show play button overlay', 'godam' ) }
-						checked={ showPlayButton }
-						onChange={ ( value ) => setAttributes( { showPlayButton: value } ) }
-						help={ showPlayButton
-							? __( 'Play button will be displayed.', 'godam' )
-							: __( 'No play button will be displayed.', 'godam' )
-						}
-						data-test-id="godam-video-thumbnail-control-show-play-button"
-					/>
-					<ToggleControl
-						label={ __( 'Link to post', 'godam' ) }
-						checked={ linkToVideo }
-						onChange={ ( value ) => setAttributes( { linkToVideo: value } ) }
-						help={ linkToVideo
-							? __( 'Thumbnail will link to the video page.', 'godam' )
-							: __( 'Thumbnail will not be linked.', 'godam' )
-						}
-						data-test-id="godam-video-thumbnail-control-link-to-video"
-					/>
-					{ linkToVideo && (
+					<div data-test-id="godam-video-thumbnail-control-show-play-button">
 						<ToggleControl
-							label={ __( 'Open in new tab', 'godam' ) }
-							checked={ openInNewTab }
-							onChange={ ( value ) => setAttributes( { openInNewTab: value } ) }
-							help={ openInNewTab
-								? __( 'Link will open in a new tab.', 'godam' )
-								: __( 'Link will open in the same tab.', 'godam' )
+							label={ __( 'Show play button overlay', 'godam' ) }
+							checked={ showPlayButton }
+							onChange={ ( value ) => setAttributes( { showPlayButton: value } ) }
+							help={ showPlayButton
+								? __( 'Play button will be displayed.', 'godam' )
+								: __( 'No play button will be displayed.', 'godam' )
 							}
-							data-test-id="godam-video-thumbnail-control-open-in-new-tab"
 						/>
+					</div>
+					<div data-test-id="godam-video-thumbnail-control-link-to-video">
+						<ToggleControl
+							label={ __( 'Link to post', 'godam' ) }
+							checked={ linkToVideo }
+							onChange={ ( value ) => setAttributes( { linkToVideo: value } ) }
+							help={ linkToVideo
+								? __( 'Thumbnail will link to the video page.', 'godam' )
+								: __( 'Thumbnail will not be linked.', 'godam' )
+							}
+						/>
+					</div>
+					{ linkToVideo && (
+						<div data-test-id="godam-video-thumbnail-control-open-in-new-tab">
+							<ToggleControl
+								label={ __( 'Open in new tab', 'godam' ) }
+								checked={ openInNewTab }
+								onChange={ ( value ) => setAttributes( { openInNewTab: value } ) }
+								help={ openInNewTab
+									? __( 'Link will open in a new tab.', 'godam' )
+									: __( 'Link will open in the same tab.', 'godam' )
+								}
+							/>
+						</div>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/assets/src/blocks/sureforms/blocks/recorder/edit.js
+++ b/assets/src/blocks/sureforms/blocks/recorder/edit.js
@@ -267,12 +267,13 @@ export default function Edit( props ) {
 		{
 			id: 'required',
 			component: (
-				<ToggleControl
-					checked={ required }
-					label={ __( 'Is recorder field required?', 'godam' ) }
-					onChange={ () => setAttributes( { required: ! required } ) }
-					data-test-id="godam-srfm-recorder-control-required"
-				/>
+				<div data-test-id="godam-srfm-recorder-control-required">
+					<ToggleControl
+						checked={ required }
+						label={ __( 'Is recorder field required?', 'godam' ) }
+						onChange={ () => setAttributes( { required: ! required } ) }
+					/>
+				</div>
 			),
 		},
 		{

--- a/assets/src/blocks/sureforms/blocks/recorder/edit.js
+++ b/assets/src/blocks/sureforms/blocks/recorder/edit.js
@@ -170,6 +170,7 @@ export default function Edit( props ) {
 						setAttributes( { label: value } );
 					} }
 					value={ label }
+					data-test-id="godam-srfm-recorder-control-label"
 				/>
 			),
 		},
@@ -185,6 +186,7 @@ export default function Edit( props ) {
 						setAttributes( { description: value } );
 					} }
 					value={ description }
+					data-test-id="godam-srfm-recorder-control-description"
 				/>
 			),
 		},
@@ -212,24 +214,28 @@ export default function Edit( props ) {
 						label={ __( 'Local files', 'godam' ) }
 						checked={ checkFileSelector( 'file_input' ) }
 						onChange={ () => updateFileSelector( 'file_input' ) }
+						data-test-id="godam-srfm-recorder-control-file-selector-local"
 					/>
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						label={ __( 'Webcam', 'godam' ) }
 						checked={ checkFileSelector( 'webcam' ) }
 						onChange={ () => updateFileSelector( 'webcam' ) }
+						data-test-id="godam-srfm-recorder-control-file-selector-webcam"
 					/>
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						label={ __( 'Screencast', 'godam' ) }
 						checked={ checkFileSelector( 'screen_capture' ) }
 						onChange={ () => updateFileSelector( 'screen_capture' ) }
+						data-test-id="godam-srfm-recorder-control-file-selector-screencast"
 					/>
 					<CheckboxControl
 						__nextHasNoMarginBottom
 						label={ __( 'Audio', 'godam' ) }
 						checked={ checkFileSelector( 'audio' ) }
 						onChange={ () => updateFileSelector( 'audio' ) }
+						data-test-id="godam-srfm-recorder-control-file-selector-audio"
 					/>
 				</>
 			),
@@ -242,6 +248,7 @@ export default function Edit( props ) {
 					__nextHasNoMarginBottom
 					placeholder={ __( '100 MB', 'godam' ) }
 					label={ __( 'Maximum file size (in MB)', 'godam' ) }
+					data-test-id="godam-srfm-recorder-control-max-file-size"
 					help={ sprintf(
 						// Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
 						__( 'Maximum allowed on this server: %s MB', 'godam' ),
@@ -264,6 +271,7 @@ export default function Edit( props ) {
 					checked={ required }
 					label={ __( 'Is recorder field required?', 'godam' ) }
 					onChange={ () => setAttributes( { required: ! required } ) }
+					data-test-id="godam-srfm-recorder-control-required"
 				/>
 			),
 		},
@@ -277,6 +285,7 @@ export default function Edit( props ) {
 					__nextHasNoMarginBottom
 					help={ __( 'Enter the required error message', 'godam' ) }
 					value={ currentErrorMsg }
+					data-test-id="godam-srfm-recorder-control-error-message"
 					onChange={ ( value ) => {
 						setCurrentErrorMsg( value );
 						setAttributes( { errorMsg: value } );
@@ -288,9 +297,9 @@ export default function Edit( props ) {
 
 	return (
 		<>
-			<div { ...blockProps }>
+			<div { ...blockProps } data-test-id="godam-srfm-recorder-canvas">
 				<InspectorControls>
-					<PanelBody title={ __( 'Field settings', 'godam' ) }>
+					<PanelBody title={ __( 'Field settings', 'godam' ) } data-test-id="godam-srfm-recorder-panel-settings">
 						{ fieldOptions.map( ( option ) => option.component ) }
 					</PanelBody>
 				</InspectorControls>
@@ -324,6 +333,7 @@ export default function Edit( props ) {
 							margin: '4px 0',
 						} }
 						className="srfm-button"
+						data-test-id="godam-srfm-recorder-button-record"
 					>
 						<RichText
 							type="label"

--- a/pages/godam/App.js
+++ b/pages/godam/App.js
@@ -122,7 +122,7 @@ const App = () => {
 			) }
 
 			<div className="godam-settings__container">
-				<nav className={ `godam-settings__container__tabs ${ isSidebarOpen ? 'open' : '' } ${ isSafari() ? 'is-safari' : '' }` }>
+				<nav className={ `godam-settings__container__tabs ${ isSidebarOpen ? 'open' : '' } ${ isSafari() ? 'is-safari' : '' }` } data-test-id="godam-settings-nav">
 					<button
 						className={ `godam-settings__close-btn ${ isSidebarOpen ? 'open' : '' }` }
 						onClick={ () => setIsSidebarOpen( false ) }
@@ -137,6 +137,7 @@ const App = () => {
 							key={ id }
 							href={ `#${ id }` }
 							className={ `sidebar-nav-item whitespace-nowrap ${ activeTab === id ? 'active' : '' }` }
+							data-test-id={ `godam-settings-nav-${ id }` }
 							onClick={ () => {
 								setActiveTab( id );
 								setIsSidebarOpen( false );
@@ -147,7 +148,7 @@ const App = () => {
 						</a>
 					) ) }
 				</nav>
-				<div id="main-content" className="godam-settings__container__content">
+				<div id="main-content" className="godam-settings__container__content" data-test-id="godam-settings-content">
 					{ activeTabData && <activeTabData.component /> }
 				</div>
 			</div>

--- a/pages/godam/components/tabs/VideoSettings/APISettings.jsx
+++ b/pages/godam/components/tabs/VideoSettings/APISettings.jsx
@@ -122,6 +122,7 @@ const APISettings = ( { setNotice } ) => {
 							disabled={ isAPIKeyLoading || hasAPIKey || ! apiKey.trim() }
 							variant="primary"
 							isBusy={ isAPIKeyLoading }
+							data-test-id="godam-settings-video-button-save-api-key"
 						>
 							{ isAPIKeyLoading ? __( 'Saving…', 'godam' ) : __( 'Save API Key', 'godam' ) }
 						</Button>
@@ -132,6 +133,7 @@ const APISettings = ( { setNotice } ) => {
 							variant="secondary"
 							isDestructive
 							isBusy={ isDeactivateLoading }
+							data-test-id="godam-settings-video-button-remove-api-key"
 						>
 							{ __( 'Remove API Key', 'godam' ) }
 						</Button>

--- a/pages/godam/components/tabs/VideoSettings/VideoSettings.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoSettings.jsx
@@ -87,7 +87,7 @@ const VideoSettings = () => {
 	}, [ isChanged ] );
 
 	return (
-		<div>
+		<div data-test-id="godam-settings-video">
 			{ notice.isVisible && (
 				<Notice
 					className="mb-4"
@@ -142,6 +142,7 @@ const VideoSettings = () => {
 					icon={ saveMediaSettingsLoading && <Spinner /> }
 					isBusy={ saveMediaSettingsLoading }
 					disabled={ saveMediaSettingsLoading || ! isChanged }
+					data-test-id="godam-settings-video-button-save"
 				>
 					{ saveMediaSettingsLoading ? __( 'Saving…', 'godam' ) : __( 'Save', 'godam' ) }
 				</Button>

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -93,29 +93,29 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 			>
 				<PanelBody>
 					<div className="flex flex-col gap-2 opacity-90 relative">
-						<ToggleControl
-							__nextHasNoMarginBottom
-							className="godam-toggle"
-							label={ __( 'Enable video watermark', 'godam' ) }
-							data-test-id="godam-settings-video-control-watermark-enabled"
-							checked={ enableWatermark }
-							onChange={ ( value ) => {
-								handleSettingChange( 'watermark', value );
-								setNotice( { ...notice, isVisible: false } );
-							} }
-							disabled={ ! hasAPIKey }
-							help={ __(
-								'If enabled, GoDAM will add a watermark to the transcoded video',
-								'godam',
-							) }
-						/>
+						<div data-test-id="godam-settings-video-control-watermark-enabled">
+							<ToggleControl
+								__nextHasNoMarginBottom
+								className="godam-toggle"
+								label={ __( 'Enable video watermark', 'godam' ) }
+								checked={ enableWatermark }
+								onChange={ ( value ) => {
+									handleSettingChange( 'watermark', value );
+									setNotice( { ...notice, isVisible: false } );
+								} }
+								disabled={ ! hasAPIKey }
+								help={ __(
+									'If enabled, GoDAM will add a watermark to the transcoded video',
+									'godam',
+								) }
+							/>
+						</div>
 						{ enableWatermark && (
 							<>
-								<div>
+								<div data-test-id="godam-settings-video-control-watermark-image-toggle">
 									<ToggleControl
 										label={ __( 'Use image watermark', 'godam' ) }
 										className="godam-toggle"
-										data-test-id="godam-settings-video-control-watermark-image-toggle"
 										checked={ useImage }
 										onChange={ ( value ) => {
 											handleSettingChange( 'use_watermark_image', value );

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -97,6 +97,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 							__nextHasNoMarginBottom
 							className="godam-toggle"
 							label={ __( 'Enable video watermark', 'godam' ) }
+							data-test-id="godam-settings-video-control-watermark-enabled"
 							checked={ enableWatermark }
 							onChange={ ( value ) => {
 								handleSettingChange( 'watermark', value );
@@ -114,6 +115,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 									<ToggleControl
 										label={ __( 'Use image watermark', 'godam' ) }
 										className="godam-toggle"
+										data-test-id="godam-settings-video-control-watermark-image-toggle"
 										checked={ useImage }
 										onChange={ ( value ) => {
 											handleSettingChange( 'use_watermark_image', value );
@@ -190,6 +192,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 										<TextControl
 											__next40pxDefaultSize
 											__nextHasNoMarginBottom
+											data-test-id="godam-settings-video-control-watermark-text"
 											value={ watermarkText }
 											onChange={ ( value ) =>
 												handleSettingChange( 'watermark_text', value )

--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -420,6 +420,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 						onClick={ handleSaveAttachmentMeta }
 						isBusy={ isSavingMeta }
 						disabled={ ! isChanged }
+						data-test-id="godam-video-editor-button-save"
 					>
 						{ isSavingMeta ? __( 'Saving…', 'godam' ) : __( 'Save', 'godam' ) }
 					</Button>
@@ -453,6 +454,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 								target="_blank"
 								className="godam-button"
 								icon={ chartBar }
+								data-test-id="godam-video-editor-button-analytics"
 							>
 								{ __( 'Analytics', 'godam' ) }
 							</Button>
@@ -474,6 +476,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 								iconPosition="left"
 								onClick={ handleCopyGoDAMVideoBlock }
 								className="godam-button"
+								data-test-id="godam-video-editor-button-copy-block"
 							>
 								{ __( 'Copy Block', 'godam' ) }
 							</Button>
@@ -484,6 +487,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 							target="_blank"
 							className="godam-button"
 							icon={ seen }
+							data-test-id="godam-video-editor-button-preview"
 						>
 							{ __( 'Preview', 'godam' ) }
 						</Button>

--- a/pages/video-editor/components/LayerSelector.jsx
+++ b/pages/video-editor/components/LayerSelector.jsx
@@ -321,6 +321,7 @@ const LayerSelector = ( { closeModal, addNewLayer } ) => {
 					{ allTabs.map( ( type ) => (
 						<button
 							key={ type }
+							data-test-id={ `godam-layer-selector-tab-${ type }` }
 							className={ `layer-tab ${ activeTab === type ? 'active' : '' } ${ searchQuery ? 'disabled' : '' }` }
 							onClick={ () => {
 								if ( ! searchQuery ) {
@@ -416,6 +417,7 @@ const LayerSelector = ( { closeModal, addNewLayer } ) => {
 					className="godam-button"
 					disabled={ ! selectedLayer }
 					onClick={ () => handleCustomiseLayer() }
+					data-test-id="godam-layer-selector-button-customise"
 				>
 					{ __( 'Customise Layer', 'godam' ) }
 				</Button>

--- a/pages/video-editor/components/ads/CustomAdSettings.js
+++ b/pages/video-editor/components/ads/CustomAdSettings.js
@@ -170,6 +170,7 @@ const CustomAdSettings = ( { layerID } ) => {
 						variant="primary"
 						onClick={ () => OpenVideoSelector() }
 						disabled={ adServer === 'ad-server' }
+						data-test-id="godam-ad-button-select-video"
 					>{ __( 'Select Ad video', 'godam' ) }</Button> ) }
 				</div>
 				{ layer?.ad_url && (
@@ -183,10 +184,10 @@ const CustomAdSettings = ( { layerID } ) => {
 						</div>
 						<div className="ml-[6px] flex flex-col">
 							<Tooltip text={ __( 'Replace Ad Video', 'godam' ) } placement="right">
-								<Button className="!text-brand-neutral-900" icon={ replace } onClick={ OpenVideoSelector } disabled={ adServer === 'ad-server' } />
+								<Button className="!text-brand-neutral-900" icon={ replace } onClick={ OpenVideoSelector } disabled={ adServer === 'ad-server' } data-test-id="godam-ad-button-replace-video" />
 							</Tooltip>
 							<Tooltip text={ __( 'Remove Ad Video', 'godam' ) } placement="right">
-								<Button className="mt-1" icon={ trash } isDestructive onClick={ () => dispatch( updateLayerField( { id: layerID, field: 'ad_url', value: '' } ) ) } disabled={ adServer === 'ad-server' } />
+								<Button className="mt-1" icon={ trash } isDestructive onClick={ () => dispatch( updateLayerField( { id: layerID, field: 'ad_url', value: '' } ) ) } disabled={ adServer === 'ad-server' } data-test-id="godam-ad-button-remove-video" />
 							</Tooltip>
 						</div>
 					</div>
@@ -197,6 +198,7 @@ const CustomAdSettings = ( { layerID } ) => {
 				__nextHasNoMarginBottom
 				className="mb-4 godam-toggle"
 				label={ __( 'Skippable', 'godam' ) }
+				data-test-id="godam-ad-control-skippable"
 				checked={ layer?.skippable ?? false }
 				onChange={ ( value ) =>
 					dispatch( updateLayerField( { id: layer.id, field: 'skippable', value } ) )
@@ -208,6 +210,7 @@ const CustomAdSettings = ( { layerID } ) => {
 				layer?.skippable &&
 				<TextControl
 					label={ __( 'Skip time', 'godam' ) }
+					data-test-id="godam-ad-control-skip-time"
 					help={ __( 'Time in seconds after which the skip button will appear', 'godam' ) }
 					value={ layer?.skip_offset }
 					className="mb-4 godam-input"
@@ -221,6 +224,7 @@ const CustomAdSettings = ( { layerID } ) => {
 			<div className="mb-4">
 				<TextControl
 					label={ __( 'Click link', 'godam' ) }
+					data-test-id="godam-ad-control-link"
 					placeholder="https://example"
 					help={ __( 'Enter the URL to redirect when the ad is clicked', 'godam' ) }
 					value={ layer?.click_link }

--- a/pages/video-editor/components/ads/CustomAdSettings.js
+++ b/pages/video-editor/components/ads/CustomAdSettings.js
@@ -194,18 +194,19 @@ const CustomAdSettings = ( { layerID } ) => {
 				) }
 			</div>
 
-			<ToggleControl
-				__nextHasNoMarginBottom
-				className="mb-4 godam-toggle"
-				label={ __( 'Skippable', 'godam' ) }
-				data-test-id="godam-ad-control-skippable"
-				checked={ layer?.skippable ?? false }
-				onChange={ ( value ) =>
-					dispatch( updateLayerField( { id: layer.id, field: 'skippable', value } ) )
-				}
-				help={ __( 'Allow user to skip ad', 'godam' ) }
-				disabled={ adServer === 'ad-server' }
-			/>
+			<div data-test-id="godam-ad-control-skippable">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					className="mb-4 godam-toggle"
+					label={ __( 'Skippable', 'godam' ) }
+					checked={ layer?.skippable ?? false }
+					onChange={ ( value ) =>
+						dispatch( updateLayerField( { id: layer.id, field: 'skippable', value } ) )
+					}
+					help={ __( 'Allow user to skip ad', 'godam' ) }
+					disabled={ adServer === 'ad-server' }
+				/>
+			</div>
 			{
 				layer?.skippable &&
 				<TextControl

--- a/pages/video-editor/components/cta/HtmlCTA.js
+++ b/pages/video-editor/components/cta/HtmlCTA.js
@@ -21,10 +21,9 @@ const HtmlCTA = ( { layerID } ) => {
 	const dispatch = useDispatch();
 
 	return (
-		<>
-			<label htmlFor="custom-css" className="text-[11px] uppercase font-medium mb-2">{ __( 'Custom HTML', 'godam' ) }</label>
+		<div data-test-id="godam-cta-editor-html">
+			<span className="text-[11px] uppercase font-medium mb-2 block">{ __( 'Custom HTML', 'godam' ) }</span>
 			<Editor
-				id="custom-css"
 				className="code-editor"
 				defaultLanguage="html"
 				defaultValue={ layer.html }
@@ -35,7 +34,7 @@ const HtmlCTA = ( { layerID } ) => {
 					dispatch( updateLayerField( { id: layer.id, field: 'html', value } ) )
 				}
 			/>
-		</>
+		</div>
 	);
 };
 

--- a/pages/video-editor/components/cta/ImageCTA.js
+++ b/pages/video-editor/components/cta/ImageCTA.js
@@ -317,6 +317,7 @@ const ImageCTA = ( { layerID } ) => {
 											: 'border-gray-300 bg-white'
 									}` }
 									aria-label={ layout.label }
+									data-test-id={ `godam-cta-button-layout-${ layout.value.replace( 'card-layout--', '' ).replace( 'desktop-', '' ) }` }
 									style={ {
 										color: isSelected ? 'var(--wp-components-color-accent, #3858e9)' : '#6b7280',
 									} }
@@ -346,6 +347,7 @@ const ImageCTA = ( { layerID } ) => {
 								variant="primary"
 								className="ml-2 godam-button"
 								aria-label={ __( 'Upload or Replace CTA Image', 'godam' ) }
+								data-test-id="godam-cta-button-upload-image"
 							>
 								{ __( 'Upload', 'godam' ) }
 							</Button>
@@ -362,10 +364,10 @@ const ImageCTA = ( { layerID } ) => {
 								/>
 								<div className="ml-[6px] flex flex-col">
 									<Tooltip text={ __( 'Replace Image', 'godam' ) } placement="right">
-										<Button className="!text-brand-neutral-900" icon={ replace } isDestructive onClick={ openImageCTAUploader } />
+										<Button className="!text-brand-neutral-900" icon={ replace } isDestructive onClick={ openImageCTAUploader } data-test-id="godam-cta-button-replace-image" />
 									</Tooltip>
 									<Tooltip text={ __( 'Remove Image', 'godam' ) } placement="right">
-										<Button className="mt-1" icon={ trash } isDestructive onClick={ removeCTAImage } />
+										<Button className="mt-1" icon={ trash } isDestructive onClick={ removeCTAImage } data-test-id="godam-cta-button-remove-image" />
 									</Tooltip>
 								</div>
 							</div>
@@ -401,6 +403,7 @@ const ImageCTA = ( { layerID } ) => {
 				__next40pxDefaultSize
 				className="godam-input"
 				label={ __( 'Title', 'godam' ) }
+				data-test-id="godam-cta-control-title"
 				value={ layer.imageText }
 				onChange={ ( value ) => {
 					updateField( 'imageText', value );
@@ -415,6 +418,7 @@ const ImageCTA = ( { layerID } ) => {
 					__next40pxDefaultSize
 					className="godam-input"
 					label={ __( 'URL', 'godam' ) }
+					data-test-id="godam-cta-control-url"
 					value={ layer.imageLink }
 					onChange={ handleUrlChange }
 					placeholder="https://rtcamp.com"
@@ -431,6 +435,7 @@ const ImageCTA = ( { layerID } ) => {
 				__next40pxDefaultSize
 				className="godam-input"
 				label={ __( 'Description', 'godam' ) }
+				data-test-id="godam-cta-control-description"
 				value={ layer.imageDescription }
 				onChange={ ( value ) => {
 					updateField( 'imageDescription', value );
@@ -443,6 +448,7 @@ const ImageCTA = ( { layerID } ) => {
 				__next40pxDefaultSize
 				className="godam-input"
 				label={ __( 'CTA Button Text', 'godam' ) }
+				data-test-id="godam-cta-control-button-text"
 				value={ layer.imageCtaButtonText }
 				onChange={ ( value ) => {
 					updateField( 'imageCtaButtonText', value );

--- a/pages/video-editor/components/cta/TextCTA.js
+++ b/pages/video-editor/components/cta/TextCTA.js
@@ -66,9 +66,9 @@ const TextCTA = ( { layerID } ) => {
 	}
 
 	return (
-		<>
+		<div data-test-id="godam-cta-editor-text">
 			<div className="mb-2 flex items-end justify-between">
-				<label htmlFor="custom-css" className="text-[11px] uppercase font-medium">{ __( 'Content', 'godam' ) }</label>
+				<label className="text-[11px] uppercase font-medium">{ __( 'Content', 'godam' ) }</label>
 			</div>
 			<QuillEditor
 				intialValue={ layer.text }
@@ -82,7 +82,7 @@ const TextCTA = ( { layerID } ) => {
 				toolbarOptions={ layer.FullEditor ? allToolbarOptions : minmalToolbarOptions }
 				className="mb-4 wysiwyg-editor"
 			/>
-		</>
+		</div>
 	);
 };
 

--- a/pages/video-editor/components/forms/FormSelector.js
+++ b/pages/video-editor/components/forms/FormSelector.js
@@ -26,26 +26,27 @@ function FormSelector( { className, disabled, formID, forms, handleChange } ) {
 
 	return (
 		<>
-			<ComboboxControl
-				disabled={ disabled }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Select form', 'godam' ) }
-				data-test-id="godam-form-control-select"
-				className={ `${ className } ${ disabled ? 'disabled' : '' }` }
-				value={ form }
-				onChange={ setFormData }
-				options={ filteredOptions }
-				onFilterValueChange={ ( inputValue ) => {
-					setFilteredOptions(
-						forms?.filter( ( _form ) =>
-							_form.label
-								.toLowerCase()
-								.startsWith( inputValue.toLowerCase() ),
-						),
-					);
-				} }
-			/>
+			<div data-test-id="godam-form-control-select">
+				<ComboboxControl
+					disabled={ disabled }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Select form', 'godam' ) }
+					className={ `${ className } ${ disabled ? 'disabled' : '' }` }
+					value={ form }
+					onChange={ setFormData }
+					options={ filteredOptions }
+					onFilterValueChange={ ( inputValue ) => {
+						setFilteredOptions(
+							forms?.filter( ( _form ) =>
+								_form.label
+									.toLowerCase()
+									.startsWith( inputValue.toLowerCase() ),
+							),
+						);
+					} }
+				/>
+			</div>
 		</>
 	);
 }

--- a/pages/video-editor/components/forms/FormSelector.js
+++ b/pages/video-editor/components/forms/FormSelector.js
@@ -31,6 +31,7 @@ function FormSelector( { className, disabled, formID, forms, handleChange } ) {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				label={ __( 'Select form', 'godam' ) }
+				data-test-id="godam-form-control-select"
 				className={ `${ className } ${ disabled ? 'disabled' : '' }` }
 				value={ form }
 				onChange={ setFormData }

--- a/pages/video-editor/components/layers/CTALayer.js
+++ b/pages/video-editor/components/layers/CTALayer.js
@@ -224,9 +224,11 @@ const CTALayer = ( { layerID, goBack, duration } ) => {
 			<LayersHeader layer={ layer } goBack={ goBack } duration={ duration } />
 
 			<div className="flex flex-col godam-form-group">
-				<label htmlFor="cta-type-select" className="mb-4 label-text">{ __( 'Call to Action', 'godam' ) }</label>
+				<label htmlFor="godam-cta-control-type" className="mb-4 label-text">{ __( 'Call to Action', 'godam' ) }</label>
 				<SelectControl
 					__next40pxDefaultSize
+					id="godam-cta-control-type"
+					data-test-id="godam-cta-control-type"
 					className="mb-4"
 					onChange={ handleCTATypeSelect }
 					options={ ctaLayerOptions }

--- a/pages/video-editor/components/layers/FormLayer.js
+++ b/pages/video-editor/components/layers/FormLayer.js
@@ -135,6 +135,7 @@ const FormLayer = ( { layerID, goBack, duration } ) => {
 			<AjaxWarning formType={ layer?.form_type } formId={ getFormId() } />
 
 			<ToggleControl
+				data-test-id="godam-form-control-allow-skip"
 				__nextHasNoMarginBottom
 				className="mb-4 godam-toggle"
 				label={ __( 'Allow user to skip', 'godam' ) }

--- a/pages/video-editor/components/layers/FormLayer.js
+++ b/pages/video-editor/components/layers/FormLayer.js
@@ -134,18 +134,19 @@ const FormLayer = ( { layerID, goBack, duration } ) => {
 
 			<AjaxWarning formType={ layer?.form_type } formId={ getFormId() } />
 
-			<ToggleControl
-				data-test-id="godam-form-control-allow-skip"
-				__nextHasNoMarginBottom
-				className="mb-4 godam-toggle"
-				label={ __( 'Allow user to skip', 'godam' ) }
-				checked={ layer.allow_skip }
-				onChange={ ( value ) =>
-					dispatch( updateLayerField( { id: layer.id, field: 'allow_skip', value } ) )
-				}
-				help={ __( 'If enabled, the user will be able to skip the form submission.', 'godam' ) }
-				disabled={ ! isPluginActive }
-			/>
+			<div data-test-id="godam-form-control-allow-skip">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					className="mb-4 godam-toggle"
+					label={ __( 'Allow user to skip', 'godam' ) }
+					checked={ layer.allow_skip }
+					onChange={ ( value ) =>
+						dispatch( updateLayerField( { id: layer.id, field: 'allow_skip', value } ) )
+					}
+					help={ __( 'If enabled, the user will be able to skip the form submission.', 'godam' ) }
+					disabled={ ! isPluginActive }
+				/>
+			</div>
 
 			<Panel className="-mx-4 border-x-0">
 				<PanelBody

--- a/pages/video-editor/components/layers/HotspotLayer.js
+++ b/pages/video-editor/components/layers/HotspotLayer.js
@@ -303,6 +303,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 			{ /* Duration */ }
 			<div className="mb-6">
 				<TextControl
+					data-test-id="godam-hotspot-control-duration"
 					label={ __( 'Layer Duration (seconds)', 'godam' ) }
 					className="godam-input"
 					type="number"
@@ -318,6 +319,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 			{ /* Pause on hover */ }
 			<div className="mb-4">
 				<ToggleControl
+					data-test-id="godam-hotspot-control-pause-on-hover"
 					className="godam-toggle"
 					label={ __( 'Pause video on hover', 'godam' ) }
 					checked={ layer?.pauseOnHover || false }
@@ -337,6 +339,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 					<div key={ hotspot.id } className="p-2 w-full border rounded">
 						<div className="flex justify-between items-center">
 							<Button
+								data-test-id={ `godam-hotspot-control-select-${ index }` }
 								icon={ expandedHotspotIndex === index ? chevronUp : chevronDown }
 								className="flex-1 text-left"
 								onClick={ () => toggleHotspotExpansion( index ) }
@@ -350,12 +353,13 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 								icon={ moreVertical }
 								label={ `Hotspot ${ index + 1 } options` }
 								/* translators: %d is the hotspot index */
-								toggleProps={ { 'aria-label': sprintf( __( 'Options for Hotspot %d', 'godam' ), index + 1 ) } }
+								toggleProps={ { 'aria-label': sprintf( __( 'Options for Hotspot %d', 'godam' ), index + 1 ), 'data-test-id': `godam-hotspot-button-options-${ index }` } }
 
 							>
 								{ () => (
 									<>
 										<MenuItem
+											data-test-id={ `godam-hotspot-control-show-style-${ index }` }
 											icon={ hotspot.showStyle ? check : '' }
 											onClick={ () => {
 												updateField(
@@ -376,6 +380,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 											{ __( 'Show Style', 'godam' ) }
 										</MenuItem>
 										<MenuItem
+											data-test-id={ `godam-hotspot-control-show-icon-${ index }` }
 											icon={ hotspot.showIcon ? check : '' }
 											onClick={ () => {
 												updateField(
@@ -395,6 +400,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 											{ __( 'Show Icon', 'godam' ) }
 										</MenuItem>
 										<MenuItem
+											data-test-id={ `godam-hotspot-button-delete-${ index }` }
 											icon={ trash }
 											onClick={ () => handleDeleteHotspot( index ) }
 											className="text-red-500"
@@ -409,6 +415,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 						{ expandedHotspotIndex === index && (
 							<div className="mt-3">
 								<TextControl
+									data-test-id={ `godam-hotspot-control-tooltip-text-${ index }` }
 									className="godam-input"
 									label={ __( 'Tooltip Text', 'godam' ) }
 									placeholder={ __( 'Click Me!', 'godam' ) }
@@ -423,6 +430,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 									}
 								/>
 								<TextControl
+									data-test-id={ `godam-hotspot-control-link-${ index }` }
 									label={ __( 'Link', 'godam' ) }
 									placeholder="https://www.example.com"
 									value={ hotspot.link }
@@ -460,6 +468,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 											{ __( 'BACKGROUND COLOR', 'godam' ) }
 										</label>
 										<ColorPalette
+											data-test-id={ `godam-hotspot-control-background-color-${ index }` }
 											id={ `hotspot-color-${ index }` }
 											value={ hotspot.backgroundColor || '#0c80dfa6' }
 											className=""
@@ -486,6 +495,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 				) ) }
 
 				<Button
+					data-test-id="godam-hotspot-button-add"
 					variant="primary"
 					id="add-hotspot-btn"
 					icon={ plus }

--- a/pages/video-editor/components/layers/HotspotLayer.js
+++ b/pages/video-editor/components/layers/HotspotLayer.js
@@ -318,13 +318,14 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 
 			{ /* Pause on hover */ }
 			<div className="mb-4">
-				<ToggleControl
-					data-test-id="godam-hotspot-control-pause-on-hover"
-					className="godam-toggle"
-					label={ __( 'Pause video on hover', 'godam' ) }
-					checked={ layer?.pauseOnHover || false }
-					onChange={ ( isChecked ) => updateField( 'pauseOnHover', isChecked ) }
-				/>
+				<div data-test-id="godam-hotspot-control-pause-on-hover">
+					<ToggleControl
+						className="godam-toggle"
+						label={ __( 'Pause video on hover', 'godam' ) }
+						checked={ layer?.pauseOnHover || false }
+						onChange={ ( isChecked ) => updateField( 'pauseOnHover', isChecked ) }
+					/>
+				</div>
 				<p className="text-xs text-gray-500 mt-1">
 					{ __(
 						'Player will pause the video while the layer is displayed and users hover over the hotspots.',

--- a/pages/video-editor/components/layers/PollLayer.js
+++ b/pages/video-editor/components/layers/PollLayer.js
@@ -38,28 +38,30 @@ const PollLayer = ( { layerID, goBack, duration } ) => {
 			<LayersHeader layer={ layer } goBack={ goBack } duration={ duration } />
 			{
 				polls?.length > 0 &&
-					<ComboboxControl
-						data-test-id="godam-poll-control-select"
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Select poll', 'godam' ) }
-						className="godam-combobox mb-4"
-						value={ layer.poll_id }
-						onChange={ handlePollChange }
-						options={ polls.map( ( poll ) => ( { value: poll.pollq_id, label: poll.pollq_question } ) ) }
-					/>
+					<div data-test-id="godam-poll-control-select">
+						<ComboboxControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Select poll', 'godam' ) }
+							className="godam-combobox mb-4"
+							value={ layer.poll_id }
+							onChange={ handlePollChange }
+							options={ polls.map( ( poll ) => ( { value: poll.pollq_id, label: poll.pollq_question } ) ) }
+						/>
+					</div>
 			}
 
-			<ToggleControl
-				data-test-id="godam-poll-control-allow-skip"
-				className="mb-4 godam-toggle"
-				label={ __( 'Allow user to skip', 'godam' ) }
-				checked={ layer.allow_skip }
-				onChange={ ( value ) =>
-					dispatch( updateLayerField( { id: layer.id, field: 'allow_skip', value } ) )
-				}
-				help={ __( 'If enabled, the user will be able to skip the form submission.', 'godam' ) }
-			/>
+			<div data-test-id="godam-poll-control-allow-skip">
+				<ToggleControl
+					className="mb-4 godam-toggle"
+					label={ __( 'Allow user to skip', 'godam' ) }
+					checked={ layer.allow_skip }
+					onChange={ ( value ) =>
+						dispatch( updateLayerField( { id: layer.id, field: 'allow_skip', value } ) )
+					}
+					help={ __( 'If enabled, the user will be able to skip the form submission.', 'godam' ) }
+				/>
+			</div>
 
 			<Panel
 				className="-mx-4 border-x-0 godam-advance-panel">

--- a/pages/video-editor/components/layers/PollLayer.js
+++ b/pages/video-editor/components/layers/PollLayer.js
@@ -39,6 +39,7 @@ const PollLayer = ( { layerID, goBack, duration } ) => {
 			{
 				polls?.length > 0 &&
 					<ComboboxControl
+						data-test-id="godam-poll-control-select"
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 						label={ __( 'Select poll', 'godam' ) }
@@ -50,6 +51,7 @@ const PollLayer = ( { layerID, goBack, duration } ) => {
 			}
 
 			<ToggleControl
+				data-test-id="godam-poll-control-allow-skip"
 				className="mb-4 godam-toggle"
 				label={ __( 'Allow user to skip', 'godam' ) }
 				checked={ layer.allow_skip }
@@ -110,6 +112,7 @@ const PollLayer = ( { layerID, goBack, duration } ) => {
 					</div>
 					{ layer.allow_skip &&
 					<Button
+						data-test-id="godam-poll-button-skip"
 						className="skip-button"
 						variant="primary"
 						icon={ chevronRight }


### PR DESCRIPTION
## Add `data-test-id` attributes across GoDAM UI for E2E automation

### What
Adds stable `data-test-id` attributes to GoDAM's editor/admin UI so the
Playwright E2E suite can locate elements deterministically — instead of
relying on CSS classes, i18n label text, placeholders, or
WordPress-generated ids (all of which break on copy changes, locale
switches, or WP version bumps).

This extends the reference PoC (`feature/data-test-id-poc`) into full
coverage and reconciles every id to one convention.

**Attribute-only change.** No logic, styling, or markup structure is
altered beyond adding attributes (plus three tiny a11y label fixes — see
below). 24 files, +123/−41.

### Naming convention
- **area** — `video`, `video-editor`, `cta`, `form`, `hotspot`, `ad`, `poll`, `layer-selector`, `gallery-v2`, `gallery-v2-item`, `audio`, `pdf`, `video-thumbnail`, `video-duration`, `srfm-recorder`, `settings`, `settings-video`
- **type** — `panel`, `control`, `button`, `toolbar`, `tab`, `nav`, `content`, `canvas`, `element`, `editor`
- Per-item ids in `.map()` loops are index/entity suffixed, e.g.
  `godam-hotspot-control-link-${index}`,
  `godam-gallery-v2-element-query-item-${video.id}`,
  `godam-cta-button-layout-${cardLayoutSuffix}`.

All ids verified **globally unique** (no duplicates).

### Coverage
| Area | File(s) | Notable ids |
| --- | --- | --- |
| Video block | `blocks/godam-player/edit.js`, `edit-common-settings.js` | placeholder select, canvas/overlay, toolbar (edit/SEO), all inspector controls |
| Video editor header | `video-editor/VideoEditor.js` | `…button-save` / `-preview` / `-copy-block` / `-analytics` |
| Layer selector | `components/LayerSelector.jsx` | `…tab-${type}`, `…button-customise` |
| CTA layer | `cta/{ImageCTA,TextCTA,HtmlCTA}.js`, `layers/CTALayer.js` | type select, 8 layout tiles, title/url/description/button-text, image buttons, text/html editor wrappers |
| Form layer | `forms/FormSelector.js`, `layers/FormLayer.js` | form combobox, allow-skip |
| Hotspot layer | `layers/HotspotLayer.js` | add/options/delete, tooltip/link/color (index-suffixed) |
| Ad layer | `ads/CustomAdSettings.js` | select/replace/remove video, skippable, skip-time, link |
| Poll layer | `layers/PollLayer.js` | poll select, allow-skip, skip |
| Gallery v2 | `blocks/godam-gallery-v2/edit.js` (+ `-item`) | panels, all controls, canvases, query items |
| Audio / PDF / Video-thumbnail / Video-duration / SureForms recorder | respective `edit.js` | panels, controls, canvas, select buttons |
| Settings page + Video tab | `pages/godam/App.js`, `VideoSettings/*` | nav + `…nav-${id}`, content, save/API-key buttons, watermark controls |

### Minor a11y fixes bundled in
Pre-existing broken `htmlFor`/`id` associations corrected while tagging
the same elements:
- `CTALayer.js` — `<label htmlFor>` now correctly points at the CTA-type `<select>` (`id` added).
- `HtmlCTA.js` / `TextCTA.js` — removed `htmlFor="custom-css"` that referenced a non-existent input (replaced with a plain heading span); wrapped editors in a tagged container.

### How it's consumed
WP components forward `data-test-id` to their root DOM node:
- `TextControl` / `TextareaControl` / `SelectControl` → the input/select itself.
- `Button` / `ToolbarButton` → the button/anchor.
- `ComboboxControl`, Monaco, Quill → a wrapper; tests scope into the inner control (`… input`, `.monaco-editor .view-lines`, `.ql-editor`).

The E2E repo's `selectors/godam.js` mirrors this inventory as the single
source of truth (page objects/specs import the constants, never raw
strings).

### Testing
- Verified all `data-test-id` values are unique across the bundle.
- No runtime behavior change — attributes only.
- Consumed by the GoDAM E2E suite (CTA author → preview → copy-block →
  paste → frontend assertions, plus video/form/hotspot/ad/poll flows).

### Notes for reviewer
- Pure additive; safe to merge ahead of the E2E suite switching over.
- If a future component reorders/renames, the `<area>-<type>-<name>`
  scheme keeps ids decoupled from layout order and visible text.