### PR TITLE
Add E2E data-test-ids for Elementor + WPBakery blocks

### DIFF
--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -38,7 +38,7 @@ $godam_block_wrapper_attributes = get_block_wrapper_attributes();
 $godam_css_classes              = trim( $godam_block_wrapper_attributes . ' ' . $godam_css_class );
 ?>
 
-<figure <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => $godam_css_classes ) ) ); ?>>
+<figure data-test-id="godam-audio-render" <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => $godam_css_classes ) ) ); ?>>
 	<audio style="display: block; width: 100%;" controls <?php echo esc_attr( $godam_autoplay ); ?> <?php echo esc_attr( $godam_loop ); ?> preload="<?php echo esc_attr( $godam_preload ); ?>">
 		<?php if ( ! empty( $godam_primary_audio ) ) : ?>
 			<source src="<?php echo esc_url( $godam_primary_audio ); ?>" type="audio/mpeg" />

--- a/assets/src/js/wpbakery/wpbakery-audio-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-audio-selector-param.js
@@ -42,7 +42,7 @@
 				// Add or update preview
 				let $preview = $container.find( '.audio-selector-preview' );
 				if ( $preview.length === 0 ) {
-					$preview = $( '<div class="audio-selector-preview" style="margin-top: 10px;"></div>' );
+					$preview = $( '<div class="audio-selector-preview" data-test-id="godam-wpb-preview-audio" style="margin-top: 10px;"></div>' );
 					$container.append( $preview );
 				}
 
@@ -56,7 +56,7 @@
 				const $buttonsWrapper = $container.find( '.audio_selector-buttons-wrapper' );
 				let $removeButton = $buttonsWrapper.find( '.audio-selector-remove' );
 				if ( $removeButton.length === 0 ) {
-					$removeButton = $( '<button class="button audio-selector-remove" data-param="' + paramName + '" style="margin-left: 5px;">Remove</button>' );
+					$removeButton = $( '<button class="button audio-selector-remove" data-test-id="godam-wpb-button-remove-audio" data-param="' + paramName + '" style="margin-left: 5px;">Remove</button>' );
 					$buttonsWrapper.append( $removeButton );
 				}
 

--- a/assets/src/js/wpbakery/wpbakery-video-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-video-selector-param.js
@@ -92,7 +92,7 @@ import { stripHtmlTags } from '../../blocks/godam-player/utils/index.js';
 
 			let $preview = $container.find( '.video-selector-preview' );
 			if ( $preview.length === 0 ) {
-				$preview = $( '<div class="video-selector-preview" style="margin-top: 10px;"></div>' );
+				$preview = $( '<div class="video-selector-preview" data-test-id="godam-wpb-preview-video" style="margin-top: 10px;"></div>' );
 				$container.append( $preview );
 			}
 
@@ -107,7 +107,7 @@ import { stripHtmlTags } from '../../blocks/godam-player/utils/index.js';
 			const $buttonsWrapper = $container.find( '.video_selector-buttons-wrapper' );
 			if ( 0 === $buttonsWrapper.find( '.video-selector-remove' ).length ) {
 				$buttonsWrapper.append(
-					'<button type="button" class="button video-selector-remove" data-param="' + paramName + '" style="margin-left: 5px;">' +
+					'<button type="button" class="button video-selector-remove" data-test-id="godam-wpb-button-remove-video" data-param="' + paramName + '" style="margin-left: 5px;">' +
 					__( 'Remove', 'godam' ) +
 					'</button>',
 				);
@@ -342,7 +342,7 @@ import { stripHtmlTags } from '../../blocks/godam-player/utils/index.js';
 
 				let $preview = $container.find( '.video-selector-preview' );
 				if ( $preview.length === 0 ) {
-					$preview = $( '<div class="video-selector-preview" style="margin-top: 10px;"></div>' );
+					$preview = $( '<div class="video-selector-preview" data-test-id="godam-wpb-preview-video" style="margin-top: 10px;"></div>' );
 					$container.append( $preview );
 				}
 
@@ -358,7 +358,7 @@ import { stripHtmlTags } from '../../blocks/godam-player/utils/index.js';
 
 				let $removeButton = $buttonsWrapper.find( '.video-selector-remove' );
 				if ( $removeButton.length === 0 ) {
-					$removeButton = $( `<button type="button" class="button video-selector-remove" style="margin-left: 5px;">${ __( 'Remove', 'godam' ) }</button>` );
+					$removeButton = $( `<button type="button" class="button video-selector-remove" data-test-id="godam-wpb-button-remove-video" style="margin-left: 5px;">${ __( 'Remove', 'godam' ) }</button>` );
 					$buttonsWrapper.append( $removeButton );
 				}
 			} );

--- a/inc/classes/elementor-controls/class-godam-media.php
+++ b/inc/classes/elementor-controls/class-godam-media.php
@@ -160,7 +160,7 @@ class Godam_Media extends \Elementor\Base_Data_Control {
 				<div class="{{{ inputWrapperClasses }}}"><?php // phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
 					<div class="elementor-control-media__content elementor-control-tag-area elementor-control-preview-area">
 						<div class="elementor-control-media-area">
-							<div class="elementor-control-media__remove elementor-control-media__content__remove" data-tooltip="<?php echo esc_attr__( 'Remove', 'godam' ); ?>">
+							<div class="elementor-control-media__remove elementor-control-media__content__remove" data-test-id="godam-media-button-remove" data-tooltip="<?php echo esc_attr__( 'Remove', 'godam' ); ?>">
 								<i class="eicon-trash-o" aria-hidden="true"></i>
 								<span class="elementor-screen-only"><?php echo esc_html__( 'Remove', 'godam' ); ?></span>
 							</div>
@@ -168,20 +168,20 @@ class Godam_Media extends \Elementor\Base_Data_Control {
 								switch( getPreviewType() ) {
 									case 'image':
 										#>
-										<div class="elementor-control-media__preview"></div>
+										<div class="elementor-control-media__preview" data-test-id="godam-media-preview"></div>
 										<#
 										break;
 
 									case 'video':
 										#>
-										<video class="elementor-control-media-video" preload="metadata"></video>
+										<video class="elementor-control-media-video" data-test-id="godam-media-preview" preload="metadata"></video>
 										<i class="eicon-video-camera" aria-hidden="true"></i>
 										<#
 										break;
 								}
 							#>
 						</div>
-						<div class="elementor-control-media-upload-button elementor-control-media__content__upload-button">
+						<div class="elementor-control-media-upload-button elementor-control-media__content__upload-button" data-test-id="godam-media-button-select">
 							<i class="eicon-plus-circle" aria-hidden="true"></i>
 							<span class="elementor-screen-only"><?php echo esc_html__( 'Add', 'godam' ); ?></span>
 						</div>
@@ -208,11 +208,11 @@ class Godam_Media extends \Elementor\Base_Data_Control {
 						</div>
 					</div>
 					<div class="elementor-control-media__file__controls">
-						<div class="elementor-control-media__remove elementor-control-media__file__controls__remove" data-tooltip="<?php echo esc_attr__( 'Remove', 'godam' ); ?>">
+						<div class="elementor-control-media__remove elementor-control-media__file__controls__remove" data-test-id="godam-media-button-remove" data-tooltip="<?php echo esc_attr__( 'Remove', 'godam' ); ?>">
 							<i class="eicon-trash-o" aria-hidden="true"></i>
 							<span class="elementor-screen-only"><?php echo esc_html__( 'Remove', 'godam' ); ?></span>
 						</div>
-						<div class="elementor-control-media__file__controls__upload-button elementor-control-media-upload-button" data-tooltip="<?php echo esc_attr__( 'Upload', 'godam' ); ?>">
+						<div class="elementor-control-media__file__controls__upload-button elementor-control-media-upload-button" data-test-id="godam-media-button-select" data-tooltip="<?php echo esc_attr__( 'Upload', 'godam' ); ?>">
 							<i class="eicon-upload" aria-hidden="true"></i>
 							<span class="elementor-screen-only"><?php echo esc_html__( 'Upload', 'godam' ); ?></span>
 						</div>

--- a/inc/classes/elementor-widgets/class-godam-audio.php
+++ b/inc/classes/elementor-widgets/class-godam-audio.php
@@ -176,7 +176,7 @@ class Godam_Audio extends Base {
 		}
 		?>
 
-		<figure class="elementor-godam-audio">
+		<figure class="elementor-godam-audio" data-test-id="godam-audio-render">
 			<audio controls <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $loop ); ?> preload="<?php echo esc_attr( $preload ); ?>">
 				<?php foreach ( $sources as $source ) : ?>
 					<source src="<?php echo esc_url( $source['src'] ); ?>" type="<?php echo esc_attr( $source['type'] ); ?>" />

--- a/inc/classes/wpbakery-elements/class-wpb-godam-params.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-params.php
@@ -89,21 +89,21 @@ class WPB_GoDAM_Params {
 		if ( ! empty( $value ) && is_numeric( $value ) ) {
 			$attachment = wp_get_attachment_url( $value );
 			if ( $attachment ) {
-				$preview_html  = '<div class="video-selector-preview" style="margin-top: 10px;">
+				$preview_html  = '<div class="video-selector-preview" data-test-id="godam-wpb-preview-video" style="margin-top: 10px;">
 					<video width="100%" height="auto" controls style="max-width: 300px;">
 						<source src="' . esc_url( $attachment ) . '" type="video/mp4">
 					</video>
 				</div>';
-				$remove_button = '<button type="button" class="button video-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
+				$remove_button = '<button type="button" class="button video-selector-remove" data-test-id="godam-wpb-button-remove-video" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
 			}
 		}
 
 		return '<div class="video_selector_block">'
-			. '<input name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput video_selector_field ' .
+			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-video" class="wpb_vc_param_value wpb-textinput video_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
 			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'
 			. '<div class="video_selector-buttons-wrapper" style="display: flex; align-items: center;">'
-			. '<button type="button" class="button video-selector-button" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
+			. '<button type="button" class="button video-selector-button" data-test-id="godam-wpb-button-select-video" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
 			. $remove_button
 			. '</div>'
 			. $preview_html
@@ -128,21 +128,21 @@ class WPB_GoDAM_Params {
 		if ( ! empty( $value ) && is_numeric( $value ) ) {
 			$attachment = wp_get_attachment_url( $value );
 			if ( $attachment ) {
-				$preview_html  = '<div class="audio-selector-preview" style="margin-top: 10px;">
+				$preview_html  = '<div class="audio-selector-preview" data-test-id="godam-wpb-preview-audio" style="margin-top: 10px;">
 					<audio controls style="max-width: 300px; width: 100%;">
 						<source src="' . esc_url( $attachment ) . '" type="audio/mpeg">
 					</audio>
 				</div>';
-				$remove_button = '<button type="button" class="button audio-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
+				$remove_button = '<button type="button" class="button audio-selector-remove" data-test-id="godam-wpb-button-remove-audio" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
 			}
 		}
 
 		return '<div class="audio_selector_block">'
-			. '<input name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput audio_selector_field ' .
+			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-audio" class="wpb_vc_param_value wpb-textinput audio_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
 			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'
 			. '<div class="audio_selector-buttons-wrapper" style="display: flex; align-items: center;">'
-			. '<button type="button" class="button audio-selector-button" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
+			. '<button type="button" class="button audio-selector-button" data-test-id="godam-wpb-button-select-audio" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
 			. $remove_button
 			. '</div>'
 			. $preview_html
@@ -165,18 +165,18 @@ class WPB_GoDAM_Params {
 		
 		// If an image is selected, show preview and remove button.
 		if ( ! empty( $value ) ) {
-			$preview_html  = '<div class="image-src-selector-preview" style="margin-top: 10px;">
+			$preview_html  = '<div class="image-src-selector-preview" data-test-id="godam-wpb-preview-image" style="margin-top: 10px;">
                 <img src="' . esc_url( $value ) . '" alt="" style="max-width: 300px; height: auto;" />
             </div>';
-			$remove_button = '<button type="button" class="button image-src-selector-remove" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
+			$remove_button = '<button type="button" class="button image-src-selector-remove" data-test-id="godam-wpb-button-remove-image" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
 		}
 
 		return '<div class="image_src_selector_block">'
-			. '<input name="' . esc_attr( $settings['param_name'] ) . '" class="wpb_vc_param_value wpb-textinput image_src_selector_field ' .
+			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-image" class="wpb_vc_param_value wpb-textinput image_src_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
 			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'
 			. '<div class="image_src_selector-buttons-wrapper" style="display: flex; align-items: center;">'
-			. '<button type="button" class="button image-src-selector-button" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
+			. '<button type="button" class="button image-src-selector-button" data-test-id="godam-wpb-button-select-image" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
 			. $remove_button
 			. '</div>'
 			. $preview_html

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -683,7 +683,7 @@ if ( empty( $godam_attachment_title ) ) {
 				</div>
 				<?php endif; ?>
 
-				<div class="easydam-video-container loading <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>" >
+				<div class="easydam-video-container loading <?php echo esc_attr( 'godam-' . strtolower( $godam_player_skin ) . '-skin' ); ?>" data-test-id="godam-video-render" >
 					<?php if ( isset( $godam_hover_select ) && 'shadow-overlay' === $godam_hover_select ) : ?>
 						<div class="godam-player-overlay"></div>
 					<?php endif; ?>

--- a/inc/templates/godam-video-gallery.php
+++ b/inc/templates/godam-video-gallery.php
@@ -373,7 +373,7 @@ if ( 'query' === $godam_gallery_mode ) {
 }
 
 ?>
-<div <?php echo wp_kses_data( $godam_wrapper_attributes ); ?>>
+<div data-test-id="godam-gallery-render" <?php echo wp_kses_data( $godam_wrapper_attributes ); ?>>
 	<div class="<?php echo esc_attr( sprintf( 'godam-gallery-v2__canvas godam-gallery-v2__canvas--%s', $godam_layout ) ); ?>">
 		<?php if ( empty( $godam_items ) && 'query' === $godam_gallery_mode ) : ?>
 			<div class="godam-gallery-v2__state">


### PR DESCRIPTION
## What

Adds stable `data-test-id` hooks to the GoDAM page-builder integrations so the Playwright E2E suite can drive the **Elementor** and **WPBakery** blocks (video, audio, gallery) with strict test-ids — no class/text workarounds — and assert the shared frontend renders.

## Editor test-ids

**WPBakery custom params** (`class-wpb-godam-params.php` + the video/audio selector JS) — for the video, audio, and image-src pickers:
- `godam-wpb-button-select-{video,audio,image}` — the "Select …" button
- `godam-wpb-input-{video,audio,image}` — the hidden value input
- `godam-wpb-preview-{video,audio,image}` / `godam-wpb-button-remove-{video,audio}` — preview + remove (PHP-rendered and the JS re-render path)

**Elementor `godam-media` control** (`class-godam-media.php` `content_template`):
- `godam-media-button-select`, `godam-media-preview`, `godam-media-button-remove` — added to **both** the viewable (video/image) and file (audio) branches.
- The control is shared across `video-file` / `poster` / `audio-file`, so consumers scope by the Elementor control wrapper `.elementor-control-<setting>`.

## Render test-ids (shared across Gutenberg + both builders)

- `godam-video-render` — player container (`godam-player.php`)
- `godam-audio-render` — audio `<figure>` (shared `render.php` + Elementor inline audio)
- `godam-gallery-render` — gallery wrapper (`godam-video-gallery.php`)

## Notes
- Additive only — no behavior change. PHP lints clean.
- The WPBakery selector JS (`.min.js`) needs a build for the JS-side test-ids to ship; the PHP-rendered ones apply without a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)