### PR TITLE
Add code-level kill-switch for media-library UI management

### DIFF
--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -69,7 +69,14 @@ class MediaLibrary {
 
 	initialize() {
 		this.setupAttachmentBrowser();
-		this.setupModalCloseCleanup();
+
+		// setupModalCloseCleanup patches wp.media.view.Modal.prototype.close globally. In additive
+		// mode keep GoDAM's footprint minimal alongside another DAM plugin and skip it; the GoDAM
+		// media-modal tab still works without it.
+		if ( ! isFolderOrgDisabled() ) {
+			this.setupModalCloseCleanup();
+		}
+
 		document.addEventListener( 'DOMContentLoaded', () => this.onDOMContentLoaded() );
 	}
 
@@ -149,12 +156,19 @@ class MediaLibrary {
 	}
 
 	setupAttachmentBrowser() {
-		if ( wp?.media?.view?.AttachmentsBrowser && AttachmentsBrowser ) {
-			wp.media.view.AttachmentsBrowser = AttachmentsBrowser;
-		}
+		// Additive mode (folder organization off): do NOT replace WordPress's library browser/grid
+		// views. Those global replacements are the main clash surface with another DAM/media
+		// plugin's directory UI. The detail-pane views and the GoDAM media-modal tab (below) are
+		// kept — they don't conflict with a folder plugin and preserve transcoding info + the cloud
+		// picker, which render on the native browser/grid.
+		if ( ! isFolderOrgDisabled() ) {
+			if ( wp?.media?.view?.AttachmentsBrowser && AttachmentsBrowser ) {
+				wp.media.view.AttachmentsBrowser = AttachmentsBrowser;
+			}
 
-		if ( wp?.media?.view?.Attachments && Attachments ) {
-			wp.media.view.Attachments = Attachments;
+			if ( wp?.media?.view?.Attachments && Attachments ) {
+				wp.media.view.Attachments = Attachments;
+			}
 		}
 
 		if ( wp?.media?.view?.Attachment?.Details && AttachmentDetails ) {
@@ -316,7 +330,10 @@ class MediaLibrary {
 			} );
 		}
 
-		new MediaListViewTableDragHandler();
+		// List-view drag-to-folder is a folder-organization feature; skip it in additive mode.
+		if ( ! isFolderOrgDisabled() ) {
+			new MediaListViewTableDragHandler();
+		}
 	}
 
 	setupMediaLibraryRoot() {

--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -75,10 +75,18 @@ class MediaLibrary {
 
 	onDOMContentLoaded() {
 		this.setupMediaLibraryRoot();
+		this.handleBannerClose();
+
+		// Additive mode (folder organization off): suppress GoDAM's WP media-library takeover
+		// (date-range filter, "Manage Media" button, search override, delete-refresh listeners).
+		// The GoDAM media-modal tab, wired in setupAttachmentBrowser(), is intentionally left intact.
+		if ( isFolderOrgDisabled() ) {
+			return;
+		}
+
 		this.initializeDateRangeFilter();
 		addManageMediaButton();
 		this.addInputPlaceholder();
-		this.handleBannerClose();
 		this.setupDeleteEventListeners();
 	}
 

--- a/assets/src/js/media-library/utility.js
+++ b/assets/src/js/media-library/utility.js
@@ -47,6 +47,12 @@ function isUploadPage() {
 /**
  * Check if folder organization is disabled.
  *
+ * This is GoDAM's media-library integration kill-switch: when disabled (additive mode),
+ * GoDAM's WordPress media-library takeover — folder sidebar, "Manage Media" button, search
+ * override, attachment-browser folder/date filters — is suppressed so GoDAM can coexist with
+ * another media/DAM plugin. The GoDAM media-modal tab, blocks, the player, and transcoding
+ * are unaffected.
+ *
  * @return {boolean} True if folder organization is disabled, false otherwise.
  */
 function isFolderOrgDisabled() {

--- a/assets/src/js/media-library/views/attachment-browser.js
+++ b/assets/src/js/media-library/views/attachment-browser.js
@@ -7,7 +7,7 @@ import MediaLibraryTaxonomyFilter from './filters/media-library-taxonomy-filter'
 import MediaDateRangeFilter from './filters/media-date-range-filter';
 import MediaRetranscode from './filters/media-retranscode';
 
-import { isAPIKeyValid, isUploadPage } from '../utility';
+import { isAPIKeyValid, isUploadPage, isFolderOrgDisabled } from '../utility';
 
 const AttachmentsBrowser = wp?.media?.view?.AttachmentsBrowser;
 
@@ -36,6 +36,13 @@ export default AttachmentsBrowser?.extend( {
 	async createToolbar() {
 		// Make sure to load the original toolbar
 		AttachmentsBrowser.prototype.createToolbar.call( this );
+
+		// Additive mode (folder organization off): skip GoDAM's folder/date/retranscode toolbar
+		// filters so the toolbar stays native. Applies to both the native Browse tab and the
+		// GoDAM tab's browser.
+		if ( isFolderOrgDisabled() ) {
+			return;
+		}
 
 		if ( MediaLibraryTaxonomyFilter ) {
 			this.toolbar.set(

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -245,18 +245,26 @@ class Assets {
 			filemtime( RTGODAM_PATH . 'assets/build/css/media-library.css' )
 		);
 
-		wp_localize_script(
-			'easydam-media-library',
-			'MediaLibraryTaxonomyFilterData',
-			array(
-				'terms' => get_terms(
-					array(
-						'taxonomy'   => 'media-folder',
-						'hide_empty' => false,
-					)
-				),
-			)
-		);
+		// The folder-organization toggle is GoDAM's media-library integration kill-switch.
+		// When off (additive mode), the WP media-library takeover is gated in JS; the bundle
+		// still loads so the GoDAM media-modal tab survives.
+		$enable_folder_organization = rtgodam_is_media_library_ui_enabled();
+
+		// Folder taxonomy terms power the folder filter UI only; skip the query when suppressed.
+		if ( $enable_folder_organization ) {
+			wp_localize_script(
+				'easydam-media-library',
+				'MediaLibraryTaxonomyFilterData',
+				array(
+					'terms' => get_terms(
+						array(
+							'taxonomy'   => 'media-folder',
+							'hide_empty' => false,
+						)
+					),
+				)
+			);
+		}
 
 		wp_localize_script(
 			'easydam-media-library',
@@ -277,8 +285,7 @@ class Assets {
 			)
 		);
 
-		$enable_folder_organization = get_option( 'rtgodam-settings', array() )['general']['enable_folder_organization'] ?? true;
-		$current_user_id            = get_current_user_id();
+		$current_user_id = get_current_user_id();
 
 		$easydam_media_library_data = array(
 			'ajaxUrl'                  => admin_url( 'admin-ajax.php' ),
@@ -400,6 +407,10 @@ class Assets {
 			'engagementFeatureEnabled'    => $engagement_feature_enabled,
 			'enableGlobalVideoEngagement' => $engagement_feature_enabled ? $enable_global_video_engagement : false,
 			'enableGlobalVideoShare'      => $enable_global_share,
+
+			// Media-library UI kill-switch: effective value + whether it's locked from code (constant/filter).
+			'mediaLibraryUIEffective'     => rtgodam_is_media_library_ui_enabled(),
+			'mediaLibraryUICodeManaged'   => rtgodam_is_media_library_ui_code_managed(),
 
 		);
 

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -249,22 +249,25 @@ class Assets {
 		// When off (additive mode), the WP media-library takeover is gated in JS; the bundle
 		// still loads so the GoDAM media-modal tab survives.
 		$enable_folder_organization = rtgodam_is_media_library_ui_enabled();
+		$folder_terms               = array();
 
 		// Folder taxonomy terms power the folder filter UI only; skip the query when suppressed.
 		if ( $enable_folder_organization ) {
-			wp_localize_script(
-				'easydam-media-library',
-				'MediaLibraryTaxonomyFilterData',
+			$folder_terms = get_terms(
 				array(
-					'terms' => get_terms(
-						array(
-							'taxonomy'   => 'media-folder',
-							'hide_empty' => false,
-						)
-					),
+					'taxonomy'   => 'media-folder',
+					'hide_empty' => false,
 				)
 			);
 		}
+
+		wp_localize_script(
+			'easydam-media-library',
+			'MediaLibraryTaxonomyFilterData',
+			array(
+				'terms' => $folder_terms,
+			)
+		);
 
 		wp_localize_script(
 			'easydam-media-library',

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -320,11 +320,14 @@ class Assets {
 		wp_enqueue_script( 'easydam-media-library' );
 
 		/**
-		 * Dependency library for date range picker.
+		 * Dependency library for the date range picker. Its only consumers (the media-library
+		 * date-range filters) are suppressed in additive mode, so skip the payload when disabled.
 		 */
-		wp_enqueue_script( 'moment-js', RTGODAM_URL . 'assets/src/libs/moment-js.min.js', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/moment-js.min.js' ), true );
-		wp_enqueue_script( 'daterangepicker-js', RTGODAM_URL . 'assets/src/libs/daterangepicker.min.js', array( 'moment-js' ), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.min.js' ), true );
-		wp_enqueue_style( 'daterangepicker-css', RTGODAM_URL . 'assets/src/libs/daterangepicker.css', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.css' ) );
+		if ( $enable_folder_organization ) {
+			wp_enqueue_script( 'moment-js', RTGODAM_URL . 'assets/src/libs/moment-js.min.js', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/moment-js.min.js' ), true );
+			wp_enqueue_script( 'daterangepicker-js', RTGODAM_URL . 'assets/src/libs/daterangepicker.min.js', array( 'moment-js' ), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.min.js' ), true );
+			wp_enqueue_style( 'daterangepicker-css', RTGODAM_URL . 'assets/src/libs/daterangepicker.css', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.css' ) );
+		}
 
 		// Only enqueue HTTP auth detector on uploads page or pages where media uploading is possible.
 		if ( godam_should_load_auth_detector_script( $screen ) ) {

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -31,10 +31,15 @@ class Media_Library_Ajax {
 	 * @return void
 	 */
 	public function setup_hooks() {
-		add_filter( 'ajax_query_attachments_args', array( $this, 'filter_media_library_by_taxonomy' ) );
-		add_action( 'pre_get_posts', array( $this, 'pre_get_post_filter' ) );
+		// Folder/date filtering and the list-view filter UI are part of GoDAM's media-library
+		// takeover. Skip them in additive mode so the WordPress media library stays native
+		// server-side (no GoDAM folder dropdown or orphaned date inputs on upload.php).
+		if ( rtgodam_is_media_library_ui_enabled() ) {
+			add_filter( 'ajax_query_attachments_args', array( $this, 'filter_media_library_by_taxonomy' ) );
+			add_action( 'pre_get_posts', array( $this, 'pre_get_post_filter' ) );
+			add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_media_filter' ) );
+		}
 
-		add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_media_filter' ) );
 		add_action( 'add_attachment', array( $this, 'add_media_library_taxonomy_on_media_upload' ), 10, 1 );
 		add_action( 'add_attachment', array( $this, 'upload_media_to_frappe_backend' ), 10, 1 );
 		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'add_media_transcoding_status_js' ), 10, 2 );

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -554,7 +554,9 @@ class Pages {
 			);
 
 			// Localize easydamMediaLibrary data for the video editor.
-			$enable_folder_organization = get_option( 'rtgodam-settings', array() )['general']['enable_folder_organization'] ?? true;
+			// Resolve through the helper so the code-level constant/filter override applies here too,
+			// keeping this global consistent on the video-editor page.
+			$enable_folder_organization = rtgodam_is_media_library_ui_enabled();
 			$current_user_id            = get_current_user_id();
 
 			$easydam_media_library_data = array(

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -558,6 +558,66 @@ function rtgodam_is_api_key_valid() {
 }
 
 /**
+ * Resolve whether GoDAM's WordPress media-library admin UI is enabled.
+ *
+ * "Additive mode" lets GoDAM coexist with another DAM/media plugin by
+ * suppressing GoDAM's media-library takeover (folder UI, "Manage Media"
+ * button, search override, attachment-browser folder/date filters) while
+ * leaving blocks, the front-end player, analytics, transcoding, REST, the
+ * GoDAM media-modal tab, and GoDAM's own admin pages intact.
+ *
+ * The single "enable folder organization" toggle (`general.enable_folder_organization`)
+ * is GoDAM's media-library integration master switch; turning it off runs GoDAM in
+ * additive mode. This helper resolves that toggle with the code-level overrides.
+ *
+ * Resolution precedence (code-level is authoritative):
+ *  1. Constant `RTGODAM_DISABLE_MEDIA_LIBRARY_UI === true` forces it off.
+ *  2. Otherwise the `rtgodam-settings` → general → `enable_folder_organization`
+ *     option (default `true`).
+ *  3. The `rtgodam_enable_media_library_ui` filter can override last.
+ *
+ * @since n.e.x.t
+ *
+ * @return bool True when the media-library UI should load (default), false in additive mode.
+ */
+function rtgodam_is_media_library_ui_enabled() {
+	if ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI ) {
+		$enabled = false;
+	} else {
+		$settings = get_option( 'rtgodam-settings', array() );
+		$enabled  = $settings['general']['enable_folder_organization'] ?? true;
+	}
+
+	/**
+	 * Filters whether GoDAM's media-library admin UI is enabled.
+	 *
+	 * Authoritative code-level override for coexistence deployments. Return
+	 * false to run GoDAM in additive mode (suppress the media-library takeover).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param bool $enabled Whether the media-library UI is enabled.
+	 */
+	return (bool) apply_filters( 'rtgodam_enable_media_library_ui', $enabled );
+}
+
+/**
+ * Check whether the media-library UI value is forced from code.
+ *
+ * Used to render the dashboard toggle as locked ("managed in code") so an
+ * admin can't fight a code-level value set via the constant or the
+ * `rtgodam_enable_media_library_ui` filter.
+ *
+ * @since n.e.x.t
+ *
+ * @return bool True when the constant is defined-truthy or the filter has a callback hooked.
+ */
+function rtgodam_is_media_library_ui_code_managed() {
+	return ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI )
+		|| has_filter( 'rtgodam_enable_media_library_ui' );
+}
+
+/**
  * Checks if the given filename is an audio file based on its name.
  *
  * Note: The files created by uppy webcam, screen capture, and audio plugin are in the same format. So we are checking the filename to determine if it's an audio file.

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -571,10 +571,11 @@ function rtgodam_is_api_key_valid() {
  * additive mode. This helper resolves that toggle with the code-level overrides.
  *
  * Resolution precedence (code-level is authoritative):
- *  1. Constant `RTGODAM_DISABLE_MEDIA_LIBRARY_UI === true` forces it off.
+ *  1. Constant `RTGODAM_DISABLE_MEDIA_LIBRARY_UI === true` forces it off and
+ *     cannot be overridden.
  *  2. Otherwise the `rtgodam-settings` → general → `enable_folder_organization`
  *     option (default `true`).
- *  3. The `rtgodam_enable_media_library_ui` filter can override last.
+ *  3. The `rtgodam_enable_media_library_ui` filter can override the option value.
  *
  * @since n.e.x.t
  *
@@ -582,17 +583,18 @@ function rtgodam_is_api_key_valid() {
  */
 function rtgodam_is_media_library_ui_enabled() {
 	if ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI ) {
-		$enabled = false;
-	} else {
-		$settings = get_option( 'rtgodam-settings', array() );
-		$enabled  = $settings['general']['enable_folder_organization'] ?? true;
+		return false;
 	}
+
+	$settings = get_option( 'rtgodam-settings', array() );
+	$enabled  = $settings['general']['enable_folder_organization'] ?? true;
 
 	/**
 	 * Filters whether GoDAM's media-library admin UI is enabled.
 	 *
-	 * Authoritative code-level override for coexistence deployments. Return
-	 * false to run GoDAM in additive mode (suppress the media-library takeover).
+	 * Code-level override for coexistence deployments when the disabling
+	 * constant is not set. Return false to run GoDAM in additive mode
+	 * (suppress the media-library takeover).
 	 *
 	 * @since n.e.x.t
 	 *

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -571,13 +571,13 @@ function rtgodam_is_api_key_valid() {
  * additive mode. This helper resolves that toggle with the code-level overrides.
  *
  * Resolution precedence (code-level is authoritative):
- *  1. Constant `RTGODAM_DISABLE_MEDIA_LIBRARY_UI === true` forces it off and
- *     cannot be overridden.
+ *  1. A defined, truthy `RTGODAM_DISABLE_MEDIA_LIBRARY_UI` constant forces it
+ *     off and cannot be overridden.
  *  2. Otherwise the `rtgodam-settings` → general → `enable_folder_organization`
  *     option (default `true`).
  *  3. The `rtgodam_enable_media_library_ui` filter can override the option value.
  *
- * @since n.e.x.t
+ * @since 1.11.1
  *
  * @return bool True when the media-library UI should load (default), false in additive mode.
  */
@@ -596,7 +596,7 @@ function rtgodam_is_media_library_ui_enabled() {
 	 * constant is not set. Return false to run GoDAM in additive mode
 	 * (suppress the media-library takeover).
 	 *
-	 * @since n.e.x.t
+	 * @since 1.11.1
 	 *
 	 * @param bool $enabled Whether the media-library UI is enabled.
 	 */
@@ -610,7 +610,7 @@ function rtgodam_is_media_library_ui_enabled() {
  * admin can't fight a code-level value set via the constant or the
  * `rtgodam_enable_media_library_ui` filter.
  *
- * @since n.e.x.t
+ * @since 1.11.1
  *
  * @return bool True when the constant is defined-truthy or the filter has a callback hooked.
  */

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -619,13 +619,31 @@ function rtgodam_is_media_library_ui_enabled() {
  * admin can't fight a code-level value set via the constant or the
  * `rtgodam_enable_media_library_ui` filter.
  *
+ * The filter only counts as "managing" the value when it actually overrides the
+ * stored option — a passthrough or observe-only hook (e.g. logging) must not lock
+ * the toggle for a setting no code really controls.
+ *
  * @since 1.11.1
  *
- * @return bool True when the constant is defined-truthy or the filter has a callback hooked.
+ * @return bool True when the constant is defined-truthy, or a filter changes the stored value.
  */
 function rtgodam_is_media_library_ui_code_managed() {
-	return ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI )
-		|| has_filter( 'rtgodam_enable_media_library_ui' );
+	if ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI ) {
+		return true;
+	}
+
+	if ( ! has_filter( 'rtgodam_enable_media_library_ui' ) ) {
+		return false;
+	}
+
+	$settings = get_option( 'rtgodam-settings', array() );
+	$general  = is_array( $settings ) && isset( $settings['general'] ) && is_array( $settings['general'] )
+		? $settings['general']
+		: array();
+	$stored   = (bool) ( $general['enable_folder_organization'] ?? true );
+
+	// Locked only if the filter resolves to something other than the stored option.
+	return rtgodam_is_media_library_ui_enabled() !== $stored;
 }
 
 /**

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -587,7 +587,16 @@ function rtgodam_is_media_library_ui_enabled() {
 	}
 
 	$settings = get_option( 'rtgodam-settings', array() );
-	$enabled  = $settings['general']['enable_folder_organization'] ?? true;
+	if ( ! is_array( $settings ) ) {
+		$settings = array();
+	}
+
+	$general_settings = $settings['general'] ?? array();
+	if ( ! is_array( $general_settings ) ) {
+		$general_settings = array();
+	}
+
+	$enabled = $general_settings['enable_folder_organization'] ?? true;
 
 	/**
 	 * Filters whether GoDAM's media-library admin UI is enabled.

--- a/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
@@ -36,6 +36,15 @@ const GeneralSettings = () => {
 	const [ saveMediaSettings, { isLoading: saveMediaSettingsLoading } ] = useSaveMediaSettingsMutation();
 	const [ notice, setNotice ] = useState( { message: '', status: 'success', isVisible: false } );
 
+	// The "folder organization" toggle is GoDAM's media-library integration kill-switch.
+	// When set from code (constant/filter) the toggle is locked and the effective value
+	// comes from the server; otherwise it reflects the saved setting.
+	const mediaLibraryUICodeManaged = window?.godamSettings?.mediaLibraryUICodeManaged || false;
+	const mediaLibraryUIEffective = window?.godamSettings?.mediaLibraryUIEffective ?? true;
+	const folderOrgEnabled = mediaLibraryUICodeManaged
+		? mediaLibraryUIEffective
+		: mediaSettings?.general?.enable_folder_organization;
+
 	// Function to show a notice message
 	const showNotice = ( message, status = 'success' ) => {
 		setNotice( { message, status, isVisible: true } );
@@ -95,8 +104,13 @@ const GeneralSettings = () => {
 						__nextHasNoMarginBottom
 						className="godam-toggle godam-margin-bottom"
 						label={ __( 'Enable folder organization in media library.', 'godam' ) }
-						help={ __( 'Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization.', 'godam' ) }
-						checked={ mediaSettings?.general?.enable_folder_organization }
+						help={
+							mediaLibraryUICodeManaged
+								? __( 'This setting is managed by your site administrator and can’t be changed here.', 'godam' )
+								: __( 'Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization.', 'godam' )
+						}
+						checked={ folderOrgEnabled }
+						disabled={ mediaLibraryUICodeManaged }
 						onChange={ ( value ) => handleSettingChange( 'enable_folder_organization', value ) }
 					/>
 

--- a/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
@@ -103,11 +103,11 @@ const GeneralSettings = () => {
 					<ToggleControl
 						__nextHasNoMarginBottom
 						className="godam-toggle godam-margin-bottom"
-						label={ __( 'Enable folder organization in media library.', 'godam' ) }
+						label={ __( 'Enable GoDAM media library features', 'godam' ) }
 						help={
 							mediaLibraryUICodeManaged
 								? __( 'This setting is managed by your site administrator and can’t be changed here.', 'godam' )
-								: __( 'Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization.', 'godam' )
+								: __( 'Turn this on to organize and manage media with GoDAM — folders, search, and filters. Turn it off to keep the WordPress media library as it is.', 'godam' )
 						}
 						checked={ folderOrgEnabled }
 						disabled={ mediaLibraryUICodeManaged }


### PR DESCRIPTION
This pull request introduces an "additive mode" to the GoDAM plugin, allowing it to coexist with other DAM/media plugins by suppressing GoDAM's takeover of the WordPress media library UI when folder organization is disabled. The core of this change is a new master switch ("Enable folder organization") that, when turned off, disables GoDAM's custom media-library UI features while leaving other GoDAM functionality (such as blocks, the player, and transcoding) intact. The setting can be managed via the dashboard or locked from code using a constant or filter, and the UI reflects this lock state.

The most important changes are:

**Media Library UI Suppression (Additive Mode):**
- Added logic in `assets/src/js/media-library/index.js` and `assets/src/js/media-library/views/attachment-browser.js` to suppress GoDAM's media-library UI enhancements (like folder sidebar, filters, and manage button) when folder organization is disabled, ensuring GoDAM can run alongside other plugins without conflicts. [[1]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0R78-L81) [[2]](diffhunk://#diff-fb7c950b71c9461563537f8c0937e81f6ff688496066c97a24ae6d3d6e0fb1deL10-R10) [[3]](diffhunk://#diff-fb7c950b71c9461563537f8c0937e81f6ff688496066c97a24ae6d3d6e0fb1deR40-R46)
- Updated `assets/src/js/media-library/utility.js` with a clear explanation and implementation of the `isFolderOrgDisabled()` function as the integration kill-switch.

**Settings Resolution and Code-level Overrides:**
- Introduced helper functions `rtgodam_is_media_library_ui_enabled()` and `rtgodam_is_media_library_ui_code_managed()` in `inc/helpers/custom-functions.php` to resolve the effective state of the media-library UI switch, supporting code-level overrides via constant or filter.
- Updated PHP asset enqueuing (`inc/classes/class-assets.php` and `inc/classes/class-pages.php`) to use the new helpers, ensuring consistent behavior and data localization across admin screens. [[1]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dR248-R254) [[2]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dR267) [[3]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dL280) [[4]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dR411-R414) [[5]](diffhunk://#diff-8f6c0412582a633d4d6c9cbd98466c31f29eecb1e995a3118df0cad252fa827eL557-R559)

**Dashboard UI Updates:**
- Modified the React settings component (`pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx`) so the "Enable folder organization" toggle is disabled and displays an appropriate message when managed from code, reflecting the effective value from the server. [[1]](diffhunk://#diff-015e1553e3c7c61907aa04d3bf0c4c8770caf23491460ee3f9236323096c5a87R39-R47) [[2]](diffhunk://#diff-015e1553e3c7c61907aa04d3bf0c4c8770caf23491460ee3f9236323096c5a87L98-R113)


https://github.com/rtCamp/godam-core/issues/1131