### PR TITLE
Update changelog date for v1.11.2 to June 8, 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog #
 
-## v1.11.2 (June 5, 2026) ##
+## v1.11.2 (June 8, 2026) ##
 
 - Feat: Added a setting to disable GoDAM's media library features, allowing GoDAM to coexist with another media or DAM plugin without changing the WordPress media library.
 

--- a/readme.txt
+++ b/readme.txt
@@ -219,7 +219,7 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 
 == Changelog ==
 
-= v1.11.2 (June 5, 2026) =
+= v1.11.2 (June 8, 2026) =
 
 - Feat: Added a setting to disable GoDAM's media library features, allowing GoDAM to coexist with another media or DAM plugin without changing the WordPress media library.
 


### PR DESCRIPTION
This pull request updates the release date for version 1.11.2 to June 8, 2026 in both the `CHANGELOG.md` and `readme.txt` files. No other changes are included.

- Updated the release date for v1.11.2 from June 5, 2026 to June 8, 2026 in `CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3) and `readme.txt` [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L222-R222).