### PR TITLE
Feature: PDF viewer widget for Elementor (#1207)

### DIFF
--- a/assets/src/blocks/godam-pdf/render.php
+++ b/assets/src/blocks/godam-pdf/render.php
@@ -36,35 +36,4 @@ if ( empty( $godam_sources ) ) {
 	return;
 }
 
-?>
-
-<figure <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-	<div class="godam-pdf-wrapper" style="height: <?php echo esc_attr( $godam_height ); ?>px;">
-		<object
-			id="pdfObject"
-			type="application/pdf"
-			width="100%"
-			height="100%"
-			data="<?php echo esc_url( $godam_sources[0] ); ?>"
-			data-sources="<?php echo esc_attr( wp_json_encode( $godam_sources ) ); ?>"
-		>
-			<p>
-				<?php
-				echo wp_kses_post(
-					sprintf(
-						/* translators: %s: PDF download URL */
-						__( 'Your browser does not support PDFs. <a href="%s">Download the PDF</a>.', 'godam' ),
-						esc_url( $godam_sources[0] )
-					)
-				);
-				?>
-			</p>
-		</object>
-	</div>
-
-	<?php if ( $godam_caption ) : ?>
-		<figcaption class="wp-element-caption">
-			<?php echo wp_kses_post( $godam_caption ); ?>
-		</figcaption>
-	<?php endif; ?>
-</figure>
+require RTGODAM_PATH . 'inc/templates/godam-pdf.php';

--- a/inc/classes/class-elementor-widgets.php
+++ b/inc/classes/class-elementor-widgets.php
@@ -15,6 +15,8 @@ use RTGODAM\Inc\Elementor_Controls\Godam_Media;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Audio;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Gallery;
 use RTGODAM\Inc\Elementor_Widgets\GoDAM_Video;
+use RTGODAM\Inc\Elementor_Widgets\GoDAM_PDF;
+
 use RTGODAM\Inc\Traits\Singleton;
 
 /**
@@ -123,6 +125,7 @@ class Elementor_Widgets {
 		\Elementor\Plugin::$instance->widgets_manager->register( new GoDAM_Video() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Gallery() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Audio() );
+		\Elementor\Plugin::$instance->widgets_manager->register( new GoDAM_PDF() );
 	}
 
 	/**

--- a/inc/classes/elementor-widgets/class-godam-pdf.php
+++ b/inc/classes/elementor-widgets/class-godam-pdf.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Register Custom Widget - GoDAM PDF
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Elementor_Widgets;
+
+use Elementor\Controls_Manager;
+
+/**
+ * GoDAM PDF Widget.
+ */
+class GoDAM_PDF extends Base {
+
+	/**
+	 * Default config for GoDAM PDF Widget.
+	 *
+	 * @return array
+	 */
+	public function set_default_config() {
+		return array(
+			'name'       => 'godam-pdf',
+			'title'      => _x( 'GoDAM PDF', 'Widget Title', 'godam' ),
+			'icon'       => 'eicon-document-file',
+			'categories' => array( 'godam' ),
+			'keywords'   => array( 'godam', 'pdf', 'document' ),
+		);
+	}
+
+	/**
+	 * Register Widget Controls.
+	 *
+	 * @access protected
+	 */
+	protected function register_controls() {
+		$this->start_controls_section(
+			'section_pdf_settings',
+			array(
+				'label' => __( 'PDF Settings', 'godam' ),
+			)
+		);
+
+		$this->add_control(
+			'pdf-file',
+			array(
+				'label'       => __( 'PDF File', 'godam' ),
+				'type'        => 'godam-media',
+				'label_block' => true,
+				'media_type'  => 'application/pdf',
+				'description' => __( 'Select the PDF file', 'godam' ),
+			)
+		);
+
+		$this->add_control(
+			'height',
+			array(
+				'label'     => __( 'Height (px)', 'godam' ),
+				'type'      => Controls_Manager::NUMBER,
+				'default'   => 600,
+				'condition' => array(
+					'pdf-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'caption',
+			array(
+				'label'     => __( 'Caption', 'godam' ),
+				'type'      => Controls_Manager::TEXTAREA,
+				'condition' => array(
+					'pdf-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Render GoDAM PDF widget output on the frontend.
+	 *
+	 * @access protected
+	 */
+	protected function render() {
+		$pdf_file            = $this->get_settings_for_display( 'pdf-file' );
+		$godam_attachment_id = ! empty( $pdf_file['id'] ) ? intval( $pdf_file['id'] ) : null;
+		$godam_src           = ! empty( $pdf_file['url'] ) ? esc_url( $pdf_file['url'] ) : '';
+		$godam_caption       = $this->get_settings_for_display( 'caption' ) ?? '';
+		$godam_height        = $this->get_settings_for_display( 'height' ) ?? 600;
+
+		if ( ! $godam_attachment_id && empty( $godam_src ) ) {
+			return;
+		}
+
+		$godam_sources = array();
+		if ( $godam_attachment_id ) {
+			$godam_pdf_url            = wp_get_attachment_url( $godam_attachment_id );
+			$godam_pdf_transcoded_url = get_post_meta( $godam_attachment_id, 'rtgodam_transcoded_url', true );
+			if ( ! empty( $godam_pdf_transcoded_url ) ) {
+				$godam_sources[] = $godam_pdf_transcoded_url;
+			}
+			if ( ! empty( $godam_pdf_url ) ) {
+				$godam_sources[] = $godam_pdf_url;
+			}
+		} else {
+			$godam_sources[] = $godam_src;
+		}
+
+		if ( empty( $godam_sources ) ) {
+			return;
+		}
+
+		$is_elementor_widget = true;
+
+		require RTGODAM_PATH . 'inc/templates/godam-pdf.php';
+	}
+}

--- a/inc/templates/godam-pdf.php
+++ b/inc/templates/godam-pdf.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Render template for the GoDAM PDF.
+ *
+ * Shared by Gutenberg block and Elementor widget.
+ *
+ * @package GoDAM
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( empty( $godam_sources ) ) {
+	return;
+}
+?>
+
+<figure <?php echo empty( $is_elementor_widget ) ? wp_kses_data( get_block_wrapper_attributes() ) : ''; ?>>
+	<div class="godam-pdf-wrapper" style="height: <?php echo esc_attr( $godam_height ); ?>px;">
+		<object
+			id="pdfObject"
+			type="application/pdf"
+			width="100%"
+			height="100%"
+			data="<?php echo esc_url( $godam_sources[0] ); ?>"
+			data-sources="<?php echo esc_attr( wp_json_encode( $godam_sources ) ); ?>"
+		>
+			<p>
+				<?php
+				echo wp_kses_post(
+					sprintf(
+						/* translators: %s: PDF download URL */
+						__( 'Your browser does not support PDFs. <a href="%s">Download the PDF</a>.', 'godam' ),
+						esc_url( $godam_sources[0] )
+					)
+				);
+				?>
+			</p>
+		</object>
+	</div>
+
+	<?php if ( $godam_caption ) : ?>
+		<figcaption class="wp-element-caption">
+			<?php echo wp_kses_post( $godam_caption ); ?>
+		</figcaption>
+	<?php endif; ?>
+</figure>


### PR DESCRIPTION
Implements a PDF viewer block for GoDAM, allowing users to embed and view PDFs directly within Elementor.

Demo:

https://github.com/user-attachments/assets/a3a25f93-6c96-4abb-9407-177a7254fe01

**Note:** WP Bakery support pending — it's a paid plugin. 
Happy to implement if the zip is provided.

