### PR TITLE
Bump version to 1.12.0 and update changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog #
 
+## v1.12.0 (June 11, 2026) ##
+
+- Feat: Added Layer Analytics feature to track how viewers interact with video layers (CTAs, hotspots, forms, and more), with per-layer engagement and conversion metrics in the analytics dashboard.
+
 ## v1.11.2 (June 8, 2026) ##
 
 - Feat: Added a setting to disable GoDAM's media library features, allowing GoDAM to coexist with another media or DAM plugin without changing the WordPress media library.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested up to: 7.0
 
 Requires PHP: 7.4
 
-Stable tag: 1.11.2
+Stable tag: 1.12.0
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 1.11.2
+ * Version: 1.12.0
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '1.11.2' );
+	define( 'RTGODAM_VERSION', '1.12.0' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "1.11.2",
+	"version": "1.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "1.11.2",
+			"version": "1.12.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "1.11.2",
+	"version": "1.12.0",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.11.2
+Stable tag: 1.12.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -219,6 +219,10 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 
 == Changelog ==
 
+= v1.12.0 (June 11, 2026) =
+
+- Feat: Added Layer Analytics feature to track how viewers interact with video layers (CTAs, hotspots, forms, and more), with per-layer engagement and conversion metrics in the analytics dashboard.
+
 = v1.11.2 (June 8, 2026) =
 
 - Feat: Added a setting to disable GoDAM's media library features, allowing GoDAM to coexist with another media or DAM plugin without changing the WordPress media library.
@@ -228,12 +232,6 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 - Fix: GoDAM Video block aspect ratio for editor and frontend.
 - Fix: Silent PHP Linter errors.
 - Fix: Broken Admin Notice when WooCommerce is not present on a site in a multisite network.
-
-= v1.11.0 (May 27, 2026) =
-
-- Tweak: Extended GoDAM analytics scripts to track Reel Pop interactions from GoDAM for Woo.
-- Tweak: Added a migration script to sync existing virtual media to GoDAM Central.
-- Fix: Improved video selection UX in the handpicked mode of the Video Gallery block.
 
 [CHECK THE FULL CHANGELOG](https://github.com/rtCamp/godam/blob/main/CHANGELOG.md)
 


### PR DESCRIPTION
Release prep for v1.12.0 (Layer Analytics).

- Added the v1.12.0 changelog entry (June 11, 2026) to readme.txt and CHANGELOG.md; dropped the oldest entry (v1.11.0) from readme.txt so it keeps the latest three.
- Stable tag → 1.12.0 in readme.txt and README.md (Tested up to stays 7.0).
- Version → 1.12.0 in the godam.php header, the RTGODAM_VERSION constant, package.json, and package-lock.json.
- No `@since n.e.x.t` placeholders to resolve this release.