### PR TITLE
 Add media-library UI kill-switch and improve integration settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog #
 
+## v1.11.2 (June 5, 2026) ##
+
+- Feat: Added a setting to disable GoDAM's media library features, allowing GoDAM to coexist with another media or DAM plugin without changing the WordPress media library.
+
 ## v1.11.1 (June 3, 2026) ##
 
 - Fix: GoDAM Video block aspect ratio for editor and frontend.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested up to: 7.0
 
 Requires PHP: 7.4
 
-Stable tag: 1.11.1
+Stable tag: 1.11.2
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -69,16 +69,31 @@ class MediaLibrary {
 
 	initialize() {
 		this.setupAttachmentBrowser();
-		this.setupModalCloseCleanup();
+
+		// setupModalCloseCleanup patches wp.media.view.Modal.prototype.close globally. In additive
+		// mode keep GoDAM's footprint minimal alongside another DAM plugin and skip it; the GoDAM
+		// media-modal tab still works without it.
+		if ( ! isFolderOrgDisabled() ) {
+			this.setupModalCloseCleanup();
+		}
+
 		document.addEventListener( 'DOMContentLoaded', () => this.onDOMContentLoaded() );
 	}
 
 	onDOMContentLoaded() {
 		this.setupMediaLibraryRoot();
+		this.handleBannerClose();
+
+		// Additive mode (folder organization off): suppress GoDAM's WP media-library takeover
+		// (date-range filter, "Manage Media" button, search override, delete-refresh listeners).
+		// The GoDAM media-modal tab, wired in setupAttachmentBrowser(), is intentionally left intact.
+		if ( isFolderOrgDisabled() ) {
+			return;
+		}
+
 		this.initializeDateRangeFilter();
 		addManageMediaButton();
 		this.addInputPlaceholder();
-		this.handleBannerClose();
 		this.setupDeleteEventListeners();
 	}
 
@@ -141,12 +156,19 @@ class MediaLibrary {
 	}
 
 	setupAttachmentBrowser() {
-		if ( wp?.media?.view?.AttachmentsBrowser && AttachmentsBrowser ) {
-			wp.media.view.AttachmentsBrowser = AttachmentsBrowser;
-		}
+		// Additive mode (folder organization off): do NOT replace WordPress's library browser/grid
+		// views. Those global replacements are the main clash surface with another DAM/media
+		// plugin's directory UI. The detail-pane views and the GoDAM media-modal tab (below) are
+		// kept — they don't conflict with a folder plugin and preserve transcoding info + the cloud
+		// picker, which render on the native browser/grid.
+		if ( ! isFolderOrgDisabled() ) {
+			if ( wp?.media?.view?.AttachmentsBrowser && AttachmentsBrowser ) {
+				wp.media.view.AttachmentsBrowser = AttachmentsBrowser;
+			}
 
-		if ( wp?.media?.view?.Attachments && Attachments ) {
-			wp.media.view.Attachments = Attachments;
+			if ( wp?.media?.view?.Attachments && Attachments ) {
+				wp.media.view.Attachments = Attachments;
+			}
 		}
 
 		if ( wp?.media?.view?.Attachment?.Details && AttachmentDetails ) {
@@ -308,7 +330,10 @@ class MediaLibrary {
 			} );
 		}
 
-		new MediaListViewTableDragHandler();
+		// List-view drag-to-folder is a folder-organization feature; skip it in additive mode.
+		if ( ! isFolderOrgDisabled() ) {
+			new MediaListViewTableDragHandler();
+		}
 	}
 
 	setupMediaLibraryRoot() {

--- a/assets/src/js/media-library/utility.js
+++ b/assets/src/js/media-library/utility.js
@@ -47,6 +47,12 @@ function isUploadPage() {
 /**
  * Check if folder organization is disabled.
  *
+ * This is GoDAM's media-library integration kill-switch: when disabled (additive mode),
+ * GoDAM's WordPress media-library takeover — folder sidebar, "Manage Media" button, search
+ * override, attachment-browser folder/date filters — is suppressed so GoDAM can coexist with
+ * another media/DAM plugin. The GoDAM media-modal tab, blocks, the player, and transcoding
+ * are unaffected.
+ *
  * @return {boolean} True if folder organization is disabled, false otherwise.
  */
 function isFolderOrgDisabled() {

--- a/assets/src/js/media-library/views/attachment-browser.js
+++ b/assets/src/js/media-library/views/attachment-browser.js
@@ -7,7 +7,7 @@ import MediaLibraryTaxonomyFilter from './filters/media-library-taxonomy-filter'
 import MediaDateRangeFilter from './filters/media-date-range-filter';
 import MediaRetranscode from './filters/media-retranscode';
 
-import { isAPIKeyValid, isUploadPage } from '../utility';
+import { isAPIKeyValid, isUploadPage, isFolderOrgDisabled } from '../utility';
 
 const AttachmentsBrowser = wp?.media?.view?.AttachmentsBrowser;
 
@@ -36,6 +36,13 @@ export default AttachmentsBrowser?.extend( {
 	async createToolbar() {
 		// Make sure to load the original toolbar
 		AttachmentsBrowser.prototype.createToolbar.call( this );
+
+		// Additive mode (folder organization off): skip GoDAM's folder/date/retranscode toolbar
+		// filters so the toolbar stays native. Applies to both the native Browse tab and the
+		// GoDAM tab's browser.
+		if ( isFolderOrgDisabled() ) {
+			return;
+		}
 
 		if ( MediaLibraryTaxonomyFilter ) {
 			this.toolbar.set(

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 1.11.1
+ * Version: 1.11.2
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '1.11.1' );
+	define( 'RTGODAM_VERSION', '1.11.2' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -245,16 +245,27 @@ class Assets {
 			filemtime( RTGODAM_PATH . 'assets/build/css/media-library.css' )
 		);
 
+		// The folder-organization toggle is GoDAM's media-library integration kill-switch.
+		// When off (additive mode), the WP media-library takeover is gated in JS; the bundle
+		// still loads so the GoDAM media-modal tab survives.
+		$enable_folder_organization = rtgodam_is_media_library_ui_enabled();
+		$folder_terms               = array();
+
+		// Folder taxonomy terms power the folder filter UI only; skip the query when suppressed.
+		if ( $enable_folder_organization ) {
+			$folder_terms = get_terms(
+				array(
+					'taxonomy'   => 'media-folder',
+					'hide_empty' => false,
+				)
+			);
+		}
+
 		wp_localize_script(
 			'easydam-media-library',
 			'MediaLibraryTaxonomyFilterData',
 			array(
-				'terms' => get_terms(
-					array(
-						'taxonomy'   => 'media-folder',
-						'hide_empty' => false,
-					)
-				),
+				'terms' => $folder_terms,
 			)
 		);
 
@@ -277,8 +288,7 @@ class Assets {
 			)
 		);
 
-		$enable_folder_organization = get_option( 'rtgodam-settings', array() )['general']['enable_folder_organization'] ?? true;
-		$current_user_id            = get_current_user_id();
+		$current_user_id = get_current_user_id();
 
 		$easydam_media_library_data = array(
 			'ajaxUrl'                  => admin_url( 'admin-ajax.php' ),
@@ -310,11 +320,14 @@ class Assets {
 		wp_enqueue_script( 'easydam-media-library' );
 
 		/**
-		 * Dependency library for date range picker.
+		 * Dependency library for the date range picker. Its only consumers (the media-library
+		 * date-range filters) are suppressed in additive mode, so skip the payload when disabled.
 		 */
-		wp_enqueue_script( 'moment-js', RTGODAM_URL . 'assets/src/libs/moment-js.min.js', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/moment-js.min.js' ), true );
-		wp_enqueue_script( 'daterangepicker-js', RTGODAM_URL . 'assets/src/libs/daterangepicker.min.js', array( 'moment-js' ), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.min.js' ), true );
-		wp_enqueue_style( 'daterangepicker-css', RTGODAM_URL . 'assets/src/libs/daterangepicker.css', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.css' ) );
+		if ( $enable_folder_organization ) {
+			wp_enqueue_script( 'moment-js', RTGODAM_URL . 'assets/src/libs/moment-js.min.js', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/moment-js.min.js' ), true );
+			wp_enqueue_script( 'daterangepicker-js', RTGODAM_URL . 'assets/src/libs/daterangepicker.min.js', array( 'moment-js' ), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.min.js' ), true );
+			wp_enqueue_style( 'daterangepicker-css', RTGODAM_URL . 'assets/src/libs/daterangepicker.css', array(), filemtime( RTGODAM_PATH . 'assets/src/libs/daterangepicker.css' ) );
+		}
 
 		// Only enqueue HTTP auth detector on uploads page or pages where media uploading is possible.
 		if ( godam_should_load_auth_detector_script( $screen ) ) {
@@ -400,6 +413,10 @@ class Assets {
 			'engagementFeatureEnabled'    => $engagement_feature_enabled,
 			'enableGlobalVideoEngagement' => $engagement_feature_enabled ? $enable_global_video_engagement : false,
 			'enableGlobalVideoShare'      => $enable_global_share,
+
+			// Media-library UI kill-switch: effective value + whether it's locked from code (constant/filter).
+			'mediaLibraryUIEffective'     => rtgodam_is_media_library_ui_enabled(),
+			'mediaLibraryUICodeManaged'   => rtgodam_is_media_library_ui_code_managed(),
 
 		);
 

--- a/inc/classes/class-media-library-ajax.php
+++ b/inc/classes/class-media-library-ajax.php
@@ -31,10 +31,15 @@ class Media_Library_Ajax {
 	 * @return void
 	 */
 	public function setup_hooks() {
-		add_filter( 'ajax_query_attachments_args', array( $this, 'filter_media_library_by_taxonomy' ) );
-		add_action( 'pre_get_posts', array( $this, 'pre_get_post_filter' ) );
+		// Folder/date filtering and the list-view filter UI are part of GoDAM's media-library
+		// takeover. Skip them in additive mode so the WordPress media library stays native
+		// server-side (no GoDAM folder dropdown or orphaned date inputs on upload.php).
+		if ( rtgodam_is_media_library_ui_enabled() ) {
+			add_filter( 'ajax_query_attachments_args', array( $this, 'filter_media_library_by_taxonomy' ) );
+			add_action( 'pre_get_posts', array( $this, 'pre_get_post_filter' ) );
+			add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_media_filter' ) );
+		}
 
-		add_action( 'restrict_manage_posts', array( $this, 'restrict_manage_media_filter' ) );
 		add_action( 'add_attachment', array( $this, 'add_media_library_taxonomy_on_media_upload' ), 10, 1 );
 		add_action( 'add_attachment', array( $this, 'upload_media_to_frappe_backend' ), 10, 1 );
 		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'add_media_transcoding_status_js' ), 10, 2 );

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -554,7 +554,9 @@ class Pages {
 			);
 
 			// Localize easydamMediaLibrary data for the video editor.
-			$enable_folder_organization = get_option( 'rtgodam-settings', array() )['general']['enable_folder_organization'] ?? true;
+			// Resolve through the helper so the code-level constant/filter override applies here too,
+			// keeping this global consistent on the video-editor page.
+			$enable_folder_organization = rtgodam_is_media_library_ui_enabled();
 			$current_user_id            = get_current_user_id();
 
 			$easydam_media_library_data = array(

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -577,7 +577,7 @@ function rtgodam_is_api_key_valid() {
  *     option (default `true`).
  *  3. The `rtgodam_enable_media_library_ui` filter can override the option value.
  *
- * @since 1.11.1
+ * @since 1.11.2
  *
  * @return bool True when the media-library UI should load (default), false in additive mode.
  */
@@ -605,7 +605,7 @@ function rtgodam_is_media_library_ui_enabled() {
 	 * constant is not set. Return false to run GoDAM in additive mode
 	 * (suppress the media-library takeover).
 	 *
-	 * @since 1.11.1
+	 * @since 1.11.2
 	 *
 	 * @param bool $enabled Whether the media-library UI is enabled.
 	 */
@@ -623,7 +623,7 @@ function rtgodam_is_media_library_ui_enabled() {
  * stored option — a passthrough or observe-only hook (e.g. logging) must not lock
  * the toggle for a setting no code really controls.
  *
- * @since 1.11.1
+ * @since 1.11.2
  *
  * @return bool True when the constant is defined-truthy, or a filter changes the stored value.
  */

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -558,6 +558,95 @@ function rtgodam_is_api_key_valid() {
 }
 
 /**
+ * Resolve whether GoDAM's WordPress media-library admin UI is enabled.
+ *
+ * "Additive mode" lets GoDAM coexist with another DAM/media plugin by
+ * suppressing GoDAM's media-library takeover (folder UI, "Manage Media"
+ * button, search override, attachment-browser folder/date filters) while
+ * leaving blocks, the front-end player, analytics, transcoding, REST, the
+ * GoDAM media-modal tab, and GoDAM's own admin pages intact.
+ *
+ * The single "enable folder organization" toggle (`general.enable_folder_organization`)
+ * is GoDAM's media-library integration master switch; turning it off runs GoDAM in
+ * additive mode. This helper resolves that toggle with the code-level overrides.
+ *
+ * Resolution precedence (code-level is authoritative):
+ *  1. A defined, truthy `RTGODAM_DISABLE_MEDIA_LIBRARY_UI` constant forces it
+ *     off and cannot be overridden.
+ *  2. Otherwise the `rtgodam-settings` → general → `enable_folder_organization`
+ *     option (default `true`).
+ *  3. The `rtgodam_enable_media_library_ui` filter can override the option value.
+ *
+ * @since 1.11.1
+ *
+ * @return bool True when the media-library UI should load (default), false in additive mode.
+ */
+function rtgodam_is_media_library_ui_enabled() {
+	if ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI ) {
+		return false;
+	}
+
+	$settings = get_option( 'rtgodam-settings', array() );
+	if ( ! is_array( $settings ) ) {
+		$settings = array();
+	}
+
+	$general_settings = $settings['general'] ?? array();
+	if ( ! is_array( $general_settings ) ) {
+		$general_settings = array();
+	}
+
+	$enabled = $general_settings['enable_folder_organization'] ?? true;
+
+	/**
+	 * Filters whether GoDAM's media-library admin UI is enabled.
+	 *
+	 * Code-level override for coexistence deployments when the disabling
+	 * constant is not set. Return false to run GoDAM in additive mode
+	 * (suppress the media-library takeover).
+	 *
+	 * @since 1.11.1
+	 *
+	 * @param bool $enabled Whether the media-library UI is enabled.
+	 */
+	return (bool) apply_filters( 'rtgodam_enable_media_library_ui', $enabled );
+}
+
+/**
+ * Check whether the media-library UI value is forced from code.
+ *
+ * Used to render the dashboard toggle as locked ("managed in code") so an
+ * admin can't fight a code-level value set via the constant or the
+ * `rtgodam_enable_media_library_ui` filter.
+ *
+ * The filter only counts as "managing" the value when it actually overrides the
+ * stored option — a passthrough or observe-only hook (e.g. logging) must not lock
+ * the toggle for a setting no code really controls.
+ *
+ * @since 1.11.1
+ *
+ * @return bool True when the constant is defined-truthy, or a filter changes the stored value.
+ */
+function rtgodam_is_media_library_ui_code_managed() {
+	if ( defined( 'RTGODAM_DISABLE_MEDIA_LIBRARY_UI' ) && RTGODAM_DISABLE_MEDIA_LIBRARY_UI ) {
+		return true;
+	}
+
+	if ( ! has_filter( 'rtgodam_enable_media_library_ui' ) ) {
+		return false;
+	}
+
+	$settings = get_option( 'rtgodam-settings', array() );
+	$general  = is_array( $settings ) && isset( $settings['general'] ) && is_array( $settings['general'] )
+		? $settings['general']
+		: array();
+	$stored   = (bool) ( $general['enable_folder_organization'] ?? true );
+
+	// Locked only if the filter resolves to something other than the stored option.
+	return rtgodam_is_media_library_ui_enabled() !== $stored;
+}
+
+/**
  * Checks if the given filename is an audio file based on its name.
  *
  * Note: The files created by uppy webcam, screen capture, and audio plugin are in the same format. So we are checking the filename to determine if it's an audio file.

--- a/languages/godam.pot
+++ b/languages/godam.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: GoDAM 1.11.1\n"
+"Project-Id-Version: GoDAM 1.11.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/godam\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-02T12:06:34+00:00\n"
+"POT-Creation-Date: 2026-06-05T11:33:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.11.0\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: godam\n"
 
 #. Plugin Name of the plugin
@@ -23,7 +23,6 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:68
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:66
 #: pages/video-editor/components/forms/CF7.js:24
-#: assets/build/pages/video-editor.min.js:15718
 msgid "GoDAM"
 msgstr ""
 
@@ -57,8 +56,6 @@ msgstr ""
 #: admin/js/godam-retranscode-media.js:6
 #: pages/tools/App.js:21
 #: pages/tools/components/tabs/RetranscodeTab.jsx:353
-#: assets/build/pages/tools.min.js:1009
-#: assets/build/pages/tools.min.js:2047
 msgid "Retranscode Media"
 msgstr ""
 
@@ -70,6 +67,7 @@ msgstr ""
 #. translators: Link to the media page.
 #: admin/class-rtgodam-retranscodemedia.php:183
 #: admin/class-rtgodam-retranscodemedia.php:395
+#, php-format
 msgid "Unable to find any media. Are you sure <a href='%s'>some exist</a>?"
 msgstr ""
 
@@ -80,6 +78,7 @@ msgstr ""
 #. translators: The URL to go back to the previous page.
 #: admin/class-rtgodam-retranscodemedia.php:206
 #: admin/class-rtgodam-retranscodemedia.php:475
+#, php-format
 msgid "To go back to the previous page, <a href=\"%s\">click here</a>."
 msgstr ""
 
@@ -118,11 +117,13 @@ msgstr ""
 
 #. translators: Count of media which were successfully and media which were failed transcoded with the time in seconds and previout page link.
 #: admin/class-rtgodam-retranscodemedia.php:478
+#, php-format
 msgid "All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were %3$s failure(s). To try transcoding the failed media again, <a href=\"%4$s\">click here</a>. %5$s"
 msgstr ""
 
 #. translators: Count of media which were successfully transcoded with the time in seconds and previout page link.
 #: admin/class-rtgodam-retranscodemedia.php:480
+#, php-format
 msgid "All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were 0 failures. %3$s"
 msgstr ""
 
@@ -141,16 +142,19 @@ msgstr ""
 
 #. translators: Total count of the media.
 #: admin/class-rtgodam-retranscodemedia.php:496
+#, php-format
 msgid "Total Media: %s"
 msgstr ""
 
 #. translators: Count of media which were successfully sent to the transcoder server.
 #: admin/class-rtgodam-retranscodemedia.php:501
+#, php-format
 msgid "Media Sent for Retranscoding: %s"
 msgstr ""
 
 #. translators: Count of media which were failed while sending to the transcoder server.
 #: admin/class-rtgodam-retranscodemedia.php:506
+#, php-format
 msgid "Failed While Sending: %s"
 msgstr ""
 
@@ -164,6 +168,7 @@ msgstr ""
 
 #. translators: Placeholder is for admin media section link.
 #: admin/class-rtgodam-retranscodemedia.php:528
+#, php-format
 msgid "You can retranscode specific media files (rather than ALL media) from the <a href='%s'>Media</a> page using Bulk Action via drop down or mouse hover a specific media (audio/video) file."
 msgstr ""
 
@@ -177,6 +182,7 @@ msgstr ""
 
 #. translators: Media name, Media ID and message for failed transcode.
 #: admin/class-rtgodam-retranscodemedia.php:555
+#, php-format
 msgid "&quot;%1$s&quot; (ID %2$s) failed to send. The error message was: %3$s"
 msgstr ""
 
@@ -185,249 +191,247 @@ msgid "Insufficient bandwidth!"
 msgstr ""
 
 #. translators: %s is the URL to the plugin settings page where the API key can be activated.
-#: admin/class-rtgodam-transcoder-admin.php:87
-#: admin/class-rtgodam-transcoder-admin.php:149
-#: admin/class-rtgodam-transcoder-admin.php:164
+#: admin/class-rtgodam-transcoder-admin.php:86
+#: admin/class-rtgodam-transcoder-admin.php:148
+#: admin/class-rtgodam-transcoder-admin.php:163
+#, php-format
 msgid "Enjoy using our <strong>DAM and Video Editor</strong> features for free! To unlock Transcoding, Analytics and more, <a href=\"%s\">please activate your API key.</a>"
 msgstr ""
 
 #. translators: %d: Number of days until trial ends
-#: admin/class-rtgodam-transcoder-admin.php:112
+#: admin/class-rtgodam-transcoder-admin.php:111
+#, php-format
 msgid "Your product is under trial. You will be charged after <strong>%d days</strong>. If you wish to cancel, please visit <a href=\"https://app.godam.io/subscription/my-account\" target=\"_blank\">your subscription settings</a>."
 msgstr ""
 
 #. translators: %d: Number of days until transcoded videos are deleted after subscription ends
-#: admin/class-rtgodam-transcoder-admin.php:136
+#: admin/class-rtgodam-transcoder-admin.php:135
+#, php-format
 msgid "Your subscription has ended. No further transcoding can be done. Transcoded videos will be removed after <strong>%d days</strong>, and Pro features will not be accessible. After the 30-day grace period, already transcoded videos will no longer be served from the CDN. Renew your subscription to keep it up and running."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:186
-#: admin/class-rtgodam-transcoder-admin.php:347
+#: admin/class-rtgodam-transcoder-admin.php:185
+#: admin/class-rtgodam-transcoder-admin.php:346
 msgid "Activate API Key"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:186
+#: admin/class-rtgodam-transcoder-admin.php:185
 msgid "Use Video Editor"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:193
-#: admin/class-rtgodam-transcoder-admin.php:337
+#: admin/class-rtgodam-transcoder-admin.php:192
+#: admin/class-rtgodam-transcoder-admin.php:336
 #: admin/godam-transcoder-functions.php:319
-#: inc/classes/class-media-library-ajax.php:1209
+#: inc/classes/class-media-library-ajax.php:1214
 #: inc/templates/video-preview.php:42
 #: pages/godam/components/GoDAMHeader.jsx:71
 #: pages/whats-new/components/Header.js:19
-#: assets/build/js/media-library.min.js:11526
-#: assets/build/pages/analytics.min.js:12399
-#: assets/build/pages/dashboard.min.js:3835
-#: assets/build/pages/godam.min.js:10286
-#: assets/build/pages/help.min.js:692
-#: assets/build/pages/tools.min.js:750
-#: assets/build/pages/video-editor.min.js:11036
-#: assets/build/pages/whats-new.min.js:749
 msgid "GoDAM Logo"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:197
+#: admin/class-rtgodam-transcoder-admin.php:196
 msgid "Welcome to GoDAM! Thank you for using our product."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:222
-#: admin/class-rtgodam-transcoder-admin.php:560
-#: admin/class-rtgodam-transcoder-admin.php:623
-#: admin/class-rtgodam-transcoder-admin.php:662
+#: admin/class-rtgodam-transcoder-admin.php:221
+#: admin/class-rtgodam-transcoder-admin.php:559
+#: admin/class-rtgodam-transcoder-admin.php:622
+#: admin/class-rtgodam-transcoder-admin.php:661
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:84
-#: assets/build/pages/godam.min.js:10991
 msgid "Learn More"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:277
-#: inc/classes/class-media-library-ajax.php:822
+#: admin/class-rtgodam-transcoder-admin.php:276
+#: inc/classes/class-media-library-ajax.php:827
 #: pages/dashboard/Dashboard.js:377
 #: pages/video-editor/AttachmentPicker.jsx:45
-#: assets/build/pages/dashboard.min.js:3125
-#: assets/build/pages/video-editor.min.js:11511
 msgid "Claim the GoDAM New Year Sale 2026 offer"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:279
-#: inc/classes/class-media-library-ajax.php:824
+#: admin/class-rtgodam-transcoder-admin.php:278
+#: inc/classes/class-media-library-ajax.php:829
 #: pages/dashboard/Dashboard.js:381
 #: pages/video-editor/AttachmentPicker.jsx:49
-#: assets/build/pages/dashboard.min.js:3129
-#: assets/build/pages/video-editor.min.js:11515
 msgid "New Year Sale 2026 offer from GoDAM"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:280
-#: inc/classes/class-media-library-ajax.php:825
+#: admin/class-rtgodam-transcoder-admin.php:279
+#: inc/classes/class-media-library-ajax.php:830
 #: pages/video-editor/AttachmentPicker.jsx:58
-#: assets/build/pages/video-editor.min.js:11524
 msgid "Dismiss banner"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:340
+#: admin/class-rtgodam-transcoder-admin.php:339
 msgid "Unlock Video Analytics, Transcoding and more with GoDAM Pro. Start with a free 60-day trial."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:344
+#: admin/class-rtgodam-transcoder-admin.php:343
 msgid "Get your Free Plan"
 msgstr ""
 
 #. translators: %1$s: bandwidth percentage, %2$s: storage percentage
-#: admin/class-rtgodam-transcoder-admin.php:523
+#: admin/class-rtgodam-transcoder-admin.php:522
+#, php-format
 msgid "Your bandwidth (%1$s%%) and storage (%2$s%%) usage have exceeded your plan limits."
 msgstr ""
 
 #. translators: %s: bandwidth percentage
-#: admin/class-rtgodam-transcoder-admin.php:530
+#: admin/class-rtgodam-transcoder-admin.php:529
+#, php-format
 msgid "Your bandwidth usage (%s%%) has exceeded your plan limit."
 msgstr ""
 
 #. translators: %s: storage percentage
-#: admin/class-rtgodam-transcoder-admin.php:536
+#: admin/class-rtgodam-transcoder-admin.php:535
+#, php-format
 msgid "Your storage usage (%s%%) has exceeded your plan limit."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:541
+#: admin/class-rtgodam-transcoder-admin.php:540
 msgid "Transcoding requests may be blocked until you upgrade your plan."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:553
+#: admin/class-rtgodam-transcoder-admin.php:552
 msgid "GoDAM Usage Limit Exceeded"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:557
-#: admin/class-rtgodam-transcoder-admin.php:659
+#: admin/class-rtgodam-transcoder-admin.php:556
+#: admin/class-rtgodam-transcoder-admin.php:658
 msgid "Upgrade Your Plan"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:563
-#: admin/class-rtgodam-transcoder-admin.php:626
-#: admin/class-rtgodam-transcoder-admin.php:665
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:146
-#: assets/build/pages/godam.min.js:12241
+#: admin/class-rtgodam-transcoder-admin.php:562
+#: admin/class-rtgodam-transcoder-admin.php:625
+#: admin/class-rtgodam-transcoder-admin.php:664
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:148
 msgid "Refresh Status"
 msgstr ""
 
 #. translators: %1$s: bandwidth percentage, %2$s: storage percentage
-#: admin/class-rtgodam-transcoder-admin.php:586
+#: admin/class-rtgodam-transcoder-admin.php:585
+#, php-format
 msgid "Your bandwidth (%1$s%%) and storage (%2$s%%) usage are approaching your plan limits."
 msgstr ""
 
 #. translators: %s: bandwidth percentage
-#: admin/class-rtgodam-transcoder-admin.php:593
+#: admin/class-rtgodam-transcoder-admin.php:592
+#, php-format
 msgid "Your bandwidth usage (%s%%) is approaching your plan limit."
 msgstr ""
 
 #. translators: %s: storage percentage
-#: admin/class-rtgodam-transcoder-admin.php:599
+#: admin/class-rtgodam-transcoder-admin.php:598
+#, php-format
 msgid "Your storage usage (%s%%) is approaching your plan limit."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:604
+#: admin/class-rtgodam-transcoder-admin.php:603
 msgid "Consider upgrading your plan to avoid service interruptions."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:616
+#: admin/class-rtgodam-transcoder-admin.php:615
 msgid "GoDAM Usage Warning"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:620
+#: admin/class-rtgodam-transcoder-admin.php:619
 msgid "View Plans"
 msgstr ""
 
 #. translators: %s: bandwidth percentage
-#: admin/class-rtgodam-transcoder-admin.php:643
+#: admin/class-rtgodam-transcoder-admin.php:642
+#, php-format
 msgid "Your bandwidth usage (%s%%) has exceeded your plan limit. Videos might not be served from CDN on frontend."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:655
+#: admin/class-rtgodam-transcoder-admin.php:654
 msgid "GoDAM Bandwidth Exceeded"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:656
+#: admin/class-rtgodam-transcoder-admin.php:655
 msgid "Transcoding will continue to work."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:708
+#: admin/class-rtgodam-transcoder-admin.php:707
 msgid "Want to help make <strong>GoDAM</strong> even more awesome? Allow GoDAM to collect anonymous diagnostic data and usage information."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:715
+#: admin/class-rtgodam-transcoder-admin.php:714
 msgid "what we collect"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:717
+#: admin/class-rtgodam-transcoder-admin.php:716
 msgid "Data we collect:"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:719
+#: admin/class-rtgodam-transcoder-admin.php:718
 msgid "Server environment details (PHP, MySQL, Server, and WordPress versions)"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:720
+#: admin/class-rtgodam-transcoder-admin.php:719
 msgid "Site and user count (Language and number of users)"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:721
+#: admin/class-rtgodam-transcoder-admin.php:720
 msgid "Plugin details (Number of active and inactive plugins)"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:722
+#: admin/class-rtgodam-transcoder-admin.php:721
 msgid "Usage data (Interactions, navigation, session replays, heatmaps, and errors via PostHog)"
 msgstr ""
 
 #. translators: %s: PostHog privacy policy URL
-#: admin/class-rtgodam-transcoder-admin.php:728
+#: admin/class-rtgodam-transcoder-admin.php:727
+#, php-format
 msgid "We are using PostHog to collect anonymous data. <a href=\"%s\" target=\"_blank\">Learn more</a>. This can be disabled from the settings on the Help page."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:740
+#: admin/class-rtgodam-transcoder-admin.php:739
 msgid "Allow"
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-admin.php:741
+#: admin/class-rtgodam-transcoder-admin.php:740
 msgid "No thanks"
 msgstr ""
 
 #. translators: %s: URL to settings page
-#: admin/class-rtgodam-transcoder-admin.php:779
+#: admin/class-rtgodam-transcoder-admin.php:778
+#, php-format
 msgid "Your GoDAM API key has expired. Transcoding and other Pro features are currently disabled. Please <a href=\"%s\">renew your subscription</a> to restore access."
 msgstr ""
 
 #. translators: %s: URL to settings page
-#: admin/class-rtgodam-transcoder-admin.php:784
+#: admin/class-rtgodam-transcoder-admin.php:783
+#, php-format
 msgid "Temporarily unable to verify your GoDAM API key. Transcoding may not work. Please <a href=\"%s\">check your settings</a> or try refreshing the status."
 msgstr ""
 
 #. translators: %s: URL to settings page
-#: admin/class-rtgodam-transcoder-admin.php:793
+#: admin/class-rtgodam-transcoder-admin.php:792
+#, php-format
 msgid "There is an issue with your GoDAM API key. Transcoding may not work. Please <a href=\"%s\">check your settings</a>."
 msgstr ""
 
-#. translators: 1: Opening link tag, 2: Closing link tag
-#: admin/class-rtgodam-transcoder-admin.php:890
-msgid "<strong>GoDAM API key has expired.</strong> Pro features in GoDAM are currently disabled. %1$sPurchase a new key%2$s to restore access."
-msgstr ""
-
 #. translators: 1: opening link tag, 2: closing link tag
-#: admin/class-rtgodam-transcoder-admin.php:946
+#: admin/class-rtgodam-transcoder-admin.php:891
+#, php-format
 msgid "<strong>Shoppable video for WooCommerce is live!</strong> %1$sActivate%2$s to start selling directly from your videos."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
-#: admin/class-rtgodam-transcoder-admin.php:954
+#: admin/class-rtgodam-transcoder-admin.php:899
+#, php-format
 msgid "<strong>GoDAM now supports WooCommerce!</strong> %1$sInstall WooCommerce%2$s to start using shoppable videos with GoDAM."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
-#: admin/class-rtgodam-transcoder-admin.php:962
+#: admin/class-rtgodam-transcoder-admin.php:907
+#, php-format
 msgid "<strong>Add shoppable videos to your WooCommerce store!</strong> %1$sUpgrade your plan%2$s to unlock this feature."
 msgstr ""
 
 #. translators: %s: storage usage percent
 #: admin/class-rtgodam-transcoder-handler.php:266
+#, php-format
 msgid "Storage exceeded (%s%%)."
 msgstr ""
 
@@ -436,12 +440,13 @@ msgid "Please upgrade your plan to continue transcoding."
 msgstr ""
 
 #: admin/class-rtgodam-transcoder-handler.php:295
-#: inc/classes/class-media-library-ajax.php:234
+#: inc/classes/class-media-library-ajax.php:239
 msgid "HTTP authentication is enabled on your site, preventing transcoding."
 msgstr ""
 
 #. translators: 1: max retry attempts, 2: retry interval in minutes
 #: admin/class-rtgodam-transcoder-handler.php:503
+#, php-format
 msgid "GoDAM Central returned a server error. Transcoding will be retried automatically (up to %1$d times, every %2$d minutes)."
 msgstr ""
 
@@ -459,6 +464,7 @@ msgstr ""
 
 #. translators: Return an error if the value is neither a string nor an array.
 #: admin/class-rtgodam-transcoder-rest-routes.php:198
+#, php-format
 msgid "%s must be a valid URL or an array of URLs."
 msgstr ""
 
@@ -472,6 +478,7 @@ msgstr ""
 
 #. translators: %s is replaced with the attachment ID for which subsizes generation failed.
 #: admin/class-rtgodam-transcoder-rest-routes.php:327
+#, php-format
 msgid "GoDAM: Failed to request image subsizes for attachment ID %s. The transcoded image URL has been saved; subsizes may be retried separately."
 msgstr ""
 
@@ -542,22 +549,18 @@ msgid "Transcoded CDN URL"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:73
-#: assets/build/js/media-library.min.js:11077
 msgid "Transcoded CDN URL (MPD)"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:87
-#: assets/build/js/media-library.min.js:11079
 msgid "The URL of the transcoded file is generated automatically and cannot be edited."
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:95
-#: assets/build/js/media-library.min.js:11089
 msgid "Transcoded CDN URL (HLS)"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:104
-#: assets/build/js/media-library.min.js:11091
 msgid "The HLS URL of the transcoded file is generated automatically and cannot be edited."
 msgstr ""
 
@@ -571,6 +574,7 @@ msgstr ""
 
 #. translators: %1$s URL to the settings page, %2$s API key label.
 #: admin/godam-transcoder-actions.php:123
+#, php-format
 msgid "Activate the <a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> to enable transcoding and adaptive bitrate streaming."
 msgstr ""
 
@@ -589,7 +593,6 @@ msgid "Media is transcoded."
 msgstr ""
 
 #: admin/godam-transcoder-functions.php:345
-#: assets/build/js/media-library.min.js:9244
 msgid "Transcoding failed, please try again."
 msgstr ""
 
@@ -639,6 +642,7 @@ msgstr ""
 #: assets/build/blocks/godam-gallery-v2/render.php:342
 #: assets/build/blocks/godam-gallery-v2/render.php:392
 #: inc/classes/rest-api/class-dynamic-gallery.php:376
+#, php-format
 msgid "Open video: %s"
 msgstr ""
 
@@ -656,13 +660,12 @@ msgstr ""
 #: inc/classes/shortcodes/class-godam-video-gallery.php:397
 #: pages/media-library/components/folder-tree/FolderTree.jsx:430
 #: pages/media-library/components/search-bar/SearchBar.jsx:213
-#: assets/build/pages/media-library.min.js:6897
-#: assets/build/pages/media-library.min.js:8032
 msgid "Load More"
 msgstr ""
 
 #. translators: %s: PDF download URL
 #: assets/build/blocks/godam-pdf/render.php:56
+#, php-format
 msgid "Your browser does not support PDFs. <a href=\"%s\">Download the PDF</a>."
 msgstr ""
 
@@ -692,6 +695,7 @@ msgstr ""
 
 #. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
 #: assets/build/blocks/sureforms/blocks/recorder/render.php:117
+#, php-format
 msgid "Maximum allowed on this server: %d MB"
 msgstr ""
 
@@ -706,6 +710,7 @@ msgstr ""
 
 #. translators: 1: Add-on name, 2: Required GoDAM version
 #: inc/classes/addons/class-addon-registry.php:97
+#, php-format
 msgid "%1$s requires GoDAM %2$s or higher. Please update the GoDAM plugin."
 msgstr ""
 
@@ -743,50 +748,49 @@ msgstr ""
 msgid "Invalid data."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:688
+#: inc/classes/class-media-library-ajax.php:693
 #: pages/media-library/App.js:214
-#: assets/build/pages/media-library.min.js:5865
 msgid "Uncategorized"
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:692
+#: inc/classes/class-media-library-ajax.php:697
 msgid "All collections"
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:774
+#: inc/classes/class-media-library-ajax.php:779
 msgid "Offer banner dismissed successfully."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:868
+#: inc/classes/class-media-library-ajax.php:873
 msgid "Invalid attachment ID or URL."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:874
+#: inc/classes/class-media-library-ajax.php:879
 #: inc/classes/rest-api/class-media-library.php:629
 msgid "Invalid attachment ID."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:886
+#: inc/classes/class-media-library-ajax.php:891
 msgid "Could not initialize WordPress filesystem."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:906
+#: inc/classes/class-media-library-ajax.php:911
 msgid "Could not move file into uploads directory."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1161
+#: inc/classes/class-media-library-ajax.php:1166
 msgid "Insufficient permissions."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1178
+#: inc/classes/class-media-library-ajax.php:1183
 msgid "HTTP auth status saved."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1211
+#: inc/classes/class-media-library-ajax.php:1216
 msgid "GoDAM Transcoding Blocked"
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1214
+#: inc/classes/class-media-library-ajax.php:1219
 msgid "HTTP authentication is enabled on your site, which prevents GoDAM from accessing media files for transcoding. Please disable HTTP authentication to enable transcoding."
 msgstr ""
 
@@ -800,6 +804,7 @@ msgstr ""
 
 #. translators: %1$s is the name of the Transcoder plugin, %2$s is the name of the GoDAM plugin.
 #: inc/classes/class-media-tracker.php:209
+#, php-format
 msgid "Please deactivate the <strong>%1$s</strong> plugin to ensure the <strong>%2$s</strong> plugin functions correctly."
 msgstr ""
 
@@ -816,10 +821,7 @@ msgstr ""
 #: inc/classes/class-pages.php:201
 #: inc/classes/class-pages.php:202
 #: inc/templates/video-preview.php:53
-#: pages/video-editor/VideoEditor.js:457
-#: assets/build/js/media-library.min.js:10517
-#: assets/build/js/media-library.min.js:10524
-#: assets/build/pages/video-editor.min.js:12022
+#: pages/video-editor/VideoEditor.js:459
 msgid "Analytics"
 msgstr ""
 
@@ -837,9 +839,6 @@ msgstr ""
 #: inc/classes/class-pages.php:248
 #: pages/dashboard/components/MarketingCarousel.jsx:94
 #: pages/godam/components/GoDAMFooter.jsx:31
-#: assets/build/pages/godam.min.js:10137
-#: assets/build/pages/help.min.js:543
-#: assets/build/pages/tools.min.js:601
 msgid "What's New"
 msgstr ""
 
@@ -847,15 +846,15 @@ msgstr ""
 msgid "Sorry, you are not allowed to edit this item."
 msgstr ""
 
-#: inc/classes/class-pages.php:637
+#: inc/classes/class-pages.php:639
 msgid "Your last request is still being processed. Please wait a while ..."
 msgstr ""
 
-#: inc/classes/class-pages.php:638
+#: inc/classes/class-pages.php:640
 msgid "Please choose a valid poll answer."
 msgstr ""
 
-#: inc/classes/class-pages.php:639
+#: inc/classes/class-pages.php:641
 msgid "Maximum number of choices allowed: "
 msgstr ""
 
@@ -891,6 +890,7 @@ msgstr ""
 
 #. translators: %d is the maximum number of retry attempts.
 #: inc/classes/cron-jobs/class-retranscode-failed-media.php:120
+#, php-format
 msgid "Transcoding failed after %d retry attempts. GoDAM Central returned a server error on each attempt."
 msgstr ""
 
@@ -900,12 +900,12 @@ msgstr ""
 
 #: inc/classes/cron-jobs/class-retranscode-failed-media.php:172
 #: pages/video-editor/components/media-grid/MediaGrid.jsx:117
-#: assets/build/pages/video-editor.min.js:19179
 msgid "Media Library"
 msgstr ""
 
 #. translators: 1: number of media items queued, 2: retry interval in minutes, 3: max retries, 4: Media Library link
 #: inc/classes/cron-jobs/class-retranscode-failed-media.php:176
+#, php-format
 msgid "%1$d media file(s) could not be sent to the GoDAM transcoding server and have been queued for automatic retry (every %2$d minutes, up to %3$d attempts). Visit the %4$s to see their status."
 msgstr ""
 
@@ -915,7 +915,6 @@ msgstr ""
 
 #: inc/classes/elementor-controls/class-godam-media.php:140
 #: pages/analytics/Analytics.js:752
-#: assets/build/pages/analytics.min.js:9762
 msgid "Choose Video"
 msgstr ""
 
@@ -941,14 +940,7 @@ msgstr ""
 #: pages/video-editor/components/appearance/Appearance.js:502
 #: pages/video-editor/components/appearance/Appearance.js:549
 #: pages/video-editor/components/appearance/Appearance.js:605
-#: pages/video-editor/components/cta/ImageCTA.js:468
-#: assets/build/js/wpbakery-video-selector-param.min.js:458
-#: assets/build/pages/godam.min.js:10734
-#: assets/build/pages/godam.min.js:12037
-#: assets/build/pages/video-editor.min.js:14576
-#: assets/build/pages/video-editor.min.js:14623
-#: assets/build/pages/video-editor.min.js:14679
-#: assets/build/pages/video-editor.min.js:15557
+#: pages/video-editor/components/cta/ImageCTA.js:474
 msgid "Remove"
 msgstr ""
 
@@ -966,11 +958,7 @@ msgstr ""
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:99
 #: pages/video-editor/components/appearance/Appearance.js:498
 #: pages/video-editor/components/appearance/Appearance.js:545
-#: pages/video-editor/components/cta/ImageCTA.js:350
-#: assets/build/pages/godam.min.js:10724
-#: assets/build/pages/video-editor.min.js:14572
-#: assets/build/pages/video-editor.min.js:14619
-#: assets/build/pages/video-editor.min.js:15439
+#: pages/video-editor/components/cta/ImageCTA.js:352
 msgid "Upload"
 msgstr ""
 
@@ -1085,7 +1073,6 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:133
 #: assets/build/blocks/godam-gallery-v2/index.js:1
 #: pages/video-editor/components/cta/ImageCTA.js:303
-#: assets/build/pages/video-editor.min.js:15392
 msgid "Layout"
 msgstr ""
 
@@ -1124,8 +1111,7 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-gallery.php:131
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:151
 #: assets/build/blocks/godam-gallery-v2/index.js:1
-#: pages/video-editor/components/cta/ImageCTA.js:403
-#: assets/build/pages/video-editor.min.js:15492
+#: pages/video-editor/components/cta/ImageCTA.js:405
 msgid "Title"
 msgstr ""
 
@@ -1134,15 +1120,12 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:152
 #: assets/build/blocks/godam-player/index.js:4
 #: pages/analytics/helper.js:708
-#: assets/build/pages/analytics.min.js:12047
-#: assets/build/pages/dashboard.min.js:2580
 msgid "Duration"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:133
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:153
 #: pages/dashboard/Dashboard.js:533
-#: assets/build/pages/dashboard.min.js:3281
 msgid "Size"
 msgstr ""
 
@@ -1274,7 +1257,6 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:43
 #: pages/video-editor/VideoEditor.js:346
-#: assets/build/pages/video-editor.min.js:11911
 msgid "Player Settings"
 msgstr ""
 
@@ -1294,7 +1276,6 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:64
 #: inc/classes/elementor-widgets/class-godam-video.php:126
 #: pages/video-editor/components/forms/CF7.js:28
-#: assets/build/pages/video-editor.min.js:15722
 msgid "Default"
 msgstr ""
 
@@ -1354,7 +1335,6 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:110
 #: assets/build/blocks/godam-player/index.js:1
 #: pages/video-editor/VideoEditor.js:352
-#: assets/build/pages/video-editor.min.js:11917
 msgid "Chapters"
 msgstr ""
 
@@ -1407,8 +1387,7 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:283
 #: assets/build/blocks/godam-player/index.js:4
 #: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: pages/video-editor/components/cta/ImageCTA.js:433
-#: assets/build/pages/video-editor.min.js:15522
+#: pages/video-editor/components/cta/ImageCTA.js:437
 msgid "Description"
 msgstr ""
 
@@ -1451,7 +1430,6 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:333
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:166
 #: assets/build/blocks/godam-player/index.js:4
-#: assets/build/js/media-library.min.js:10173
 msgid "Video Thumbnail"
 msgstr ""
 
@@ -1510,6 +1488,7 @@ msgstr ""
 
 #. translators: %s is the max file size in MB
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:248
+#, php-format
 msgid "Max file size: %s MB"
 msgstr ""
 
@@ -1577,9 +1556,6 @@ msgstr ""
 #: pages/video-editor/components/LayerSelector.jsx:140
 #: pages/video-editor/components/LayerSelector.jsx:149
 #: pages/video-editor/components/SidebarLayers.js:97
-#: assets/build/pages/video-editor.min.js:13082
-#: assets/build/pages/video-editor.min.js:13091
-#: assets/build/pages/video-editor.min.js:13519
 msgid "Everest Forms"
 msgstr ""
 
@@ -1622,6 +1598,7 @@ msgstr ""
 #: inc/classes/fluentforms/fields/class-recorder-field.php:431
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:259
 #: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#, php-format,js-format
 msgid "Maximum allowed on this server: %s MB"
 msgstr ""
 
@@ -1689,26 +1666,31 @@ msgstr ""
 
 #. translators: %s is the allowed file types.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:152
+#, php-format
 msgid "Accepted file types: %s"
 msgstr ""
 
 #. translators: %s is the maximum file size allowed.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:158
+#, php-format
 msgid "Max. file size: %s"
 msgstr ""
 
 #. translators: %s is the maximum duration.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:165
+#, php-format
 msgid "Max. duration: %s"
 msgstr ""
 
 #. translators: %s is the maximum number of files allowed.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:175
+#, php-format
 msgid "Max. files: %s"
 msgstr ""
 
 #. translators: %d is the number of files.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:264
+#, php-format
 msgid "%d files"
 msgstr ""
 
@@ -1758,7 +1740,7 @@ msgid "Leave empty to allow any duration. Example: 180 = 3 minutes."
 msgstr ""
 
 #: inc/classes/gravity-forms/class-init.php:314
-#: inc/helpers/custom-functions.php:754
+#: inc/helpers/custom-functions.php:843
 msgid "Gravity forms"
 msgstr ""
 
@@ -1789,6 +1771,7 @@ msgstr ""
 
 #. translators: %d is the error code returned by ZipArchive::open()
 #: inc/classes/media-library/class-media-folder-create-zip.php:175
+#, php-format
 msgid "Failed to create ZIP file. Error code: %d"
 msgstr ""
 
@@ -1798,6 +1781,7 @@ msgstr ""
 
 #. translators: %1$d: added files, %2$d: skipped files, %3$d: total attachments
 #: inc/classes/media-library/class-media-folder-create-zip.php:267
+#, php-format
 msgid "ZIP file created successfully. %1$d files added, %2$d files skipped out of %3$d total attachments."
 msgstr ""
 
@@ -1820,6 +1804,7 @@ msgstr ""
 
 #. translators: %d is the Metform ID
 #: inc/classes/metform/class-metform-rest-api.php:152
+#, php-format
 msgid "Unable to find the Metform with ID:%d"
 msgstr ""
 
@@ -1849,6 +1834,7 @@ msgstr ""
 
 #. Translators: %s: Maximum allowed file size in MB.
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:443
+#, php-format
 msgid "File exceeds maximum file size. File must be under %sMB."
 msgstr ""
 
@@ -1857,9 +1843,6 @@ msgstr ""
 #: pages/video-editor/components/LayerSelector.jsx:153
 #: pages/video-editor/components/LayerSelector.jsx:162
 #: pages/video-editor/components/SidebarLayers.js:103
-#: assets/build/pages/video-editor.min.js:13095
-#: assets/build/pages/video-editor.min.js:13104
-#: assets/build/pages/video-editor.min.js:13525
 msgid "Ninja Forms"
 msgstr ""
 
@@ -1874,6 +1857,7 @@ msgstr ""
 
 #. translators: %d is the Ninja Form ID
 #: inc/classes/ninja-forms/class-ninja-forms-rest-api.php:130
+#, php-format
 msgid "Unable to find the Ninja Form with ID:%d"
 msgstr ""
 
@@ -1929,15 +1913,15 @@ msgstr ""
 msgid "Plugin is already active."
 msgstr ""
 
-#: inc/classes/rest-api/class-addon-toggle.php:130
+#: inc/classes/rest-api/class-addon-toggle.php:137
 msgid "Plugin activated successfully."
 msgstr ""
 
-#: inc/classes/rest-api/class-addon-toggle.php:140
+#: inc/classes/rest-api/class-addon-toggle.php:147
 msgid "Plugin is already inactive."
 msgstr ""
 
-#: inc/classes/rest-api/class-addon-toggle.php:153
+#: inc/classes/rest-api/class-addon-toggle.php:160
 msgid "Plugin deactivated successfully."
 msgstr ""
 
@@ -1977,6 +1961,7 @@ msgstr ""
 
 #. translators: %s is the error message from the API response.
 #: inc/classes/rest-api/class-analytics.php:351
+#, php-format
 msgid "Error fetching history data: %s"
 msgstr ""
 
@@ -2078,11 +2063,13 @@ msgstr ""
 
 #. translators: 1: Parameter.
 #: inc/classes/rest-api/class-engagement.php:957
+#, php-format
 msgid "%1$s is invalid."
 msgstr ""
 
 #. translators: 1: Parameter.
 #: inc/classes/rest-api/class-engagement.php:967
+#, php-format
 msgid "%1$s is empty."
 msgstr ""
 
@@ -2189,6 +2176,7 @@ msgstr ""
 
 #. translators: %s is the field label.
 #: inc/classes/rest-api/class-jetpack.php:711
+#, php-format
 msgid "Valid %s is required."
 msgstr ""
 
@@ -2202,6 +2190,7 @@ msgstr ""
 
 #. translators: %d is the number of errors, %s is the error text, %s is the list of errors.
 #: inc/classes/rest-api/class-jetpack.php:722
+#, php-format
 msgid "Please make sure all fields are valid. You need to fix %1$d %2$s:<br>%3$s"
 msgstr ""
 
@@ -2331,6 +2320,7 @@ msgstr ""
 #. translators: %s is the HTTP status code from the GoDAM API response.
 #: inc/classes/rest-api/class-media-library.php:797
 #: inc/classes/rest-api/class-media-library.php:1504
+#, php-format
 msgid "GoDAM API returned HTTP status: %s"
 msgstr ""
 
@@ -2389,37 +2379,44 @@ msgstr ""
 #. translators: %s is the invalid folder ID.
 #: inc/classes/rest-api/class-media-library.php:1188
 #: inc/classes/rest-api/class-media-library.php:1257
+#, php-format
 msgid "Invalid folder ID: %s"
 msgstr ""
 
 #. translators: %s is the invalid folder ID.
 #: inc/classes/rest-api/class-media-library.php:1196
 #: inc/classes/rest-api/class-media-library.php:1265
+#, php-format
 msgid "Folder ID %s not found or invalid."
 msgstr ""
 
 #. translators: %s is the invalid folder ID where delete failed.
 #: inc/classes/rest-api/class-media-library.php:1204
+#, php-format
 msgid "Failed to delete folder %s"
 msgstr ""
 
 #. translators: %s is the ID of folder not found.
 #: inc/classes/rest-api/class-media-library.php:1207
+#, php-format
 msgid "Folder ID %s not found during deletion attempt."
 msgstr ""
 
 #. translators: %s is the invalid folder ID.
 #: inc/classes/rest-api/class-media-library.php:1210
+#, php-format
 msgid "Folder ID %s cannot be deleted (possibly uncategorized or default term)."
 msgstr ""
 
 #. translators: %d is the number of folders deleted.
 #: inc/classes/rest-api/class-media-library.php:1221
+#, php-format
 msgid "%d folder(s) deleted successfully."
 msgstr ""
 
 #. translators: %1$d is the number of folders deleted, %2$s are the errors.
 #: inc/classes/rest-api/class-media-library.php:1229
+#, php-format
 msgid "Error deleting some folders. Deleted: %1$d. Errors: %2$s"
 msgstr ""
 
@@ -2433,21 +2430,25 @@ msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1318
+#, php-format
 msgid "%d folder(s) locked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1320
+#, php-format
 msgid "%d folder(s) unlocked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1334
+#, php-format
 msgid "Some folders locked, but issues occurred with others. Locked: %d."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1336
+#, php-format
 msgid "Some folders unlocked, but issues occurred with others. Unlocked: %d."
 msgstr ""
 
@@ -2457,21 +2458,25 @@ msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1376
+#, php-format
 msgid "%d folder(s) bookmarked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1378
+#, php-format
 msgid "%d folder(s) unbookmarked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1392
+#, php-format
 msgid "Some folders bookmarked, but issues occurred with others. Bookmarked: %d."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1394
+#, php-format
 msgid "Some folders unbookmarked, but issues occurred with others. Unbookmarked: %d."
 msgstr ""
 
@@ -2481,6 +2486,7 @@ msgstr ""
 
 #. translators: %s is the error message from the GoDAM API request.
 #: inc/classes/rest-api/class-media-library.php:1489
+#, php-format
 msgid "GoDAM API request failed: %s"
 msgstr ""
 
@@ -2649,6 +2655,7 @@ msgstr ""
 
 #. translators: %s is the storage usage percentage.
 #: inc/classes/rest-api/class-transcoding.php:369
+#, php-format
 msgid "Storage limit exceeded (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
 msgstr ""
 
@@ -2658,36 +2665,43 @@ msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:518
+#, php-format
 msgid "%1$s (ID %2$d) transcoding request failed. Transcoding requests are not allowed in the localhost environment."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:538
+#, php-format
 msgid "%1$s (ID %2$d) is virtual media from GoDAM Central. Please retranscode this media on GoDAM Central."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:558
+#, php-format
 msgid "%1$s (ID %2$d) is migrated Vimeo video. Please retranscode this video on GoDAM Central."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID, 3: storage usage percent.
 #: inc/classes/rest-api/class-transcoding.php:581
+#, php-format
 msgid "%1$s (ID %2$d) cannot be retranscoded. Storage limit exceeded (%3$s%%). Please upgrade your plan to continue transcoding."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:602
+#, php-format
 msgid "%1$s (ID %2$d) cannot be transcoded. HTTP authentication is enabled on your site. Please disable it to allow transcoding."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:652
+#, php-format
 msgid "%1$s (ID %2$d) transcoding request failed. Unknown error"
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:668
+#, php-format
 msgid "%1$s (ID %2$d) transcoding request was sent successfully"
 msgstr ""
 
@@ -2707,6 +2721,7 @@ msgstr ""
 
 #. translators: %1$d is the number of posts processed, %2$d is the total number of posts to process and %3$d is the migration name
 #: inc/classes/rest-api/class-video-migration.php:123
+#, php-format
 msgid "Processed %1$d of %2$d posts. %3$s aborted."
 msgstr ""
 
@@ -2732,6 +2747,7 @@ msgstr ""
 
 #. translators: %d is the number of batches scheduled for processing
 #: inc/classes/rest-api/class-video-migration.php:414
+#, php-format
 msgid "Scheduled %d batches for processing"
 msgstr ""
 
@@ -2741,16 +2757,19 @@ msgstr ""
 
 #. translators: %1$d is the number of posts processed, %2$d is the total number of posts, %3$d is the progress percentage
 #: inc/classes/rest-api/class-video-migration.php:541
+#, php-format
 msgid "Processed %1$d/%2$d posts (%3$d%% complete)"
 msgstr ""
 
 #. translators: 1: total posts processed, 2: migrated Vimeo embeds, 3: total Vimeo embeds found
 #: inc/classes/rest-api/class-video-migration.php:554
+#, php-format
 msgid "Migration completed! Processed %1$d posts. Migrated %2$d out of %3$d Vimeo Embed Blocks found."
 msgstr ""
 
 #. translators: %d is the total number of posts processed
 #: inc/classes/rest-api/class-video-migration.php:562
+#, php-format
 msgid "Migration completed! Processed %d posts."
 msgstr ""
 
@@ -2760,6 +2779,7 @@ msgstr ""
 
 #. translators: %s: error message
 #: inc/classes/rest-api/class-video-migration.php:1153
+#, php-format
 msgid "Error fetching video info: %s"
 msgstr ""
 
@@ -2800,7 +2820,6 @@ msgstr ""
 
 #: inc/classes/shortcodes/class-godam-video-gallery.php:421
 #: pages/dashboard/Dashboard.js:610
-#: assets/build/pages/dashboard.min.js:3358
 msgid "No videos found."
 msgstr ""
 
@@ -2961,17 +2980,11 @@ msgstr ""
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:99
 #: pages/video-editor/components/appearance/Appearance.js:498
 #: pages/video-editor/components/appearance/Appearance.js:545
-#: assets/build/js/wpbakery-video-selector-param.min.js:246
-#: assets/build/js/wpbakery-video-selector-param.min.js:438
-#: assets/build/pages/godam.min.js:10724
-#: assets/build/pages/video-editor.min.js:14572
-#: assets/build/pages/video-editor.min.js:14619
 msgid "Replace"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:84
 #: pages/analytics/index.js:37
-#: assets/build/pages/analytics.min.js:96787
 msgid "Select video"
 msgstr ""
 
@@ -3216,6 +3229,7 @@ msgstr ""
 
 #. translators: %s : Maximum file upload size in human readable format.
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:255
+#, php-format
 msgid "Maximum allowed on this server: %s "
 msgstr ""
 
@@ -3262,11 +3276,13 @@ msgstr ""
 
 #. translators: %s: Content type (Audio or Video)
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:50
+#, php-format
 msgid "%s transcoding process has not started."
 msgstr ""
 
 #. translators: %s: Content type (Audio or Video)
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:57
+#, php-format
 msgid "%s saved and transcoded successfully on GoDAM"
 msgstr ""
 
@@ -3279,10 +3295,8 @@ msgid "Video transcoding process is in-progress."
 msgstr ""
 
 #: inc/helpers/custom-functions.php:209
-#: pages/video-editor/components/cta/ImageCTA.js:450
+#: pages/video-editor/components/cta/ImageCTA.js:456
 #: pages/video-editor/components/layers/CTALayer.js:155
-#: assets/build/pages/video-editor.min.js:15539
-#: assets/build/pages/video-editor.min.js:17611
 msgid "Check now"
 msgstr ""
 
@@ -3292,17 +3306,18 @@ msgstr ""
 
 #: inc/helpers/custom-functions.php:234
 #: pages/video-editor/components/layers/CTALayer.js:137
-#: assets/build/pages/video-editor.min.js:17593
 msgid "No Image"
 msgstr ""
 
 #. translators: %s: storage usage percentage
 #: inc/helpers/custom-functions.php:427
+#, php-format
 msgid "Storage limit exceeded (%s%%). Please upgrade your plan to continue."
 msgstr ""
 
 #. translators: %s: bandwidth usage percentage
 #: inc/helpers/custom-functions.php:436
+#, php-format
 msgid "Bandwidth limit exceeded (%s%%). Please upgrade your plan to continue."
 msgstr ""
 
@@ -3314,32 +3329,33 @@ msgstr ""
 msgid "Error fetching data for storage and bandwidth ( remove and add again the API key to get usage analytics )"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:649
+#: inc/helpers/custom-functions.php:738
 msgid "Form transcoding has been disabled by the site administrator."
 msgstr ""
 
 #. translators: %s: Entry ID for which transcoding failed
-#: inc/helpers/custom-functions.php:790
+#: inc/helpers/custom-functions.php:879
+#, php-format
 msgid "Transcoding failed | entry Id: %s"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:826
+#: inc/helpers/custom-functions.php:915
 msgid "s"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:860
+#: inc/helpers/custom-functions.php:949
 msgid "Anonymous"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1102
+#: inc/helpers/custom-functions.php:1191
 msgid "Oops! We could not locate your video"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1109
+#: inc/helpers/custom-functions.php:1198
 msgid "Note: This is a simple video preview. The video player may display differently when added to a page based on theme styles."
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1208
+#: inc/helpers/custom-functions.php:1297
 msgid "Video not found"
 msgstr ""
 
@@ -3350,6 +3366,7 @@ msgstr ""
 
 #. translators: %s: video ID.
 #: inc/templates/video-embed.php:27
+#, php-format
 msgid "Video Embed: Attachment(%s)"
 msgstr ""
 
@@ -3361,13 +3378,12 @@ msgstr ""
 
 #. translators: %s: video ID.
 #: inc/templates/video-preview.php:23
+#, php-format
 msgid "Video Preview: Attachment(%s)"
 msgstr ""
 
 #: inc/templates/video-preview.php:59
 #: assets/build/blocks/godam-player/index.js:6
-#: assets/build/js/media-library.min.js:10515
-#: assets/build/js/media-library.min.js:10523
 msgid "Edit Video"
 msgstr ""
 
@@ -3412,10 +3428,8 @@ msgid "Unified GoDAM Central media library"
 msgstr ""
 
 #: inc/templates/video-preview.php:110
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:283
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:310
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:55
-#: assets/build/pages/godam.min.js:11066
-#: assets/build/pages/godam.min.js:11396
 msgid "Upgrade to Pro"
 msgstr ""
 
@@ -3537,8 +3551,6 @@ msgstr ""
 #: assets/build/blocks/godam-gallery-v2/index.js:1
 #: assets/build/blocks/godam-player/index.js:1
 #: pages/analytics/PlaybackPerformance.js:346
-#: assets/build/pages/analytics.min.js:10299
-#: assets/build/pages/dashboard.min.js:832
 msgid "Performance"
 msgstr ""
 
@@ -3644,6 +3656,7 @@ msgstr ""
 
 #. translators: %s: video caption label.
 #: assets/build/blocks/godam-player/index.js:4
+#, js-format
 msgctxt "video caption"
 msgid "Edit %s"
 msgstr ""
@@ -3730,12 +3743,10 @@ msgid "Headline *"
 msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:4
-#: assets/build/js/godam-elementor-frontend.min.js:439
 msgid "Description of the video"
 msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:4
-#: assets/build/js/godam-elementor-frontend.min.js:436
 msgid "It is recommended to add a description for better video SEO."
 msgstr ""
 
@@ -3753,36 +3764,21 @@ msgstr ""
 #: pages/media-library/components/modal/FolderCreationModal.jsx:132
 #: pages/media-library/components/modal/RenameModal.jsx:104
 #: pages/video-editor/components/layers/LayersHeader.js:156
-#: pages/video-editor/components/LayerSelector.jsx:412
-#: assets/build/js/deactivation-feedback.min.js:92
-#: assets/build/pages/media-library.min.js:5829
-#: assets/build/pages/media-library.min.js:7546
-#: assets/build/pages/media-library.min.js:7689
-#: assets/build/pages/media-library.min.js:7804
-#: assets/build/pages/video-editor.min.js:13354
-#: assets/build/pages/video-editor.min.js:18898
+#: pages/video-editor/components/LayerSelector.jsx:413
 msgid "Cancel"
 msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:4
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:130
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:123
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:332
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:137
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:359
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:522
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:146
-#: pages/video-editor/VideoEditor.js:424
-#: assets/build/pages/godam.min.js:10617
-#: assets/build/pages/godam.min.js:10900
-#: assets/build/pages/godam.min.js:11445
-#: assets/build/pages/godam.min.js:12086
-#: assets/build/pages/godam.min.js:12604
-#: assets/build/pages/video-editor.min.js:11989
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:147
+#: pages/video-editor/VideoEditor.js:425
 msgid "Save"
 msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:4
-#: assets/build/js/media-library.min.js:10079
-#: assets/build/js/media-library.min.js:10080
 msgid "Upload Custom Thumbnail"
 msgstr ""
 
@@ -3808,6 +3804,7 @@ msgstr ""
 
 #. translators: %s: thumbnail URL
 #: assets/build/blocks/godam-player/index.js:5
+#, js-format
 msgid "Select thumbnail: %s"
 msgstr ""
 
@@ -3825,6 +3822,7 @@ msgstr ""
 
 #. translators: %d: Label of the video text track e.g: "French subtitles".
 #: assets/build/blocks/godam-player/index.js:6
+#, js-format
 msgctxt "video caption"
 msgid "Failed to load video data with id: %d"
 msgstr ""
@@ -3891,21 +3889,17 @@ msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:6
 #: pages/video-editor/components/appearance/Appearance.js:530
-#: assets/build/pages/video-editor.min.js:14604
 msgid "Top"
 msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:6
 #: pages/video-editor/components/appearance/Appearance.js:528
 #: pages/video-editor/components/appearance/Appearance.js:536
-#: assets/build/pages/video-editor.min.js:14602
-#: assets/build/pages/video-editor.min.js:14610
 msgid "Center"
 msgstr ""
 
 #: assets/build/blocks/godam-player/index.js:6
 #: pages/video-editor/components/appearance/Appearance.js:531
-#: assets/build/pages/video-editor.min.js:14605
 msgid "Bottom"
 msgstr ""
 
@@ -3919,11 +3913,13 @@ msgstr ""
 
 #. translators: %s: formatted time
 #: assets/build/blocks/godam-player/index.js:7
+#, js-format
 msgid "Overlay will be visible for %s from the start of the video."
 msgstr ""
 
 #. translators: %s: formatted time
 #: assets/build/blocks/godam-player/index.js:8
+#, js-format
 msgid "Video duration: %s"
 msgstr ""
 
@@ -4045,23 +4041,20 @@ msgstr ""
 
 #: assets/build/blocks/sureforms/blocks/recorder/index.js:4
 #: pages/analytics/charts.js:172
-#: assets/build/pages/analytics.min.js:11081
-#: assets/build/pages/dashboard.min.js:1614
 msgid "Untitled"
 msgstr ""
 
 #. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
 #: assets/build/blocks/sureforms/blocks/recorder/index.js:7
+#, js-format
 msgid "Maximum allowed size: %s MB"
 msgstr ""
 
 #: pages/analytics/Analytics.js:396
-#: assets/build/pages/analytics.min.js:9406
 msgid "Select Video to Perform Performance Comparison Testing"
 msgstr ""
 
 #: pages/analytics/Analytics.js:398
-#: assets/build/pages/analytics.min.js:9408
 msgid "Use this Video"
 msgstr ""
 
@@ -4069,84 +4062,61 @@ msgstr ""
 #: pages/analytics/Analytics.js:546
 #: pages/dashboard/Dashboard.js:354
 #: pages/dashboard/Dashboard.js:424
-#: assets/build/pages/analytics.min.js:9511
-#: assets/build/pages/analytics.min.js:9556
-#: assets/build/pages/dashboard.min.js:3102
-#: assets/build/pages/dashboard.min.js:3172
 msgid "Go to plugin settings"
 msgstr ""
 
 #: pages/analytics/Analytics.js:513
 #: pages/dashboard/Dashboard.js:390
-#: assets/build/pages/analytics.min.js:9523
-#: assets/build/pages/dashboard.min.js:3138
 msgid "Upgrade to unlock the media performance report."
 msgstr ""
 
 #: pages/analytics/Analytics.js:517
 #: pages/dashboard/Dashboard.js:394
-#: assets/build/pages/analytics.min.js:9527
-#: assets/build/pages/dashboard.min.js:3142
 msgid "If you already have a premium plan, connect your"
 msgstr ""
 
 #: pages/analytics/Analytics.js:520
 #: pages/dashboard/Dashboard.js:397
-#: assets/build/pages/analytics.min.js:9530
-#: assets/build/pages/dashboard.min.js:3145
 msgid "API in the settings"
 msgstr ""
 
 #: pages/analytics/Analytics.js:534
 #: pages/dashboard/Dashboard.js:411
-#: assets/build/pages/analytics.min.js:9544
-#: assets/build/pages/dashboard.min.js:3159
 msgid "Buy Plan"
 msgstr ""
 
 #: pages/analytics/Analytics.js:543
 #: pages/dashboard/Dashboard.js:421
-#: assets/build/pages/analytics.min.js:9553
-#: assets/build/pages/dashboard.min.js:3169
 msgid "An unknown error occurred. Please check your plugin settings."
 msgstr ""
 
 #: pages/analytics/Analytics.js:571
-#: assets/build/pages/analytics.min.js:9581
 msgid "This media doesn't exist."
 msgstr ""
 
 #: pages/analytics/Analytics.js:573
-#: assets/build/pages/analytics.min.js:9583
 msgid "Go to Dashboard"
 msgstr ""
 
 #: pages/analytics/Analytics.js:594
-#: assets/build/pages/analytics.min.js:9604
 msgid "Analytics report of"
 msgstr ""
 
 #: pages/analytics/Analytics.js:597
-#: assets/build/pages/analytics.min.js:9607
 msgid "Analytics report"
 msgstr ""
 
 #: pages/analytics/Analytics.js:599
-#: assets/build/pages/analytics.min.js:9609
 msgid "Back to Video Editor"
 msgstr ""
 
 #: pages/analytics/Analytics.js:613
 #: pages/analytics/Analytics.js:863
 #: pages/dashboard/Dashboard.js:537
-#: assets/build/pages/analytics.min.js:9623
-#: assets/build/pages/analytics.min.js:9873
-#: assets/build/pages/dashboard.min.js:3285
 msgid "Average Engagement"
 msgstr ""
 
 #: pages/analytics/Analytics.js:614
-#: assets/build/pages/analytics.min.js:9624
 msgid "Video engagement rate is the percentage of video watched. Average Engagement = Total time played / (Total plays x Video length)"
 msgstr ""
 
@@ -4157,244 +4127,166 @@ msgstr ""
 #: pages/analytics/PlaybackPerformance.js:579
 #: pages/dashboard/Dashboard.js:473
 #: pages/dashboard/Dashboard.js:534
-#: assets/build/pages/analytics.min.js:9634
-#: assets/build/pages/analytics.min.js:9893
-#: assets/build/pages/analytics.min.js:10393
-#: assets/build/pages/analytics.min.js:10532
-#: assets/build/pages/analytics.min.js:11443
-#: assets/build/pages/dashboard.min.js:926
-#: assets/build/pages/dashboard.min.js:1065
-#: assets/build/pages/dashboard.min.js:1976
-#: assets/build/pages/dashboard.min.js:3221
-#: assets/build/pages/dashboard.min.js:3282
 msgid "Play Rate"
 msgstr ""
 
 #: pages/analytics/Analytics.js:625
 #: pages/dashboard/Dashboard.js:474
-#: assets/build/pages/analytics.min.js:9635
-#: assets/build/pages/dashboard.min.js:3222
 msgid "Play rate is the percentage of page visitors who clicked play. Play Rate = Total plays / Page loads"
 msgstr ""
 
 #: pages/analytics/Analytics.js:635
 #: pages/analytics/helper.js:110
 #: pages/dashboard/Dashboard.js:485
-#: assets/build/pages/analytics.min.js:9645
-#: assets/build/pages/analytics.min.js:11449
-#: assets/build/pages/dashboard.min.js:1982
-#: assets/build/pages/dashboard.min.js:3233
 msgid "Watch Time"
 msgstr ""
 
 #: pages/analytics/Analytics.js:636
 #: pages/dashboard/Dashboard.js:486
-#: assets/build/pages/analytics.min.js:9646
-#: assets/build/pages/dashboard.min.js:3234
 msgid "Total time the video has been watched, aggregated across all plays"
 msgstr ""
 
 #: pages/analytics/Analytics.js:689
-#: assets/build/pages/analytics.min.js:9699
 msgid "Views by Source"
 msgstr ""
 
 #: pages/analytics/Analytics.js:700
-#: assets/build/pages/analytics.min.js:9710
 msgid "Performance Comparison"
 msgstr ""
 
 #: pages/analytics/Analytics.js:711
-#: assets/build/pages/analytics.min.js:9721
 msgid "In Progress"
 msgstr ""
 
 #: pages/analytics/Analytics.js:716
-#: assets/build/pages/analytics.min.js:9726
 msgid "Initiate the test comparison to generate analytical insights."
 msgstr ""
 
 #: pages/analytics/Analytics.js:721
-#: assets/build/pages/analytics.min.js:9731
 msgid "The test is complete! Review results to identify the best-performing video."
 msgstr ""
 
 #: pages/analytics/Analytics.js:733
-#: assets/build/pages/analytics.min.js:9743
 msgid "Start Test"
 msgstr ""
 
 #: pages/analytics/Analytics.js:764
-#: assets/build/pages/analytics.min.js:9774
 msgid "Test this video against others to see which performs better."
 msgstr ""
 
 #: pages/analytics/Analytics.js:773
-#: pages/video-editor/components/cta/ImageCTA.js:348
-#: assets/build/pages/analytics.min.js:9783
-#: assets/build/pages/video-editor.min.js:15437
+#: pages/video-editor/components/cta/ImageCTA.js:349
 msgid "Upload or Replace CTA Image"
 msgstr ""
 
 #: pages/analytics/Analytics.js:778
-#: assets/build/pages/analytics.min.js:9788
 msgid "Choose"
 msgstr ""
 
 #: pages/analytics/Analytics.js:849
-#: assets/build/pages/analytics.min.js:9859
 msgid "Views"
 msgstr ""
 
 #: pages/analytics/Analytics.js:872
 #: pages/dashboard/Dashboard.js:535
-#: assets/build/pages/analytics.min.js:9882
-#: assets/build/pages/dashboard.min.js:3283
 msgid "Total Plays"
 msgstr ""
 
 #: pages/analytics/Analytics.js:897
-#: assets/build/pages/analytics.min.js:9907
 msgid "Page Loads"
 msgstr ""
 
 #: pages/analytics/Analytics.js:911
-#: assets/build/pages/analytics.min.js:9921
 msgid "Play Time"
 msgstr ""
 
 #: pages/analytics/Analytics.js:925
-#: assets/build/pages/analytics.min.js:9935
 msgid "Video Length"
 msgstr ""
 
 #: pages/analytics/helper.js:98
 #: pages/analytics/PlaybackPerformance.js:433
 #: pages/analytics/PlaybackPerformance.js:548
-#: assets/build/pages/analytics.min.js:10386
-#: assets/build/pages/analytics.min.js:10501
-#: assets/build/pages/analytics.min.js:11437
-#: assets/build/pages/dashboard.min.js:919
-#: assets/build/pages/dashboard.min.js:1034
-#: assets/build/pages/dashboard.min.js:1970
 msgid "Engagement Rate"
 msgstr ""
 
 #: pages/analytics/helper.js:116
 #: pages/analytics/PlaysVsViewers.js:125
-#: assets/build/pages/analytics.min.js:10701
-#: assets/build/pages/analytics.min.js:11455
-#: assets/build/pages/dashboard.min.js:1234
-#: assets/build/pages/dashboard.min.js:1988
 msgid "Plays"
 msgstr ""
 
 #: pages/analytics/helper.js:122
-#: assets/build/pages/analytics.min.js:11461
-#: assets/build/pages/dashboard.min.js:1994
 msgid "Total Videos"
 msgstr ""
 
 #: pages/analytics/helper.js:179
-#: assets/build/pages/analytics.min.js:11518
-#: assets/build/pages/dashboard.min.js:2051
 msgid "No data available."
 msgstr ""
 
 #: pages/analytics/helper.js:704
-#: assets/build/pages/analytics.min.js:12043
-#: assets/build/pages/dashboard.min.js:2576
 msgid "View"
 msgstr ""
 
 #: pages/analytics/index.js:39
 #: pages/video-editor/components/media-grid/MediaItem.jsx:118
-#: assets/build/pages/analytics.min.js:96789
-#: assets/build/pages/video-editor.min.js:19329
 msgid "View analytics"
 msgstr ""
 
 #: pages/analytics/index.js:79
-#: assets/build/pages/analytics.min.js:96829
 msgid "No video is selected"
 msgstr ""
 
 #: pages/analytics/index.js:89
-#: assets/build/pages/analytics.min.js:96839
 msgid "Select Video to Edit"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:516
-#: assets/build/pages/analytics.min.js:10469
-#: assets/build/pages/dashboard.min.js:1002
 msgid "Playback Performance"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:588
-#: assets/build/pages/analytics.min.js:10541
-#: assets/build/pages/dashboard.min.js:1074
 msgctxt "All time period"
 msgid "All"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:594
-#: assets/build/pages/analytics.min.js:10547
-#: assets/build/pages/dashboard.min.js:1080
 msgctxt "7 days period"
 msgid "7D"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:600
-#: assets/build/pages/analytics.min.js:10553
-#: assets/build/pages/dashboard.min.js:1086
 msgctxt "1 month period"
 msgid "1M"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:606
-#: assets/build/pages/analytics.min.js:10559
-#: assets/build/pages/dashboard.min.js:1092
 msgctxt "6 months period"
 msgid "6M"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:612
-#: assets/build/pages/analytics.min.js:10565
-#: assets/build/pages/dashboard.min.js:1098
 msgctxt "1 year period"
 msgid "1Y"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:100
-#: assets/build/pages/analytics.min.js:10676
-#: assets/build/pages/dashboard.min.js:1209
 msgid "Plays / Unique viewers"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:126
-#: assets/build/pages/analytics.min.js:10702
-#: assets/build/pages/dashboard.min.js:1235
 msgid "Unique viewers"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:131
 #: pages/analytics/SingleMetrics.js:152
-#: assets/build/pages/analytics.min.js:10707
-#: assets/build/pages/analytics.min.js:10883
-#: assets/build/pages/dashboard.min.js:1240
-#: assets/build/pages/dashboard.min.js:1416
 msgid "Last 7 days"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:139
-#: assets/build/pages/analytics.min.js:10715
-#: assets/build/pages/dashboard.min.js:1248
 msgid "Sessions per user:"
 msgstr ""
 
 #: pages/analytics/SingleMetrics.js:148
-#: assets/build/pages/analytics.min.js:10879
-#: assets/build/pages/dashboard.min.js:1412
 msgid "All time"
 msgstr ""
 
@@ -4407,353 +4299,217 @@ msgid "Feature Screenshot"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:459
-#: assets/build/pages/dashboard.min.js:3207
 msgid "Active Videos"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:460
-#: assets/build/pages/dashboard.min.js:3208
 msgid "Number of unique videos that received user interactions each day, such as views or plays."
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:522
-#: assets/build/pages/dashboard.min.js:3270
 msgid "Top Videos"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:525
-#: assets/build/pages/dashboard.min.js:3273
 msgid "Export"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:532
-#: assets/build/pages/dashboard.min.js:3280
 msgid "Name"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:536
-#: assets/build/pages/dashboard.min.js:3284
 msgid "Total Watch Time"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:559
 #: pages/dashboard/Dashboard.js:573
-#: assets/build/pages/dashboard.min.js:3307
-#: assets/build/pages/dashboard.min.js:3321
 msgid "Video thumbnail"
 msgstr ""
 
 #. translators: %1$d is the current page number, %2$d is the total number of pages
 #: pages/dashboard/Dashboard.js:622
-#: assets/build/pages/dashboard.min.js:3370
+#, js-format
 msgid "Page %1$d of %2$d"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:636
-#: assets/build/pages/dashboard.min.js:3384
 msgid "Previous"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:643
-#: assets/build/pages/dashboard.min.js:3391
 msgid "Next"
 msgstr ""
 
 #: pages/godam/App.js:34
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:92
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:101
 #: pages/help/App.js:55
-#: assets/build/pages/godam.min.js:9952
-#: assets/build/pages/godam.min.js:10869
-#: assets/build/pages/help.min.js:1260
 msgid "General Settings"
 msgstr ""
 
 #: pages/godam/App.js:40
 #: pages/help/App.js:59
-#: assets/build/pages/godam.min.js:9958
-#: assets/build/pages/help.min.js:1264
 msgid "Video Settings"
 msgstr ""
 
 #: pages/godam/App.js:46
-#: assets/build/pages/godam.min.js:9964
 msgid "Video Player"
 msgstr ""
 
 #: pages/godam/App.js:55
-#: assets/build/pages/godam.min.js:9973
 msgid "Video Ads"
 msgstr ""
 
 #: pages/godam/App.js:64
-#: assets/build/pages/godam.min.js:9982
 msgid "Integrations Settings"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:19
-#: assets/build/pages/godam.min.js:10125
-#: assets/build/pages/help.min.js:531
-#: assets/build/pages/tools.min.js:589
 msgid "Support"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:23
-#: assets/build/pages/godam.min.js:10129
-#: assets/build/pages/help.min.js:535
-#: assets/build/pages/tools.min.js:593
 msgid "Docs"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:27
-#: assets/build/pages/godam.min.js:10133
-#: assets/build/pages/help.min.js:539
-#: assets/build/pages/tools.min.js:597
 msgid "Newsletter"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:39
-#: assets/build/pages/godam.min.js:10145
-#: assets/build/pages/help.min.js:551
-#: assets/build/pages/tools.min.js:609
 msgid "Twitter X"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:44
-#: assets/build/pages/godam.min.js:10150
-#: assets/build/pages/help.min.js:556
-#: assets/build/pages/tools.min.js:614
 msgid "Facebook"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:49
-#: assets/build/pages/godam.min.js:10155
-#: assets/build/pages/help.min.js:561
-#: assets/build/pages/tools.min.js:619
 msgid "Linkedin"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:54
-#: assets/build/pages/godam.min.js:10160
-#: assets/build/pages/help.min.js:566
-#: assets/build/pages/tools.min.js:624
 msgid "Instagram"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:59
-#: assets/build/pages/godam.min.js:10165
-#: assets/build/pages/help.min.js:571
-#: assets/build/pages/tools.min.js:629
 msgid "Youtube"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:64
-#: assets/build/pages/godam.min.js:10170
-#: assets/build/pages/help.min.js:576
-#: assets/build/pages/tools.min.js:634
 msgid "WordPress.org"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:67
-#: assets/build/pages/godam.min.js:10173
-#: assets/build/pages/help.min.js:579
-#: assets/build/pages/tools.min.js:637
 msgid "Rate us on WordPress.org"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:77
-#: assets/build/pages/godam.min.js:10183
-#: assets/build/pages/help.min.js:589
-#: assets/build/pages/tools.min.js:647
 msgid "Made with ♥ by the GoDAM Team"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:89
-#: assets/build/pages/analytics.min.js:12417
-#: assets/build/pages/dashboard.min.js:3853
-#: assets/build/pages/godam.min.js:10304
-#: assets/build/pages/help.min.js:710
-#: assets/build/pages/tools.min.js:768
-#: assets/build/pages/video-editor.min.js:11054
 msgid "Need help?"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:97
-#: assets/build/pages/analytics.min.js:12425
-#: assets/build/pages/dashboard.min.js:3861
-#: assets/build/pages/godam.min.js:10312
-#: assets/build/pages/help.min.js:718
-#: assets/build/pages/tools.min.js:776
-#: assets/build/pages/video-editor.min.js:11062
 msgid "Install GoDAM Screen Recorder"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:107
-#: assets/build/js/media-library.min.js:9525
-#: assets/build/pages/analytics.min.js:12435
-#: assets/build/pages/dashboard.min.js:3871
-#: assets/build/pages/godam.min.js:10322
-#: assets/build/pages/help.min.js:728
-#: assets/build/pages/tools.min.js:786
-#: assets/build/pages/video-editor.min.js:10839
-#: assets/build/pages/video-editor.min.js:11072
 msgid "Manage Media"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:119
-#: assets/build/pages/analytics.min.js:12447
-#: assets/build/pages/dashboard.min.js:3883
-#: assets/build/pages/godam.min.js:10334
-#: assets/build/pages/help.min.js:740
-#: assets/build/pages/tools.min.js:798
-#: assets/build/pages/video-editor.min.js:11084
 msgid "Premium feature"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:119
-#: assets/build/pages/analytics.min.js:12447
-#: assets/build/pages/dashboard.min.js:3883
-#: assets/build/pages/godam.min.js:10334
-#: assets/build/pages/help.min.js:740
-#: assets/build/pages/tools.min.js:798
-#: assets/build/pages/video-editor.min.js:11084
 msgid "GoDAM Central"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:133
-#: assets/build/pages/analytics.min.js:12461
-#: assets/build/pages/dashboard.min.js:3897
-#: assets/build/pages/godam.min.js:10348
-#: assets/build/pages/help.min.js:754
-#: assets/build/pages/tools.min.js:812
-#: assets/build/pages/video-editor.min.js:11098
 msgid "Upgrade plan"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:146
-#: assets/build/pages/analytics.min.js:12474
-#: assets/build/pages/dashboard.min.js:3910
-#: assets/build/pages/godam.min.js:10361
-#: assets/build/pages/help.min.js:767
-#: assets/build/pages/tools.min.js:825
-#: assets/build/pages/video-editor.min.js:11111
 msgid "Get GoDAM"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:59
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:58
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:156
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:67
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:182
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:90
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:67
-#: assets/build/pages/godam.min.js:10546
-#: assets/build/pages/godam.min.js:10835
-#: assets/build/pages/godam.min.js:11268
-#: assets/build/pages/godam.min.js:11654
-#: assets/build/pages/godam.min.js:12525
 msgid "Settings saved successfully."
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:62
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:65
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:61
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:64
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:159
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:162
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:70
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:73
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:185
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:188
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:93
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:96
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:70
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:73
-#: assets/build/pages/godam.min.js:10549
-#: assets/build/pages/godam.min.js:10552
-#: assets/build/pages/godam.min.js:10838
-#: assets/build/pages/godam.min.js:10841
-#: assets/build/pages/godam.min.js:11271
-#: assets/build/pages/godam.min.js:11274
-#: assets/build/pages/godam.min.js:11657
-#: assets/build/pages/godam.min.js:11660
-#: assets/build/pages/godam.min.js:12528
-#: assets/build/pages/godam.min.js:12531
 msgid "Failed to save settings."
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:74
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:73
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:171
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:82
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:197
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:379
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:82
 #: pages/video-editor/VideoEditor.js:81
-#: assets/build/pages/godam.min.js:10561
-#: assets/build/pages/godam.min.js:10850
-#: assets/build/pages/godam.min.js:11283
-#: assets/build/pages/godam.min.js:11943
-#: assets/build/pages/godam.min.js:12540
-#: assets/build/pages/video-editor.min.js:11646
 msgid "You have unsaved changes. Are you sure you want to leave?"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:94
-#: assets/build/pages/godam.min.js:10581
 msgid "Video Ads Settings"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:98
-#: assets/build/pages/godam.min.js:10585
 msgid "Enable Global Video Ads"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:99
-#: assets/build/pages/godam.min.js:10586
 msgid "Enable or disable video ads on all videos across the site"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:108
 #: pages/video-editor/components/appearance/Appearance.js:667
-#: assets/build/pages/godam.min.js:10595
-#: assets/build/pages/video-editor.min.js:14741
 msgid "Ad Tag URL"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:111
 #: pages/video-editor/components/appearance/Appearance.js:670
-#: assets/build/pages/godam.min.js:10598
-#: assets/build/pages/video-editor.min.js:14744
 msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:112
 #: pages/video-editor/components/appearance/Appearance.js:671
-#: assets/build/pages/godam.min.js:10599
-#: assets/build/pages/video-editor.min.js:14745
 msgid "Learn more."
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:130
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:123
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:332
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:137
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:359
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:522
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:126
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:146
-#: pages/video-editor/VideoEditor.js:424
-#: assets/build/pages/godam.min.js:10617
-#: assets/build/pages/godam.min.js:10900
-#: assets/build/pages/godam.min.js:11445
-#: assets/build/pages/godam.min.js:12086
-#: assets/build/pages/godam.min.js:12221
-#: assets/build/pages/godam.min.js:12604
-#: assets/build/pages/video-editor.min.js:11989
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:127
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:147
+#: pages/video-editor/VideoEditor.js:425
 msgid "Saving…"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:36
 #: pages/video-editor/components/appearance/Appearance.js:244
-#: assets/build/pages/godam.min.js:10661
-#: assets/build/pages/video-editor.min.js:14318
 msgid "Select Brand Image"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:38
 #: pages/video-editor/components/appearance/Appearance.js:246
-#: assets/build/pages/godam.min.js:10663
-#: assets/build/pages/video-editor.min.js:14320
 msgid "Use this brand image"
 msgstr ""
 
@@ -4763,314 +4519,255 @@ msgstr ""
 #: pages/video-editor/components/appearance/Appearance.js:271
 #: pages/video-editor/components/cta/ImageCTA.js:146
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:81
-#: assets/build/pages/godam.min.js:10678
-#: assets/build/pages/godam.min.js:12752
-#: assets/build/pages/video-editor.min.js:14273
-#: assets/build/pages/video-editor.min.js:14345
-#: assets/build/pages/video-editor.min.js:15235
-#: assets/build/pages/video-editor.min.js:17226
 msgid "Only Image files are allowed"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:89
-#: assets/build/pages/godam.min.js:10714
 msgid "Custom brand logo"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:118
-#: pages/video-editor/components/cta/ImageCTA.js:360
-#: assets/build/pages/godam.min.js:10743
-#: assets/build/pages/video-editor.min.js:15449
+#: pages/video-editor/components/cta/ImageCTA.js:362
 msgid "Selected custom brand"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:138
-#: assets/build/pages/godam.min.js:10763
 msgid "The brand logo will not be applied to the player skin."
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:144
-#: assets/build/pages/godam.min.js:10769
 msgid "Upload a custom brand logo to display beside the player controls when selected. This can be overridden for individual videos"
 msgstr ""
 
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:97
-#: assets/build/pages/godam.min.js:10874
-msgid "Enable folder organization in media library."
-msgstr ""
-
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:98
-#: assets/build/pages/godam.min.js:10875
-msgid "Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization."
-msgstr ""
-
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:106
-#: assets/build/pages/godam.min.js:10883
+msgid "Enable GoDAM media library features"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:109
+msgid "This setting is managed by your site administrator and can’t be changed here."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:110
+msgid "Turn this on to organize and manage media with GoDAM — folders, search, and filters. Turn it off to keep the WordPress media library as it is."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:120
 msgid "Enable GTM Tracking"
 msgstr ""
 
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:107
-#: assets/build/pages/godam.min.js:10884
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:121
 msgid "Enable Google Tag Manager video tracking for analytics and conversion tracking."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:22
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:26
-#: assets/build/pages/godam.min.js:11474
-#: assets/build/pages/godam.min.js:11478
 msgid "WooCommerce"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:23
-#: assets/build/pages/godam.min.js:11475
 msgid "GoDAM for Woo"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:28
-#: assets/build/pages/godam.min.js:11480
 msgid "Beta"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:61
-#: assets/build/pages/godam.min.js:10968
 msgid "Installing…"
 msgstr ""
 
 #. translators: %s: Add-on plugin name, e.g. "GoDAM for Woo".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:66
-#: assets/build/pages/godam.min.js:10973
+#, js-format
 msgid "Install %s"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:98
-#: assets/build/pages/godam.min.js:11005
 msgid "Upgrade Plan"
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:93
-#: assets/build/pages/godam.min.js:11205
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:110
+msgid "Integration status updated successfully."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:119
 msgid "Failed to toggle add-on."
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:122
-#: assets/build/pages/godam.min.js:11234
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:148
 msgid "Add-on installed successfully! Reloading…"
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:130
-#: assets/build/pages/godam.min.js:11242
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:156
 msgid "Installation failed."
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:196
-#: assets/build/pages/godam.min.js:11309
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:223
 msgid "Integration Settings"
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:236
-#: assets/build/pages/godam.min.js:11349
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:263
 msgid "Installation failed. Please download the ZIP and install it like any other WordPress plugin."
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:245
-#: assets/build/pages/godam.min.js:11358
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:272
 msgid "Download ZIP"
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:255
-#: assets/build/pages/godam.min.js:11368
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:282
 msgid "View Installation Guide"
 msgstr ""
 
 #. translators: %s: Integration name, e.g. "WooCommerce".
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:266
-#: assets/build/pages/godam.min.js:11379
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:293
+#, js-format
 msgid "The %s add-on plugin is not installed. Please install it to enable this integration."
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:275
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:302
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:47
-#: assets/build/pages/godam.min.js:11058
-#: assets/build/pages/godam.min.js:11388
 msgid "This is a Pro feature."
 msgstr ""
 
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:287
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:314
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:59
-#: assets/build/pages/godam.min.js:11070
-#: assets/build/pages/godam.min.js:11400
 msgid "to use this integration."
 msgstr ""
 
 #. translators: %s: Integration name, e.g. "WooCommerce".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:36
-#: assets/build/pages/godam.min.js:11047
+#, js-format
 msgid "Enable %s Integration"
 msgstr ""
 
 #. translators: %s: Integration name, e.g. "WooCommerce".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:64
-#: assets/build/pages/godam.min.js:11075
+#, js-format
 msgid "Enable or disable the %s integration."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/CustomVideoPlayerCSS.jsx:50
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:507
-#: pages/video-editor/components/layers/FormLayer.js:166
-#: pages/video-editor/components/layers/PollLayer.js:84
-#: assets/build/pages/godam.min.js:11539
-#: assets/build/pages/godam.min.js:12071
-#: assets/build/pages/video-editor.min.js:17923
-#: assets/build/pages/video-editor.min.js:19017
+#: pages/video-editor/components/layers/FormLayer.js:168
+#: pages/video-editor/components/layers/PollLayer.js:88
 msgid "Custom CSS"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:409
-#: assets/build/pages/godam.min.js:11973
 msgid "Player Skin"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:450
-#: assets/build/pages/godam.min.js:12014
 msgid "Customize Branding"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:458
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:462
-#: assets/build/pages/godam.min.js:12022
-#: assets/build/pages/godam.min.js:12026
 msgid "Brand color"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:485
-#: assets/build/pages/godam.min.js:12049
 msgid "The brand color will not be applied to the player skin."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:491
-#: assets/build/pages/godam.min.js:12055
 msgid "Select a brand color to apply to the video block. This can be overridden for individual videos by the video editor"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:510
-#: assets/build/pages/godam.min.js:12074
 msgid "Any custom CSS you add will be applied to all player skins. It's global and not tied to a specific skin style."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:30
-#: assets/build/pages/godam.min.js:12125
 msgid "Please enter a valid API key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:40
-#: assets/build/pages/godam.min.js:12135
 msgid "API key verified successfully!"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:48
-#: assets/build/pages/godam.min.js:12143
 msgid "Failed to verify API key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:63
-#: assets/build/pages/godam.min.js:12158
 msgid "API key deactivated successfully!"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:71
-#: assets/build/pages/godam.min.js:12166
 msgid "Failed to deactivate API key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:86
-#: assets/build/pages/godam.min.js:12181
 msgid "API key status refreshed!"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:97
-#: assets/build/pages/godam.min.js:12192
 msgid "Failed to refresh API key status"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:107
-#: assets/build/pages/godam.min.js:12202
 msgid "API Settings"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:126
-#: assets/build/pages/godam.min.js:12221
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:127
 msgid "Save API Key"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:136
-#: assets/build/pages/godam.min.js:12231
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:138
 msgid "Remove API Key"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:146
-#: assets/build/pages/godam.min.js:12241
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:148
 msgid "Refreshing…"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
-#: assets/build/pages/godam.min.js:12246
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:153
 msgid "Having any issues?"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:158
-#: assets/build/pages/godam.min.js:12253
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:160
 msgid "Contact Support"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:41
-#: assets/build/pages/godam.min.js:12943
 msgid "Account"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:50
-#: assets/build/pages/godam.min.js:12952
 msgid "Your API key is required to access the features. You can get your active API key from your"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:60
-#: assets/build/pages/godam.min.js:12962
 msgid "Your API Key has expired. You can renew it from your"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:67
-#: assets/build/pages/godam.min.js:12969
 msgid "Unable to verify API key. Please click \"Refresh Status\" to try again."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:84
-#: assets/build/pages/godam.min.js:12986
 msgid "API Key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:88
-#: assets/build/pages/godam.min.js:12990
 msgid "Enter your API key here"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:108
-#: assets/build/pages/godam.min.js:13010
 msgid "Hide password"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:108
-#: assets/build/pages/godam.min.js:13010
 msgid "Show password"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:48
-#: assets/build/pages/godam.min.js:12313
 msgid "BANDWIDTH"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:49
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:66
-#: assets/build/pages/godam.min.js:12314
-#: assets/build/pages/godam.min.js:12331
 msgid "Available:"
 msgstr ""
 
@@ -5078,1341 +4775,1036 @@ msgstr ""
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:51
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:66
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:68
-#: assets/build/pages/godam.min.js:12314
-#: assets/build/pages/godam.min.js:12316
-#: assets/build/pages/godam.min.js:12331
-#: assets/build/pages/godam.min.js:12333
 msgctxt "gigabyte"
 msgid "GB"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:51
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:68
-#: assets/build/pages/godam.min.js:12316
-#: assets/build/pages/godam.min.js:12333
 msgid "Used:"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:65
-#: assets/build/pages/godam.min.js:12330
 msgid "STORAGE"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:13
-#: assets/build/pages/godam.min.js:12354
 msgid "Highest quality (100%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:14
-#: assets/build/pages/godam.min.js:12355
 msgid "Higher quality (80%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:15
-#: assets/build/pages/godam.min.js:12356
 msgid "Medium quality (60%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:16
-#: assets/build/pages/godam.min.js:12357
 msgid "Lower quality (40%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:17
-#: assets/build/pages/godam.min.js:12358
 msgid "Lowest quality (20%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:25
-#: assets/build/pages/godam.min.js:12366
 msgid "Video Quality"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:36
-#: assets/build/pages/godam.min.js:12377
 msgid "Video quality"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:40
-#: assets/build/pages/godam.min.js:12381
 msgid "Select the video quality."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:25
-#: assets/build/pages/godam.min.js:12416
 msgid "Video Engagements"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:34
-#: assets/build/pages/godam.min.js:12425
 msgid "Enable video engagement globally"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:40
-#: assets/build/pages/godam.min.js:12431
 msgid "If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:49
-#: assets/build/pages/godam.min.js:12440
 msgid "Enable video share globally"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:104
-#: assets/build/pages/godam.min.js:12562
 msgid "Ensure Smooth Video Playback"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:106
-#: assets/build/pages/godam.min.js:12564
 msgid "Set up your video transcoding settings to optimize playback across all devices and network conditions. 🚀"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:115
-#: assets/build/pages/godam.min.js:12573
 msgid "Choose GoDAM plan"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:120
-#: assets/build/pages/godam.min.js:12578
 msgid "Start with GoDAM Free for 60 days, or plans starting from $9/mo."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:47
-#: assets/build/js/media-library.min.js:10350
-#: assets/build/js/media-library.min.js:10910
-#: assets/build/pages/godam.min.js:12660
 msgid "Video Thumbnails"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:53
-#: assets/build/pages/godam.min.js:12666
 msgid "Number of video thumbnails generated"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:63
-#: assets/build/pages/godam.min.js:12676
 msgid "This field specifies the number of video thumbnails that will be generated by the GoDAM. To choose from the generated thumbnails for a video, go to Media > Edit > Video Thumbnails. Thumbnails are only generated when the video is first uploaded. Please enter a value between 1 and 10"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:49
-#: assets/build/pages/godam.min.js:12735
 msgid "Select a Watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:51
-#: assets/build/pages/godam.min.js:12737
 msgid "Use this watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:91
-#: assets/build/pages/godam.min.js:12777
 msgid "Video Watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:99
-#: assets/build/pages/godam.min.js:12785
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:100
 msgid "Enable video watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:106
-#: assets/build/pages/godam.min.js:12792
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:107
 msgid "If enabled, GoDAM will add a watermark to the transcoded video"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:115
-#: assets/build/pages/godam.min.js:12801
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:117
 msgid "Use image watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:124
-#: assets/build/pages/godam.min.js:12810
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:126
 msgid "If enabled, Transcoder will use an image instead of text as the watermark for the transcoded video"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:129
-#: assets/build/pages/godam.min.js:12815
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:131
 msgid "(Recommended dimensions: 200 px width × 70 px height)"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:147
-#: assets/build/pages/godam.min.js:12833
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:149
 msgid "Change Watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:148
-#: assets/build/pages/godam.min.js:12834
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:150
 msgid "Select Watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:160
-#: assets/build/pages/godam.min.js:12846
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:162
 msgid "Remove Watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:168
-#: assets/build/pages/godam.min.js:12854
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:170
 msgid "Selected watermark"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:188
-#: assets/build/pages/godam.min.js:12874
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:190
 msgid "Watermark Text"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:197
-#: assets/build/pages/godam.min.js:12883
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:200
 msgid "Enter watermark text"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:199
-#: assets/build/pages/godam.min.js:12885
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:202
 msgid "Specify the watermark text that will be added to transcoded videos"
 msgstr ""
 
 #: pages/godam/utils/index.js:77
-#: assets/build/js/godam-lifterlms-embed.min.js:77
-#: assets/build/js/lifterLMSEmbed.min.js:77
-#: assets/build/pages/analytics.min.js:12563
-#: assets/build/pages/dashboard.min.js:3999
-#: assets/build/pages/godam.min.js:13343
-#: assets/build/pages/help.min.js:1163
-#: assets/build/pages/tools.min.js:914
-#: assets/build/pages/video-editor.min.js:11200
 msgid "Your API key has expired."
 msgstr ""
 
 #: pages/godam/utils/index.js:78
-#: assets/build/js/godam-lifterlms-embed.min.js:78
-#: assets/build/js/lifterLMSEmbed.min.js:78
-#: assets/build/pages/analytics.min.js:12564
-#: assets/build/pages/dashboard.min.js:4000
-#: assets/build/pages/godam.min.js:13344
-#: assets/build/pages/help.min.js:1164
-#: assets/build/pages/tools.min.js:915
-#: assets/build/pages/video-editor.min.js:11201
 msgid "Please renew your subscription from your Account to continue."
 msgstr ""
 
 #: pages/godam/utils/index.js:86
-#: assets/build/js/godam-lifterlms-embed.min.js:86
-#: assets/build/js/lifterLMSEmbed.min.js:86
-#: assets/build/pages/analytics.min.js:12572
-#: assets/build/pages/dashboard.min.js:4008
-#: assets/build/pages/godam.min.js:13352
-#: assets/build/pages/help.min.js:1172
-#: assets/build/pages/tools.min.js:923
-#: assets/build/pages/video-editor.min.js:11209
 msgid "Unable to verify API key."
 msgstr ""
 
 #: pages/godam/utils/index.js:87
-#: assets/build/js/godam-lifterlms-embed.min.js:87
-#: assets/build/js/lifterLMSEmbed.min.js:87
-#: assets/build/pages/analytics.min.js:12573
-#: assets/build/pages/dashboard.min.js:4009
-#: assets/build/pages/godam.min.js:13353
-#: assets/build/pages/help.min.js:1173
-#: assets/build/pages/tools.min.js:924
-#: assets/build/pages/video-editor.min.js:11210
 msgid "This may be a temporary issue. Please try again later."
 msgstr ""
 
 #: pages/godam/utils/index.js:95
-#: assets/build/js/godam-lifterlms-embed.min.js:95
-#: assets/build/js/lifterLMSEmbed.min.js:95
-#: assets/build/pages/analytics.min.js:12581
-#: assets/build/pages/dashboard.min.js:4017
-#: assets/build/pages/godam.min.js:13361
-#: assets/build/pages/help.min.js:1181
-#: assets/build/pages/tools.min.js:932
-#: assets/build/pages/video-editor.min.js:11218
 msgid "API key issue detected."
 msgstr ""
 
 #: pages/godam/utils/index.js:96
-#: assets/build/js/godam-lifterlms-embed.min.js:96
-#: assets/build/js/lifterLMSEmbed.min.js:96
-#: assets/build/pages/analytics.min.js:12582
-#: assets/build/pages/dashboard.min.js:4018
-#: assets/build/pages/godam.min.js:13362
-#: assets/build/pages/help.min.js:1182
-#: assets/build/pages/tools.min.js:933
-#: assets/build/pages/video-editor.min.js:11219
 msgid "Please check your API key settings."
 msgstr ""
 
 #: pages/help/App.js:63
-#: assets/build/pages/help.min.js:1268
 msgid "Configuring the Video Block"
 msgstr ""
 
 #: pages/help/App.js:73
-#: assets/build/pages/help.min.js:1278
 msgid "Appearance Customisation"
 msgstr ""
 
 #: pages/help/App.js:77
-#: assets/build/pages/help.min.js:1282
 msgid "Call To Actions"
 msgstr ""
 
 #: pages/help/App.js:81
-#: assets/build/pages/help.min.js:1286
 msgid "Hotspots"
 msgstr ""
 
 #: pages/help/App.js:85
 #: pages/video-editor/components/SidebarLayers.js:50
-#: assets/build/pages/help.min.js:1290
-#: assets/build/pages/video-editor.min.js:13472
 msgid "Forms"
 msgstr ""
 
 #: pages/help/App.js:89
-#: assets/build/pages/help.min.js:1294
 msgid "ADs"
 msgstr ""
 
 #: pages/help/App.js:99
-#: assets/build/pages/help.min.js:1304
 msgid "Interface"
 msgstr ""
 
 #: pages/help/App.js:103
-#: assets/build/pages/help.min.js:1308
 msgid "How Tos"
 msgstr ""
 
 #: pages/help/App.js:131
-#: assets/build/pages/help.min.js:1336
 msgid "Hi, How can we help?"
 msgstr ""
 
 #: pages/help/App.js:132
-#: assets/build/pages/help.min.js:1337
 msgid "Welcome to the GoDAM Help Center!"
 msgstr ""
 
 #: pages/help/App.js:134
-#: assets/build/pages/help.min.js:1339
 msgid "Click on the documentation links below to find step-by-step guides, FAQs, and troubleshooting tips for the features you need help with."
 msgstr ""
 
 #: pages/help/App.js:148
 #: pages/help/App.js:150
-#: assets/build/pages/help.min.js:1353
-#: assets/build/pages/help.min.js:1355
 msgid "Search using keywords"
 msgstr ""
 
 #: pages/help/App.js:214
-#: assets/build/pages/help.min.js:1419
 msgid "Help us improve GoDAM"
 msgstr ""
 
 #: pages/help/App.js:217
-#: assets/build/pages/help.min.js:1422
 msgid "Allows the GoDAM plugin to track anonymous events for analytics purposes. This helps us improve the product experience."
 msgstr ""
 
 #: pages/media-library/App.js:167
-#: assets/build/pages/media-library.min.js:5818
 msgid "New Folder"
 msgstr ""
 
 #: pages/media-library/App.js:178
-#: assets/build/pages/media-library.min.js:5829
 msgid "Bulk Select"
 msgstr ""
 
 #: pages/media-library/App.js:186
-#: assets/build/pages/media-library.min.js:5837
 msgid "By Name (A-Z)"
 msgstr ""
 
 #: pages/media-library/App.js:187
-#: assets/build/pages/media-library.min.js:5838
 msgid "By Name (Z-A)"
 msgstr ""
 
 #: pages/media-library/App.js:202
-#: assets/build/pages/media-library.min.js:5853
 msgid "All Media"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:202
-#: assets/build/pages/media-library.min.js:6098
 msgid "Folder ID is missing for download."
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:211
-#: assets/build/pages/media-library.min.js:6107
 msgid "Preparing ZIP file…"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:219
-#: assets/build/pages/media-library.min.js:6115
 msgid "Failed to create ZIP file"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:225
-#: assets/build/pages/media-library.min.js:6121
 msgid "Invalid response: missing ZIP URL"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:243
-#: assets/build/pages/media-library.min.js:6139
 msgid "Failed to download folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:268
-#: assets/build/pages/media-library.min.js:6164
 msgid "Invalid folder for bookmark."
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:291
-#: assets/build/pages/media-library.min.js:6187
 msgid "Bookmark removed successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:292
-#: assets/build/pages/media-library.min.js:6188
 msgid "Bookmark added successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:302
-#: assets/build/pages/media-library.min.js:6198
 msgid "Bookmarks added successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:308
-#: assets/build/pages/media-library.min.js:6204
 msgid "Failed to update bookmark status"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:324
-#: assets/build/pages/media-library.min.js:6220
 msgid "Invalid folder to lock."
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:340
-#: assets/build/pages/media-library.min.js:6236
 msgid "Folder unlocked successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:341
-#: assets/build/pages/media-library.min.js:6237
 msgid "Folder locked successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:363
-#: assets/build/pages/media-library.min.js:6259
 msgid "Folders locked successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:370
-#: assets/build/pages/media-library.min.js:6266
 msgid "Failed to update folder lock status"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:422
-#: assets/build/pages/media-library.min.js:6318
 msgid "New Sub-folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:430
 #: pages/media-library/components/modal/RenameModal.jsx:98
-#: assets/build/pages/media-library.min.js:6326
-#: assets/build/pages/media-library.min.js:7798
 msgid "Rename"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:438
-#: assets/build/pages/media-library.min.js:6334
 msgid "Lock Folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:438
-#: assets/build/pages/media-library.min.js:6334
 msgid "Unlock Folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:446
-#: assets/build/pages/media-library.min.js:6342
 msgid "Add Bookmark"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:446
-#: assets/build/pages/media-library.min.js:6342
 msgid "Remove Bookmark"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:456
-#: assets/build/pages/media-library.min.js:6352
 msgid "Download Zip"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:465
 #: pages/media-library/components/modal/DeleteModal.jsx:114
-#: assets/build/pages/media-library.min.js:6361
-#: assets/build/pages/media-library.min.js:7539
 msgid "Delete"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/BookmarkTab.jsx:56
 #: pages/media-library/components/folder-tree/BookmarkTab.jsx:76
-#: assets/build/pages/media-library.min.js:6425
-#: assets/build/pages/media-library.min.js:6445
 msgid "Bookmarks"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/BookmarkTab.jsx:64
-#: assets/build/pages/media-library.min.js:6433
 msgid "No bookmarks yet"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:125
-#: assets/build/pages/media-library.min.js:6592
 msgid "The parent folder is locked, so this folder cannot be moved."
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:155
-#: assets/build/pages/media-library.min.js:6622
 msgid "The destination folder is locked and cannot be modified"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:260
-#: assets/build/pages/media-library.min.js:6727
 msgid "Currently opened folder is locked and cannot be modified"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:271
-#: assets/build/pages/media-library.min.js:6738
 msgid "This folder is locked and cannot be modified"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:285
-#: assets/build/pages/media-library.min.js:6752
 msgid "Items assigned successfully"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:305
-#: assets/build/pages/media-library.min.js:6772
 msgid "Failed to assign items"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:387
 #: pages/media-library/components/folder-tree/FolderTree.jsx:430
 #: pages/video-editor/components/media-grid/MediaGrid.jsx:141
-#: assets/build/pages/media-library.min.js:6854
-#: assets/build/pages/media-library.min.js:6897
-#: assets/build/pages/video-editor.min.js:19203
 msgid "Loading…"
 msgstr ""
 
 #. translators: %s is the error message
 #: pages/media-library/components/folder-tree/FolderTree.jsx:392
-#: assets/build/pages/media-library.min.js:6859
+#, js-format
 msgid "Error: %s"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/LockedTab.jsx:65
 #: pages/media-library/components/folder-tree/LockedTab.jsx:85
-#: assets/build/pages/media-library.min.js:6985
-#: assets/build/pages/media-library.min.js:7005
 msgid "Locked"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/LockedTab.jsx:73
-#: assets/build/pages/media-library.min.js:6993
 msgid "No locked folders yet"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/TreeItem.jsx:97
-#: assets/build/pages/media-library.min.js:7229
 msgid "Collapse folder"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/TreeItem.jsx:97
-#: assets/build/pages/media-library.min.js:7229
 msgid "Expand folder"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:63
-#: assets/build/pages/media-library.min.js:7488
 msgid "Folders deleted successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:63
-#: assets/build/pages/media-library.min.js:7488
 msgid "Folder deleted successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:72
-#: assets/build/pages/media-library.min.js:7497
 msgid "Failed to delete folder"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:91
-#: assets/build/pages/media-library.min.js:7516
 msgid "Confirm Delete"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7523
 msgid "Deleting"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7523
 msgid "these"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7523
 msgid "folders"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7523
 msgid "will remove them and all its subfolders, but"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7523
 msgid "media associated with them will not be deleted"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:102
-#: assets/build/pages/media-library.min.js:7527
 msgid "Deleting the folder"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:102
-#: assets/build/pages/media-library.min.js:7527
 msgid "will remove it and all its subfolders, but"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:102
-#: assets/build/pages/media-library.min.js:7527
 msgid "media associated with it will not be deleted"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:107
-#: assets/build/pages/media-library.min.js:7532
 msgid "Are you sure you want to proceed? This action cannot be undone."
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:71
-#: assets/build/pages/media-library.min.js:7628
 msgid "Folder created successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:83
-#: assets/build/pages/media-library.min.js:7640
 msgid "Folder with that name already exists."
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:90
-#: assets/build/pages/media-library.min.js:7647
 msgid "Failed to create folder"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:110
-#: assets/build/pages/media-library.min.js:7667
 msgid "Create a new folder"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:118
 #: pages/media-library/components/modal/RenameModal.jsx:88
-#: assets/build/pages/media-library.min.js:7675
-#: assets/build/pages/media-library.min.js:7788
 msgid "Folder Name"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:126
-#: assets/build/pages/media-library.min.js:7683
 msgid "Create"
 msgstr ""
 
 #: pages/media-library/components/modal/RenameModal.jsx:57
-#: assets/build/pages/media-library.min.js:7757
 msgid "Folder renamed successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/RenameModal.jsx:64
-#: assets/build/pages/media-library.min.js:7764
 msgid "Failed to rename folder"
 msgstr ""
 
 #: pages/media-library/components/modal/RenameModal.jsx:83
-#: assets/build/pages/media-library.min.js:7783
 msgid "Rename folder"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:173
-#: assets/build/pages/media-library.min.js:7992
 msgid "Search folder"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:190
-#: assets/build/pages/media-library.min.js:8009
 msgid "No folders found."
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:220
-#: assets/build/pages/media-library.min.js:8039
 msgid "Searching…"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:220
-#: assets/build/pages/media-library.min.js:8039
 msgid "Loading more results…"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:221
-#: assets/build/pages/media-library.min.js:8040
 msgid "Error fetching results."
 msgstr ""
 
 #: pages/tools/App.js:27
-#: assets/build/pages/tools.min.js:1015
 msgid "Video Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:36
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:40
-#: assets/build/pages/tools.min.js:1175
-#: assets/build/pages/tools.min.js:1493
 msgid "Starting…"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:54
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:69
-#: assets/build/pages/tools.min.js:1193
-#: assets/build/pages/tools.min.js:1522
 msgid "Something went wrong while starting migration."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:130
-#: assets/build/pages/tools.min.js:1269
 msgid "WordPress core video migration completed successfully 🎉"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:133
-#: assets/build/pages/tools.min.js:1272
 msgid "WordPress core video migration failed. Please try again."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:165
-#: assets/build/pages/tools.min.js:1304
 msgid "Core video Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:167
-#: assets/build/pages/tools.min.js:1306
 msgid "This tool replaces WordPress core video blocks with GoDAM video blocks. It does not replace videos added in the WordPress Classic Editor."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:186
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:222
-#: assets/build/pages/tools.min.js:1325
-#: assets/build/pages/tools.min.js:1675
 msgid "Abort"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
-#: assets/build/pages/tools.min.js:1334
-#: assets/build/pages/tools.min.js:1684
 msgid "Restart Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
-#: assets/build/pages/tools.min.js:1334
-#: assets/build/pages/tools.min.js:1684
 msgid "Start Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:141
-#: assets/build/pages/tools.min.js:1594
 msgid "Vimeo Video Migration has been successfully completed for all posts and pages 🎉"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:144
-#: assets/build/pages/tools.min.js:1597
 msgid "Vimeo Video Migration failed. Please try again."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:176
-#: assets/build/pages/tools.min.js:1629
 msgid "Vimeo video Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:178
-#: assets/build/pages/tools.min.js:1631
 msgid "This tool replaces WordPress Vimeo Embed blocks with GoDAM Video blocks. It does not replace Vimeo videos added in the WordPress Classic Editor."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:183
-#: assets/build/pages/tools.min.js:1636
 msgid "This migrator will only migrate Vimeo videos that are already fetched on GoDAM Central."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:184
-#: assets/build/pages/tools.min.js:1637
 msgid "Open"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:199
-#: assets/build/pages/tools.min.js:1652
 msgid "Vimeo video migration in WordPress can only begin after all Vimeo videos have been successfully migrated to GoDAM Central, "
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:201
-#: assets/build/pages/tools.min.js:1654
 msgid "Check here!"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:210
-#: assets/build/pages/tools.min.js:1663
 msgid "Migration is in progress. Please wait…"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:65
-#: assets/build/pages/tools.min.js:1759
 msgid "The requested operation is not allowed. The nonce provided in the URL is invalid or expired."
 msgstr ""
 
 #. translators: %d is the number of selected media files to be transcoded.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:95
 #: pages/tools/components/tabs/RetranscodeTab.jsx:120
-#: assets/build/pages/tools.min.js:1789
-#: assets/build/pages/tools.min.js:1814
+#, js-format
 msgid "%d selected media file(s) will be transcoded."
 msgstr ""
 
 #. translators: %d is the number of selected media files to be retranscoded.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:105
-#: assets/build/pages/tools.min.js:1799
+#, js-format
 msgid "%d selected media file(s) will be retranscoded."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:153
-#: assets/build/pages/tools.min.js:1847
 msgid "No media files found for retranscoding. Please ensure you have media files that require retranscoding."
 msgstr ""
 
 #. translators: %s is the error message.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:160
-#: assets/build/pages/tools.min.js:1854
+#, js-format
 msgid "Failed to fetch media for retranscoding: %s"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:177
-#: assets/build/pages/tools.min.js:1871
 msgid "Aborting operation to send media for retranscoding."
 msgstr ""
 
 #. translators: %d is the number of virtual media files found.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:286
-#: assets/build/pages/tools.min.js:1980
+#, js-format
 msgid "%d virtual media file(s) found, which need to be retranscoded on GoDAM Central."
 msgstr ""
 
 #. translators: %d is the number of media files retranscoded.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:295
-#: assets/build/pages/tools.min.js:1989
+#, js-format
 msgid "Successfully sent %d media file(s) for retranscoding."
 msgstr ""
 
 #. translators: %d is the number of media files that failed to retranscode.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:310
-#: assets/build/pages/tools.min.js:2004
+#, js-format
 msgid "Failed to send %d media file(s) for retranscoding."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:323
-#: assets/build/pages/tools.min.js:2017
 msgid "Operation completed without any media files to retranscode."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:356
-#: assets/build/pages/tools.min.js:2050
 msgid "This tool allows you to retranscode your media files. You can either retranscode specific files selected from the Media Library, or those that are not yet transcoded."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:363
-#: assets/build/pages/tools.min.js:2057
 msgid "Checking the \"Force retranscode\" option will retranscode all media files regardless of their current state."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:368
-#: assets/build/pages/tools.min.js:2062
 msgid "Note: Transcoding and retranscoding will use your bandwidth allowance. Use the force retranscode option carefully."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:379
-#: assets/build/pages/tools.min.js:2073
 msgid "Storage Limit Exceeded:"
 msgstr ""
 
 #. translators: %s is the storage usage percentage.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:382
-#: assets/build/pages/tools.min.js:2076
+#, js-format
 msgid "Your storage usage has exceeded your plan limit (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:403
-#: assets/build/pages/tools.min.js:2097
 msgid "Force retranscode (even if already transcoded)"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:419
-#: assets/build/pages/tools.min.js:2113
 msgid "Fetching media that require retranscoding…"
 msgstr ""
 
 #. translators: %d is the number of untranscoded media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:438
-#: assets/build/pages/tools.min.js:2132
+#, js-format
 msgid "%d untranscoded media file(s) selected"
 msgstr ""
 
 #. translators: %d is the number of transcoded media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:447
-#: assets/build/pages/tools.min.js:2141
+#, js-format
 msgid "%d transcoded media file(s) selected"
 msgstr ""
 
 #. translators: 1: number of media files that require retranscoding, 2: total number of media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:460
-#: assets/build/pages/tools.min.js:2154
+#, js-format
 msgid "%1$d/%2$d media file(s) require retranscoding."
 msgstr ""
 
 #. translators: 1: number of media files that will be retranscoded regardless of their current state, 2: total number of media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:466
-#: assets/build/pages/tools.min.js:2160
+#, js-format
 msgid "%1$d/%2$d media file(s) will be retranscoded regardless of their current state."
 msgstr ""
 
 #. translators: 1: number of media files sent for retranscoding, 2: total number of media files selected.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:479
-#: assets/build/pages/tools.min.js:2173
+#, js-format
 msgid "%1$d/%2$d media files sent for retranscoding…"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:518
-#: assets/build/pages/tools.min.js:2212
 msgid "Fetch Media"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:522
-#: assets/build/pages/tools.min.js:2216
 msgid "Start Transcoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:524
-#: assets/build/pages/tools.min.js:2218
 msgid "Start Retranscoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:528
-#: assets/build/pages/tools.min.js:2222
 msgid "Restart Transcoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:530
-#: assets/build/pages/tools.min.js:2224
 msgid "Restart Retranscoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:544
-#: assets/build/pages/tools.min.js:2238
 msgid "Abort Operation"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:556
-#: assets/build/pages/tools.min.js:2250
 msgid "Reset"
 msgstr ""
 
 #: pages/video-editor/AttachmentPicker.jsx:66
-#: assets/build/pages/video-editor.min.js:11532
 msgid "Videos"
 msgstr ""
 
 #: pages/video-editor/AttachmentPicker.jsx:74
-#: assets/build/pages/video-editor.min.js:11540
 msgid "Search videos"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:79
-#: assets/build/pages/video-editor.min.js:13910
 msgid "Select / Upload Ad video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:81
-#: assets/build/pages/video-editor.min.js:13912
 msgid "Add video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:161
 #: pages/video-editor/components/SidebarLayers.js:121
-#: assets/build/pages/video-editor.min.js:13543
-#: assets/build/pages/video-editor.min.js:13992
 msgid "This ad will be overridden by Ad server's ads"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:165
-#: assets/build/pages/video-editor.min.js:13996
 msgid "Custom Ad"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:173
-#: assets/build/pages/video-editor.min.js:14004
+#: pages/video-editor/components/ads/CustomAdSettings.js:174
 msgid "Select Ad video"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:185
-#: assets/build/pages/video-editor.min.js:14016
+#: pages/video-editor/components/ads/CustomAdSettings.js:186
 msgid "Replace Ad Video"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:188
-#: assets/build/pages/video-editor.min.js:14019
+#: pages/video-editor/components/ads/CustomAdSettings.js:189
 msgid "Remove Ad Video"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:199
-#: assets/build/pages/video-editor.min.js:14030
+#: pages/video-editor/components/ads/CustomAdSettings.js:201
 msgid "Skippable"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:204
-#: assets/build/pages/video-editor.min.js:14035
+#: pages/video-editor/components/ads/CustomAdSettings.js:206
 msgid "Allow user to skip ad"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:210
-#: assets/build/pages/video-editor.min.js:14041
+#: pages/video-editor/components/ads/CustomAdSettings.js:213
 msgid "Skip time"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:211
-#: assets/build/pages/video-editor.min.js:14042
+#: pages/video-editor/components/ads/CustomAdSettings.js:215
 msgid "Time in seconds after which the skip button will appear"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:223
-#: assets/build/pages/video-editor.min.js:14054
+#: pages/video-editor/components/ads/CustomAdSettings.js:227
 msgid "Click link"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:225
-#: assets/build/pages/video-editor.min.js:14056
+#: pages/video-editor/components/ads/CustomAdSettings.js:230
 msgid "Enter the URL to redirect when the ad is clicked"
 msgstr ""
 
-#: pages/video-editor/components/ads/CustomAdSettings.js:234
+#: pages/video-editor/components/ads/CustomAdSettings.js:239
 #: pages/video-editor/components/cta/ImageCTA.js:236
 #: pages/video-editor/components/cta/ImageCTA.js:254
-#: pages/video-editor/components/layers/HotspotLayer.js:441
-#: assets/build/pages/video-editor.min.js:14065
-#: assets/build/pages/video-editor.min.js:15325
-#: assets/build/pages/video-editor.min.js:15343
-#: assets/build/pages/video-editor.min.js:18387
+#: pages/video-editor/components/layers/HotspotLayer.js:450
 msgid "Please enter a valid URL (e.g., https://example.com)"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:172
-#: assets/build/pages/video-editor.min.js:14246
 msgid "Select Custom Play Button Image"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:174
-#: assets/build/pages/video-editor.min.js:14248
 msgid "Use this Image"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:224
 #: pages/video-editor/components/appearance/Appearance.js:542
 #: pages/video-editor/VideoJSPlayer.js:251
-#: assets/build/pages/video-editor.min.js:12361
-#: assets/build/pages/video-editor.min.js:14298
-#: assets/build/pages/video-editor.min.js:14616
 msgid "Custom Play Button"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:431
-#: assets/build/pages/video-editor.min.js:14505
 msgid "Display Settings"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:439
-#: assets/build/pages/video-editor.min.js:14513
 msgid "Show Volume Slider"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:446
-#: assets/build/pages/video-editor.min.js:14520
 msgid "Display Captions"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:459
-#: assets/build/pages/video-editor.min.js:14533
 msgid "Adjust Skip Duration"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:479
-#: assets/build/pages/video-editor.min.js:14553
 msgid "Customization Settings"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:488
-#: assets/build/pages/video-editor.min.js:14562
 msgid "Show Branding"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:495
-#: assets/build/pages/video-editor.min.js:14569
 msgid "Custom Brand Logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:525
-#: assets/build/pages/video-editor.min.js:14599
 msgid "Play Button Position"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:529
-#: assets/build/pages/video-editor.min.js:14603
 msgid "Left"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:532
-#: assets/build/pages/video-editor.min.js:14606
 msgid "Right"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:569
-#: assets/build/pages/video-editor.min.js:14643
 msgid "Player Theme"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:574
-#: assets/build/pages/video-editor.min.js:14648
 msgid "Player Appearance"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:613
-#: assets/build/pages/video-editor.min.js:14687
 msgid "Icons hover color"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:644
-#: assets/build/pages/video-editor.min.js:14718
 msgid "Ad Server"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:653
-#: assets/build/pages/video-editor.min.js:14727
 msgid "Use ad server's ads"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:654
-#: assets/build/pages/video-editor.min.js:14728
 msgid "Enable this option to use ads from the ad server. This option will disable the ads layer"
 msgstr ""
 
 #: pages/video-editor/components/chapters/AddChapter.js:43
-#: assets/build/pages/video-editor.min.js:14811
 msgid "Time is greater than video duration"
 msgstr ""
 
 #: pages/video-editor/components/chapters/AddChapter.js:45
-#: assets/build/pages/video-editor.min.js:14813
 msgid "Time cannot be less than 0"
 msgstr ""
 
 #: pages/video-editor/components/chapters/AddChapter.js:47
-#: assets/build/pages/video-editor.min.js:14815
 msgid "Time is similar to another chapter"
 msgstr ""
 
 #: pages/video-editor/components/chapters/AddChapter.js:49
-#: assets/build/pages/video-editor.min.js:14817
 msgid "Time cannot be empty"
 msgstr ""
 
 #: pages/video-editor/components/chapters/AddChapter.js:51
-#: assets/build/pages/video-editor.min.js:14819
 msgid "Error in chapter time"
 msgstr ""
 
 #: pages/video-editor/components/chapters/Chapters.js:69
-#: assets/build/pages/video-editor.min.js:14969
 msgid "No chapters added"
 msgstr ""
 
 #: pages/video-editor/components/chapters/Chapters.js:111
-#: assets/build/pages/video-editor.min.js:15011
 msgid "Add chapter at "
 msgstr ""
 
 #: pages/video-editor/components/chapters/Chapters.js:120
-#: assets/build/pages/video-editor.min.js:15020
 msgid "There is already a chapter at this timestamp. Please choose a different timestamp."
 msgstr ""
 
 #: pages/video-editor/components/chapters/Chapters.js:128
-#: assets/build/pages/video-editor.min.js:15028
 msgid "Read more about timestamp format "
 msgstr ""
 
 #: pages/video-editor/components/chapters/Chapters.js:135
-#: assets/build/pages/video-editor.min.js:15035
 msgid "here"
 msgstr ""
 
 #: pages/video-editor/components/cta/HtmlCTA.js:25
-#: assets/build/pages/video-editor.min.js:15071
 msgid "Custom HTML"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:129
-#: assets/build/pages/video-editor.min.js:15218
 msgid "Select Custom Background Image"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:131
-#: assets/build/pages/video-editor.min.js:15220
 msgid "Use this Background Image"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:277
-#: assets/build/pages/video-editor.min.js:15366
 msgid "Image Left, Text Right (Full Height)"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:278
-#: assets/build/pages/video-editor.min.js:15367
 msgid "Text Left, Image Right (Full Height)"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:279
-#: assets/build/pages/video-editor.min.js:15368
 msgid "Image Left, Text Right"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:280
-#: assets/build/pages/video-editor.min.js:15369
 msgid "Text Left, Image Right"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:281
-#: assets/build/pages/video-editor.min.js:15370
 msgid "Image Top, Text Bottom"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:282
-#: assets/build/pages/video-editor.min.js:15371
 msgid "Text Top, Image Bottom"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:283
-#: assets/build/pages/video-editor.min.js:15372
 msgid "Image Background"
 msgstr ""
 
 #: pages/video-editor/components/cta/ImageCTA.js:284
-#: assets/build/pages/video-editor.min.js:15373
 msgid "Text Only (No Image)"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:341
-#: assets/build/pages/video-editor.min.js:15430
+#: pages/video-editor/components/cta/ImageCTA.js:342
 msgid "Add Image"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:364
-#: assets/build/pages/video-editor.min.js:15453
+#: pages/video-editor/components/cta/ImageCTA.js:366
 msgid "Replace Image"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:367
-#: assets/build/js/media-library.min.js:10131
-#: assets/build/js/media-library.min.js:10135
-#: assets/build/pages/video-editor.min.js:15456
+#: pages/video-editor/components/cta/ImageCTA.js:369
 msgid "Remove Image"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:387
-#: assets/build/pages/video-editor.min.js:15476
+#: pages/video-editor/components/cta/ImageCTA.js:389
 msgid "Image Width (%)"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:393
-#: assets/build/pages/video-editor.min.js:15482
+#: pages/video-editor/components/cta/ImageCTA.js:395
 msgid "Applies to horizontal layouts only"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:408
-#: assets/build/pages/video-editor.min.js:15497
+#: pages/video-editor/components/cta/ImageCTA.js:411
 msgid "Add title here"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:417
-#: assets/build/pages/video-editor.min.js:15506
+#: pages/video-editor/components/cta/ImageCTA.js:420
 msgid "URL"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:438
-#: assets/build/pages/video-editor.min.js:15527
+#: pages/video-editor/components/cta/ImageCTA.js:443
 msgid "Your Description"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:445
-#: assets/build/pages/video-editor.min.js:15534
+#: pages/video-editor/components/cta/ImageCTA.js:450
 msgid "CTA Button Text"
 msgstr ""
 
-#: pages/video-editor/components/cta/ImageCTA.js:456
-#: assets/build/pages/video-editor.min.js:15545
+#: pages/video-editor/components/cta/ImageCTA.js:462
 msgid "CTA Button Background Color"
 msgstr ""
 
 #: pages/video-editor/components/cta/TextCTA.js:71
-#: assets/build/pages/video-editor.min.js:15639
 msgid "Content"
 msgstr ""
 
 #: pages/video-editor/components/forms/AjaxWarning.js:19
-#: assets/build/pages/video-editor.min.js:15677
 msgid "AJAX submission is required to prevent the form from reloading the video page on submit. "
 msgstr ""
 
 #: pages/video-editor/components/forms/AjaxWarning.js:20
-#: assets/build/pages/video-editor.min.js:15678
 msgid "Make sure it's enabled in your"
 msgstr ""
 
 #: pages/video-editor/components/forms/AjaxWarning.js:28
-#: assets/build/pages/video-editor.min.js:15686
 msgid "form settings"
 msgstr ""
 
 #: pages/video-editor/components/forms/CF7.js:64
-#: assets/build/pages/video-editor.min.js:15758
 msgid "Please activate the Contact Form 7 plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/CF7.js:74
 #: pages/video-editor/components/forms/GravityForm.js:73
-#: assets/build/pages/video-editor.min.js:15768
-#: assets/build/pages/video-editor.min.js:16179
 msgid "Select form theme"
 msgstr ""
 
@@ -6426,16 +5818,6 @@ msgstr ""
 #: pages/video-editor/components/forms/NinjaForm.js:86
 #: pages/video-editor/components/forms/Sureform.js:74
 #: pages/video-editor/components/forms/WPForm.js:74
-#: assets/build/pages/video-editor.min.js:15792
-#: assets/build/pages/video-editor.min.js:15905
-#: assets/build/pages/video-editor.min.js:16020
-#: assets/build/pages/video-editor.min.js:16202
-#: assets/build/pages/video-editor.min.js:16440
-#: assets/build/pages/video-editor.min.js:16594
-#: assets/build/pages/video-editor.min.js:16714
-#: assets/build/pages/video-editor.min.js:16822
-#: assets/build/pages/video-editor.min.js:16929
-#: assets/build/pages/video-editor.min.js:17112
 msgid "Loading form…"
 msgstr ""
 
@@ -6449,16 +5831,6 @@ msgstr ""
 #: pages/video-editor/components/forms/NinjaForm.js:99
 #: pages/video-editor/components/forms/Sureform.js:86
 #: pages/video-editor/components/forms/WPForm.js:86
-#: assets/build/pages/video-editor.min.js:15804
-#: assets/build/pages/video-editor.min.js:15917
-#: assets/build/pages/video-editor.min.js:16032
-#: assets/build/pages/video-editor.min.js:16214
-#: assets/build/pages/video-editor.min.js:16466
-#: assets/build/pages/video-editor.min.js:16607
-#: assets/build/pages/video-editor.min.js:16727
-#: assets/build/pages/video-editor.min.js:16834
-#: assets/build/pages/video-editor.min.js:16941
-#: assets/build/pages/video-editor.min.js:17124
 msgid "Edit form"
 msgstr ""
 
@@ -6472,334 +5844,255 @@ msgstr ""
 #: pages/video-editor/components/forms/NinjaForm.js:110
 #: pages/video-editor/components/forms/Sureform.js:97
 #: pages/video-editor/components/forms/WPForm.js:97
-#: pages/video-editor/components/layers/CTALayer.js:291
-#: pages/video-editor/components/layers/PollLayer.js:119
-#: assets/build/pages/video-editor.min.js:15815
-#: assets/build/pages/video-editor.min.js:15928
-#: assets/build/pages/video-editor.min.js:16043
-#: assets/build/pages/video-editor.min.js:16225
-#: assets/build/pages/video-editor.min.js:16500
-#: assets/build/pages/video-editor.min.js:16618
-#: assets/build/pages/video-editor.min.js:16738
-#: assets/build/pages/video-editor.min.js:16845
-#: assets/build/pages/video-editor.min.js:16952
-#: assets/build/pages/video-editor.min.js:17135
-#: assets/build/pages/video-editor.min.js:17747
-#: assets/build/pages/video-editor.min.js:19052
+#: pages/video-editor/components/layers/CTALayer.js:293
+#: pages/video-editor/components/layers/PollLayer.js:124
 msgid "Skip"
 msgstr ""
 
 #: pages/video-editor/components/forms/EverestForm.js:49
-#: assets/build/pages/video-editor.min.js:15874
 msgid "Please activate the Everest Forms plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/FluentForm.js:51
-#: assets/build/pages/video-editor.min.js:15989
 msgid "Please activate the Fluent Forms plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/forminatorForms.js:49
-#: assets/build/pages/video-editor.min.js:17087
 msgid "Please activate the Forminator Forms plugin to use this feature."
 msgstr ""
 
-#: pages/video-editor/components/forms/FormSelector.js:33
-#: assets/build/pages/video-editor.min.js:16086
+#: pages/video-editor/components/forms/FormSelector.js:34
 msgid "Select form"
 msgstr ""
 
 #: pages/video-editor/components/forms/GravityForm.js:24
-#: assets/build/pages/video-editor.min.js:16130
 msgid "Orbital"
 msgstr ""
 
 #: pages/video-editor/components/forms/GravityForm.js:28
-#: assets/build/pages/video-editor.min.js:16134
 msgid "Gravity"
 msgstr ""
 
 #: pages/video-editor/components/forms/GravityForm.js:62
-#: assets/build/pages/video-editor.min.js:16168
 msgid "Please activate the Gravity Forms plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:171
-#: assets/build/pages/video-editor.min.js:16406
 msgid "Please activate the Jetpack plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:212
-#: assets/build/pages/video-editor.min.js:16447
 msgid "Error loading form. Please check if the form exists."
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:219
-#: assets/build/pages/video-editor.min.js:16454
 msgid "No form selected or form not found."
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:242
-#: assets/build/pages/video-editor.min.js:16477
 msgid "No Jetpack forms found. Please"
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:249
-#: assets/build/pages/video-editor.min.js:16484
 msgid "create a Jetpack contact form"
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:251
-#: assets/build/pages/video-editor.min.js:16486
 msgid "first."
 msgstr ""
 
 #: pages/video-editor/components/forms/MetForm.js:50
-#: assets/build/pages/video-editor.min.js:16560
 msgid "Please activate the MetForm plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/NinjaForm.js:50
-#: assets/build/pages/video-editor.min.js:16678
 msgid "Please activate the Ninja Forms plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/Sureform.js:49
-#: assets/build/pages/video-editor.min.js:16797
 msgid "Please activate the SureForms plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/WPForm.js:49
-#: assets/build/pages/video-editor.min.js:16904
 msgid "Please activate the WPForms plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:66
-#: assets/build/pages/video-editor.min.js:17211
 msgid "Select or Upload Custom Icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:68
-#: assets/build/pages/video-editor.min.js:17213
 msgid "Use this icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:125
-#: assets/build/pages/video-editor.min.js:17270
 msgid "HOTSPOT ICON"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:148
-#: assets/build/pages/video-editor.min.js:17293
 msgid "Select Icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:164
-#: assets/build/pages/video-editor.min.js:17309
 msgid "Search icons…"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:231
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:238
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:241
-#: pages/video-editor/components/layers/HotspotLayer.js:660
-#: assets/build/pages/video-editor.min.js:17376
-#: assets/build/pages/video-editor.min.js:17383
-#: assets/build/pages/video-editor.min.js:17386
-#: assets/build/pages/video-editor.min.js:18606
+#: pages/video-editor/components/layers/HotspotLayer.js:671
 msgid "Custom Icon"
 msgstr ""
 
 #: pages/video-editor/components/layers/AdsLayer.js:33
-#: assets/build/pages/video-editor.min.js:17448
 msgid "Self hosted video Ad"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:59
-#: assets/build/pages/video-editor.min.js:17515
 msgid "Card"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:63
-#: assets/build/pages/video-editor.min.js:17519
 msgid "Text"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:67
-#: assets/build/pages/video-editor.min.js:17523
 msgid "HTML"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:227
-#: assets/build/pages/video-editor.min.js:17683
 msgid "Call to Action"
 msgstr ""
 
-#: pages/video-editor/components/layers/CTALayer.js:234
-#: assets/build/pages/video-editor.min.js:17690
+#: pages/video-editor/components/layers/CTALayer.js:236
 msgid "Select the type of Call to Action layer."
 msgstr ""
 
-#: pages/video-editor/components/layers/CTALayer.js:243
-#: assets/build/pages/video-editor.min.js:17699
+#: pages/video-editor/components/layers/CTALayer.js:245
 msgid "Advanced"
 msgstr ""
 
-#: pages/video-editor/components/layers/CTALayer.js:247
-#: pages/video-editor/components/layers/FormLayer.js:156
-#: pages/video-editor/components/layers/PollLayer.js:74
-#: assets/build/pages/video-editor.min.js:17703
-#: assets/build/pages/video-editor.min.js:17913
-#: assets/build/pages/video-editor.min.js:19007
+#: pages/video-editor/components/layers/CTALayer.js:249
+#: pages/video-editor/components/layers/FormLayer.js:158
+#: pages/video-editor/components/layers/PollLayer.js:78
 msgid "Color"
 msgstr ""
 
-#: pages/video-editor/components/layers/CTALayer.js:251
-#: pages/video-editor/components/layers/FormLayer.js:160
-#: pages/video-editor/components/layers/PollLayer.js:79
-#: assets/build/pages/video-editor.min.js:17707
-#: assets/build/pages/video-editor.min.js:17917
-#: assets/build/pages/video-editor.min.js:19012
+#: pages/video-editor/components/layers/CTALayer.js:253
+#: pages/video-editor/components/layers/FormLayer.js:162
+#: pages/video-editor/components/layers/PollLayer.js:83
 msgid "Layer background color"
 msgstr ""
 
-#: pages/video-editor/components/layers/FormLayer.js:140
-#: pages/video-editor/components/layers/PollLayer.js:54
-#: assets/build/pages/video-editor.min.js:17897
-#: assets/build/pages/video-editor.min.js:18987
+#: pages/video-editor/components/layers/FormLayer.js:141
+#: pages/video-editor/components/layers/PollLayer.js:57
 msgid "Allow user to skip"
 msgstr ""
 
-#: pages/video-editor/components/layers/FormLayer.js:145
-#: pages/video-editor/components/layers/PollLayer.js:59
-#: assets/build/pages/video-editor.min.js:17902
-#: assets/build/pages/video-editor.min.js:18992
+#: pages/video-editor/components/layers/FormLayer.js:146
+#: pages/video-editor/components/layers/PollLayer.js:62
 msgid "If enabled, the user will be able to skip the form submission."
 msgstr ""
 
-#: pages/video-editor/components/layers/FormLayer.js:151
-#: pages/video-editor/components/layers/PollLayer.js:65
-#: assets/build/pages/video-editor.min.js:17908
-#: assets/build/pages/video-editor.min.js:18998
+#: pages/video-editor/components/layers/FormLayer.js:153
+#: pages/video-editor/components/layers/PollLayer.js:69
 msgid "Advance"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:106
-#: assets/build/pages/video-editor.min.js:18052
 msgid "Layer duration exceeds the remaining video length. Please reduce the duration."
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:153
-#: assets/build/pages/video-editor.min.js:18099
 msgid "New Hotspot"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:306
-#: assets/build/pages/video-editor.min.js:18252
+#: pages/video-editor/components/layers/HotspotLayer.js:307
 msgid "Layer Duration (seconds)"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:314
-#: assets/build/pages/video-editor.min.js:18260
+#: pages/video-editor/components/layers/HotspotLayer.js:315
 msgid "Duration (in seconds) this layer will stay visible. Maximum: 10 hours (36000 seconds)"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:322
-#: assets/build/pages/video-editor.min.js:18268
+#: pages/video-editor/components/layers/HotspotLayer.js:324
 msgid "Pause video on hover"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:327
-#: assets/build/pages/video-editor.min.js:18273
+#: pages/video-editor/components/layers/HotspotLayer.js:330
 msgid "Player will pause the video while the layer is displayed and users hover over the hotspots."
 msgstr ""
 
 #. translators: %d is the hotspot index
-#: pages/video-editor/components/layers/HotspotLayer.js:346
-#: assets/build/pages/video-editor.min.js:18292
+#: pages/video-editor/components/layers/HotspotLayer.js:350
+#, js-format
 msgid "Hotspot %d"
 msgstr ""
 
 #. translators: %d is the hotspot index
-#: pages/video-editor/components/layers/HotspotLayer.js:353
-#: assets/build/pages/video-editor.min.js:18299
+#: pages/video-editor/components/layers/HotspotLayer.js:357
+#, js-format
 msgid "Options for Hotspot %d"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:376
-#: assets/build/pages/video-editor.min.js:18322
+#: pages/video-editor/components/layers/HotspotLayer.js:381
 msgid "Show Style"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:395
-#: assets/build/pages/video-editor.min.js:18341
+#: pages/video-editor/components/layers/HotspotLayer.js:401
 msgid "Show Icon"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:402
-#: assets/build/pages/video-editor.min.js:18348
+#: pages/video-editor/components/layers/HotspotLayer.js:409
 msgid "Delete Hotspot"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:413
-#: assets/build/pages/video-editor.min.js:18359
+#: pages/video-editor/components/layers/HotspotLayer.js:421
 msgid "Tooltip Text"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:414
-#: assets/build/pages/video-editor.min.js:18360
+#: pages/video-editor/components/layers/HotspotLayer.js:422
 msgid "Click Me!"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:426
-#: assets/build/pages/video-editor.min.js:18372
+#: pages/video-editor/components/layers/HotspotLayer.js:435
 msgid "Link"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:460
-#: assets/build/pages/video-editor.min.js:18406
+#: pages/video-editor/components/layers/HotspotLayer.js:469
 msgid "BACKGROUND COLOR"
 msgstr ""
 
-#: pages/video-editor/components/layers/HotspotLayer.js:496
-#: assets/build/pages/video-editor.min.js:18442
+#: pages/video-editor/components/layers/HotspotLayer.js:507
 msgid "Add Hotspot"
 msgstr ""
 
 #: pages/video-editor/components/layers/Layer.js:84
-#: assets/build/pages/video-editor.min.js:18726
 msgid "Error: No layer components registered"
 msgstr ""
 
 #: pages/video-editor/components/layers/Layer.js:90
-#: assets/build/pages/video-editor.min.js:18732
 msgid "Loading layer…"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayersHeader.js:72
-#: assets/build/pages/video-editor.min.js:18814
 msgid " layer at"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayersHeader.js:147
 #: pages/video-editor/components/layers/LayersHeader.js:163
-#: assets/build/pages/video-editor.min.js:18889
-#: assets/build/pages/video-editor.min.js:18905
 msgid "Delete layer"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayersHeader.js:174
-#: assets/build/pages/video-editor.min.js:18916
 msgid "A layer already exists at this timestamp!"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayersHeader.js:183
-#: assets/build/pages/video-editor.min.js:18925
 msgid "The timestamp cannot be an empty value!"
 msgstr ""
 
-#: pages/video-editor/components/layers/PollLayer.js:44
-#: assets/build/pages/video-editor.min.js:18977
+#: pages/video-editor/components/layers/PollLayer.js:45
 msgid "Select poll"
 msgstr ""
 
@@ -6807,15 +6100,10 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:38
 #: pages/video-editor/components/SidebarLayers.js:41
 #: pages/video-editor/VideoJSPlayer.js:36
-#: assets/build/pages/video-editor.min.js:12146
-#: assets/build/pages/video-editor.min.js:12980
-#: assets/build/pages/video-editor.min.js:13460
-#: assets/build/pages/video-editor.min.js:13463
 msgid "CTA"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:39
-#: assets/build/pages/video-editor.min.js:12981
 msgid "Guide users toward a specific action"
 msgstr ""
 
@@ -6823,15 +6111,10 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:44
 #: pages/video-editor/components/SidebarLayers.js:47
 #: pages/video-editor/VideoJSPlayer.js:41
-#: assets/build/pages/video-editor.min.js:12151
-#: assets/build/pages/video-editor.min.js:12987
-#: assets/build/pages/video-editor.min.js:13466
-#: assets/build/pages/video-editor.min.js:13469
 msgid "Hotspot"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:46
-#: assets/build/pages/video-editor.min.js:12988
 msgid "Highlighting key areas with focus"
 msgstr ""
 
@@ -6839,15 +6122,10 @@ msgstr ""
 #: pages/video-editor/components/LayerSelector.jsx:60
 #: pages/video-editor/components/SidebarLayers.js:55
 #: pages/video-editor/VideoJSPlayer.js:31
-#: assets/build/pages/video-editor.min.js:12141
-#: assets/build/pages/video-editor.min.js:12994
-#: assets/build/pages/video-editor.min.js:13002
-#: assets/build/pages/video-editor.min.js:13477
 msgid "Gravity Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:53
-#: assets/build/pages/video-editor.min.js:12995
 msgid "Collect user input using Gravity Forms"
 msgstr ""
 
@@ -6861,130 +6139,90 @@ msgstr ""
 #: pages/video-editor/components/LayerSelector.jsx:149
 #: pages/video-editor/components/LayerSelector.jsx:162
 #: pages/video-editor/components/LayerSelector.jsx:174
-#: assets/build/pages/video-editor.min.js:13002
-#: assets/build/pages/video-editor.min.js:13014
-#: assets/build/pages/video-editor.min.js:13026
-#: assets/build/pages/video-editor.min.js:13039
-#: assets/build/pages/video-editor.min.js:13052
-#: assets/build/pages/video-editor.min.js:13065
-#: assets/build/pages/video-editor.min.js:13078
-#: assets/build/pages/video-editor.min.js:13091
-#: assets/build/pages/video-editor.min.js:13104
-#: assets/build/pages/video-editor.min.js:13116
 msgid "plugin is required to use Form layer"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:64
 #: pages/video-editor/components/SidebarLayers.js:61
-#: assets/build/pages/video-editor.min.js:13006
-#: assets/build/pages/video-editor.min.js:13483
 msgid "WPForms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:65
-#: assets/build/pages/video-editor.min.js:13007
 msgid "Collect user input using WPForms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:72
-#: assets/build/pages/video-editor.min.js:13014
 msgid "WP Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:76
 #: pages/video-editor/components/LayerSelector.jsx:84
 #: pages/video-editor/components/SidebarLayers.js:67
-#: assets/build/pages/video-editor.min.js:13018
-#: assets/build/pages/video-editor.min.js:13026
-#: assets/build/pages/video-editor.min.js:13489
 msgid "Contact Form 7"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:77
-#: assets/build/pages/video-editor.min.js:13019
 msgid "Collect user input using Contact Form 7"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:88
 #: pages/video-editor/components/SidebarLayers.js:73
-#: assets/build/pages/video-editor.min.js:13030
-#: assets/build/pages/video-editor.min.js:13495
 msgid "Jetpack Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:89
-#: assets/build/pages/video-editor.min.js:13031
 msgid "Collect user input using Jetpack Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:97
-#: assets/build/pages/video-editor.min.js:13039
 msgid "Jetpack"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:101
 #: pages/video-editor/components/LayerSelector.jsx:110
 #: pages/video-editor/components/SidebarLayers.js:79
-#: assets/build/pages/video-editor.min.js:13043
-#: assets/build/pages/video-editor.min.js:13052
-#: assets/build/pages/video-editor.min.js:13501
 msgid "SureForms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:102
-#: assets/build/pages/video-editor.min.js:13044
 msgid "Collect user input using SureForms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:114
 #: pages/video-editor/components/LayerSelector.jsx:123
 #: pages/video-editor/components/SidebarLayers.js:85
-#: assets/build/pages/video-editor.min.js:13056
-#: assets/build/pages/video-editor.min.js:13065
-#: assets/build/pages/video-editor.min.js:13507
 msgid "Forminator Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:115
-#: assets/build/pages/video-editor.min.js:13057
 msgid "Collect user input using Forminator Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:127
 #: pages/video-editor/components/LayerSelector.jsx:136
 #: pages/video-editor/components/SidebarLayers.js:91
-#: assets/build/pages/video-editor.min.js:13069
-#: assets/build/pages/video-editor.min.js:13078
-#: assets/build/pages/video-editor.min.js:13513
 msgid "Fluent Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:128
-#: assets/build/pages/video-editor.min.js:13070
 msgid "Collect user input using Fluent Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:141
-#: assets/build/pages/video-editor.min.js:13083
 msgid "Collect user input using Everest Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:154
-#: assets/build/pages/video-editor.min.js:13096
 msgid "Collect user input using Ninja Forms"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:166
 #: pages/video-editor/components/LayerSelector.jsx:174
 #: pages/video-editor/components/SidebarLayers.js:109
-#: assets/build/pages/video-editor.min.js:13108
-#: assets/build/pages/video-editor.min.js:13116
-#: assets/build/pages/video-editor.min.js:13531
 msgid "MetForm"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:167
-#: assets/build/pages/video-editor.min.js:13109
 msgid "Collect user input using MetForm"
 msgstr ""
 
@@ -6992,15 +6230,10 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:117
 #: pages/video-editor/components/SidebarLayers.js:120
 #: pages/video-editor/VideoJSPlayer.js:46
-#: assets/build/pages/video-editor.min.js:12156
-#: assets/build/pages/video-editor.min.js:13120
-#: assets/build/pages/video-editor.min.js:13539
-#: assets/build/pages/video-editor.min.js:13542
 msgid "Ad"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:179
-#: assets/build/pages/video-editor.min.js:13121
 msgid "Redirect user to custom advertisement"
 msgstr ""
 
@@ -7008,347 +6241,182 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:124
 #: pages/video-editor/components/SidebarLayers.js:127
 #: pages/video-editor/VideoJSPlayer.js:51
-#: assets/build/pages/video-editor.min.js:12161
-#: assets/build/pages/video-editor.min.js:13127
-#: assets/build/pages/video-editor.min.js:13546
-#: assets/build/pages/video-editor.min.js:13549
 msgid "Poll"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:186
-#: assets/build/pages/video-editor.min.js:13128
 msgid "Gather opinions through interactive voting"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:191
-#: assets/build/pages/video-editor.min.js:13133
 msgid "WP-Polls"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:191
-#: assets/build/pages/video-editor.min.js:13133
 msgid "plugin is required to use Poll layer"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:237
-#: assets/build/pages/video-editor.min.js:13179
 msgid "All"
 msgstr ""
 
 #: pages/video-editor/components/LayerSelector.jsx:316
 #: pages/video-editor/VideoEditor.js:333
-#: assets/build/pages/video-editor.min.js:11898
-#: assets/build/pages/video-editor.min.js:13258
 msgid "Layers"
 msgstr ""
 
-#: pages/video-editor/components/LayerSelector.jsx:345
-#: assets/build/pages/video-editor.min.js:13287
+#: pages/video-editor/components/LayerSelector.jsx:346
 msgid "search layers…"
 msgstr ""
 
-#: pages/video-editor/components/LayerSelector.jsx:391
-#: assets/build/pages/video-editor.min.js:13333
+#: pages/video-editor/components/LayerSelector.jsx:392
 msgid "Layer"
 msgstr ""
 
-#: pages/video-editor/components/LayerSelector.jsx:420
-#: assets/build/pages/video-editor.min.js:13362
+#: pages/video-editor/components/LayerSelector.jsx:422
 msgid "Customise Layer"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaGrid.jsx:106
-#: assets/build/pages/video-editor.min.js:19168
 msgid "No video found"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaGrid.jsx:109
-#: assets/build/pages/video-editor.min.js:19171
 msgid "Upload videos from WordPress"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaGrid.jsx:120
-#: assets/build/pages/video-editor.min.js:19182
 msgid "to use them in GoDAM."
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaItem.jsx:41
 #: pages/video-editor/VideoEditor.js:318
-#: assets/build/pages/video-editor.min.js:11883
-#: assets/build/pages/video-editor.min.js:19252
 msgid "GoDAM Video Block copied to clipboard"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaItem.jsx:44
 #: pages/video-editor/VideoEditor.js:321
-#: assets/build/pages/video-editor.min.js:11886
-#: assets/build/pages/video-editor.min.js:19255
 msgid "Failed to copy GoDAM Video Block"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaItem.jsx:97
-#: assets/build/pages/video-editor.min.js:19308
 msgid "Preview Video"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaItem.jsx:104
-#: assets/build/pages/video-editor.min.js:19315
 msgid "Copy Video Block"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaItem.jsx:111
-#: assets/build/pages/video-editor.min.js:19322
 msgid "Copy video Link"
 msgstr ""
 
 #: pages/video-editor/components/media-grid/MediaItem.jsx:122
-#: assets/build/pages/video-editor.min.js:19333
 msgid "Quick actions."
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:58
-#: assets/build/pages/video-editor.min.js:13480
 msgid "Gravity Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:64
-#: assets/build/pages/video-editor.min.js:13486
 msgid "WPForms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:70
-#: assets/build/pages/video-editor.min.js:13492
 msgid "Contact Form 7 plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:76
-#: assets/build/pages/video-editor.min.js:13498
 msgid "Jetpack plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:82
-#: assets/build/pages/video-editor.min.js:13504
 msgid "SureForms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:88
-#: assets/build/pages/video-editor.min.js:13510
 msgid "Forminator Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:94
-#: assets/build/pages/video-editor.min.js:13516
 msgid "Fluent Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:100
-#: assets/build/pages/video-editor.min.js:13522
 msgid "Everest Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:106
-#: assets/build/pages/video-editor.min.js:13528
 msgid "Ninja Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:112
-#: assets/build/pages/video-editor.min.js:13534
 msgid "MetForm plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:129
-#: assets/build/pages/video-editor.min.js:13551
 msgid "Poll plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:339
-#: assets/build/pages/video-editor.min.js:13761
 msgid "No layers added"
 msgstr ""
 
 #. translators: %s is the current time in seconds.
 #: pages/video-editor/components/SidebarLayers.js:373
-#: assets/build/pages/video-editor.min.js:13795
+#, js-format
 msgid "Add layer at %ss"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:378
-#: assets/build/pages/video-editor.min.js:13800
 msgid "There is already a layer at this timestamp. Please choose a different timestamp."
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:384
-#: assets/build/pages/video-editor.min.js:13806
 msgid "Play video to add layer."
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:271
-#: assets/build/pages/video-editor.min.js:11836
 msgid "Please select a form for the layer at timestamp:"
 msgid_plural "Please select a form for the layers at timestamps:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pages/video-editor/VideoEditor.js:434
-#: assets/build/pages/video-editor.min.js:11999
+#: pages/video-editor/VideoEditor.js:435
 msgid "Video changes saved successfully"
 msgstr ""
 
-#: pages/video-editor/VideoEditor.js:463
-#: assets/build/pages/video-editor.min.js:12028
+#: pages/video-editor/VideoEditor.js:465
 msgid "You can copy the block into one of the two options:"
 msgstr ""
 
-#: pages/video-editor/VideoEditor.js:465
-#: assets/build/pages/video-editor.min.js:12030
+#: pages/video-editor/VideoEditor.js:467
 msgid "1. Insert as a block in the Block editor."
 msgstr ""
 
-#: pages/video-editor/VideoEditor.js:467
-#: assets/build/pages/video-editor.min.js:12032
+#: pages/video-editor/VideoEditor.js:469
 msgid "2. Insert as HTML content in the Block editor."
 msgstr ""
 
-#: pages/video-editor/VideoEditor.js:478
-#: assets/build/pages/video-editor.min.js:12043
+#: pages/video-editor/VideoEditor.js:481
 msgid "Copy Block"
 msgstr ""
 
-#: pages/video-editor/VideoEditor.js:488
-#: assets/build/pages/video-editor.min.js:12053
+#: pages/video-editor/VideoEditor.js:492
 msgid "Preview"
 msgstr ""
 
 #: pages/video-editor/VideoJSPlayer.js:727
-#: assets/build/pages/video-editor.min.js:12837
 msgid "Add layer at this time"
 msgstr ""
 
 #: pages/video-editor/VideoJSPlayer.js:732
-#: assets/build/pages/video-editor.min.js:12842
 msgid "ADD LAYER"
 msgstr ""
 
 #: pages/whats-new/components/Header.js:25
-#: assets/build/pages/whats-new.min.js:755
 msgid "What's New in GoDAM"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:78
-msgid "Select a reason"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:79
-msgid "I found a better plugin"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:80
-msgid "The plugin is not working as expected"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:81
-msgid "I was just testing"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:82
-msgid "Other"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:84
-msgid "Additional details…"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:88
-msgid "Skip & Deactivate"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:93
-msgid "Submit & Deactivate"
-msgstr ""
-
-#. translators: %d: Maximum allowed file size in MB.
-#: assets/build/js/everestforms.min.js:117
-msgid "File size exceeds the maximum limit of %d MB."
-msgstr ""
-
-#: assets/build/js/everestforms.min.js:287
-#: assets/build/js/fluentforms.min.js:301
-#: assets/build/js/ninja-forms.min.js:272
-msgid "File upload in progress…"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9263
-msgid "Not started"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9283
-msgid "Media is transcoded"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9319
-msgid "Transcoding…"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9530
-#: assets/build/pages/video-editor.min.js:10844
-msgid "Premium Feature"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9870
-msgid "No thumbnails found"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10027
-msgid "Select Custom Thumbnail"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10028
-msgid "Use this image"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10040
-msgid "Please select a valid image file (JPEG, PNG, GIF, etc.)."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10076
-#: assets/build/js/media-library.min.js:10077
-msgid "Only 3 custom thumbnails allowed"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10124
-msgid "Custom Video Thumbnail"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:11065
-msgid "oEmbed Video URL"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:11067
-msgid "The oEmbed URL can be used to embed the video in other platforms that support oEmbed."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:77980
-msgid "Search Media"
-msgstr ""
-
-#: assets/build/js/ninja-forms.min.js:336
-msgid "Upload failed. Please try again."
-msgstr ""
-
-#: assets/build/js/wpforms-godam-recorder-editor.min.js:69932
-msgid "Select or Upload Video Of Your Choice"
-msgstr ""
-
-#: assets/build/js/wpforms-godam-recorder-editor.min.js:69937
-msgid "Use this video"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:9748
-msgid "Invalid item"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:11196
-msgid "Integration status updated successfully."
 msgstr ""
 
 #: assets/build/blocks/godam-audio/block.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "1.11.1",
+	"version": "1.11.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "1.11.1",
+			"version": "1.11.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "1.11.1",
+	"version": "1.11.2",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
@@ -36,6 +36,15 @@ const GeneralSettings = () => {
 	const [ saveMediaSettings, { isLoading: saveMediaSettingsLoading } ] = useSaveMediaSettingsMutation();
 	const [ notice, setNotice ] = useState( { message: '', status: 'success', isVisible: false } );
 
+	// The "folder organization" toggle is GoDAM's media-library integration kill-switch.
+	// When set from code (constant/filter) the toggle is locked and the effective value
+	// comes from the server; otherwise it reflects the saved setting.
+	const mediaLibraryUICodeManaged = window?.godamSettings?.mediaLibraryUICodeManaged || false;
+	const mediaLibraryUIEffective = window?.godamSettings?.mediaLibraryUIEffective ?? true;
+	const folderOrgEnabled = mediaLibraryUICodeManaged
+		? mediaLibraryUIEffective
+		: mediaSettings?.general?.enable_folder_organization;
+
 	// Function to show a notice message
 	const showNotice = ( message, status = 'success' ) => {
 		setNotice( { message, status, isVisible: true } );
@@ -94,9 +103,14 @@ const GeneralSettings = () => {
 					<ToggleControl
 						__nextHasNoMarginBottom
 						className="godam-toggle godam-margin-bottom"
-						label={ __( 'Enable folder organization in media library.', 'godam' ) }
-						help={ __( 'Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization.', 'godam' ) }
-						checked={ mediaSettings?.general?.enable_folder_organization }
+						label={ __( 'Enable GoDAM media library features', 'godam' ) }
+						help={
+							mediaLibraryUICodeManaged
+								? __( 'This setting is managed by your site administrator and can’t be changed here.', 'godam' )
+								: __( 'Turn this on to organize and manage media with GoDAM — folders, search, and filters. Turn it off to keep the WordPress media library as it is.', 'godam' )
+						}
+						checked={ folderOrgEnabled }
+						disabled={ mediaLibraryUICodeManaged }
 						onChange={ ( value ) => handleSettingChange( 'enable_folder_organization', value ) }
 					/>
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.11.1
+Stable tag: 1.11.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -219,6 +219,10 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 
 == Changelog ==
 
+= v1.11.2 (June 5, 2026) =
+
+- Feat: Added a setting to disable GoDAM's media library features, allowing GoDAM to coexist with another media or DAM plugin without changing the WordPress media library.
+
 = v1.11.1 (June 3, 2026) =
 
 - Fix: GoDAM Video block aspect ratio for editor and frontend.
@@ -230,11 +234,6 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 - Tweak: Extended GoDAM analytics scripts to track Reel Pop interactions from GoDAM for Woo.
 - Tweak: Added a migration script to sync existing virtual media to GoDAM Central.
 - Fix: Improved video selection UX in the handpicked mode of the Video Gallery block.
-
-= v1.10.2 (May 22, 2026) =
-
-- Feat: Enhanced Type 1 video analytics tracking with viewport detection.
-- Fix: Resolved cancelled Type 2 Analytics requests for Gallery iframe.
 
 [CHECK THE FULL CHANGELOG](https://github.com/rtCamp/godam/blob/main/CHANGELOG.md)
 


### PR DESCRIPTION
This pull request introduces a new "additive mode" to GoDAM, allowing site administrators to disable GoDAM's media library features so it can coexist with other DAM or media plugins without altering the native WordPress media library. The change is controlled by a new setting (with code-level overrides), and when disabled, GoDAM suppresses its media library UI integrations while keeping its modal tab, blocks, transcoding, and other features intact. The update includes both backend and frontend logic, a settings UI update, and documentation.

**Additive Mode / Media Library UI Toggle:**

* Added a new backend setting and helper functions (`rtgodam_is_media_library_ui_enabled`, `rtgodam_is_media_library_ui_code_managed`) to control whether GoDAM's media library takeover is enabled, with support for code-level overrides via constant or filter.
* Updated the admin and video editor scripts to localize and respect the new setting, ensuring consistent behavior across the plugin. [[1]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dL248-R268) [[2]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dL280) [[3]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dL313-R330) [[4]](diffhunk://#diff-e329e454999381b4aad93a6c5811e683aed9bf08f0428fb7f991feb9975b791dR417-R420) [[5]](diffhunk://#diff-8f6c0412582a633d4d6c9cbd98466c31f29eecb1e995a3118df0cad252fa827eL557-R559)
* Modified media library JS (`assets/src/js/media-library`) to conditionally suppress GoDAM's folder UI, toolbar filters, event listeners, and drag-to-folder features in additive mode, preserving only the GoDAM media-modal tab and non-conflicting features. [[1]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0R72-L81) [[2]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0R159-R172) [[3]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0R333-R337) [[4]](diffhunk://#diff-9ee098078438429f0c7dcb498e01c5a558ff80439d9e11e7ede6b8b71fe38474R50-R55) [[5]](diffhunk://#diff-fb7c950b71c9461563537f8c0937e81f6ff688496066c97a24ae6d3d6e0fb1deL10-R10) [[6]](diffhunk://#diff-fb7c950b71c9461563537f8c0937e81f6ff688496066c97a24ae6d3d6e0fb1deR40-R46) [[7]](diffhunk://#diff-e6c06f26bbf00355f8d258a05bf0ccc8294b2d11d97c9750135a6d035fb9b7e4R34-R42)

**Settings UI:**

* Updated the General Settings tab to display the new toggle as "Enable GoDAM media library features", with logic to lock the toggle and display appropriate help text when the value is managed by code. [[1]](diffhunk://#diff-015e1553e3c7c61907aa04d3bf0c4c8770caf23491460ee3f9236323096c5a87R39-R47) [[2]](diffhunk://#diff-015e1553e3c7c61907aa04d3bf0c4c8770caf23491460ee3f9236323096c5a87L97-R113)

**Documentation & Versioning:**

* Updated `CHANGELOG.md`, `readme.txt`, `README.md`, and `package.json` with the new version (1.11.2) and documented the new feature. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R222-R225) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L234-L238) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[6]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Bumped plugin version in `godam.php` and related files. [[1]](diffhunk://#diff-11ad0cbfc6e1732b964b5298a09e2b1cd2df3efc7f60babe88d5d0e88d748916L6-R6) [[2]](diffhunk://#diff-11ad0cbfc6e1732b964b5298a09e2b1cd2df3efc7f60babe88d5d0e88d748916L46-R46)

These changes make GoDAM more flexible for sites using multiple media management solutions and ensure a seamless experience for both administrators and end users.