### PR TITLE
fix(gallery-v2): hover play, first-frame thumbs, play button toggle, sequential autoplay, load-more parity

### DIFF
--- a/assets/src/blocks/godam-gallery-v2-item/edit.js
+++ b/assets/src/blocks/godam-gallery-v2-item/edit.js
@@ -220,6 +220,50 @@ export default function Edit( { attributes, setAttributes, context, clientId } )
 				</div>
 			</>
 		);
+	} else if ( videoId ) {
+		// Video selected but no thumbnail yet — show a generic video placeholder
+		// with the title so the editor tile looks populated, not empty.
+		previewContent = (
+			<>
+				<div className="godam-gallery-v2-item__placeholder godam-gallery-v2-item__placeholder--no-thumb">
+					{ videoIcon }
+				</div>
+				<div className="godam-gallery-v2-item__preview-overlay">
+					<MediaUploadCheck>
+						<MediaUpload
+							onSelect={ onSelectVideo }
+							allowedTypes={ [ 'video' ] }
+							value={ videoId }
+							render={ ( { open: openMediaModal } ) => (
+								<Button
+									variant="secondary"
+									icon={ pencil }
+									className="godam-gallery-v2-item__overlay-action"
+									onClick={ ( event ) => {
+										event.stopPropagation();
+										openMediaModal();
+									} }
+								>
+									{ __( 'Replace', 'godam' ) }
+								</Button>
+							) }
+						/>
+					</MediaUploadCheck>
+					<Button
+						variant="secondary"
+						icon={ closeSmall }
+						isDestructive
+						className="godam-gallery-v2-item__overlay-action"
+						onClick={ ( event ) => {
+							event.stopPropagation();
+							removeBlock( clientId );
+						} }
+					>
+						{ __( 'Remove', 'godam' ) }
+					</Button>
+				</div>
+			</>
+		);
 	} else {
 		previewContent = (
 			<div className="godam-gallery-v2-item__placeholder">

--- a/assets/src/blocks/godam-gallery-v2/block.json
+++ b/assets/src/blocks/godam-gallery-v2/block.json
@@ -79,6 +79,18 @@
 		"engagements": {
 			"type": "boolean",
 			"default": true
+		},
+		"autoplay": {
+			"type": "boolean",
+			"default": false
+		},
+		"playOnHover": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPlayButton": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"providesContext": {

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
+	RadioControl,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
@@ -21,16 +22,34 @@ import {
 	Popover,
 	Notice,
 	Spinner,
+	Button,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
-	Button,
 } from '@wordpress/components';
 import { useDispatch, useSelect, select as dataSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
-import { columns, grid, listView, plus } from '@wordpress/icons';
+import { columns, grid, listView, plus, trash } from '@wordpress/icons';
+
+/**
+ * External dependencies
+ */
+import {
+	DndContext,
+	closestCenter,
+	PointerSensor,
+	useSensor,
+	useSensors,
+	DragOverlay,
+} from '@dnd-kit/core';
+import {
+	SortableContext,
+	verticalListSortingStrategy,
+	useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 /**
  * Internal dependencies
@@ -38,13 +57,10 @@ import { columns, grid, listView, plus } from '@wordpress/icons';
 import './editor.scss';
 
 const ALLOWED_BLOCKS = [ 'godam/gallery-v2-item' ];
-const performanceModeOptions = [
-	{ label: __( 'Balanced', 'godam' ), value: 'balanced' },
-	{ label: __( 'Priority', 'godam' ), value: 'priority' },
-];
+
 const performanceModeHelpText = {
-	balanced: __( 'Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it. Best for overall page performance.', 'godam' ),
-	priority: __( 'For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly - one or two per page.', 'godam' ),
+	balanced: __( 'Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it.', 'godam' ),
+	priority: __( 'For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly.', 'godam' ),
 };
 
 const formatDisplayDate = ( dateString ) => {
@@ -126,8 +142,12 @@ const getPreviewQueryArgs = ( attributes ) => {
 		customDateEnd,
 	} = attributes;
 
-	const mediaFolderIds = parseIdList( mediaFolder ).map( ( value ) => parseInt( value, 10 ) ).filter( ( value ) => ! Number.isNaN( value ) && value > 0 );
-	const authorIds = parseIdList( author ).map( ( value ) => parseInt( value, 10 ) ).filter( ( value ) => ! Number.isNaN( value ) && value > 0 );
+	const mediaFolderIds = parseIdList( mediaFolder )
+		.map( ( value ) => parseInt( value, 10 ) )
+		.filter( ( value ) => ! Number.isNaN( value ) && value > 0 );
+	const authorIds = parseIdList( author )
+		.map( ( value ) => parseInt( value, 10 ) )
+		.filter( ( value ) => ! Number.isNaN( value ) && value > 0 );
 	const queryArgs = {
 		per_page: count,
 		orderby,
@@ -169,6 +189,99 @@ const getPreviewQueryArgs = ( attributes ) => {
 	return queryArgs;
 };
 
+// ── Video list item in inspector panel ───────────────────────────────────────
+
+function VideoListItemContent( { block, onRemove, dragHandleProps = {}, isDragging = false } ) {
+	const { media } = useSelect(
+		( select ) => {
+			const videoId = block.attributes?.videoId;
+			if ( ! videoId ) {
+				return { media: null };
+			}
+			return { media: select( coreStore ).getMedia( videoId ) };
+		},
+		[ block.attributes?.videoId ],
+	);
+
+	const thumbnail = getVideoThumbnail( media );
+	const title = media?.title?.rendered || __( 'Loading…', 'godam' );
+	const date = formatDisplayDate( media?.date );
+
+	return (
+		<div className={ `godam-gallery-v2__video-item${ isDragging ? ' is-dragging' : '' }` }>
+			<span
+				className="godam-gallery-v2__drag-handle"
+				{ ...dragHandleProps }
+			>
+				<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<circle cx="6.5" cy="5" r="1.5" fill="currentColor" />
+					<circle cx="11.5" cy="5" r="1.5" fill="currentColor" />
+					<circle cx="6.5" cy="9" r="1.5" fill="currentColor" />
+					<circle cx="11.5" cy="9" r="1.5" fill="currentColor" />
+					<circle cx="6.5" cy="13" r="1.5" fill="currentColor" />
+					<circle cx="11.5" cy="13" r="1.5" fill="currentColor" />
+				</svg>
+			</span>
+			<div className="godam-gallery-v2__video-thumb-wrap">
+				{ thumbnail ? (
+					<img
+						src={ thumbnail }
+						alt=""
+						className="godam-gallery-v2__video-thumb"
+					/>
+				) : (
+					<span className="dashicons dashicons-video-alt2 godam-gallery-v2__video-thumb-fallback" />
+				) }
+			</div>
+			<div className="godam-gallery-v2__video-meta">
+				<span className="godam-gallery-v2__video-name" title={ title }>
+					{ title }
+				</span>
+				{ date && (
+					<span className="godam-gallery-v2__video-date">{ date }</span>
+				) }
+			</div>
+			<Button
+				icon={ trash }
+				label={ __( 'Remove', 'godam' ) }
+				isDestructive
+				size="small"
+				onClick={ onRemove }
+			/>
+		</div>
+	);
+}
+
+function VideoListItem( { block, onRemove } ) {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable( { id: block.clientId } );
+
+	const style = {
+		transform: CSS.Transform.toString( transform ),
+		transition,
+		opacity: isDragging ? 0.4 : 1,
+	};
+
+	return (
+		<div ref={ setNodeRef } style={ style }>
+			<VideoListItemContent
+				block={ block }
+				onRemove={ onRemove }
+				dragHandleProps={ { ...attributes, ...listeners } }
+				isDragging={ isDragging }
+			/>
+		</div>
+	);
+}
+
+// ── AddVideoAppender used inside canvas ──────────────────────────────────────
+
 const AddVideoAppender = ( { onSelect } ) => (
 	<MediaUploadCheck>
 		<MediaUpload
@@ -190,6 +303,8 @@ const AddVideoAppender = ( { onSelect } ) => (
 	</MediaUploadCheck>
 );
 
+// ── Main Edit component ───────────────────────────────────────────────────────
+
 export default function Edit( { attributes, setAttributes, clientId } ) {
 	const {
 		mode,
@@ -210,39 +325,80 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		layout,
 		performanceMode,
 		engagements,
+		autoplay,
+		showPlayButton,
 	} = attributes;
+
 	const engagementFeatureEnabled = window?.godamSettings?.engagementFeatureEnabled ?? false;
-	const showEngagementSetting = engagementFeatureEnabled && ( window?.godamSettings?.enableGlobalVideoEngagement ?? false );
+	const showEngagementSetting =
+		engagementFeatureEnabled && ( window?.godamSettings?.enableGlobalVideoEngagement ?? false );
+
 	const [ startDatePopoverOpen, setStartDatePopoverOpen ] = useState( false );
 	const [ endDatePopoverOpen, setEndDatePopoverOpen ] = useState( false );
 	const [ dateError, setDateError ] = useState( '' );
-	const { insertBlocks, updateBlockAttributes, removeBlock } = useDispatch( blockEditorStore );
+
+	const { insertBlocks, updateBlockAttributes, removeBlock, moveBlockToPosition } = useDispatch( blockEditorStore );
 	const { createNotice } = useDispatch( noticesStore );
 
-	// Tracks {virtualId, blockClientId} pairs for GoDAM virtual insertions
-	// so the godam-virtual-attachment-created event can update the correct block.
 	const pendingVirtualInserts = useRef( [] );
 
-	const { mediaFolders, authors, queryPreviewVideos, wasJustInserted } = useSelect(
-		( select ) => {
-			const coreSelect = select( coreStore );
-			const blockEditorSelect = select( blockEditorStore );
-			const queryArgs = getPreviewQueryArgs( attributes );
+	const { mediaFolders, authors, queryPreviewVideos, wasJustInserted, handpickedBlocks } =
+		useSelect(
+			( select ) => {
+				const coreSelect = select( coreStore );
+				const blockEditorSelect = select( blockEditorStore );
+				const queryArgs = getPreviewQueryArgs( attributes );
 
-			return {
-				mediaFolders: coreSelect.getEntityRecords( 'taxonomy', 'media-folder', { per_page: -1 } ),
-				authors: coreSelect.getUsers( { per_page: -1 } ),
-				queryPreviewVideos:
-					mode === 'query'
-						? coreSelect.getEntityRecords( 'postType', 'attachment', queryArgs )
-						: [],
-				wasJustInserted:
-					blockEditorSelect.wasBlockJustInserted( clientId, 'inserter' ) ||
-					blockEditorSelect.wasBlockJustInserted( clientId, 'directInsert' ) ||
-					blockEditorSelect.wasBlockJustInserted( clientId, 'transform' ),
-			};
+				return {
+					mediaFolders: coreSelect.getEntityRecords( 'taxonomy', 'media-folder', {
+						per_page: -1,
+					} ),
+					authors: coreSelect.getUsers( { per_page: -1 } ),
+					queryPreviewVideos:
+						mode === 'query'
+							? coreSelect.getEntityRecords( 'postType', 'attachment', queryArgs )
+							: [],
+					wasJustInserted:
+						blockEditorSelect.wasBlockJustInserted( clientId, 'inserter' ) ||
+						blockEditorSelect.wasBlockJustInserted( clientId, 'directInsert' ) ||
+						blockEditorSelect.wasBlockJustInserted( clientId, 'transform' ),
+					handpickedBlocks:
+						mode === 'handpicked'
+							? ( blockEditorSelect.getBlocks( clientId ) || [] )
+							: [],
+				};
+			},
+			[ attributes, clientId, mode ],
+		);
+
+	// ── Drag-and-drop (defined after useSelect so handpickedBlocks is in scope) ──
+
+	const [ activeId, setActiveId ] = useState( null );
+
+	const sensors = useSensors(
+		useSensor( PointerSensor, {
+			activationConstraint: { distance: 5 },
+		} ),
+	);
+
+	const handleDragStart = useCallback( ( { active } ) => {
+		setActiveId( active.id );
+	}, [] );
+
+	const handleDragEnd = useCallback(
+		( { active, over } ) => {
+			setActiveId( null );
+			if ( ! over || active.id === over.id ) {
+				return;
+			}
+			const oldIndex = handpickedBlocks.findIndex( ( b ) => b.clientId === active.id );
+			const newIndex = handpickedBlocks.findIndex( ( b ) => b.clientId === over.id );
+			if ( oldIndex === -1 || newIndex === -1 ) {
+				return;
+			}
+			moveBlockToPosition( active.id, clientId, clientId, newIndex );
 		},
-		[ attributes, clientId, mode ],
+		[ handpickedBlocks, clientId, moveBlockToPosition ],
 	);
 
 	useEffect( () => {
@@ -260,14 +416,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			moreItemsBehavior: 'button',
 			infiniteScroll: false,
 		} );
-	}, [
-		enableMoreItems,
-		infiniteScroll,
-		mode,
-		moreItemsBehavior,
-		setAttributes,
-		wasJustInserted,
-	] );
+	}, [ enableMoreItems, infiniteScroll, mode, moreItemsBehavior, setAttributes, wasJustInserted ] );
 
 	const resolvedEnableMoreItems =
 		typeof enableMoreItems === 'boolean' ? enableMoreItems : true;
@@ -277,7 +426,10 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			? 'infinite'
 			: moreItemsBehavior || ( infiniteScroll ? 'infinite' : 'button' );
 
-	const updateMoreItemsSettings = ( nextEnableMoreItems, nextBehavior = resolvedMoreItemsBehavior ) => {
+	const updateMoreItemsSettings = (
+		nextEnableMoreItems,
+		nextBehavior = resolvedMoreItemsBehavior,
+	) => {
 		const behavior =
 			isCarouselLayout && nextEnableMoreItems ? 'infinite' : nextBehavior;
 
@@ -346,7 +498,10 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const selectedMediaFolderToken = useMemo(
 		() =>
 			parseIdList( mediaFolder )
-				.map( ( id ) => mediaFolderOptions.find( ( option ) => option.id === id )?.value )
+				.map(
+					( id ) =>
+						mediaFolderOptions.find( ( option ) => option.id === id )?.value,
+				)
 				.filter( Boolean ),
 		[ mediaFolder, mediaFolderOptions ],
 	);
@@ -354,7 +509,10 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const selectedAuthorToken = useMemo(
 		() =>
 			parseIdList( author )
-				.map( ( id ) => authorOptions.find( ( option ) => `${ option.id }` === id )?.value )
+				.map(
+					( id ) =>
+						authorOptions.find( ( option ) => `${ option.id }` === id )?.value,
+				)
 				.filter( Boolean ),
 		[ author, authorOptions ],
 	);
@@ -371,12 +529,13 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 	const insertHandpickedVideo = useCallback(
 		( mediaItemOrArray ) => {
-			const items = Array.isArray( mediaItemOrArray ) ? mediaItemOrArray : [ mediaItemOrArray ];
+			const items = Array.isArray( mediaItemOrArray )
+				? mediaItemOrArray
+				: [ mediaItemOrArray ];
 			if ( ! items.length ) {
 				return;
 			}
 
-			// Get existing video IDs from inner blocks to prevent duplicates.
 			const { getBlock } = dataSelect( blockEditorStore );
 			const parentBlock = getBlock( clientId );
 			const existingVideoIds = new Set(
@@ -394,7 +553,6 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					return;
 				}
 
-				// Only allow video attachments.
 				if ( mediaItem.type && mediaItem.type !== 'video' ) {
 					skippedNonVideo = true;
 					return;
@@ -405,10 +563,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				}
 
 				const numericId = parseInt( mediaItem.id, 10 );
-				const isVirtual = ! ( numericId > 0 && String( numericId ) === String( mediaItem.id ) );
+				const isVirtual = ! (
+					numericId > 0 && String( numericId ) === String( mediaItem.id )
+				);
 
 				if ( ! isVirtual ) {
-					// Skip if this video is already in the gallery.
 					if ( existingVideoIds.has( numericId ) ) {
 						skippedDuplicate = true;
 						return;
@@ -431,17 +590,19 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			} );
 
 			if ( skippedNonVideo ) {
-				createNotice( 'warning', __( 'Only video files can be added to the gallery.', 'godam' ), {
-					type: 'snackbar',
-					isDismissible: true,
-				} );
+				createNotice(
+					'warning',
+					__( 'Only video files can be added to the gallery.', 'godam' ),
+					{ type: 'snackbar', isDismissible: true },
+				);
 			}
 
 			if ( skippedDuplicate ) {
-				createNotice( 'warning', __( 'Duplicate videos were skipped.', 'godam' ), {
-					type: 'snackbar',
-					isDismissible: true,
-				} );
+				createNotice(
+					'warning',
+					__( 'Duplicate videos were skipped.', 'godam' ),
+					{ type: 'snackbar', isDismissible: true },
+				);
 			}
 
 			if ( newBlocks.length > 0 ) {
@@ -451,8 +612,6 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		[ clientId, createNotice, insertBlocks ],
 	);
 
-	// When GoDAM creates a real WP attachment, find the pending child block
-	// and set its videoId to the actual attachment ID.
 	useEffect( () => {
 		const handleVirtualAttachmentCreated = ( event ) => {
 			const { attachment, virtualMediaId } = event.detail || {};
@@ -470,28 +629,34 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 			const [ { blockClientId } ] = pendingVirtualInserts.current.splice( idx, 1 );
 
-			// Skip if this video already exists in another gallery item.
 			const { getBlock } = dataSelect( blockEditorStore );
 			const parentBlock = getBlock( clientId );
 			const isDuplicate = ( parentBlock?.innerBlocks || [] ).some(
-				( block ) => block.clientId !== blockClientId && block.attributes?.videoId === attachment.id,
+				( block ) =>
+					block.clientId !== blockClientId &&
+					block.attributes?.videoId === attachment.id,
 			);
 			if ( isDuplicate ) {
-				createNotice( 'warning', __( 'Duplicate videos were skipped.', 'godam' ), {
-					type: 'snackbar',
-					isDismissible: true,
-				} );
+				createNotice(
+					'warning',
+					__( 'Duplicate videos were skipped.', 'godam' ),
+					{ type: 'snackbar', isDismissible: true },
+				);
 				removeBlock( blockClientId );
 				return;
 			}
 
 			updateBlockAttributes( blockClientId, { videoId: attachment.id } );
 		};
-
-		document.addEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
-
+		document.addEventListener(
+			'godam-virtual-attachment-created',
+			handleVirtualAttachmentCreated,
+		);
 		return () => {
-			document.removeEventListener( 'godam-virtual-attachment-created', handleVirtualAttachmentCreated );
+			document.removeEventListener(
+				'godam-virtual-attachment-created',
+				handleVirtualAttachmentCreated,
+			);
 		};
 	}, [ clientId, createNotice, removeBlock, updateBlockAttributes ] );
 
@@ -507,16 +672,16 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		}
 
 		const selectedIds = tokens
-			.map( ( token ) =>
-				mediaFolderOptions.find(
-					( option ) => normalizeTokenValue( option.value ) === normalizeTokenValue( token ),
-				)?.id,
+			.map(
+				( token ) =>
+					mediaFolderOptions.find(
+						( option ) =>
+							normalizeTokenValue( option.value ) ===
+							normalizeTokenValue( token ),
+					)?.id,
 			)
 			.filter( Boolean );
-
-		setAttributes( {
-			mediaFolder: selectedIds.join( ',' ),
-		} );
+		setAttributes( { mediaFolder: selectedIds.join( ',' ) } );
 	};
 
 	const updateAuthorToken = ( tokens ) => {
@@ -526,16 +691,16 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		}
 
 		const selectedIds = tokens
-			.map( ( token ) =>
-				authorOptions.find(
-					( option ) => normalizeTokenValue( option.value ) === normalizeTokenValue( token ),
-				)?.id,
+			.map(
+				( token ) =>
+					authorOptions.find(
+						( option ) =>
+							normalizeTokenValue( option.value ) ===
+							normalizeTokenValue( token ),
+					)?.id,
 			)
 			.filter( Boolean );
-
-		setAttributes( {
-			author: selectedIds.join( ',' ),
-		} );
+		setAttributes( { author: selectedIds.join( ',' ) } );
 	};
 
 	const previewItems = useMemo( () => {
@@ -562,8 +727,9 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 		const selectedDate = new Date( nextDate );
 		selectedDate.setHours( 0, 0, 0, 0 );
-
-		const compareDate = new Date( type === 'start' ? customDateEnd : customDateStart );
+		const compareDate = new Date(
+			type === 'start' ? customDateEnd : customDateStart,
+		);
 		if ( ! Number.isNaN( compareDate.getTime() ) ) {
 			compareDate.setHours( 0, 0, 0, 0 );
 		}
@@ -582,14 +748,23 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 		setDateError( '' );
 		setAttributes( {
-			[ type === 'start' ? 'customDateStart' : 'customDateEnd' ]: getStoredDateValue( nextDate, type ),
+			[ type === 'start' ? 'customDateStart' : 'customDateEnd' ]:
+				getStoredDateValue( nextDate, type ),
 		} );
 	};
+
+	const hasHandpickedVideos = handpickedBlocks.length > 0;
 
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Source', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-source">
+
+				{ /* ── Source ─────────────────────────────────────────────── */ }
+				<PanelBody
+					title={ __( 'Source', 'godam' ) }
+					initialOpen={ true }
+					data-test-id="godam-gallery-v2-panel-source"
+				>
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						isBlock
@@ -602,12 +777,85 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							}
 						} }
 					>
-						<ToggleGroupControlOption value="handpicked" label={ __( 'Handpicked', 'godam' ) } />
-						<ToggleGroupControlOption value="query" label={ __( 'Query', 'godam' ) } />
+						<ToggleGroupControlOption
+							value="handpicked"
+							label={ __( 'Handpicked', 'godam' ) }
+						/>
+						<ToggleGroupControlOption
+							value="query"
+							label={ __( 'Query', 'godam' ) }
+						/>
 					</ToggleGroupControl>
 				</PanelBody>
 
-				<PanelBody title={ __( 'Gallery Settings', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-settings">
+				{ /* ── Video Selection (handpicked only) ───────────────────── */ }
+				{ mode === 'handpicked' && (
+					<PanelBody
+						title={ __( 'Video Selection', 'godam' ) }
+						initialOpen={ true }
+					>
+						<p className="godam-gallery-v2__panel-hint">
+							{ __( 'Videos play on mute by default', 'godam' ) }
+						</p>
+
+						{ handpickedBlocks.length > 0 && (
+							<DndContext
+								sensors={ sensors }
+								collisionDetection={ closestCenter }
+								onDragStart={ handleDragStart }
+								onDragEnd={ handleDragEnd }
+							>
+								<SortableContext
+									items={ handpickedBlocks.map( ( b ) => b.clientId ) }
+									strategy={ verticalListSortingStrategy }
+								>
+									<div className="godam-gallery-v2__video-list">
+										{ handpickedBlocks.map( ( block ) => (
+											<VideoListItem
+												key={ block.clientId }
+												block={ block }
+												onRemove={ () => removeBlock( block.clientId ) }
+											/>
+										) ) }
+									</div>
+								</SortableContext>
+								<DragOverlay>
+									{ activeId ? (
+										<VideoListItemContent
+											block={ handpickedBlocks.find( ( b ) => b.clientId === activeId ) }
+											onRemove={ () => {} }
+											isDragging
+										/>
+									) : null }
+								</DragOverlay>
+							</DndContext>
+						) }
+
+						<MediaUploadCheck>
+							<MediaUpload
+								allowedTypes={ [ 'video' ] }
+								multiple
+								onSelect={ insertHandpickedVideo }
+								render={ ( { open } ) => (
+									<Button
+										variant="secondary"
+										onClick={ open }
+										className="godam-gallery-v2__add-video-btn"
+									>
+										{ __( '+ Add Video', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</PanelBody>
+				) }
+
+				{ /* ── Gallery Settings ────────────────────────────────────── */ }
+				<PanelBody
+					title={ __( 'Gallery Settings', 'godam' ) }
+					initialOpen={ true }
+					data-test-id="godam-gallery-v2-panel-settings"
+				>
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						isBlock
@@ -647,13 +895,16 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							value="list"
 						/>
 					</ToggleGroupControl>
+
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'View Ratio', 'godam' ) }
 						data-test-id="godam-gallery-v2-control-view-ratio"
 						value={ viewRatio }
-						onChange={ ( value ) => value && setAttributes( { viewRatio: value } ) }
+						onChange={ ( value ) =>
+							value && setAttributes( { viewRatio: value } )
+						}
 					>
 						<ToggleGroupControlOption label="4:3" value="4:3" />
 						<ToggleGroupControlOption label="9:16" value="9:16" />
@@ -661,47 +912,146 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						<ToggleGroupControlOption label="1:1" value="1:1" />
 						<ToggleGroupControlOption label="16:9" value="16:9" />
 					</ToggleGroupControl>
+
 					<ToggleGroupControl
 						__nextHasNoMarginBottom
 						isBlock
 						label={ __( 'Item Size', 'godam' ) }
 						data-test-id="godam-gallery-v2-control-item-width"
 						value={ itemWidth }
-						onChange={ ( value ) => value && setAttributes( { itemWidth: value } ) }
+						onChange={ ( value ) =>
+							value && setAttributes( { itemWidth: value } )
+						}
 						help={ __( 'Size of each gallery item.', 'godam' ) }
 					>
 						<ToggleGroupControlOption label={ __( 'S', 'godam' ) } value="S" />
 						<ToggleGroupControlOption label={ __( 'M', 'godam' ) } value="M" />
 						<ToggleGroupControlOption label={ __( 'L', 'godam' ) } value="L" />
 					</ToggleGroupControl>
-					<div data-test-id="godam-gallery-v2-control-show-title">
-						<ToggleControl
-							label={ __( 'Show Video Titles and Dates', 'godam' ) }
-							checked={ !! showTitle }
-							onChange={ ( value ) => setAttributes( { showTitle: value } ) }
-						/>
-					</div>
-					{
-						showEngagementSetting && (
-							<ToggleControl
-								label={ __( 'Enable Likes & Comments', 'godam' ) }
-								checked={ !! engagements }
-								onChange={ ( value ) => setAttributes( { engagements: value } ) }
-								help={ __( 'Engagement will only be visible for transcoded videos', 'godam' ) }
-							/>
-						)
-					}
-					<SelectControl
-						label={ __( 'Performance', 'godam' ) }
-						value={ performanceMode || 'balanced' }
-						options={ performanceModeOptions }
-						help={ performanceModeHelpText[ performanceMode || 'balanced' ] }
-						onChange={ ( value ) => setAttributes( { performanceMode: value } ) }
+				</PanelBody>
+
+				{ /* ── Info Display ─────────────────────────────────────────── */ }
+				<PanelBody title={ __( 'Info Display', 'godam' ) } initialOpen={ true }>
+					<RadioControl
+						label={ __( 'Info Display', 'godam' ) }
+						hideLabelFromVision
+						selected={ showTitle ? 'title' : 'image' }
+						options={ [
+							{
+								label: __( 'Only Image', 'godam' ),
+								value: 'image',
+							},
+							{
+								label: __( 'Show Video Title and Date', 'godam' ),
+								value: 'title',
+							},
+						] }
+						onChange={ ( value ) =>
+							setAttributes( { showTitle: value === 'title' } )
+						}
+						data-test-id="godam-gallery-v2-control-show-title"
 					/>
 				</PanelBody>
 
+				{ /* ── Interaction ──────────────────────────────────────────── */ }
+				<PanelBody title={ __( 'Interaction', 'godam' ) } initialOpen={ true }>
+					<div className="godam-gallery-v2__radio-group">
+						{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+						<label className="godam-gallery-v2__radio-option">
+							<input
+								type="radio"
+								name={ `godam-gallery-interaction-${ clientId }` }
+								value="autoplay"
+								checked={ !! autoplay }
+								onChange={ () =>
+									setAttributes( { autoplay: true, playOnHover: false } )
+								}
+							/>
+							<span className="godam-gallery-v2__radio-label">
+								{ __( 'Autoplay all videos', 'godam' ) }
+							</span>
+							<span className="godam-gallery-v2__radio-hint">
+								{ __( 'Visible videos autoplay one at a time and continue through the full video.', 'godam' ) }
+							</span>
+						</label>
+						{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+						<label className="godam-gallery-v2__radio-option">
+							<input
+								type="radio"
+								name={ `godam-gallery-interaction-${ clientId }` }
+								value="hover"
+								checked={ ! autoplay }
+								onChange={ () =>
+									setAttributes( { autoplay: false, playOnHover: true } )
+								}
+							/>
+							<span className="godam-gallery-v2__radio-label">
+								{ __( 'Play on hover', 'godam' ) }
+							</span>
+							<span className="godam-gallery-v2__radio-hint">
+								{ __( 'Videos will play when hovered over', 'godam' ) }
+							</span>
+						</label>
+					</div>
+
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show play button', 'godam' ) }
+						checked={ showPlayButton !== false }
+						onChange={ ( value ) => setAttributes( { showPlayButton: value } ) }
+						help={ showPlayButton !== false
+							? __( 'Play button overlay is visible on each tile.', 'godam' )
+							: __( 'Play button overlay is hidden.', 'godam' )
+						}
+					/>
+				</PanelBody>
+
+				{ /* ── Performance ──────────────────────────────────────────── */ }
+				<PanelBody title={ __( 'Performance', 'godam' ) } initialOpen={ true }>
+					<ToggleGroupControl
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Performance', 'godam' ) }
+						hideLabelFromVision
+						value={ performanceMode || 'balanced' }
+						onChange={ ( value ) =>
+							value && setAttributes( { performanceMode: value } )
+						}
+						help={ performanceModeHelpText[ performanceMode || 'balanced' ] }
+					>
+						<ToggleGroupControlOption
+							label={ __( 'Priority', 'godam' ) }
+							value="priority"
+						/>
+						<ToggleGroupControlOption
+							label={ __( 'Balanced', 'godam' ) }
+							value="balanced"
+						/>
+					</ToggleGroupControl>
+				</PanelBody>
+
+				{ /* ── Engagements (conditional) ────────────────────────────── */ }
+				{ showEngagementSetting && (
+					<PanelBody title={ __( 'Engagement', 'godam' ) } initialOpen={ false }>
+						<ToggleControl
+							label={ __( 'Enable Likes & Comments', 'godam' ) }
+							checked={ !! engagements }
+							onChange={ ( value ) => setAttributes( { engagements: value } ) }
+							help={ __(
+								'Engagement will only be visible for transcoded videos',
+								'godam',
+							) }
+						/>
+					</PanelBody>
+				) }
+
+				{ /* ── Query Settings (query mode only) ────────────────────── */ }
 				{ mode === 'query' && (
-					<PanelBody title={ __( 'Query Settings', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-query">
+					<PanelBody
+						title={ __( 'Query Settings', 'godam' ) }
+						initialOpen={ true }
+						data-test-id="godam-gallery-v2-panel-query"
+					>
 						<RangeControl
 							label={ __( 'Number of videos', 'godam' ) }
 							data-test-id="godam-gallery-v2-control-count"
@@ -719,7 +1069,9 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 										{ label: __( 'Date', 'godam' ), value: 'date' },
 										{ label: __( 'Title', 'godam' ), value: 'title' },
 									] }
-									onChange={ ( value ) => setAttributes( { orderby: value } ) }
+									onChange={ ( value ) =>
+										setAttributes( { orderby: value } )
+									}
 								/>
 							</div>
 							<div className="godam-gallery-v2__query-col">
@@ -727,8 +1079,14 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 									label={ __( 'Order', 'godam' ) }
 									value={ order }
 									options={ [
-										{ label: __( 'Descending', 'godam' ), value: 'desc' },
-										{ label: __( 'Ascending', 'godam' ), value: 'asc' },
+										{
+											label: __( 'Descending', 'godam' ),
+											value: 'desc',
+										},
+										{
+											label: __( 'Ascending', 'godam' ),
+											value: 'asc',
+										},
 									] }
 									onChange={ ( value ) => setAttributes( { order: value } ) }
 								/>
@@ -763,16 +1121,21 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 								{ label: __( 'Last 7 Days', 'godam' ), value: '7days' },
 								{ label: __( 'Last 30 Days', 'godam' ), value: '30days' },
 								{ label: __( 'Last 90 Days', 'godam' ), value: '90days' },
-								{ label: __( 'Custom Range', 'godam' ), value: 'custom' },
+								{
+									label: __( 'Custom Range', 'godam' ),
+									value: 'custom',
+								},
 							] }
 							onChange={ ( value ) =>
 								setAttributes( {
 									dateRange: value,
-									customDateStart: value === 'custom' ? customDateStart : '',
+									customDateStart:
+										value === 'custom' ? customDateStart : '',
 									customDateEnd: value === 'custom' ? customDateEnd : '',
 								} )
 							}
 						/>
+
 						{ dateRange === 'custom' && (
 							<div className="godam-gallery-v2__date-range-picker">
 								{ dateError && (
@@ -781,14 +1144,18 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 									</Notice>
 								) }
 								<div className="godam-gallery-v2__date-field">
-									<label htmlFor="godam-gallery-v2-start-date">{ __( 'Start Date', 'godam' ) }</label>
+									<label htmlFor="godam-gallery-v2-start-date">
+										{ __( 'Start Date', 'godam' ) }
+									</label>
 									<button
 										id="godam-gallery-v2-start-date"
 										type="button"
 										className={ `godam-gallery-v2__date-button ${ dateError ? 'has-error' : '' }` }
 										onClick={ () => setStartDatePopoverOpen( true ) }
 									>
-										{ customDateStart ? formatDisplayDate( customDateStart ) : __( 'Select Start Date', 'godam' ) }
+										{ customDateStart
+											? formatDisplayDate( customDateStart )
+											: __( 'Select Start Date', 'godam' ) }
 									</button>
 									{ startDatePopoverOpen && (
 										<Popover
@@ -807,14 +1174,18 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 									) }
 								</div>
 								<div className="godam-gallery-v2__date-field">
-									<label htmlFor="godam-gallery-v2-end-date">{ __( 'End Date', 'godam' ) }</label>
+									<label htmlFor="godam-gallery-v2-end-date">
+										{ __( 'End Date', 'godam' ) }
+									</label>
 									<button
 										id="godam-gallery-v2-end-date"
 										type="button"
 										className={ `godam-gallery-v2__date-button ${ dateError ? 'has-error' : '' }` }
 										onClick={ () => setEndDatePopoverOpen( true ) }
 									>
-										{ customDateEnd ? formatDisplayDate( customDateEnd ) : __( 'Select End Date', 'godam' ) }
+										{ customDateEnd
+											? formatDisplayDate( customDateEnd )
+											: __( 'Select End Date', 'godam' ) }
 									</button>
 									{ endDatePopoverOpen && (
 										<Popover
@@ -834,6 +1205,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 								</div>
 							</div>
 						) }
+
 						<div data-test-id="godam-gallery-v2-control-enable-more-items">
 							<ToggleControl
 								label={ __( 'Enable More Items', 'godam' ) }
@@ -846,8 +1218,14 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 								label={ __( 'More Items Behavior', 'godam' ) }
 								value={ resolvedMoreItemsBehavior }
 								options={ [
-									{ label: __( 'Load More Button', 'godam' ), value: 'button' },
-									{ label: __( 'Infinite Scroll', 'godam' ), value: 'infinite' },
+									{
+										label: __( 'Load More Button', 'godam' ),
+										value: 'button',
+									},
+									{
+										label: __( 'Infinite Scroll', 'godam' ),
+										value: 'infinite',
+									},
 								] }
 								disabled={ isCarouselLayout }
 								help={
@@ -855,32 +1233,89 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 										? __( 'Carousel layout always uses Infinite Scroll when more items are enabled.', 'godam' )
 										: __( 'Choose how visitors load more videos in query galleries.', 'godam' )
 								}
-								onChange={ ( value ) => updateMoreItemsSettings( true, value ) }
+								onChange={ ( value ) =>
+									updateMoreItemsSettings( true, value )
+								}
 							/>
 						) }
 					</PanelBody>
 				) }
+
 			</InspectorControls>
 
+			{ /* ── Block Canvas ──────────────────────────────────────────────── */ }
 			<div { ...blockProps } data-test-id="godam-gallery-v2-canvas">
 
+				{ /* Handpicked mode */ }
 				{ mode === 'handpicked' && (
 					<div
 						className={ `godam-gallery-v2__canvas godam-gallery-v2__canvas--${ layout }` }
 						data-test-id="godam-gallery-v2-canvas-handpicked"
+						data-show-play-button={ showPlayButton !== false ? 'true' : 'false' }
 					>
-						<InnerBlocks
-							allowedBlocks={ ALLOWED_BLOCKS }
-							orientation={ layout === 'carousel' ? 'horizontal' : 'vertical' }
-							renderAppender={ renderVideoAppender }
-						/>
+						{ /* Custom empty state shown when no videos are selected */ }
+						{ ! hasHandpickedVideos && (
+							<div className="godam-gallery-v2__empty-state">
+								<div className="godam-gallery-v2__empty-tiles">
+									{ [ ...Array( 6 ) ].map( ( _, i ) => (
+										<div
+											key={ i }
+											className="godam-gallery-v2__empty-tile"
+											aria-hidden="true"
+										/>
+									) ) }
+								</div>
+								<h3 className="godam-gallery-v2__empty-heading">
+									{ __( 'Create your media gallery', 'godam' ) }
+								</h3>
+								<p className="godam-gallery-v2__empty-desc">
+									{ __( 'Upload or select videos to add to your gallery.', 'godam' ) }
+								</p>
+								<MediaUploadCheck>
+									<MediaUpload
+										allowedTypes={ [ 'video' ] }
+										multiple
+										onSelect={ insertHandpickedVideo }
+										render={ ( { open } ) => (
+											<Button
+												variant="primary"
+												onClick={ open }
+												className="godam-gallery-v2__empty-btn"
+											>
+												{ __( '+ Add Video', 'godam' ) }
+											</Button>
+										) }
+									/>
+								</MediaUploadCheck>
+								{ /* InnerBlocks always mounted so block tree stays registered */ }
+								<div className="godam-gallery-v2__inner-blocks-mount">
+									<InnerBlocks
+										allowedBlocks={ ALLOWED_BLOCKS }
+										renderAppender={ false }
+									/>
+								</div>
+							</div>
+						) }
+
+						{ /* Videos list */ }
+						{ hasHandpickedVideos && (
+							<InnerBlocks
+								allowedBlocks={ ALLOWED_BLOCKS }
+								orientation={
+									layout === 'carousel' ? 'horizontal' : 'vertical'
+								}
+								renderAppender={ renderVideoAppender }
+							/>
+						) }
 					</div>
 				) }
 
+				{ /* Query mode */ }
 				{ mode === 'query' && (
 					<div
 						className={ `godam-gallery-v2__canvas godam-gallery-v2__canvas--${ layout }` }
 						data-test-id="godam-gallery-v2-canvas-query"
+						data-show-play-button={ showPlayButton !== false ? 'true' : 'false' }
 					>
 						{ queryPreviewVideos === null && (
 							<div className="godam-gallery-v2__state godam-gallery-v2__state--loading">
@@ -889,10 +1324,16 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							</div>
 						) }
 
-						{ Array.isArray( queryPreviewVideos ) && queryPreviewVideos.length === 0 && (
+						{ Array.isArray( queryPreviewVideos ) &&
+							queryPreviewVideos.length === 0 && (
 							<div className="godam-gallery-v2__state">
 								<strong>{ __( 'No videos found', 'godam' ) }</strong>
-								<p>{ __( 'Try changing the selected folder, author, or dates.', 'godam' ) }</p>
+								<p>
+									{ __(
+										'Try changing the selected folder, author, or dates.',
+										'godam',
+									) }
+								</p>
 							</div>
 						) }
 
@@ -906,9 +1347,21 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 									>
 										<div className="godam-gallery-v2__query-thumb">
 											{ video.thumbnail ? (
-												<img src={ video.thumbnail } alt={ video.title } />
+												<img
+													src={ video.thumbnail }
+													alt={ video.title }
+												/>
 											) : (
-												<span data-test-id="godam-gallery-v2-element-thumbnail-fallback">{ __( 'Video', 'godam' ) }</span>
+												<span data-test-id="godam-gallery-v2-element-thumbnail-fallback">
+													{ __( 'Video', 'godam' ) }
+												</span>
+											) }
+											{ showPlayButton !== false && (
+												<div className="godam-gallery-v2__play-icon" aria-hidden="true">
+													<svg viewBox="0 0 24 24" fill="currentColor">
+														<path d="M8 5v14l11-7z" />
+													</svg>
+												</div>
 											) }
 										</div>
 										{ showTitle && (
@@ -923,6 +1376,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						) }
 					</div>
 				) }
+
 			</div>
 		</>
 	);

--- a/assets/src/blocks/godam-gallery-v2/editor.scss
+++ b/assets/src/blocks/godam-gallery-v2/editor.scss
@@ -25,7 +25,7 @@
 
 	&__panel-hint {
 		font-size: 12px;
-		color: #757575;
+		color: var(--wp-components-color-foreground-muted, #757575);
 		margin: 0 0 12px;
 	}
 
@@ -71,7 +71,7 @@
 	// DragOverlay ghost card
 	.godam-gallery-v2__video-item[data-dnd-overlay] {
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		border-color: #007cba;
+		border-color: var(--wp-admin-theme-color, #007cba);
 		background: #f0f7fb;
 		opacity: 1;
 		cursor: grabbing;
@@ -113,12 +113,12 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		color: #1e1e1e;
+		color: var(--wp-components-color-foreground, #1e1e1e);
 	}
 
 	&__video-date {
 		font-size: 11px;
-		color: #757575;
+		color: var(--wp-components-color-foreground-muted, #757575);
 	}
 
 	&__add-video-btn {
@@ -152,7 +152,7 @@
 		}
 
 		&:has(input:checked) {
-			border-color: #007cba;
+			border-color: var(--wp-admin-theme-color, #007cba);
 			background: #f0f7fb;
 		}
 
@@ -171,13 +171,13 @@
 	&__radio-label {
 		font-size: 13px;
 		font-weight: 500;
-		color: #1e1e1e;
+		color: var(--wp-components-color-foreground, #1e1e1e);
 		line-height: 1.4;
 	}
 
 	&__radio-hint {
 		font-size: 11px;
-		color: #757575;
+		color: var(--wp-components-color-foreground-muted, #757575);
 		line-height: 1.4;
 	}
 
@@ -248,11 +248,11 @@
 
 .godam-gallery-v2__canvas {
 	width: 90%;
-    margin: 12px auto;
+	margin: 12px auto;
 	background: #F2F2FF;
-    border: 4px dotted #5A13D51A;
-    padding: 30px;
-    border-radius: 6px;
+	border: 4px dotted #5A13D51A;
+	padding: 30px;
+	border-radius: 6px;
 }
 
 .godam-gallery-v2__canvas--list {

--- a/assets/src/blocks/godam-gallery-v2/editor.scss
+++ b/assets/src/blocks/godam-gallery-v2/editor.scss
@@ -21,6 +21,218 @@
 		width: 100%;
 	}
 
+	// ── Video Selection panel ─────────────────────────────────────────────────
+
+	&__panel-hint {
+		font-size: 12px;
+		color: #757575;
+		margin: 0 0 12px;
+	}
+
+	&__video-list {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-bottom: 12px;
+	}
+
+	&__video-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 4px;
+		border-radius: 4px;
+		background: #fff;
+		border: 1px solid #e0e0e0;
+
+		&:hover {
+			border-color: #b0b0b0;
+		}
+	}
+
+	&__drag-handle {
+		flex: 0 0 18px;
+		color: #999;
+		cursor: grab;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		touch-action: none;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
+	&__video-item.is-dragging {
+		opacity: 0.4;
+	}
+
+	// DragOverlay ghost card
+	.godam-gallery-v2__video-item[data-dnd-overlay] {
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+		border-color: #007cba;
+		background: #f0f7fb;
+		opacity: 1;
+		cursor: grabbing;
+	}
+
+	&__video-thumb-wrap {
+		flex: 0 0 44px;
+		height: 44px;
+		border-radius: 4px;
+		overflow: hidden;
+		background: #f0f0f0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	&__video-thumb {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	&__video-thumb-fallback {
+		font-size: 22px;
+		color: #999;
+	}
+
+	&__video-meta {
+		flex: 1 1 auto;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	&__video-name {
+		font-size: 12px;
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		color: #1e1e1e;
+	}
+
+	&__video-date {
+		font-size: 11px;
+		color: #757575;
+	}
+
+	&__add-video-btn {
+		width: 100%;
+		justify-content: center;
+	}
+
+	// ── Interaction panel custom radio group ──────────────────────────────────
+
+	&__radio-group {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-bottom: 16px;
+	}
+
+	&__radio-option {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		padding: 10px 12px;
+		border-radius: 6px;
+		border: 1px solid #e0e0e0;
+		cursor: pointer;
+		transition: border-color 0.15s ease, background 0.15s ease;
+
+		input[type="radio"] {
+			flex: 0 0 auto;
+			margin-top: 2px;
+			cursor: pointer;
+		}
+
+		&:has(input:checked) {
+			border-color: #007cba;
+			background: #f0f7fb;
+		}
+
+		&:hover:not(:has(input:checked)) {
+			border-color: #b0b0b0;
+			background: #fafafa;
+		}
+	}
+
+	&__radio-content {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	&__radio-label {
+		font-size: 13px;
+		font-weight: 500;
+		color: #1e1e1e;
+		line-height: 1.4;
+	}
+
+	&__radio-hint {
+		font-size: 11px;
+		color: #757575;
+		line-height: 1.4;
+	}
+
+	// ── Empty state (handpicked, no videos selected) ──────────────────────────
+
+	&__empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		padding: 24px 16px;
+	}
+
+	&__empty-tiles {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 12px;
+		width: 100%;
+		margin-bottom: 24px;
+		background: #F2F2FF;
+		border-radius: 8px;
+		padding: 46px;
+	}
+
+	&__empty-tile {
+		aspect-ratio: 4 / 3;
+		border-radius: 6px;
+		background: #fbfbfb;
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.06);
+	}
+
+	&__empty-heading {
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--wp-components-color-foreground, #1e1e1e);
+		margin: 0 0 8px;
+	}
+
+	&__empty-desc {
+		font-size: 13px;
+		color: var(--wp-components-color-foreground-muted, #757575);
+		margin: 0 0 16px;
+	}
+
+	&__empty-btn {
+		padding: 8px 18px;
+		letter-spacing: 1px;
+	}
+
+	// InnerBlocks always mounted but hidden when no videos exist
+	// so the block tree stays properly registered.
+	&__inner-blocks-mount {
+		display: none;
+	}
+
 	&__state--loading {
 		display: flex;
 		align-items: center;
@@ -32,6 +244,15 @@
 		position: initial;
 		width: 100%;
 	}
+}
+
+.godam-gallery-v2__canvas {
+	width: 90%;
+    margin: 12px auto;
+	background: #F2F2FF;
+    border: 4px dotted #5A13D51A;
+    padding: 30px;
+    border-radius: 6px;
 }
 
 .godam-gallery-v2__canvas--list {

--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -68,6 +68,7 @@
 	align-items: center;
 	justify-content: center;
 	position: relative;
+	overflow: hidden;
 	color: #66705d;
 	font-weight: 600;
 
@@ -76,6 +77,53 @@
 		width: 100% !important;
 		height: 100% !important;
 		object-fit: cover;
+	}
+}
+
+// Play icon for query tiles (mirrors .godam-gallery-v2-item__play-icon).
+.godam-gallery-v2__play-icon {
+	position: absolute;
+	width: 52px;
+	height: 52px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 999px;
+	background: rgba(19, 25, 14, 0.62);
+	color: #fff;
+	pointer-events: none;
+	z-index: 2;
+	transition: opacity 0.2s ease;
+
+	svg {
+		width: 24px;
+		height: 24px;
+	}
+}
+
+// Preview video — shared by both handpicked and query tiles.
+.godam-gallery-v2-item__preview-video {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	opacity: 1;
+	pointer-events: none;
+	transition: opacity 0.3s ease;
+	z-index: 1;
+}
+
+.godam-gallery-v2__query-button.is-previewing,
+.godam-gallery-v2-item__button.is-previewing {
+
+	.godam-gallery-v2-item__preview-video {
+		opacity: 1;
+	}
+
+	.godam-gallery-v2__play-icon,
+	.godam-gallery-v2-item__play-icon {
+		opacity: 0;
 	}
 }
 
@@ -176,6 +224,9 @@
 		width: 100% !important;
 		height: 100% !important;
 		object-fit: cover;
+		// No opacity: 0 here — items without a blur-up placeholder must show
+		// immediately. The .godam-gallery-blurred-img block manages the fade-in
+		// only for items that have a placeholder image.
 	}
 
 	&__play-icon {
@@ -353,6 +404,17 @@
 .godam-gallery-v2__query-item--ratio-16-9 .godam-gallery-v2__query-thumb,
 .godam-gallery-v2-item--ratio-16-9 .godam-gallery-v2-item__preview {
 	aspect-ratio: 16 / 9;
+}
+
+// ── Show play button toggle ───────────────────────────────────────────────────
+// When the editor sets data-show-play-button="false" on the gallery wrapper,
+// hide the play icon overlays on all tile types.
+[data-show-play-button="false"] {
+
+	.godam-gallery-v2__play-icon,
+	.godam-gallery-v2-item__play-icon {
+		display: none;
+	}
 }
 
 @keyframes godam_gallery_v2_blur_pulse {

--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -236,6 +236,11 @@ const { __ } = require( '@wordpress/i18n' );
 			// Track items that already have preview listeners attached.
 			this.initializedPreviewItems = new WeakSet();
 
+			// AbortControllers keyed by video element — used to cancel stale
+			// loadeddata/canplay listeners when a new play attempt starts before
+			// the previous one resolved (e.g. rapid hover in/out).
+			this.pendingPlayControllers = new WeakMap();
+
 			this.refreshItems();
 			initBlurUpPlaceholders( this.element );
 			this.bindEvents();
@@ -393,7 +398,6 @@ const { __ } = require( '@wordpress/i18n' );
 					this.currentOffset = this.totalItems;
 				}
 				this.refreshItems();
-				this.initFirstFrameThumbnails();
 				this.initNewItemsBehavior();
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
@@ -414,6 +418,13 @@ const { __ } = require( '@wordpress/i18n' );
 				return;
 			}
 
+			// Respect the user's OS-level motion preference (WCAG 2.2.2).
+			// Skip autoplay entirely; hover-play is still allowed since it requires
+			// deliberate user interaction.
+			if ( this.autoplay && window.matchMedia?.( '(prefers-reduced-motion: reduce)' ).matches ) {
+				this.autoplay = false;
+			}
+
 			this.items.forEach( ( item ) => this.initVideoPreviewItem( item ) );
 
 			// Proactively load metadata for visible items so hover play is instant.
@@ -426,19 +437,23 @@ const { __ } = require( '@wordpress/i18n' );
 
 		/**
 		 * Called after new items are injected by load-more / infinite scroll.
-		 * Wires up hover, autoplay, and preload for any uninitialised items.
+		 * Wires up hover, autoplay, preload, and first-frame thumbnails for
+		 * any uninitialised items only — avoids rescanning the full item list.
 		 */
 		initNewItemsBehavior() {
-			if ( ! this.autoplay && ! this.playOnHover ) {
-				return;
-			}
-
 			// Find items that haven't been initialised yet.
 			const uninitialised = this.items.filter(
 				( item ) => ! this.initializedPreviewItems.has( item ),
 			);
 
 			if ( uninitialised.length === 0 ) {
+				return;
+			}
+
+			// First-frame thumbnails work regardless of hover/autoplay settings.
+			this.initFirstFrameThumbnails( uninitialised );
+
+			if ( ! this.autoplay && ! this.playOnHover ) {
 				return;
 			}
 
@@ -538,9 +553,20 @@ const { __ } = require( '@wordpress/i18n' );
 		 * The pending <img> placeholder is hidden and the item receives
 		 * `godam-gallery-v2-item--no-thumb` so CSS keeps the video visible at
 		 * all times (not only on hover).
+		 *
+		 * @param {Element[]} items Gallery tiles.
 		 */
-		initFirstFrameThumbnails() {
-			this.items.forEach( ( item ) => {
+		initFirstFrameThumbnails( items = null ) {
+			// Default to all items, but accept a subset (e.g. newly loaded tiles)
+			// to avoid scanning the entire list on every load-more append.
+			const targets = items || this.items;
+
+			targets.forEach( ( item ) => {
+				// Skip items that have already been processed.
+				if ( item.classList.contains( 'godam-gallery-v2-item--no-thumb' ) ) {
+					return;
+				}
+
 				const pending = item.querySelector( '.godam-gallery-v2__thumbnail--pending' );
 				if ( ! pending ) {
 					return;
@@ -647,6 +673,16 @@ const { __ } = require( '@wordpress/i18n' );
 				return;
 			}
 
+			// Cancel any stale pending-play callback for this video before doing
+			// anything else. This prevents listener accumulation when syncPreviewVideo
+			// is called multiple times before the video has loaded (e.g. rapid
+			// hover in/out or autoplay re-sequencing).
+			const staleController = this.pendingPlayControllers.get( video );
+			if ( staleController ) {
+				staleController.abort();
+				this.pendingPlayControllers.delete( video );
+			}
+
 			if ( shouldPlay ) {
 				const shouldMute = Object.prototype.hasOwnProperty.call( options, 'muted' )
 					? !! options.muted
@@ -670,8 +706,15 @@ const { __ } = require( '@wordpress/i18n' );
 						video.preload = 'metadata';
 						video.load();
 					}
-					video.addEventListener( 'loadeddata', attemptPlay, { once: true } );
-					video.addEventListener( 'canplay', attemptPlay, { once: true } );
+
+					// Use an AbortController so we can cancel these listeners if
+					// syncPreviewVideo is called again before they fire.
+					const controller = new AbortController();
+					this.pendingPlayControllers.set( video, controller );
+					const { signal } = controller;
+
+					video.addEventListener( 'loadeddata', attemptPlay, { once: true, signal } );
+					video.addEventListener( 'canplay', attemptPlay, { once: true, signal } );
 				}
 				return;
 			}

--- a/assets/src/blocks/godam-gallery-v2/view.js
+++ b/assets/src/blocks/godam-gallery-v2/view.js
@@ -195,12 +195,16 @@ const { __ } = require( '@wordpress/i18n' );
 		return sharedModal;
 	}
 
+	const HOVER_INTENT_DELAY_MS = 200;
+
 	class GalleryV2 {
 		constructor( element ) {
 			this.element = element;
 			this.mode = element.dataset.mode || 'handpicked';
 			this.embedBaseUrl = element.dataset.embedBaseUrl || '/';
 			this.engagements = element.dataset.engagements || '';
+			this.autoplay = element.dataset.autoplay === 'true';
+			this.playOnHover = element.dataset.playOnHover !== 'false';
 			this.currentIndex = -1;
 			this.previouslyFocusedElement = null;
 			this.isLoading = false;
@@ -222,11 +226,23 @@ const { __ } = require( '@wordpress/i18n' );
 				this.enableMoreItems && this.moreItemsBehavior === 'infinite';
 			this.items = [];
 
+			// Autoplay / hover-play state (mirrors shoppable video block).
+			this.autoplayActiveItem = null;
+			this.hoverActiveItem = null;
+			this.hoverIntentTimers = new Map();
+			this.loadedVideos = new Set();
+			this.modalOpen = false;
+
+			// Track items that already have preview listeners attached.
+			this.initializedPreviewItems = new WeakSet();
+
 			this.refreshItems();
 			initBlurUpPlaceholders( this.element );
 			this.bindEvents();
 			this.initInfiniteScroll();
 			this.updateLoadControls();
+			this.initVideoPreview();
+			this.initFirstFrameThumbnails();
 		}
 
 		parseQueryArgs( value ) {
@@ -361,14 +377,14 @@ const { __ } = require( '@wordpress/i18n' );
 				if ( data?.status === 'success' && data?.html ) {
 					const template = document.createElement( 'template' );
 					template.innerHTML = data.html.trim();
-					const newItems = Array.from(
+					const newQueryItems = Array.from(
 						template.content.querySelectorAll( '.godam-gallery-v2__query-item' ),
 					);
 
-					if ( newItems.length > 0 ) {
+					if ( newQueryItems.length > 0 ) {
 						const insertionTarget = this.loadMoreItem || this.sentinel;
 						this.queryList.insertBefore( template.content, insertionTarget );
-						this.currentOffset += newItems.length;
+						this.currentOffset += newQueryItems.length;
 						initBlurUpPlaceholders( this.element );
 					} else {
 						this.currentOffset = this.totalItems;
@@ -377,6 +393,8 @@ const { __ } = require( '@wordpress/i18n' );
 					this.currentOffset = this.totalItems;
 				}
 				this.refreshItems();
+				this.initFirstFrameThumbnails();
+				this.initNewItemsBehavior();
 			} catch ( error ) {
 				// eslint-disable-next-line no-console
 				console.error( 'Error loading more gallery items:', error );
@@ -384,6 +402,450 @@ const { __ } = require( '@wordpress/i18n' );
 				this.isLoading = false;
 				this.updateLoadControls();
 			}
+		}
+
+		// ── Video preview (autoplay / hover-play) ────────────────────────────
+
+		/**
+		 * Initialise hover and autoplay for all tiles that have a preview video.
+		 */
+		initVideoPreview() {
+			if ( ! this.autoplay && ! this.playOnHover ) {
+				return;
+			}
+
+			this.items.forEach( ( item ) => this.initVideoPreviewItem( item ) );
+
+			// Proactively load metadata for visible items so hover play is instant.
+			this.initViewportPreload();
+
+			if ( this.autoplay ) {
+				this.initAutoplayObserver();
+			}
+		}
+
+		/**
+		 * Called after new items are injected by load-more / infinite scroll.
+		 * Wires up hover, autoplay, and preload for any uninitialised items.
+		 */
+		initNewItemsBehavior() {
+			if ( ! this.autoplay && ! this.playOnHover ) {
+				return;
+			}
+
+			// Find items that haven't been initialised yet.
+			const uninitialised = this.items.filter(
+				( item ) => ! this.initializedPreviewItems.has( item ),
+			);
+
+			if ( uninitialised.length === 0 ) {
+				return;
+			}
+
+			uninitialised.forEach( ( item ) => this.initVideoPreviewItem( item ) );
+
+			// Register new items with the preload observer.
+			if ( this.viewportPreloadObserver ) {
+				this.initViewportPreload( uninitialised );
+			}
+
+			// Register new items with the autoplay observer.
+			if ( this.autoplay && this.autoplayObserver ) {
+				this.initAutoplayObserver( uninitialised );
+			}
+		}
+
+		/**
+		 * Wire up preview-video behaviour for a single item.
+		 * Safe to call multiple times — skips items already initialised.
+		 *
+		 * @param {Element} item Gallery tile.
+		 */
+		initVideoPreviewItem( item ) {
+			if ( this.initializedPreviewItems.has( item ) ) {
+				return;
+			}
+
+			const video = item.querySelector( '.godam-gallery-v2-item__preview-video' );
+			if ( ! video ) {
+				return;
+			}
+
+			this.initializedPreviewItems.add( item );
+			this.initItemVideoState( item, video );
+
+			if ( this.playOnHover ) {
+				item.addEventListener( 'mouseenter', () => this.scheduleItemHoverStart( item ) );
+				item.addEventListener( 'mouseleave', () => this.handleItemHoverEnd( item ) );
+			}
+		}
+
+		/**
+		 * Observe items entering/leaving the viewport and preload their video
+		 * metadata — mirrors the shoppable video block so hover play is instant.
+		 * @param {Element[]} newItems
+		 */
+		initViewportPreload( newItems = null ) {
+			if ( ! this.viewportPreloadObserver ) {
+				const observerRoot = this.element.dataset.layout === 'carousel'
+					? ( this.element.querySelector( '.godam-gallery-v2__canvas' ) || null )
+					: null;
+
+				this.viewportPreloadObserver = new IntersectionObserver(
+					( entries ) => {
+						entries.forEach( ( entry ) => {
+							entry.target.dataset.isPreloadVisible = entry.isIntersecting ? 'true' : 'false';
+						} );
+						this.updateVideoPreloadStrategy();
+					},
+					{ root: observerRoot, threshold: 0.1 },
+				);
+			}
+
+			const targets = newItems || this.items;
+			targets.forEach( ( item ) => {
+				item.dataset.isPreloadVisible = 'false';
+				this.viewportPreloadObserver.observe( item );
+			} );
+
+			// Run once immediately so items already in view are preloaded.
+			this.updateVideoPreloadStrategy();
+		}
+
+		/**
+		 * Set preload="metadata" on every visible item's preview video so the
+		 * browser fetches metadata before the user hovers.
+		 */
+		updateVideoPreloadStrategy() {
+			this.items.forEach( ( item ) => {
+				const video = item.querySelector( '.godam-gallery-v2-item__preview-video' );
+				if ( ! video || video.preload === 'metadata' ) {
+					return;
+				}
+
+				if ( item.dataset.isPreloadVisible === 'true' ) {
+					video.preload = 'metadata';
+					video.load();
+				}
+			} );
+		}
+
+		/**
+		 * For tiles that have no server-side thumbnail, show the preview video
+		 * element itself as the thumbnail — the browser renders the first frame
+		 * once metadata loads, exactly like the shoppable video block does.
+		 *
+		 * The pending <img> placeholder is hidden and the item receives
+		 * `godam-gallery-v2-item--no-thumb` so CSS keeps the video visible at
+		 * all times (not only on hover).
+		 */
+		initFirstFrameThumbnails() {
+			this.items.forEach( ( item ) => {
+				const pending = item.querySelector( '.godam-gallery-v2__thumbnail--pending' );
+				if ( ! pending ) {
+					return;
+				}
+
+				const video = item.querySelector( '.godam-gallery-v2-item__preview-video' );
+				if ( ! video || ! video.src ) {
+					return;
+				}
+
+				// Hide the unused placeholder img — the video is the thumbnail now.
+				pending.hidden = true;
+
+				// Mark the button so CSS makes the video visible immediately.
+				item.classList.add( 'godam-gallery-v2-item--no-thumb' );
+
+				// Start loading metadata so the browser can render the first frame.
+				if ( video.preload === 'none' ) {
+					video.preload = 'metadata';
+					video.load();
+				}
+			} );
+		}
+
+		/**
+		 * Track loadeddata / ended events so UI stays in sync.
+		 *
+		 * @param {Element}          item  The gallery tile.
+		 * @param {HTMLVideoElement} video The preview video element.
+		 */
+		initItemVideoState( item, video ) {
+			if ( video._godamGalleryStateBound ) {
+				return;
+			}
+			video._godamGalleryStateBound = true;
+
+			video.addEventListener( 'loadeddata', () => {
+				this.loadedVideos.add( video );
+
+				if (
+					this.autoplay &&
+					! this.modalOpen &&
+					item === this.autoplayActiveItem &&
+					video.paused
+				) {
+					video.muted = true;
+					video.play().catch( () => {} );
+				}
+			} );
+
+			video.addEventListener( 'ended', () => {
+				if ( this.autoplay && ! this.modalOpen && item === this.autoplayActiveItem ) {
+					this.advanceAutoplaySequence( item );
+				}
+			} );
+		}
+
+		/**
+		 * Use IntersectionObserver to drive autoplay sequencing by viewport visibility.
+		 * @param {Element[]} newItems
+		 */
+		initAutoplayObserver( newItems = null ) {
+			if ( ! this.autoplayObserver ) {
+				const observerRoot = this.element.dataset.layout === 'carousel'
+					? ( this.element.querySelector( '.godam-gallery-v2__canvas' ) || null )
+					: null;
+
+				this.autoplayObserver = new IntersectionObserver(
+					( entries ) => {
+						entries.forEach( ( entry ) => {
+							entry.target.dataset.isInViewport = entry.isIntersecting ? 'true' : 'false';
+						} );
+						this.syncAutoplaySequence();
+					},
+					{ root: observerRoot, threshold: 0.5 },
+				);
+			}
+
+			const targets = newItems || this.items;
+			targets.forEach( ( item ) => {
+				item.dataset.isInViewport = 'false';
+				this.autoplayObserver.observe( item );
+			} );
+		}
+
+		/**
+		 * @param {HTMLVideoElement} video
+		 * @return {boolean} Whether the video is currently playing.
+		 */
+		isVideoPlaying( video ) {
+			return !! ( video && ! video.paused && ! video.ended );
+		}
+
+		/**
+		 * Start or stop preview playback for a tile.
+		 *
+		 * @param {Element} item       Gallery tile.
+		 * @param {boolean} shouldPlay Whether to play.
+		 * @param {Object}  options    { restart, muted, reset }
+		 */
+		syncPreviewVideo( item, shouldPlay, options = {} ) {
+			const video = item?.querySelector( '.godam-gallery-v2-item__preview-video' );
+			if ( ! video ) {
+				return;
+			}
+
+			if ( shouldPlay ) {
+				const shouldMute = Object.prototype.hasOwnProperty.call( options, 'muted' )
+					? !! options.muted
+					: true;
+
+				const attemptPlay = () => {
+					if ( this.hoverActiveItem === item || this.autoplayActiveItem === item ) {
+						video.muted = shouldMute;
+						if ( options.restart ) {
+							video.currentTime = 0;
+						}
+						video.play().catch( () => {} );
+					}
+				};
+
+				if ( this.loadedVideos.has( video ) ) {
+					attemptPlay();
+				} else {
+					// Kick off loading if not already started.
+					if ( video.preload !== 'metadata' ) {
+						video.preload = 'metadata';
+						video.load();
+					}
+					video.addEventListener( 'loadeddata', attemptPlay, { once: true } );
+					video.addEventListener( 'canplay', attemptPlay, { once: true } );
+				}
+				return;
+			}
+
+			video.pause();
+			if ( options.reset !== false ) {
+				video.currentTime = 0;
+			}
+		}
+
+		/**
+		 * Pause all tiles except the active one.
+		 *
+		 * @param {Element|null} activeItem
+		 */
+		stopInactiveItems( activeItem = null ) {
+			this.items.forEach( ( item ) => {
+				if ( item !== activeItem ) {
+					item.classList.remove( 'is-previewing' );
+					this.syncPreviewVideo( item, false, { reset: true } );
+				}
+			} );
+		}
+
+		// ── Hover play ────────────────────────────────────────────────────────
+
+		/**
+		 * @param {Element} item
+		 */
+		scheduleItemHoverStart( item ) {
+			if ( this.modalOpen ) {
+				return;
+			}
+
+			const video = item.querySelector( '.godam-gallery-v2-item__preview-video' );
+			if ( video && ! this.loadedVideos.has( video ) ) {
+				video.preload = 'metadata';
+			}
+
+			if ( this.hoverIntentTimers.has( item ) ) {
+				clearTimeout( this.hoverIntentTimers.get( item ) );
+			}
+
+			const timerId = setTimeout( () => {
+				this.hoverIntentTimers.delete( item );
+				this.handleItemHoverStart( item );
+			}, HOVER_INTENT_DELAY_MS );
+
+			this.hoverIntentTimers.set( item, timerId );
+		}
+
+		/**
+		 * @param {Element} item
+		 */
+		handleItemHoverStart( item ) {
+			if ( this.modalOpen ) {
+				return;
+			}
+
+			this.hoverActiveItem = item;
+
+			if ( this.autoplay ) {
+				// In autoplay mode hover just redirects the sequence to this item.
+				if ( this.autoplayActiveItem !== item ) {
+					this.playAutoplayItem( item, { restart: true } );
+				}
+				return;
+			}
+
+			this.stopInactiveItems( item );
+			item.classList.add( 'is-previewing' );
+
+			// Hover play should loop so the video keeps playing while hovered.
+			const hoverVideo = item.querySelector( '.godam-gallery-v2-item__preview-video' );
+			if ( hoverVideo ) {
+				hoverVideo.loop = true;
+			}
+
+			this.syncPreviewVideo( item, true, { restart: true, muted: true } );
+		}
+
+		/**
+		 * @param {Element} item
+		 */
+		handleItemHoverEnd( item ) {
+			if ( this.hoverIntentTimers.has( item ) ) {
+				clearTimeout( this.hoverIntentTimers.get( item ) );
+				this.hoverIntentTimers.delete( item );
+			}
+
+			if ( this.hoverActiveItem === item ) {
+				this.hoverActiveItem = null;
+			}
+
+			if ( this.autoplay ) {
+				return; // Let autoplay sequence continue.
+			}
+
+			item.classList.remove( 'is-previewing' );
+			this.syncPreviewVideo( item, false, { reset: true } );
+		}
+
+		// ── Autoplay sequencing ───────────────────────────────────────────────
+
+		/**
+		 * @param {Element} item
+		 * @param {Object}  options
+		 */
+		playAutoplayItem( item, options = {} ) {
+			if ( ! item ) {
+				return;
+			}
+			this.autoplayActiveItem = item;
+			item.classList.add( 'is-previewing' );
+			this.stopInactiveItems( item );
+
+			// Ensure loop is off so the 'ended' event fires and advances the sequence.
+			const video = item.querySelector( '.godam-gallery-v2-item__preview-video' );
+			if ( video ) {
+				video.loop = false;
+			}
+
+			this.syncPreviewVideo( item, true, { restart: options.restart !== false, muted: true } );
+		}
+
+		stopAutoplaySequence() {
+			if ( this.autoplayActiveItem ) {
+				this.autoplayActiveItem.classList.remove( 'is-previewing' );
+				this.syncPreviewVideo( this.autoplayActiveItem, false, { reset: true } );
+			}
+			this.autoplayActiveItem = null;
+		}
+
+		/**
+		 * @param {Element|null} currentItem
+		 */
+		advanceAutoplaySequence( currentItem = this.autoplayActiveItem ) {
+			if ( ! this.autoplay || this.modalOpen ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			const visibleItems = this.items.filter( ( i ) => i.dataset.isInViewport === 'true' );
+			const pool = visibleItems.length > 0 ? visibleItems : this.items;
+			if ( pool.length === 0 ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			const currentIdx = pool.indexOf( currentItem );
+			const nextIdx = currentIdx === -1 ? 0 : ( currentIdx + 1 ) % pool.length;
+			this.playAutoplayItem( pool[ nextIdx ], { restart: true } );
+		}
+
+		syncAutoplaySequence() {
+			if ( ! this.autoplay || this.modalOpen ) {
+				return;
+			}
+
+			const visibleItems = this.items.filter( ( i ) => i.dataset.isInViewport === 'true' );
+			if ( visibleItems.length === 0 ) {
+				this.stopAutoplaySequence();
+				return;
+			}
+
+			if (
+				this.autoplayActiveItem &&
+				visibleItems.includes( this.autoplayActiveItem )
+			) {
+				this.stopInactiveItems( this.autoplayActiveItem );
+				return;
+			}
+
+			this.playAutoplayItem( visibleItems[ 0 ], { restart: true } );
 		}
 
 		openModalByIndex( index ) {
@@ -397,6 +859,21 @@ const { __ } = require( '@wordpress/i18n' );
 
 			if ( this.currentIndex === -1 ) {
 				this.previouslyFocusedElement = this.element.ownerDocument.activeElement;
+			}
+
+			// Pause all preview videos when modal opens.
+			this.modalOpen = true;
+			this.hoverIntentTimers.forEach( ( t ) => clearTimeout( t ) );
+			this.hoverIntentTimers.clear();
+			this.hoverActiveItem = null;
+
+			if ( this.autoplay ) {
+				this.stopAutoplaySequence();
+			} else {
+				this.items.forEach( ( i ) => {
+					i.classList.remove( 'is-previewing' );
+					this.syncPreviewVideo( i, false, { reset: true } );
+				} );
 			}
 
 			this.currentIndex = index;
@@ -450,6 +927,7 @@ const { __ } = require( '@wordpress/i18n' );
 
 			document.body.classList.remove( 'godam-gallery-v2-modal-open' );
 			this.currentIndex = -1;
+			this.modalOpen = false;
 
 			if ( activeGallery === this ) {
 				activeGallery = null;
@@ -458,6 +936,11 @@ const { __ } = require( '@wordpress/i18n' );
 			if ( this.previouslyFocusedElement ) {
 				this.previouslyFocusedElement.focus();
 				this.previouslyFocusedElement = null;
+			}
+
+			// Resume preview playback after modal closes.
+			if ( this.autoplay ) {
+				this.syncAutoplaySequence();
 			}
 		}
 	}

--- a/inc/classes/rest-api/class-dynamic-gallery.php
+++ b/inc/classes/rest-api/class-dynamic-gallery.php
@@ -168,12 +168,19 @@ class Dynamic_Gallery extends Base {
 				/* translators: %s: video title. */
 				echo '<button type="button" class="godam-gallery-v2__query-button" data-godam-gallery-v2-trigger="true" data-video-id="' . esc_attr( $item['id'] ) . '" aria-label="' . esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $item['title'] ) ) . '">';
 				echo '<div class="godam-gallery-v2__query-thumb' . ( ! empty( $item['placeholder'] ) ? ' godam-gallery-blurred-img' : '' ) . '"' . ( ! empty( $item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $item['placeholder'] ) . '\')"' : '' ) . '>';
+
 				if ( ! empty( $item['thumbnail'] ) ) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $thumbnail_attributes comes from rtgodam_format_html_attributes() which pre-sanitizes.
 					echo '<img src="' . esc_url( $item['thumbnail'] ) . '" alt="' . esc_attr( $item['title'] ) . '" class="godam-gallery-v2__thumbnail"' . ( $thumbnail_attributes ? ' ' . $thumbnail_attributes : '' ) . ' />';
 				} else {
-					echo '<span>' . esc_html__( 'Video', 'godam' ) . '</span>';
+					echo '<img class="godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending" alt="' . esc_attr( $item['title'] ) . '" aria-hidden="true" />';
 				}
+
+				if ( ! empty( $item['video_url'] ) ) {
+					echo '<video class="godam-gallery-v2-item__preview-video" src="' . esc_url( $item['video_url'] ) . '" muted playsinline preload="none" aria-hidden="true" tabindex="-1"></video>';
+				}
+
+				echo '<div class="godam-gallery-v2__play-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg></div>';
 				echo '</div>';
 
 				if ( $show_title ) {

--- a/inc/templates/godam-video-gallery.php
+++ b/inc/templates/godam-video-gallery.php
@@ -239,12 +239,20 @@ if ( ! function_exists( 'rtgodam_gallery_v2_get_video_data' ) ) {
 			return null;
 		}
 
+		// Use the original attachment URL for the silent preview video.
+		// rtgodam_transcoded_url stores an MPEG-DASH (.mpd) manifest which cannot
+		// be played by a plain <video> element — only video.js can decode it.
+		// The source MP4 is always browser-playable and is good enough for the
+		// muted hover-preview thumbnail.
+		$godam_video_url = wp_get_attachment_url( $attachment_id );
+
 		return array(
 			'id'          => $attachment_id,
 			'title'       => get_the_title( $attachment_id ) ?: __( 'Untitled video', 'godam' ),
 			'date'        => rtgodam_gallery_v2_format_display_date( $post->post_date ),
 			'thumbnail'   => rtgodam_gallery_v2_get_thumbnail_url( $attachment_id ),
 			'placeholder' => rtgodam_gallery_v2_get_placeholder_thumbnail_url( $attachment_id ),
+			'video_url'   => $godam_video_url ?: '',
 		);
 	}
 }
@@ -306,14 +314,21 @@ $godam_inline_styles = sprintf(
 	esc_attr( $godam_block_gap )
 );
 
+$godam_autoplay         = ! empty( $attributes['autoplay'] );
+$godam_play_on_hover    = isset( $attributes['playOnHover'] ) ? (bool) $attributes['playOnHover'] : true;
+$godam_show_play_button = ! isset( $attributes['showPlayButton'] ) || (bool) $attributes['showPlayButton'];
+
 $godam_wrapper_attrs = array(
-	'class'               => sprintf( 'godam-gallery-v2 godam-gallery-v2--%s', $godam_gallery_mode ),
-	'style'               => $godam_inline_styles,
-	'data-mode'           => $godam_gallery_mode,
-	'data-layout'         => $godam_layout,
-	'data-ratio'          => $godam_view_ratio,
-	'data-embed-base-url' => home_url( '/' ),
-	'data-engagements'    => rtgodam_is_engagement_feature_enabled() && ! empty( $attributes['engagements'] ) ? 'show' : '',
+	'class'                 => sprintf( 'godam-gallery-v2 godam-gallery-v2--%s', $godam_gallery_mode ),
+	'style'                 => $godam_inline_styles,
+	'data-mode'             => $godam_gallery_mode,
+	'data-layout'           => $godam_layout,
+	'data-ratio'            => $godam_view_ratio,
+	'data-embed-base-url'   => home_url( '/' ),
+	'data-engagements'      => rtgodam_is_engagement_feature_enabled() && ! empty( $attributes['engagements'] ) ? 'show' : '',
+	'data-autoplay'         => $godam_autoplay ? 'true' : 'false',
+	'data-play-on-hover'    => $godam_play_on_hover ? 'true' : 'false',
+	'data-show-play-button' => $godam_show_play_button ? 'true' : 'false',
 );
 
 if ( $godam_is_shortcode ) {
@@ -409,8 +424,24 @@ if ( 'query' === $godam_gallery_mode ) {
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
 									<img src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" class="godam-gallery-v2__thumbnail" <?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?> />
 								<?php else : ?>
-									<span><?php esc_html_e( 'Video', 'godam' ); ?></span>
+									<img class="godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" aria-hidden="true" />
 								<?php endif; ?>
+								<?php if ( ! empty( $godam_item['video_url'] ) ) : ?>
+									<video
+										class="godam-gallery-v2-item__preview-video"
+										src="<?php echo esc_url( $godam_item['video_url'] ); ?>"
+										muted
+										playsinline
+										preload="none"
+										aria-hidden="true"
+										tabindex="-1"
+									></video>
+								<?php endif; ?>
+								<div class="godam-gallery-v2__play-icon" aria-hidden="true">
+									<svg viewBox="0 0 24 24" fill="currentColor">
+										<path d="M8 5v14l11-7z" />
+									</svg>
+								</div>
 							</div>
 							<?php if ( $godam_show_title ) : ?>
 								<div class="godam-gallery-v2__query-meta">
@@ -464,9 +495,22 @@ if ( 'query' === $godam_gallery_mode ) {
 										<?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?>
 									/>
 								<?php else : ?>
-									<div class="godam-gallery-v2-item__placeholder">
-										<span><?php esc_html_e( 'Video', 'godam' ); ?></span>
-									</div>
+									<img
+										class="godam-gallery-v2-item__thumbnail godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending"
+										alt="<?php echo esc_attr( $godam_item['title'] ); ?>"
+										aria-hidden="true"
+									/>
+								<?php endif; ?>
+								<?php if ( ! empty( $godam_item['video_url'] ) ) : ?>
+									<video
+										class="godam-gallery-v2-item__preview-video"
+										src="<?php echo esc_url( $godam_item['video_url'] ); ?>"
+										muted
+										playsinline
+										preload="none"
+										aria-hidden="true"
+										tabindex="-1"
+									></video>
 								<?php endif; ?>
 								<div class="godam-gallery-v2-item__play-icon" aria-hidden="true">
 									<svg viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
# Video Gallery V2 — Feature & Bug Fix Batch

Fixes rtCamp/godam-plugin-wp#4

## What changed and why

**1. Fix hover/preview play for transcoded videos**
`rtgodam_transcoded_url` stores an MPEG-DASH `.mpd` manifest that a plain `<video>` element cannot decode. Switched `video_url` in `rtgodam_gallery_v2_get_video_data()` to always use `wp_get_attachment_url()` (the original MP4), which is universally browser-playable and sufficient for the muted hover preview.

**2. First-frame video thumbnail (no-thumbnail fallback)**
When a video has no manually set thumbnail, the frontend now shows the video's first frame — matching the shoppable video block's behaviour. This is done by:
- Emitting a `<img class="godam-gallery-v2__thumbnail--pending">` in the PHP template when no thumbnail URL exists
- In `view.js`, `initFirstFrameThumbnails()` detects this placeholder, hides it, sets `preload="metadata"` + `video.load()` on the preview video, and adds a `--no-thumb` CSS class that keeps the video element permanently visible
- A CSS rule for `--no-thumb` items sets `opacity: 1` on the preview video so the browser-rendered first frame is visible as the thumbnail

**3. Fix thumbnail CSS opacity bug**
The global `opacity: 0` rule on `.godam-gallery-v2__thumbnail` was preventing thumbnails from rendering for items that don't go through the blur-up placeholder flow. Removed the global rule; the blur-up system manages its own opacity transition independently.

**4. Editor: default placeholder for videos without a thumbnail**
In the block editor, a tile with a video selected but no thumbnail was incorrectly showing the "Select Video" empty state. Added a distinct `--no-thumb` placeholder state that shows the video icon with Replace/Remove actions, making it clear a video is attached.

**5. Show Play Button toggle**
Added a `showPlayButton` boolean attribute (default `true`) and a `ToggleControl` in the Interaction panel of the block inspector. When off:
- PHP template passes `data-show-play-button="false"` on the gallery wrapper
- CSS `[data-show-play-button="false"]` hides `.godam-gallery-v2__play-icon` and `.godam-gallery-v2-item__play-icon` via `display: none`
- Editor query-tab preview was also fixed — the play icon SVG was missing from the React JSX for query preview tiles, so it's now rendered conditionally based on the `showPlayButton` attribute

**6. Sequential autoplay (one video at a time, full playback)**
The `<video>` elements had the `loop` HTML attribute, which prevents the `ended` event from ever firing. The existing `advanceAutoplaySequence` handler was listening for `ended` but never received it, so autoplay never advanced. Fixed by:
- Removing `loop` from both `<video>` elements in the PHP template
- Setting `video.loop = false` in `playAutoplayItem()` before play, ensuring `ended` always fires
- Setting `video.loop = true` in the hover-play path (`handleItemHoverStart`) so hovered videos still loop continuously

**7. Load-more / infinite scroll parity**
New tiles injected by Load More or infinite scroll were missing all interactive behaviour because two separate issues compounded:
- `class-dynamic-gallery.php` (the REST endpoint for load-more HTML) had its own stripped-down tile template that omitted the `<video>` element, play icon SVG, and `--pending` thumbnail — so the required DOM nodes were simply absent
- `initVideoPreview()` only ran once at construction and never re-ran for new items

Both are fixed:
- REST endpoint now renders the full tile structure (video element, play icon, `--pending` img) matching `godam-video-gallery.php`
- Introduced `initializedPreviewItems` WeakSet to track wired-up tiles
- Extracted `initVideoPreviewItem(item)` — idempotent per-item setup (event listeners + `initItemVideoState`)
- `initViewportPreload()` and `initAutoplayObserver()` now create their observers once and accept an optional item list to observe, so new items can be registered without re-creating the observers
- New `initNewItemsBehavior()` method called at the end of `loadMoreItems()` — finds uninitialised items, wires them up, and registers them with existing observers

## Files changed
- `inc/templates/godam-video-gallery.php` — video_url fix, `--pending` thumbnail markup, `loop` removal, `data-show-play-button` attribute
- `inc/classes/rest-api/class-dynamic-gallery.php` — full tile HTML parity (video, play icon, pending thumbnail)
- `assets/src/blocks/godam-gallery-v2/view.js` — first-frame thumbnails, sequential autoplay, load-more initialisation, viewport preload refactor
- `assets/src/blocks/godam-gallery-v2/edit.js` — show play button toggle, play icon in query preview JSX, `data-show-play-button` on canvas wrappers
- `assets/src/blocks/godam-gallery-v2/block.json` — `showPlayButton` attribute
- `assets/src/blocks/godam-gallery-v2/style.scss` — `--no-thumb` opacity, play button hide rule, thumbnail opacity fix
- `assets/src/blocks/godam-gallery-v2-item/edit.js` — no-thumbnail placeholder state in editor

## Demo


https://github.com/user-attachments/assets/50532b42-95ba-4881-a759-f3658bebb4d3

