### PR TITLE
fix: record the real post title in analytics instead of document.title

### DIFF
--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -626,11 +626,15 @@ function rtgodam_get_localize_array() {
 
 	$localize_array = array();
 
-	$localize_array['endpoint']   = RTGODAM_ANALYTICS_BASE;
-	$localize_array['isPost']     = empty( is_single() ) ? 0 : is_single();
-	$localize_array['isPage']     = empty( is_page() ) ? 0 : is_page();
-	$localize_array['isArchive']  = empty( is_archive() ) ? 0 : is_archive();
-	$localize_array['postTitle']  = get_the_title();
+	$localize_array['endpoint']  = RTGODAM_ANALYTICS_BASE;
+	$localize_array['isPost']    = empty( is_single() ) ? 0 : is_single();
+	$localize_array['isPage']    = empty( is_page() ) ? 0 : is_page();
+	$localize_array['isArchive'] = empty( is_archive() ) ? 0 : is_archive();
+	// Resolve the title from the queried object, not the global $post: this runs
+	// on wp_enqueue_scripts, where the loop global can hold an unrelated post
+	// (first post on archives, or one left behind by a secondary query). Empty
+	// on non-singular pages — there is no single post to attribute the view to.
+	$localize_array['postTitle']  = is_singular() ? get_the_title( get_queried_object_id() ) : '';
 	$localize_array['locationIP'] = rtgodam_get_user_ip();
 
 	/**

--- a/assets/src/js/godam-player/analytics-helpers.js
+++ b/assets/src/js/godam-player/analytics-helpers.js
@@ -206,7 +206,11 @@ export function buildAnalyticsRequestBody( {
 		email: emailId || '',
 		visitor_timestamp: visitorTimestamp || Date.now(),
 		visit_entry_action_url: window.location.href,
-		visit_entry_action_name: document.title,
+		// Prefer the WP-resolved post title: document.title is the SEO/document
+		// title ("Post – Site Name", or whatever an SEO plugin emits), not the
+		// post title. PHP localizes postTitle only on singular pages; elsewhere
+		// document.title is the best page name available.
+		visit_entry_action_name: postTitle || document.title,
 		referer_type: '',
 		referer_name: document.referrer || '',
 		referer_url: document.referrer || '',


### PR DESCRIPTION
## Problem

Addresses the P1 item **"On blog post data ingestion - analytics payload sends wrong post title"** from the analytics EPIC rtCamp/godam-analytics#171.

Two related defects in the analytics payload:

1. `visit_entry_action_name` was sent as raw `document.title`. On WordPress that is the SEO/document title — `"{Post Title} – {Site Name}"` by default, or whatever an SEO plugin (Yoast/RankMath title templates) generates — not the post title. Every blog-post view was ingested with this polluted title. Verified on a live site: post **"Hello world!"** ingests as **"Hello world! – subodh-multisite.rt.gw"**.

2. `postTitle` was localized via `get_the_title()` with no post ID on `wp_enqueue_scripts`, which reads the loop global `$post`. On archives/home it records the **first post of the loop** as the post title for every view on that page (confirmed live: blog index sends `postTitle: "Hello world!", postId: 1` while `isPost: 0`), and on singular pages it silently breaks when a theme/plugin runs a secondary query before `wp_head` without resetting postdata.

## Fix

- **PHP** (`rtgodam_get_localize_array()`): resolve the title from the queried object — `is_singular() ? get_the_title( get_queried_object_id() ) : ''` — immune to loop-global pollution; empty on non-singular pages where there is no single post to attribute the view to.
- **JS** (`analytics-helpers.js`): `visit_entry_action_name: postTitle || document.title` — the clean WP post title on singular pages, `document.title` as fallback elsewhere (on archives the document title *is* the best available page name).

No schema or analytics-service change needed; both fields already exist in the ingest payload. GoDAM Central's client keeps sending `document.title` for its own (non-WP) pages, which remains correct there.

## Verification

- Runtime assertions against the modified `buildAnalyticsRequestBody()` (module executed with stubbed globals): singular → `visit_entry_action_name === postTitle`; archive → falls back to `document.title` with `post_title: ''`; missing `postTitle` key (stale cached localize) → falls back; unverified-token bail-out unchanged.
- WP Playground run with the plugin mounted: single post localizes `postTitle: "Hello world!"`, static page `"Sample Page"`, blog index `""` — while the post's `<title>` is `Hello world! – My WordPress Website`, demonstrating the pollution the fix removes.
- `phpcs` and `wp-scripts lint-js` clean on the changed files; built `godam-player-analytics.min.js` confirmed to contain the new expression (build artifacts not committed, per release process).

## Follow-up (separate repo)

`godam-for-woo` reel-pops analytics (`assets/src/js/reel-pops/analytics/analytics.js`) duplicates the `visit_entry_action_name: document.title` pattern and will need the same one-line change; its `post_title` benefits from this PR automatically since it reads the same localized `videoAnalyticsParams`.