### PR TITLE
fix: remove stale WooCommerce block build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,16 +120,12 @@
 		"yauzl": "3.2.1"
 	},
 	"scripts": {
-		"start:blocks": "npm-run-all --parallel start:blocks:main start:blocks:wc",
-		"start:blocks:main": "wp-scripts start --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./assets/src/blocks/ --output-path=./assets/build/blocks/",
-		"start:blocks:wc": "wp-scripts start --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./integrations/woocommerce/blocks/ --output-path=./assets/build/integrations/woocommerce/blocks/",
+		"start:blocks": "wp-scripts start --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./assets/src/blocks/ --output-path=./assets/build/blocks/",
 		"start:js": "wp-scripts start --config ./webpack.config.js",
 		"start": "npm-run-all --parallel start:*",
 		"build:dev": "cross-env NODE_ENV=development npm-run-all 'build:!(dev|prod)'",
 		"build:prod": "cross-env NODE_ENV=production npm-run-all 'build:!(dev|prod)'",
-		"build:blocks": "npm-run-all --parallel build:blocks:main build:blocks:wc",
-		"build:blocks:main": "wp-scripts build --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./assets/src/blocks/ --output-path=./assets/build/blocks/",
-		"build:blocks:wc": "wp-scripts build --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./integrations/woocommerce/blocks/ --output-path=./assets/build/integrations/woocommerce/blocks/",
+		"build:blocks": "wp-scripts build --config ./node_modules/@wordpress/scripts/config/webpack.config.js --webpack-src-dir=./assets/src/blocks/ --output-path=./assets/build/blocks/",
 		"build:js": "wp-scripts build --config ./webpack.config.js",
 		"lint": "npm-run-all --parallel lint:*",
 		"lint:css": "wp-scripts lint-style",


### PR DESCRIPTION
## Summary

`start:blocks:wc` and `build:blocks:wc` still point at `integrations/woocommerce/blocks/`, which was removed in #1806 when the WooCommerce integration moved to the standalone GoDAM for Woo plugin (the commit message for #1806 mentions removing these from package.json, but the root package.json was never touched — only webpack.config.js was cleaned up).

As a result, every `npm run start` / `npm run build:prod` prints this twice and runs an empty webpack compile:

```
Source directory "./integrations/woocommerce/blocks/" was not found. Please confirm there is a "src" directory in the root or the value passed with "--output-path" is correct.
```

## Changes

- Remove the two stale `:wc` scripts.
- Collapse `start:blocks` / `build:blocks` to the single wp-scripts command, since the `:main`/`:wc` split is no longer needed. The `start` and `build:dev`/`build:prod` aggregates are unaffected (`start:*` and `build:!(dev|prod)` still match).

## Testing

- `npm run build:blocks` before the change reproduces the warning; after the change it builds all blocks with no warning (verified locally, exit 0).
- `git grep "blocks:main\|blocks:wc\|integrations/woocommerce"` confirms no remaining references in the repo (CI workflows, webpack config, PHP).