### PR TITLE
Fix API Key Status Cache Synchronization and Expired State Handling

### DIFF
--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -495,6 +495,7 @@ function rtgodam_verify_api_key( $api_key, $save = false ) {
 		if ( $has_existing_key && ( Api_Key_Status::VALID === $previous_status ) ) {
 			// Previously saved key is expired - preserve it and mark as expired. This function will also check if it is already expired.
 			rtgodam_mark_api_key_expired();
+			delete_option( 'rtgodam_user_data' );
 			// Key is already in DB, no need to save again.
 			return new \WP_Error( 'expired_api_key', $error_message, array( 'status' => 400 ) );
 		}

--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -495,6 +495,14 @@ function rtgodam_verify_api_key( $api_key, $save = false ) {
 		if ( $has_existing_key && ( Api_Key_Status::VALID === $previous_status ) ) {
 			// Previously saved key is expired - preserve it and mark as expired. This function will also check if it is already expired.
 			rtgodam_mark_api_key_expired();
+
+			/*
+			 * Purge the stale "valid" cache so it is rebuilt with corrected data.
+			 * Automatic path (via rtgodam_get_user_data): cache is immediately rewritten
+			 * in the same request with valid_api_key=false and api_key_status=EXPIRED.
+			 * Manual settings path (class-settings.php): caller returns early on this
+			 * WP_Error, so the delete sticks until the next page load.
+			 */
 			delete_option( 'rtgodam_user_data' );
 			// Key is already in DB, no need to save again.
 			return new \WP_Error( 'expired_api_key', $error_message, array( 'status' => 400 ) );

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -358,6 +358,7 @@ function rtgodam_get_user_data( $use_for_localize_array = false, $timeout = HOUR
 		$should_verify = true;
 	}
 
+	// If we're skipping verification due to expired key past grace period, ensure the cache reflects that status.
 	if ( $skip_verification ) {
 		$rtgodam_user_data = is_array( $rtgodam_user_data ) ? $rtgodam_user_data : array();
 
@@ -379,6 +380,9 @@ function rtgodam_get_user_data( $use_for_localize_array = false, $timeout = HOUR
 		$rtgodam_user_data['valid_api_key']  = false;
 		$rtgodam_user_data['api_key_status'] = \RTGODAM\Inc\Enums\Api_Key_Status::EXPIRED;
 		$rtgodam_user_data['user_data']      = $user_data;
+
+		// Clear any stale usage error — it is irrelevant once the key is expired.
+		unset( $rtgodam_user_data['storageBandwidthError'] );
 
 		if ( $cache_needs_correction ) {
 			$rtgodam_user_data['timestamp'] = time();

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -359,6 +359,23 @@ function rtgodam_get_user_data( $use_for_localize_array = false, $timeout = HOUR
 		$should_verify = true;
 	}
 
+	if ( $skip_verification ) {
+		$rtgodam_user_data = is_array( $rtgodam_user_data ) ? $rtgodam_user_data : array();
+		$user_data         = isset( $rtgodam_user_data['user_data'] ) ? $rtgodam_user_data['user_data'] : array();
+		$user_data         = is_object( $user_data ) ? (array) $user_data : $user_data;
+		$user_data         = is_array( $user_data ) ? $user_data : array();
+
+		$user_data['masked_api_key'] = rtgodam_mask_string( $api_key );
+
+		$rtgodam_user_data['currentUserId']  = get_current_user_id();
+		$rtgodam_user_data['valid_api_key']  = false;
+		$rtgodam_user_data['api_key_status'] = \RTGODAM\Inc\Enums\Api_Key_Status::EXPIRED;
+		$rtgodam_user_data['user_data']      = $user_data;
+		$rtgodam_user_data['timestamp']      = time();
+
+		update_option( 'rtgodam_user_data', $rtgodam_user_data );
+	}
+
 	if ( $should_verify ) {
 		// Verify the user's API Key.
 		$result = rtgodam_verify_api_key( $api_key );

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -114,7 +114,6 @@ function rtgodam_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, 
 
 		default:
 			return null;
-
 	}
 
 	// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
@@ -361,9 +360,18 @@ function rtgodam_get_user_data( $use_for_localize_array = false, $timeout = HOUR
 
 	if ( $skip_verification ) {
 		$rtgodam_user_data = is_array( $rtgodam_user_data ) ? $rtgodam_user_data : array();
-		$user_data         = isset( $rtgodam_user_data['user_data'] ) ? $rtgodam_user_data['user_data'] : array();
-		$user_data         = is_object( $user_data ) ? (array) $user_data : $user_data;
-		$user_data         = is_array( $user_data ) ? $user_data : array();
+
+		// Determine whether the DB needs correcting before we overwrite the in-memory array.
+		// Once the cache already reflects EXPIRED + valid_api_key=false, subsequent requests
+		// must not write to wp_options again — the timestamp would always differ and cause a
+		// real DB write on every admin page load for the entire post-grace lifetime of the key.
+		$cache_needs_correction =
+			( $rtgodam_user_data['api_key_status'] ?? null ) !== \RTGODAM\Inc\Enums\Api_Key_Status::EXPIRED ||
+			false !== ( $rtgodam_user_data['valid_api_key'] ?? null );
+
+		$user_data = isset( $rtgodam_user_data['user_data'] ) ? $rtgodam_user_data['user_data'] : array();
+		$user_data = is_object( $user_data ) ? (array) $user_data : $user_data;
+		$user_data = is_array( $user_data ) ? $user_data : array();
 
 		$user_data['masked_api_key'] = rtgodam_mask_string( $api_key );
 
@@ -371,9 +379,11 @@ function rtgodam_get_user_data( $use_for_localize_array = false, $timeout = HOUR
 		$rtgodam_user_data['valid_api_key']  = false;
 		$rtgodam_user_data['api_key_status'] = \RTGODAM\Inc\Enums\Api_Key_Status::EXPIRED;
 		$rtgodam_user_data['user_data']      = $user_data;
-		$rtgodam_user_data['timestamp']      = time();
 
-		update_option( 'rtgodam_user_data', $rtgodam_user_data );
+		if ( $cache_needs_correction ) {
+			$rtgodam_user_data['timestamp'] = time();
+			update_option( 'rtgodam_user_data', $rtgodam_user_data );
+		}
 	}
 
 	if ( $should_verify ) {


### PR DESCRIPTION
Closes https://github.com/rtCamp/godam-core/issues/1070
## Overview

This PR improves API key status handling by ensuring cached user data remains consistent with the persisted API key state, particularly during expiration and grace-period flows.

## Changes

### 1. Force EXPIRED State After Grace Period

When verification is skipped after the grace period ($skip_verification), cached user data is now explicitly updated with:

- valid_api_key = false
- api_key_status = EXPIRED
- Updated timestamp

and persisted back to rtgodam_user_data.

Why: Ensures stale verification results cannot persist in cache once the grace period has ended.

---

### 2. Clear Cache When API Key Expires

When a previously valid API key is determined to be expired:

```php
rtgodam_mark_api_key_expired();
    delete_option( 'rtgodam_user_data' ); 
```

the cached user data is immediately removed.

Why: Prevents requests from using data generated while the key was still valid and forces regeneration on the next request.

---
## Impact

- Prevents stale cache after API key expiration.
- Keeps cached data aligned with persisted API key status.
- Ensures deterministic behavior after grace-period expiry.
- Improves overall cache consistency and reliability.

## Video Demo

https://github.com/user-attachments/assets/5998bc23-89cc-4847-9249-654a4e541d4c


