### PR TITLE
Address Copilot review feedback on layer analytics (#1946)

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -317,7 +317,7 @@ function observePageLoadForVideo( video ) {
 	window.GoDAM.findVideoElementById = findVideoElementById; // Exposed for other plugins as a global helper.
 
 	// Layer analytics buffer + constants — exposed for add-ons (e.g. godam-for-woo)
-	// so they can write into the same localStorage buffer and benefit from the
+	// so they can write into the same sessionStorage buffer and benefit from the
 	// shared pagehide flush. Single source of truth for layer-action semantics
 	// lives in utils/layerActions.js.
 	window.GoDAM.addLayerInteraction = bufferAddLayerInteraction;
@@ -359,7 +359,7 @@ function observePageLoadForVideo( video ) {
 	} );
 
 	/**
-	 * Flush the localStorage layer-interactions buffer to /analytics/ as
+	 * Flush the sessionStorage layer-interactions buffer to /analytics/ as
 	 * one or more type=3 POSTs, one per videoKey.
 	 *
 	 * Called on pagehide (and via the gallery iframe teardown path, if needed

--- a/assets/src/js/godam-player/managers/layers/formLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/formLayerManager.js
@@ -74,7 +74,7 @@ export default class FormLayerManager {
 	}
 
 	/**
-	 * Emit a layer interaction event into the localStorage buffer.
+	 * Emit a layer interaction event into the sessionStorage buffer.
 	 *
 	 * No-op when `window.GoDAM.addLayerInteraction` isn't loaded yet (the
 	 * shared analytics bundle ships separately and may not be present on

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -90,7 +90,7 @@ export default class HotspotLayerManager {
 	}
 
 	/**
-	 * Emit a sub-hotspot interaction event into the localStorage buffer.
+	 * Emit a sub-hotspot interaction event into the sessionStorage buffer.
 	 *
 	 * Sub-hotspots emit engagement events only — `hovered` and `clicked`.
 	 * Parent-level `viewed` is the layer-wide visibility signal and is

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -852,10 +852,14 @@ class Pages {
 				'godamAnalyticsConfig',
 				array(
 					'addonLayerOptions' => is_array( $addon_layer_options ) ? array_values( $addon_layer_options ) : array(),
-					// Empty array means "config unknown" — frontend fails
-					// open (treats everything as active) so analytics never
-					// blanks out if postmeta is missing.
-					'activeLayerConfig' => $active_layer_config,
+					// null means "config unknown" — the frontend fails open
+					// (treats everything as active). That's the case when the
+					// page loads without a video id: the media-selector flow
+					// sets the id client-side via history.replaceState with no
+					// reload, so this localization never re-runs. An empty
+					// ARRAY is meaningful: valid id, zero published layers —
+					// the frontend then renders every layer as removed.
+					'activeLayerConfig' => $analytics_video_id > 0 ? $active_layer_config : null,
 				)
 			);
 

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -4,6 +4,11 @@
 import { useMemo } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import {
@@ -164,12 +169,34 @@ const TRACKER_AUTO_NAME_RE = new RegExp(
 );
 
 /**
+ * Whether a server-delivered layer_name is missing, a bare UUID, or a
+ * tracker-side auto-generated name — i.e. anything we should replace with
+ * a locally generated (localized) fallback. Also drives the `name_is_auto`
+ * flag on parent entries, which the detail panel uses to suppress the
+ * redundant "Appeared at" line (auto names already encode the timestamp).
+ *
+ * @param {string} rawName Server-delivered layer_name.
+ * @return {boolean} True when the name should be auto-generated locally.
+ */
+export function isAutoOrMissingName( rawName ) {
+	const trimmed = ( rawName || '' ).toString().trim();
+	return (
+		! trimmed ||
+		UUID_SHAPE_RE.test( trimmed ) ||
+		TRACKER_AUTO_NAME_RE.test( trimmed )
+	);
+}
+
+/**
  * Resolve the display name for a layer at render time.
  *
  * Custom name (from the future editor naming UI) wins whenever the server
  * delivered a non-empty, non-UUID, non-auto-pattern value. Otherwise we
- * generate `<TypeLabel> layer at <t>s` locally — using the localized
- * `meta.label` so the admin sees the layer type in its current language.
+ * generate a localized "<TypeLabel> layer at <t>s" fallback — both the
+ * type label and the surrounding template go through i18n, so the admin
+ * sees the whole name in their current language. (The tracker's wire-side
+ * auto names stay English by design — TRACKER_AUTO_NAME_RE catches those
+ * and we regenerate here.)
  *
  * For form layers with a known `form_type`, the type label is replaced by
  * the form-integration brand name (e.g. "WPForms layer at 2.59s"), so
@@ -183,19 +210,20 @@ const TRACKER_AUTO_NAME_RE = new RegExp(
  */
 function resolveLayerName( rawName, meta, timestamp, formType ) {
 	const trimmed = ( rawName || '' ).toString().trim();
-	const isAutoOrMissing =
-		! trimmed ||
-		UUID_SHAPE_RE.test( trimmed ) ||
-		TRACKER_AUTO_NAME_RE.test( trimmed );
-	if ( ! isAutoOrMissing ) {
+	if ( ! isAutoOrMissingName( trimmed ) ) {
 		return trimmed;
 	}
-	let label = meta?.label || 'Layer';
+	let label = meta?.label || __( 'Layer', 'godam' );
 	if ( meta?.id === 'form' && formType && FORM_TYPE_LABELS[ formType ] ) {
 		label = FORM_TYPE_LABELS[ formType ];
 	}
 	const t = Number.isFinite( Number( timestamp ) ) ? Number( timestamp ) : 0;
-	return `${ label } layer at ${ t.toFixed( 2 ) }s`;
+	return sprintf(
+		/* translators: 1: layer type label (e.g. "CTA"), 2: position in the video in seconds. */
+		__( '%1$s layer at %2$ss', 'godam' ),
+		label,
+		t.toFixed( 2 ),
+	);
 }
 
 /**
@@ -491,6 +519,11 @@ export function groupRows( rows, layerType, configIndex ) {
 		parents.push( {
 			id: parentId,
 			name: parentName,
+			// True when `name` was generated locally (localized "<Type> layer
+			// at <t>s") rather than a custom name. The detail panel keys its
+			// "Appeared at" suppression on this — a locale-proof flag instead
+			// of pattern-matching the (now translated) name.
+			name_is_auto: isAutoOrMissingName( parentRawName ),
 			layer_type: layerType,
 			form_type: bucket.formType || '',
 			timestamp: parentTimestamp,

--- a/pages/analytics/timeline/LayerDetailPanel.js
+++ b/pages/analytics/timeline/LayerDetailPanel.js
@@ -96,9 +96,9 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 	// Auto-generated names already encode the position ("<Type> layer at
 	// <t>s"), so a separate "Appeared at X:XX" line just repeats it. Show that
 	// line only for custom-named layers, where the name carries no timestamp.
-	// resolveLayerName emits the " layer at <t>s" suffix in English regardless
-	// of locale, so this literal match is locale-safe.
-	const nameEncodesTimestamp = / layer at \d+(\.\d+)?s$/.test( parent.name || '' );
+	// `name_is_auto` is set by the data hook when it generated the (localized)
+	// fallback name — a locale-proof flag, unlike matching the name text.
+	const nameEncodesTimestamp = parent.name_is_auto === true;
 
 	// Resolve the active funnel data — parent aggregate by default, sub-hotspot
 	// when one is selected from the rail.

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -622,7 +622,12 @@ const Dashboard = () => {
 											<td
 												title={
 													item.total_converting_sessions > 0
-														? `${ item.total_converting_sessions } of ${ item.plays } sessions converted`
+														? sprintf(
+															/* translators: 1: converting sessions, 2: total plays. */
+															__( '%1$s of %2$s sessions converted', 'godam' ),
+															Number( item.total_converting_sessions ).toLocaleString(),
+															Number( item.plays ).toLocaleString(),
+														)
 														: __( 'No layer conversions in this period', 'godam' )
 												}
 											>


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-core/issues/1135
Addresses the Copilot review comments on #1946:

- **`activeLayerConfig` null vs empty array** — the analytics page can get its video id client-side via the media selector (`history.replaceState`, no reload), in which case PHP localized an empty array and the timeline would mark every layer as Removed. PHP now sends `null` when no valid `?id=` is present (frontend fails open, JS already handles non-array values); an empty array now always means a valid id with zero published layers.
- **i18n** — the dashboard conversion-rate tooltip and the auto-generated layer fallback name ("<Type> layer at <t>s") are now translatable. The detail panel keys its "Appeared at" suppression on a `name_is_auto` flag from the data hook instead of pattern-matching the English name.
- **Stale comments** — three comments said the layer-interaction buffer is localStorage; it is sessionStorage (per-tab, deliberately — see `utils/storage.js`).

JS unit tests (16) pass; PHPCS and ESLint clean.