### PR TITLE
feat(layer-analytics): record sub-hotspot lifetimes + forward to analytics (#196 WP side)

### DIFF
--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -267,11 +267,37 @@ class Analytics extends Base {
 			$query_params['job_id'] = $job_id;
 		}
 
+		// #196: for layer types that have sub-hotspots, forward the per-sub
+		// lifetime map (added_at / deleted_at, recorded on save) so the service
+		// credits a sub's inherited `viewed` only for the days it existed. The
+		// endpoint accepts GET or POST and reads `layer_lifetimes` from the body;
+		// atomic layer types send nothing and keep the GET path. A sub absent
+		// from the map is treated as full-history, so this is a no-op until the
+		// map is populated.
+		$layer_lifetimes = array();
+		if ( $attachment_id && in_array( $layer_type, array( 'hotspot', 'woo' ), true ) ) {
+			$meta = get_post_meta( $attachment_id, 'rtgodam_meta', true );
+			if ( is_array( $meta ) && ! empty( $meta['layer_lifetimes'] ) && is_array( $meta['layer_lifetimes'] ) ) {
+				$layer_lifetimes = $meta['layer_lifetimes'];
+			}
+		}
+
 		$endpoint = add_query_arg( $query_params, RTGODAM_ANALYTICS_BASE . '/processed-layer-analytics/' );
 		// Bounded timeout: useVideoLayerData fires one of these per layer type
 		// (5 in parallel) on page load, so a hung upstream must not pin a PHP
 		// worker for the full default (5s) — and certainly not 5s × 5.
-		$response = wp_remote_get( $endpoint, array( 'timeout' => 3 ) );
+		if ( ! empty( $layer_lifetimes ) ) {
+			$response = wp_remote_post(
+				$endpoint,
+				array(
+					'timeout' => 3,
+					'headers' => array( 'Content-Type' => 'application/json' ),
+					'body'    => wp_json_encode( $layer_lifetimes ),
+				)
+			);
+		} else {
+			$response = wp_remote_get( $endpoint, array( 'timeout' => 3 ) );
+		}
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_REST_Response(

--- a/inc/classes/rest-api/class-meta-rest-fields.php
+++ b/inc/classes/rest-api/class-meta-rest-fields.php
@@ -40,6 +40,7 @@ class Meta_Rest_Fields {
 					return get_post_meta( $post['id'], 'rtgodam_meta', true );
 				},
 				'update_callback' => function ( $value, $post ) {
+					$value = $this->record_layer_lifetimes( $post->ID, $value );
 					return update_post_meta( $post->ID, 'rtgodam_meta', $value );
 				},
 			)
@@ -99,5 +100,111 @@ class Meta_Rest_Fields {
 				},
 			)
 		);
+	}
+
+	/**
+	 * Record per-sub-hotspot lifetimes (added_at / deleted_at) when a video's
+	 * layer config is saved, so the analytics service can credit a sub-hotspot's
+	 * inherited `viewed` only for the days it actually existed
+	 * (rtCamp/godam-analytics#196).
+	 *
+	 * Diffs the incoming layers against the previously-saved ones, keyed by the
+	 * composite sub-hotspot id the player emits (`parent.id::<hotspot.id>` or
+	 * `parent.id::p<productId>`):
+	 *  - a sub that appears this save (and was not present before) gets
+	 *    added_at=today and a cleared deleted_at (covers re-adds too);
+	 *  - a sub that disappears gets deleted_at=today.
+	 * A sub that is unchanged is left untouched, and a pre-existing sub never
+	 * touched after this ships gets NO entry at all — the service treats a
+	 * sub absent from the map as "full history" (open-ended), so historical
+	 * content is not retroactively truncated. The map is stored back into
+	 * rtgodam_meta['layer_lifetimes'] and survives deletion (a removed sub is
+	 * gone from layers[] but its lifetime row must persist). Dates are UTC
+	 * Y-m-d to match the service's daily buckets.
+	 *
+	 * @param int   $post_id Attachment ID.
+	 * @param mixed $value   Incoming rtgodam_meta value being saved.
+	 * @return mixed The value with an updated `layer_lifetimes` map.
+	 */
+	private function record_layer_lifetimes( $post_id, $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$old_meta = get_post_meta( $post_id, 'rtgodam_meta', true );
+
+		// The authoritative existing map is read from storage, never trusted
+		// from the incoming $value (the editor does not manage this field).
+		$lifetimes = ( is_array( $old_meta ) && ! empty( $old_meta['layer_lifetimes'] ) && is_array( $old_meta['layer_lifetimes'] ) )
+			? $old_meta['layer_lifetimes']
+			: array();
+
+		$old_ids = $this->collect_subhotspot_ids( is_array( $old_meta ) ? ( $old_meta['layers'] ?? array() ) : array() );
+		$new_ids = $this->collect_subhotspot_ids( $value['layers'] ?? array() );
+
+		$today = gmdate( 'Y-m-d' );
+
+		// Appeared this save (new or re-added) -> start a fresh live window.
+		foreach ( $new_ids as $id ) {
+			if ( ! in_array( $id, $old_ids, true ) ) {
+				$lifetimes[ $id ] = array(
+					'added_at'   => $today,
+					'deleted_at' => null,
+				);
+			}
+		}
+
+		// Disappeared this save -> stamp deleted_at once, keep the row.
+		foreach ( $old_ids as $id ) {
+			if ( ! in_array( $id, $new_ids, true ) && empty( $lifetimes[ $id ]['deleted_at'] ) ) {
+				if ( empty( $lifetimes[ $id ] ) ) {
+					$lifetimes[ $id ] = array( 'added_at' => null );
+				}
+				$lifetimes[ $id ]['deleted_at'] = $today;
+			}
+		}
+
+		if ( ! empty( $lifetimes ) ) {
+			$value['layer_lifetimes'] = $lifetimes;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Build the set of composite sub-hotspot ids present in a layers array,
+	 * matching the ids the player emits and the analytics service keys on:
+	 * `parent.id::<hotspot.id>` for hotspot layers and `parent.id::p<productId>`
+	 * for woo layers. Atomic layer types (cta/form/poll) have no sub-hotspots
+	 * and are skipped.
+	 *
+	 * @param mixed $layers Layers array from rtgodam_meta.
+	 * @return string[] Unique composite sub-hotspot ids.
+	 */
+	private function collect_subhotspot_ids( $layers ) {
+		$ids = array();
+		if ( ! is_array( $layers ) ) {
+			return $ids;
+		}
+		foreach ( $layers as $layer ) {
+			if ( empty( $layer['id'] ) || empty( $layer['type'] ) ) {
+				continue;
+			}
+			$parent = (string) $layer['id'];
+			if ( 'hotspot' === $layer['type'] && ! empty( $layer['hotspots'] ) && is_array( $layer['hotspots'] ) ) {
+				foreach ( $layer['hotspots'] as $hotspot ) {
+					if ( ! empty( $hotspot['id'] ) ) {
+						$ids[] = $parent . '::' . (string) $hotspot['id'];
+					}
+				}
+			} elseif ( 'woo' === $layer['type'] && ! empty( $layer['productHotspots'] ) && is_array( $layer['productHotspots'] ) ) {
+				foreach ( $layer['productHotspots'] as $product ) {
+					if ( ! empty( $product['productId'] ) ) {
+						$ids[] = $parent . '::p' . (int) $product['productId'];
+					}
+				}
+			}
+		}
+		return array_values( array_unique( $ids ) );
 	}
 }

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -422,12 +422,11 @@ export function groupRows( rows, layerType, configIndex ) {
 		const subHotspots = bucket.subRows
 			.map( ( { row, md }, idx ) => {
 				const counts = pluckCounts( row );
-				const noAction = computeNoAction( layerType, {
-					...counts,
-					// Sub-hotspots inherit viewed from the parent (all sub-
-					// hotspots in one layer become visible together).
-					viewed: parentCounts.viewed,
-				} );
+				// Use the server's per-sub `viewed`: it inherits the parent's
+				// impression, sliced to the sub's lifetime when the proxy
+				// forwards a lifetime map (#196), else the full range — identical
+				// to the parent's count until the map is populated.
+				const noAction = computeNoAction( layerType, counts );
 				// Per-sub conversion comes from the server: the sub's converting
 				// sessions over the PARENT's viewed (subs don't emit their own
 				// viewed), a UNION over the layer type's conversion actions — so
@@ -474,11 +473,10 @@ export function groupRows( rows, layerType, configIndex ) {
 				return {
 					id: subId,
 					name: subName,
-					counts: {
-						...counts,
-						// Inherit viewed; per-sub viewed isn't emitted anymore.
-						viewed: parentCounts.viewed,
-					},
+					// `viewed` is the server's per-sub value: the parent's
+					// impression, sliced to the sub's lifetime when a lifetime
+					// map is forwarded (#196), else the full range.
+					counts,
 					no_action: noAction,
 					conversion_rate: conversion,
 					product_id: md.product_id || null,


### PR DESCRIPTION
WordPress companion for **rtCamp/godam-analytics#196** (analytics side: rtCamp/godam-analytics#209). Implements **direction (b)** — record per-sub-hotspot lifetimes and forward them so the analytics service credits a sub's inherited `viewed` only for the days it actually existed.

## Problem
Sub-hotspots (hotspot items / Woo product hotspots) don't emit their own `viewed` — the parent layer fires one impression per session and the service copies the parent's **full-range** `viewed` onto every sub. So a **deleted** sub keeps gaining Views forever, and a **newly added** sub instantly shows Views from before it existed.

## What this PR does (3 coupled changes)
1. **Record lifetimes on save** — `class-meta-rest-fields.php`: the `rtgodam_meta` update_callback now diffs old-vs-new layers and records `added_at`/`deleted_at` per composite sub id (`parent::hotspot.id` / `parent::p<productId>`, matching what the player emits) into `rtgodam_meta['layer_lifetimes']`.
   - A sub that **appears** this save → `added_at = today` (covers re-adds).
   - A sub that **disappears** → `deleted_at = today` (the row persists past deletion).
   - A **pre-existing, untouched** sub gets **no entry** → the service treats it as full-history, so historical content is **not** retroactively truncated.
   - Dates are UTC `Y-m-d` to match the service's daily buckets.
2. **Forward the map** — `class-analytics.php`: for `hotspot`/`woo` layer types the proxy POSTs the lifetime map (JSON body) to `/processed-layer-analytics/`, preserving the existing query params + 3s timeout + soft-error handling. Atomic types (cta/form/poll) keep the GET path.
3. **Use the server's sliced `viewed`** — `useVideoLayerData.js`: the dashboard hook stops re-inheriting the parent's full-range `viewed` onto sub rows client-side (which would have undone the slice) and uses the server's per-sub value.

## Safety / sequencing
- **Forward-compatible & no-op until both sides are live:** a sub absent from the map = full history; and a service **without** rtCamp/godam-analytics#209 simply ignores the POST body (query params still apply). Change 3 is a no-op against today's service (sub `viewed` already equals the parent's) and only takes effect once the map + #209 are live.
- Recommended order: ship the analytics side (#209) first or together, then this.

## Scope
WooCommerce product hotspots are stored in **this plugin's** `rtgodam_meta` and saved through this plugin's pipeline, so **godam-for-woo needs no change** for direction (b). (Direction (c) — `active_subs` on the emitted event — is the only thing that would touch godam-for-woo; not in scope here.)

## Testing notes
No PHPUnit harness in this repo. Manual: create a hotspot/Woo layer with ≥2 subs, save; delete one sub, save → `rtgodam_meta['layer_lifetimes']` gets a `deleted_at` for it; add a new sub, save → it gets `added_at`. With #209 deployed, the removed sub's Views stop climbing and the new sub no longer shows pre-existence Views.
