### PR TITLE
refactor: make godam-admin-root styles global for add-ons

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -127,6 +127,54 @@ $media-frame-width: calc(300px + 2 * 24px);
 	}
 }
 
+/* Style for GoDAM admin pages container */
+.godam-admin-root {
+	margin-left: -20px;
+
+	&.not-safari {
+		color: #000;
+		min-height: calc(100vh - var(--wp-admin--admin-bar--height, 0));
+		padding-top: var(--wp-admin--admin-bar--height, 0);
+		position: fixed;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		margin-left: 160px;
+		overflow: auto;
+
+		&.godam-video-editor-page {
+			background-color: #fff;
+		}
+	}
+
+	#root-video-help {
+		margin-left: 20px;
+	}
+}
+
+.folded .godam-admin-root.not-safari {
+	margin-left: 36px;
+}
+
+@media screen and (max-width: 960px) {
+
+	.auto-fold .godam-admin-root.not-safari {
+		margin-left: 36px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+
+	.godam-admin-root {
+		margin-left: -10px;
+	}
+
+	.auto-fold .godam-admin-root.not-safari {
+		margin-left: 0;
+	}
+}
+
 .media-frame-menu:has(#menu-item-gallery) {
 
 	#media-folder-toggle-button {

--- a/assets/src/js/admin.js
+++ b/assets/src/js/admin.js
@@ -2,6 +2,30 @@
  * Write your JS code here for admin.
  */
 
+/**
+ * Tag `.godam-admin-root` wrappers with `.not-safari` outside Safari so the
+ * fixed-position admin layout in admin.scss can apply. Runs on every admin
+ * page so add-ons (e.g. godam-for-woo) get the same treatment.
+ */
+( function() {
+	const isSafari = /Safari/.test( navigator.userAgent ) && ! /Chrome|Chromium|Edg|CriOS|FxiOS|OPR/.test( navigator.userAgent );
+	if ( isSafari ) {
+		return;
+	}
+
+	const addClass = function() {
+		document.querySelectorAll( '.godam-admin-root' ).forEach( function( el ) {
+			el.classList.add( 'not-safari' );
+		} );
+	};
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', addClass );
+	} else {
+		addClass();
+	}
+}() );
+
 // Utility function to join URL paths
 window.pathJoin = function( parts, sep = '/' ) {
 	return parts

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,21 +2,3 @@
  * Internal dependencies
  */
 import './style.css';
-
-( function() {
-	const isSafari = /Safari/.test( navigator.userAgent ) && ! /Chrome|Chromium|Edg|CriOS|FxiOS|OPR/.test( navigator.userAgent );
-	if ( ! isSafari ) {
-		const addClass = function() {
-			const elements = document.querySelectorAll( '.godam-admin-root' );
-			elements.forEach( function( el ) {
-				el.classList.add( 'not-safari' );
-			} );
-		};
-
-		if ( document.readyState === 'loading' ) {
-			document.addEventListener( 'DOMContentLoaded', addClass );
-		} else {
-			addClass();
-		}
-	}
-}() );

--- a/pages/style.css
+++ b/pages/style.css
@@ -565,55 +565,6 @@ input, textarea, select {
 	}
 }
 
-/* Style for GoDAM admin pages container container */
-.godam-admin-root {
-	margin-left: -20px;
-}
-
-/* Chrome-specific styles (not Safari) */
-.godam-admin-root.not-safari {
-	color: #000;
-	min-height: calc( 100vh - var(--wp-admin--admin-bar--height, 0) );
-	padding-top: var(--wp-admin--admin-bar--height, 0);
-	position: fixed;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	margin-left: 160px;
-	overflow: auto;
-}
-
-.godam-admin-root.not-safari.godam-video-editor-page {
-	background-color: #fff;
-}
-
-.folded .godam-admin-root.not-safari {
-	margin-left: 36px;
-}
-
-.godam-admin-root #root-video-help {
-	margin-left: 20px;
-}
-
-@media screen and (max-width: 960px) {
-
-	.auto-fold .godam-admin-root.not-safari {
-		margin-left: 36px;
-	}
-}
-
-@media screen and (max-width: 782px) {
-
-	.godam-admin-root {
-		margin-left: -10px;
-	}
-
-	.auto-fold .godam-admin-root.not-safari {
-		margin-left: 0;
-	}
-}
-
 @media screen and (min-width: 410px) {
 
 	.godam-version-label {


### PR DESCRIPTION
Change required related on GoDAM plugin for issue: https://github.com/rtCamp/godam-for-woo/issues/109
PR:  [Refactor the UI/UX of ReelPop admin pages. (rtCamp/godam-for-woo#110)](https://github.com/rtCamp/godam-for-woo/pull/110)

This pull request refactors the way browser-specific admin layout styles are applied for GoDAM admin pages. The logic that adds the `.not-safari` class to `.godam-admin-root` elements (to enable fixed-position layouts outside Safari) is moved from `pages/index.js` to a new, more global location in `assets/src/js/admin.js`. At the same time, the related CSS is consolidated into `assets/src/css/admin.scss` and removed from `pages/style.css`. This makes the browser detection and styling more consistent across all admin pages and add-ons.

Key changes:

**JavaScript logic consolidation:**
- Moved the script that adds the `.not-safari` class to `.godam-admin-root` elements (outside Safari) from `pages/index.js` to `assets/src/js/admin.js`, ensuring the behavior is applied globally across all admin pages and add-ons. [[1]](diffhunk://#diff-3080393b71e98a04ac3347fe12e68e679585ae364e404dcda2d451893a94c87eR5-R28) [[2]](diffhunk://#diff-7c97c1ad17c63f34774324965f81661cea32f533a65c39ab03576069972e4d0eL5-L22)

**CSS consolidation and cleanup:**
- Moved all GoDAM admin layout styles, including browser-specific rules for `.godam-admin-root` and its `.not-safari` variant, from `pages/style.css` to `assets/src/css/admin.scss`. This centralizes the admin layout styling and removes duplication. [[1]](diffhunk://#diff-b4c816476dac8b5b0eb773a3634b8a21986afe7fe1ed652e53d8c99e98dd9801R130-R177) [[2]](diffhunk://#diff-7beefb06dc5f63ddbb44837e202cc5960b2526c23b7897be82b619ff6f76ba6eL568-L616)

**Responsive and folded state handling:**
- Maintained and migrated responsive and sidebar-folded state styles for `.godam-admin-root` and `.not-safari` to ensure consistent layout across different screen sizes and sidebar states. [[1]](diffhunk://#diff-b4c816476dac8b5b0eb773a3634b8a21986afe7fe1ed652e53d8c99e98dd9801R130-R177) [[2]](diffhunk://#diff-7beefb06dc5f63ddbb44837e202cc5960b2526c23b7897be82b619ff6f76ba6eL568-L616)