### PR TITLE
fix(analytics): cap engagement rate at 100% in dashboard charts

### DIFF
--- a/pages/analytics/PlaybackPerformance.js
+++ b/pages/analytics/PlaybackPerformance.js
@@ -85,7 +85,9 @@ export default function PlaybackPerformanceDashboard( {
 				if ( mode === 'dashboard' ) {
 					return {
 						date,
-						engagement_rate: +entry.avg_engagement?.toFixed( 2 ) || 0,
+						// Engagement is a share of the video watched: cap at 100%
+						// as a display guard (the backend already bounds it).
+						engagement_rate: Math.min( +entry.avg_engagement?.toFixed( 2 ) || 0, 100 ),
 						play_rate: +( entry.play_rate * 100 || 0 ).toFixed( 2 ),
 						watch_time: +( entry.watch_time || 0 ).toFixed( 2 ),
 					};
@@ -98,10 +100,12 @@ export default function PlaybackPerformanceDashboard( {
 					plays: dailyPlays,
 				} = entry;
 
-				const dailyEngagementRate =
+				const dailyEngagementRate = Math.min(
 					dailyPlays && dailyVideoLength
 						? ( dailyPlayTime / ( dailyPlays * dailyVideoLength ) ) * 100
-						: 0;
+						: 0,
+					100,
+				);
 
 				const dailyPlayRate = dailyPageLoad
 					? ( dailyPlays / dailyPageLoad ) * 100

--- a/pages/analytics/helper.js
+++ b/pages/analytics/helper.js
@@ -289,7 +289,11 @@ export function singleMetricsChart(
 export function calculateEngagementRate( plays, videoLength, playTime ) {
 	const engagementRate =
     plays && videoLength ? ( playTime / ( plays * videoLength ) ) * 100 : 0;
-	return engagementRate.toFixed( 2 );
+	// Engagement is the share of the video watched, so it can never exceed
+	// 100%. play_time and plays are kept consistent server-side (orphan
+	// playback is excluded from both); this cap guards the display against
+	// stale or legacy data that predates that fix.
+	return Math.min( engagementRate, 100 ).toFixed( 2 );
 }
 
 export function calculatePlayRate( pageLoad, plays ) {


### PR DESCRIPTION
## Problem (P0)

The GoDAM dashboard reported an **Engagement Rate of 318.81%**. Engagement is the share of a video watched and cannot exceed 100%.

## Fix (display-side guard)

The root-cause fix lives in the analytics service — rtCamp/godam-analytics#172 — which keeps `play_time` consistent with `plays` (orphan playback excluded from both). This PR adds the matching **display-side guard** in the WP plugin so the UI never renders above 100%, even from stale or legacy cached data:

- `calculateEngagementRate()` clamps to 100%.
- `PlaybackPerformance` dashboard-mode and single-video computations clamp to 100%.

## Notes

Once both PRs ship, engagement is bounded server-side *and* client-side. Existing dashboards displaying historical (pre-fix) rows will now show ≤ 100% instead of the 318% spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
