### PR TITLE
Misc bug fixes for GoDAM plugin

### DIFF
--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -89,6 +89,17 @@ function AudioEdit( {
 			return;
 		}
 
+		// Guard against non-audio selections. The media library lets users pick
+		// any attachment type even when allowedTypes is set, so re-check here.
+		const mediaType = media.type || ( media.mime || media.mime_type || '' ).split( '/' )[ 0 ];
+		if ( mediaType && mediaType !== 'audio' ) {
+			createErrorNotice(
+				__( 'Only audio files are allowed in the GoDAM Audio block.', 'godam' ),
+				{ type: 'snackbar' },
+			);
+			return;
+		}
+
 		if ( isBlobURL( media.url ) ) {
 			setTemporaryURL( media.url );
 			return;

--- a/assets/src/blocks/godam-audio/editor.scss
+++ b/assets/src/blocks/godam-audio/editor.scss
@@ -1,3 +1,10 @@
+// WP 7.0+ collapses ToggleControl bottom margin to zero (the
+// `__nextHasNoMarginBottom` prop is now a no-op). Restore consistent
+// vertical spacing for toggles rendered in the block inspector sidebar.
+.block-editor-block-inspector .components-panel__body .components-toggle-control {
+	margin-bottom: 12px;
+}
+
 .wp-block-godam-audio {
 	// Remove the left and right margin the figure is born with.
 	margin-left: 0;

--- a/assets/src/blocks/godam-gallery-v2/editor.scss
+++ b/assets/src/blocks/godam-gallery-v2/editor.scss
@@ -1,3 +1,10 @@
+// WP 7.0+ collapses ToggleControl bottom margin to zero (the
+// `__nextHasNoMarginBottom` prop is now a no-op). Restore consistent
+// vertical spacing for toggles rendered in the block inspector sidebar.
+.block-editor-block-inspector .components-panel__body .components-toggle-control {
+	margin-bottom: 12px;
+}
+
 .godam-gallery-v2 {
 	// Only apply 100% width when no block-level alignment is set.
 	// alignfull/alignwide rely on theme/editor CSS for their own width.

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -464,6 +464,18 @@ function VideoEdit( {
 			return;
 		}
 
+		// Guard against non-video selections. The media library lets users pick
+		// any attachment type even when allowedTypes is set, so re-check here.
+		const mediaType = media.type || ( media.mime || media.mime_type || '' ).split( '/' )[ 0 ];
+		if ( mediaType && mediaType !== 'video' ) {
+			createErrorNotice(
+				__( 'Only video files are allowed in the GoDAM Video block.', 'godam' ),
+				{ type: 'snackbar' },
+			);
+			setIsVideoSelecting( false );
+			return;
+		}
+
 		if ( isBlobURL( media.url ) ) {
 			setTemporaryURL( media.url );
 			setIsVideoSelecting( false );

--- a/assets/src/blocks/godam-player/editor.scss
+++ b/assets/src/blocks/godam-player/editor.scss
@@ -3,6 +3,14 @@
  * These styles ensure the block works correctly in the editor,
  * including in flex layouts (Row/Stack).
  */
+
+// WP 7.0+ collapses ToggleControl bottom margin to zero (the
+// `__nextHasNoMarginBottom` prop is now a no-op). Restore consistent
+// vertical spacing for toggles rendered in the block inspector sidebar.
+.block-editor-block-inspector .components-panel__body .components-toggle-control {
+	margin-bottom: 12px;
+}
+
 .wp-block-godam-video {
 	min-width: 0; // Allow shrinking in flex layouts (Row/Stack)
 

--- a/assets/src/css/_common.scss
+++ b/assets/src/css/_common.scss
@@ -97,6 +97,19 @@
 		font-weight: 400;
 	}
 
+	select {
+		border: 1px solid rgba(225, 225, 225, 1) !important;
+		background: rgba(255, 255, 255, 1) !important;
+		border-radius: 0.5rem !important;
+		padding: 0.75rem !important;
+		height: auto !important;
+
+		font-size: 0.875rem !important;
+		line-height: 1.375 !important;
+		font-weight: 400;
+		margin-top: -0.75rem !important;
+	}
+
 	&.godam-input__api-key {
 
 		.components-text-control__input{

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -133,9 +133,7 @@ export default class HotspotLayerManager {
 		layerObj.hotspots.forEach( ( hotspot, index ) => {
 			const hotspotDiv = this.createHotspotElement( hotspot, index, containerWidth, containerHeight, baseWidth, baseHeight );
 
-			if ( layerObj.pauseOnHover ) {
-				this.setupHotspotHoverEvents( hotspotDiv );
-			}
+			this.setupHotspotHoverEvents( hotspotDiv, layerObj.pauseOnHover );
 
 			layerObj.layerElement.appendChild( hotspotDiv );
 
@@ -391,17 +389,33 @@ export default class HotspotLayerManager {
 	/**
 	 * Setup hotspot hover events
 	 *
-	 * @param {HTMLElement} hotspotDiv - The hotspot element to add hover events to
+	 * @param {HTMLElement} hotspotDiv   - The hotspot element to add hover events to
+	 * @param {boolean}     pauseOnHover - Whether to pause video playback on hover
 	 */
-	setupHotspotHoverEvents( hotspotDiv ) {
+	setupHotspotHoverEvents( hotspotDiv, pauseOnHover = false ) {
 		hotspotDiv.addEventListener( 'mouseenter', () => {
-			this.wasPlayingBeforeHover = ! this.player.paused();
-			this.player.pause();
+			if ( pauseOnHover ) {
+				this.wasPlayingBeforeHover = ! this.player.paused();
+				this.player.pause();
+			}
+
+			const layer = hotspotDiv.closest( '.easydam-layer.hotspot-layer' );
+
+			if ( layer ) {
+				const computedZ = window.getComputedStyle( layer ).zIndex;
+				const current = parseInt( computedZ, 10 ) || 0;
+				layer.style.zIndex = current + 1;
+			}
 		} );
 
 		hotspotDiv.addEventListener( 'mouseleave', () => {
-			if ( this.wasPlayingBeforeHover ) {
+			if ( pauseOnHover && this.wasPlayingBeforeHover ) {
 				this.player.play();
+			}
+
+			const layer = hotspotDiv.closest( '.easydam-layer.hotspot-layer' );
+			if ( layer ) {
+				layer.style.zIndex = '';
 			}
 		} );
 	}

--- a/pages/video-editor/components/appearance/Appearance.js
+++ b/pages/video-editor/components/appearance/Appearance.js
@@ -14,6 +14,7 @@ import {
 	Button,
 	CustomSelectControl,
 	Notice,
+	SelectControl,
 	TextareaControl,
 	ToggleControl,
 	Icon,
@@ -366,8 +367,8 @@ const Appearance = () => {
 		setOpenSections( ( prev ) => ( { ...prev, [ section ]: ! prev[ section ] } ) );
 	};
 
-	function handleSkipTimeSettings( e ) {
-		const selectedSkipVal = parseFloat( e.selectedItem.name );
+	function handleSkipTimeSettings( value ) {
+		const selectedSkipVal = parseFloat( value );
 		dispatch(
 			updateVideoConfig( {
 				controlBar: {
@@ -447,21 +448,18 @@ const Appearance = () => {
 								onChange={ handleCaptionsToggle }
 								checked={ videoConfig.controlBar.subsCapsButton }
 							/>
-							<CustomSelectControl
-								__next40pxDefaultSize
-								className="godam-input"
-								onChange={ handleSkipTimeSettings }
-								options={ [
-									{ key: '5', name: '5' },
-									{ key: '10', name: '10' },
-									{ key: '30', name: '30' },
-								] }
-								label={ __( 'Adjust Skip Duration', 'godam' ) }
-								value={ {
-									key: videoConfig.controlBar.skipButtons?.forward?.toString() || '10',
-									name: videoConfig.controlBar.skipButtons?.forward?.toString() || '10',
-								} }
-							/>
+							<div className="godam-input">
+								<SelectControl
+									onChange={ handleSkipTimeSettings }
+									options={ [
+										{ label: '5', value: '5' },
+										{ label: '10', value: '10' },
+										{ label: '30', value: '30' },
+									] }
+									label={ __( 'Adjust Skip Duration', 'godam' ) }
+									value={ videoConfig.controlBar.skipButtons?.forward?.toString() || '10' }
+								/>
+							</div>
 						</div>
 					) }
 				</div>

--- a/pages/video-editor/components/layers/HotspotLayer.js
+++ b/pages/video-editor/components/layers/HotspotLayer.js
@@ -417,7 +417,7 @@ const HotspotLayer = ( { layerID, goBack, duration } ) => {
 							<div className="mt-3">
 								<TextControl
 									data-test-id={ `godam-hotspot-control-tooltip-text-${ index }` }
-									className="godam-input"
+									className="godam-input mb-2"
 									label={ __( 'Tooltip Text', 'godam' ) }
 									placeholder={ __( 'Click Me!', 'godam' ) }
 									value={ hotspot.tooltipText }


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1938

1. Fix the hotspot overlapping with the other hotspot layer pop-up.
2. Handle the selection of non-video files for the godam video block.
3. Handle the selection of non-audio files for the godam audio block.
4. GoDAM Video Gallery and Shoppable videos are already handling the non-video file selections. (Self-tested) 
5. Fix vertical spacing for `ToggleControl` in block inspector across audio, gallery, and player blocks.

This pull request introduces several improvements and bug fixes across the GoDAM audio and video blocks, as well as the Hotspot Layer Manager. The most notable changes include stricter media type validation for audio and video blocks to prevent incorrect file selection, restoration of consistent UI spacing in the block inspector sidebar, and enhancements to hotspot hover behavior for video playback and visual stacking.

**Media Type Validation Enhancements:**

* Added explicit checks in `AudioEdit` and `VideoEdit` components to ensure only audio or video files can be selected, displaying an error notice if the wrong type is chosen. This prevents users from accidentally inserting unsupported file types due to media library limitations. [[1]](diffhunk://#diff-f6b2e4d63567e93a73ddd90e3545ff9bcc28f9ff25365c16e3faaf3738605cb3R92-R102) [[2]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66R467-R478)

**UI Consistency Improvements:**

* Restored consistent vertical spacing for `ToggleControl` components in the block inspector sidebar across audio, video, and gallery blocks, addressing a regression in WordPress 7.0+. [[1]](diffhunk://#diff-6b039ac0976f361f9fbb1af15cafb92ca5e22d65c0258d9b13ba1b052d922e0bR1-R7) [[2]](diffhunk://#diff-3fbe485411a910b05202873b9e280e626ee3f9ca385d3d2192f1b5c96280906dR1-R7) [[3]](diffhunk://#diff-2da561cc60d267b68baaad3869d1f5fc8b60db4bbc15584d15a1ae71f1e8e7fdR6-R13)

**Hotspot Layer Manager Enhancements:**

* Refactored hotspot hover event setup to always attach the handlers, with conditional pausing of video based on the `pauseOnHover` flag.
* Improved z-index management on hotspot hover to ensure hovered hotspots are visually on top, and reset on mouse leave.
