### PR TITLE
fix: remove redundant expired API key notice and update API key status notice display conditions

### DIFF
--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -42,7 +42,6 @@ class RTGODAM_Transcoder_Admin {
 			add_action( 'admin_notices', array( $this, 'usage_limit_notices' ) );
 			add_action( 'admin_notices', array( $this, 'posthog_tracking_notice' ) );
 			add_action( 'admin_notices', array( $this, 'api_key_status_notice' ) );
-			add_action( 'admin_notices', array( $this, 'expired_api_key_notice' ) );
 			add_action( 'admin_notices', array( $this, 'woo_integration_promo_notice' ) );
 			add_action( 'admin_init', array( $this, 'handle_posthog_tracking_action' ) );
 			add_action( 'admin_init', array( $this, 'handle_clear_godam_cache' ) );
@@ -748,9 +747,9 @@ class RTGODAM_Transcoder_Admin {
 	 * @since 1.7.0
 	 */
 	public function api_key_status_notice() {
-		// Only show in media library and upload pages.
+		// Only show on dashboard, media library, and upload pages.
 		$screen = get_current_screen();
-		if ( ! $screen || ! in_array( $screen->id, array( 'upload', 'media' ), true ) ) {
+		if ( ! $screen || ! in_array( $screen->id, array( 'dashboard', 'upload', 'media' ), true ) ) {
 			return;
 		}
 
@@ -839,60 +838,6 @@ class RTGODAM_Transcoder_Admin {
 
 		wp_safe_redirect( esc_url_raw( remove_query_arg( array( 'godam_tracker_optin', 'godam_tracker_optout', '_wpnonce' ) ) ) );
 		exit;
-	}
-
-	/**
-	 * Show a warning notice on all admin pages when the GoDAM API key has expired.
-	 *
-	 * Only displayed when:
-	 * - An API key is configured but is no longer valid.
-	 *
-	 * @since 1.8.0
-	 */
-	public function expired_api_key_notice() {
-
-		$api_key = \RTGODAM\Inc\Helpers\Api_Key::get_key();
-		if ( empty( $api_key ) || rtgodam_is_api_key_valid() ) {
-			return;
-		}
-
-		// rtgodam_get_api_key_status() only reads the persistent DB status option
-		// ('rtgodam-api-key-status') which can NEVER contain 'verification_failed'
-		// because that state is transient and not persistable. The actual runtime
-		// status — including transient 'verification_failed' — is stored in the
-		// 'rtgodam_user_data' option by rtgodam_get_user_data(). Read from there
-		// so we don't show a false "expired" banner when the server is temporarily
-		// unreachable.
-		$cached_user_data = get_option( 'rtgodam_user_data', array() );
-		$runtime_status   = isset( $cached_user_data['api_key_status'] )
-			? $cached_user_data['api_key_status']
-			: rtgodam_get_api_key_status();
-
-		if ( \RTGODAM\Inc\Enums\Api_Key_Status::VERIFICATION_FAILED === $runtime_status ) {
-			return;
-		}
-
-		$pricing_url = add_query_arg(
-			array(
-				'utm_campaign' => 'expired-key',
-				'utm_source'   => rawurlencode( site_url() ),
-				'utm_medium'   => 'plugin',
-				'utm_content'  => 'godam-admin-notice',
-			),
-			'https://godam.io/pricing'
-		);
-
-		printf(
-			'<div class="notice notice-warning"><p>%s</p></div>',
-			wp_kses_post(
-				sprintf(
-					/* translators: 1: Opening link tag, 2: Closing link tag */
-					__( '<strong>GoDAM API key has expired.</strong> Pro features in GoDAM are currently disabled. %1$sPurchase a new key%2$s to restore access.', 'godam' ),
-					'<a href="' . esc_url( $pricing_url ) . '" target="_blank" rel="noopener noreferrer">',
-					'</a>'
-				)
-			)
-		);
 	}
 
 	/**

--- a/admin/class-rtgodam-transcoder-admin.php
+++ b/admin/class-rtgodam-transcoder-admin.php
@@ -742,12 +742,12 @@ class RTGODAM_Transcoder_Admin {
 	}
 
 	/**
-	 * Display admin notice when API key is expired or invalid in media library.
+	 * Display admin notice when API key is expired or invalid in dashboard, and media library.
 	 *
 	 * @since 1.7.0
 	 */
 	public function api_key_status_notice() {
-		// Only show on dashboard, media library, and upload pages.
+		// Only show on dashboard, media library pages.
 		$screen = get_current_screen();
 		if ( ! $screen || ! in_array( $screen->id, array( 'dashboard', 'upload', 'media' ), true ) ) {
 			return;


### PR DESCRIPTION
This pull request makes targeted adjustments to the admin notices related to API key status in the `rtgodam-transcoder-admin.php` file. The main changes involve removing the redundant expired API key warning notice and expanding the visibility of the API key status notice to include the dashboard page.

**Admin notice adjustments:**

* Removed the `expired_api_key_notice` method and its associated admin notice, so users will no longer see a warning when the GoDAM API key has expired.
* Stopped registering the `expired_api_key_notice` action in the constructor, reflecting the removal of the expired API key warning.

**API key status notice improvements:**

* Expanded the visibility of the `api_key_status_notice` to also display on the dashboard page, in addition to the media library and upload pages.


## Demo

https://github.com/user-attachments/assets/079152fe-7428-4f1d-9ca8-a9e2d8f693dc


