### PR TITLE
Update migration version to 1.12.2 and add new migration classes

### DIFF
--- a/inc/classes/migrations/class-runner.php
+++ b/inc/classes/migrations/class-runner.php
@@ -105,7 +105,7 @@ class Runner {
 			Gallery_V1_To_V2::class,
 			Godam_Cpt_Cleanup::class,
 		),
-		'1.12.0' => array(
+		'1.12.2' => array(
 			Elementor_Gallery_Widget_V1_To_V2::class,
 			WPBakery_Gallery_Shortcode_V1_To_V2::class,
 		),


### PR DESCRIPTION
This pull request makes a minor update to the migration runner by changing the version key for a set of migrations from '1.12.0' to '1.12.2' in the `Runner` class. This likely ensures that these migrations are associated with the correct plugin version.

- Changed the migration version key from `'1.12.0'` to `'1.12.2'` in the `Runner` class to properly align migrations with the intended release.