### PR TITLE
feat(audio-block): revamp block UI with card layout

### DIFF
--- a/assets/src/blocks/godam-audio/block.json
+++ b/assets/src/blocks/godam-audio/block.json
@@ -35,6 +35,25 @@
 		"preload": {
 			"type": "string",
 			"default": "metadata"
+		},
+		"audioTitle": {
+			"type": "string",
+			"default": "",
+			"role": "content"
+		},
+		"description": {
+			"type": "string",
+			"default": "",
+			"role": "content"
+		},
+		"thumbnail": {
+			"type": "string",
+			"default": "",
+			"role": "content"
+		},
+		"thumbnailId": {
+			"type": "number",
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -175,6 +175,7 @@ function AudioEdit( {
 										variant="secondary"
 										onClick={ open }
 										className="godam-audio__add-btn"
+										data-test-id="godam-audio-button-select"
 									>
 										{ __( '+ Add Audio File', 'godam' ) }
 									</Button>
@@ -184,7 +185,7 @@ function AudioEdit( {
 					</PanelBody>
 				</InspectorControls>
 
-				<figure { ...blockProps }>
+				<figure { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
 					<div className="godam-audio-empty">
 						<h3 className="godam-audio-empty__title">
 							{ __( 'Add an audio file', 'godam' ) }
@@ -203,6 +204,7 @@ function AudioEdit( {
 										variant="primary"
 										onClick={ open }
 										className="godam-audio-empty__btn"
+										data-test-id="godam-audio-button-upload"
 									>
 										{ __( '+ Upload Audio', 'godam' ) }
 									</Button>
@@ -237,7 +239,7 @@ function AudioEdit( {
 			<InspectorControls>
 
 				{ /* Audio Selection */ }
-				<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true } data-test-id="godam-audio-panel-selection">
 					{ fileName && (
 						<div className="godam-audio-file-row">
 							<span className="godam-audio-file-row__icon dashicons dashicons-media-audio" />
@@ -250,6 +252,7 @@ function AudioEdit( {
 								isDestructive
 								size="small"
 								onClick={ onRemoveAudio }
+								data-test-id="godam-audio-button-remove"
 							/>
 						</div>
 					) }
@@ -258,6 +261,7 @@ function AudioEdit( {
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 						label={ __( 'Audio Title', 'godam' ) }
+						data-test-id="godam-audio-control-title"
 						value={ audioTitle }
 						placeholder={ __( 'Add a title…', 'godam' ) }
 						onChange={ ( value ) => setAttributes( { audioTitle: value } ) }
@@ -266,6 +270,7 @@ function AudioEdit( {
 					<TextareaControl
 						__nextHasNoMarginBottom
 						label={ __( 'Description', 'godam' ) }
+						data-test-id="godam-audio-control-description"
 						value={ description }
 						placeholder={ __( 'Add a short description…', 'godam' ) }
 						rows={ 4 }
@@ -274,7 +279,7 @@ function AudioEdit( {
 				</PanelBody>
 
 				{ /* Thumbnail */ }
-				<PanelBody title={ __( 'Thumbnail', 'godam' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Thumbnail', 'godam' ) } initialOpen={ true } data-test-id="godam-audio-panel-thumbnail">
 					{ thumbnail ? (
 						<div className="godam-audio-thumbnail-preview">
 							<img src={ thumbnail } alt={ __( 'Audio thumbnail', 'godam' ) } />
@@ -285,7 +290,7 @@ function AudioEdit( {
 										allowedTypes={ ALLOWED_THUMBNAIL_TYPES }
 										value={ thumbnailId }
 										render={ ( { open } ) => (
-											<Button variant="secondary" size="small" onClick={ open }>
+											<Button variant="secondary" size="small" onClick={ open } data-test-id="godam-audio-button-replace-thumbnail">
 												{ __( 'Replace', 'godam' ) }
 											</Button>
 										) }
@@ -296,6 +301,7 @@ function AudioEdit( {
 									size="small"
 									isDestructive
 									onClick={ onRemoveThumbnail }
+									data-test-id="godam-audio-button-remove-thumbnail"
 								>
 									{ __( 'Remove', 'godam' ) }
 								</Button>
@@ -313,6 +319,7 @@ function AudioEdit( {
 										variant="secondary"
 										onClick={ open }
 										className="godam-audio__add-btn"
+										data-test-id="godam-audio-button-upload-thumbnail"
 									>
 										{ __( '+ Upload Image', 'godam' ) }
 									</Button>
@@ -365,7 +372,7 @@ function AudioEdit( {
 			<figure { ...blockProps } data-test-id="godam-audio-canvas">
 				<div className="godam-audio-card">
 					{ /* Thumbnail */ }
-					<div className="godam-audio-card__cover">
+					<div className="godam-audio-card__cover" data-test-id="godam-audio-element-cover">
 						{ thumbnail ? (
 							<img src={ thumbnail } alt={ audioTitle || __( 'Audio thumbnail', 'godam' ) } />
 						) : (
@@ -378,10 +385,10 @@ function AudioEdit( {
 					{ /* Info + player */ }
 					<div className="godam-audio-card__body">
 						{ audioTitle && (
-							<p className="godam-audio-card__title">{ audioTitle }</p>
+							<p className="godam-audio-card__title" data-test-id="godam-audio-element-title">{ audioTitle }</p>
 						) }
 						{ description && (
-							<p className="godam-audio-card__description">{ description }</p>
+							<p className="godam-audio-card__description" data-test-id="godam-audio-element-description">{ description }</p>
 						) }
 						<Disabled isDisabled={ ! isSingleSelected }>
 							<audio controls src={ src ?? temporaryURL } style={ { width: '100%' } } />

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -8,17 +8,20 @@ import clsx from 'clsx';
  */
 import { isBlobURL } from '@wordpress/blob';
 import {
+	Button,
 	Disabled,
 	PanelBody,
 	SelectControl,
 	Spinner,
+	TextControl,
+	TextareaControl,
 	ToggleControl,
 } from '@wordpress/components';
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
-	MediaPlaceholder,
+	MediaUpload,
+	MediaUploadCheck,
 	MediaReplaceFlow,
 	useBlockProps,
 } from '@wordpress/block-editor';
@@ -26,15 +29,16 @@ import { __, _x } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from '@wordpress/element';
+import { trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { Caption } from './caption';
 import './editor.scss';
-import { ReactComponent as icon } from '../../images/godam-audio-filled.svg';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+const ALLOWED_THUMBNAIL_TYPES = [ 'image' ];
 
 /**
  * Edit component for the GoDAM Audio block.
@@ -55,7 +59,7 @@ function AudioEdit( {
 	isSelected: isSingleSelected,
 	insertBlocksAfter,
 } ) {
-	const { id, autoplay, loop, preload, src } = attributes;
+	const { id, autoplay, loop, preload, src, audioTitle, description, thumbnail, thumbnailId } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 
 	function toggleAttribute( attribute ) {
@@ -77,8 +81,6 @@ function AudioEdit( {
 
 	function onSelectAudio( media ) {
 		if ( ! media || ! media.url ) {
-			// In this case there was an error and we should continue in the editing state
-			// previous attributes should be removed because they may be temporary blob urls.
 			setAttributes( {
 				src: undefined,
 				id: undefined,
@@ -89,8 +91,7 @@ function AudioEdit( {
 			return;
 		}
 
-		// Guard against non-audio selections. The media library lets users pick
-		// any attachment type even when allowedTypes is set, so re-check here.
+		// Guard against non-audio selections.
 		const mediaType = media.type || ( media.mime || media.mime_type || '' ).split( '/' )[ 0 ];
 		if ( mediaType && mediaType !== 'audio' ) {
 			createErrorNotice(
@@ -105,44 +106,105 @@ function AudioEdit( {
 			return;
 		}
 
-		// Always store the src and id returned by the media selection.
 		setAttributes( {
 			blob: undefined,
 			src: media.url,
 			id: media.id,
 			caption: media.caption || media.title,
+			audioTitle: audioTitle || media.title || '',
 		} );
 		setTemporaryURL();
 	}
+
+	function onRemoveAudio() {
+		setAttributes( {
+			src: undefined,
+			id: undefined,
+			caption: undefined,
+			blob: undefined,
+		} );
+	}
+
+	function onSelectThumbnail( media ) {
+		if ( ! media || ! media.url ) {
+			return;
+		}
+		setAttributes( { thumbnail: media.url, thumbnailId: media.id } );
+	}
+
+	function onRemoveThumbnail() {
+		setAttributes( { thumbnail: '', thumbnailId: undefined } );
+	}
+
+	const hasAudio = !! ( src || temporaryURL );
+	const fileName = src ? src.split( '/' ).pop().split( '?' )[ 0 ] : '';
 
 	const classes = clsx( className, {
 		'is-transient': !! temporaryURL,
 	} );
 
-	const blockProps = useBlockProps( {
-		className: classes,
-	} );
+	const blockProps = useBlockProps( { className: classes } );
 
-	if ( ! src && ! temporaryURL ) {
+	// ── Empty state ───────────────────────────────────────────────────────────
+	if ( ! hasAudio ) {
 		return (
-			<div { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
-				<div data-test-id="godam-audio-button-select">
-					<MediaPlaceholder
-						icon={ <BlockIcon icon={ icon } /> }
-						onSelect={ onSelectAudio }
-						accept="audio/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ attributes }
-						onError={ onUploadError }
-						labels={ { title: __( 'Audio', 'godam' ) } }
-					/>
-				</div>
-			</div>
+			<>
+				<InspectorControls>
+					<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true }>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectAudio }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								accept="audio/*"
+								render={ ( { open } ) => (
+									<Button
+										__next40pxDefaultSize
+										variant="secondary"
+										onClick={ open }
+										className="godam-audio__add-btn"
+									>
+										{ __( '+ Add Audio File', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</PanelBody>
+				</InspectorControls>
+
+				<figure { ...blockProps }>
+					<div className="godam-audio-empty">
+						<h3 className="godam-audio-empty__title">
+							{ __( 'Add an audio file', 'godam' ) }
+						</h3>
+						<p className="godam-audio-empty__subtitle">
+							{ __( 'Upload an audio file to embed a player on your page or post.', 'godam' ) }
+						</p>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectAudio }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								accept="audio/*"
+								render={ ( { open } ) => (
+									<Button
+										variant="primary"
+										onClick={ open }
+										className="godam-audio-empty__btn"
+									>
+										{ __( '+ Upload Audio', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</div>
+				</figure>
+			</>
 		);
 	}
 
+	// ── Has audio ─────────────────────────────────────────────────────────────
 	return (
 		<>
+			{ /* ── Toolbar ─────────────────────────────────────────────────── */ }
 			{ isSingleSelected && (
 				<BlockControls group="other">
 					<MediaReplaceFlow
@@ -156,8 +218,98 @@ function AudioEdit( {
 					/>
 				</BlockControls>
 			) }
+
+			{ /* ── Inspector ─────────────────────────────────────────────────── */ }
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'godam' ) } data-test-id="godam-audio-panel-settings">
+
+				{ /* Audio Selection */ }
+				<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true }>
+					{ fileName && (
+						<div className="godam-audio-file-row">
+							<span className="godam-audio-file-row__icon dashicons dashicons-media-audio" />
+							<span className="godam-audio-file-row__name" title={ fileName }>
+								{ fileName }
+							</span>
+							<Button
+								icon={ trash }
+								label={ __( 'Remove audio', 'godam' ) }
+								isDestructive
+								size="small"
+								onClick={ onRemoveAudio }
+							/>
+						</div>
+					) }
+
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Audio Title', 'godam' ) }
+						value={ audioTitle }
+						placeholder={ __( 'Placeholder', 'godam' ) }
+						onChange={ ( value ) => setAttributes( { audioTitle: value } ) }
+					/>
+
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={ __( 'Description', 'godam' ) }
+						value={ description }
+						placeholder={ __( 'This is a sample description.', 'godam' ) }
+						rows={ 4 }
+						onChange={ ( value ) => setAttributes( { description: value } ) }
+					/>
+				</PanelBody>
+
+				{ /* Thumbnail */ }
+				<PanelBody title={ __( 'Thumbnail', 'godam' ) } initialOpen={ true }>
+					{ thumbnail ? (
+						<div className="godam-audio-thumbnail-preview">
+							<img src={ thumbnail } alt={ __( 'Audio thumbnail', 'godam' ) } />
+							<div className="godam-audio-thumbnail-preview__actions">
+								<MediaUploadCheck>
+									<MediaUpload
+										onSelect={ onSelectThumbnail }
+										allowedTypes={ ALLOWED_THUMBNAIL_TYPES }
+										value={ thumbnailId }
+										render={ ( { open } ) => (
+											<Button variant="secondary" size="small" onClick={ open }>
+												{ __( 'Replace', 'godam' ) }
+											</Button>
+										) }
+									/>
+								</MediaUploadCheck>
+								<Button
+									variant="secondary"
+									size="small"
+									isDestructive
+									onClick={ onRemoveThumbnail }
+								>
+									{ __( 'Remove', 'godam' ) }
+								</Button>
+							</div>
+						</div>
+					) : (
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectThumbnail }
+								allowedTypes={ ALLOWED_THUMBNAIL_TYPES }
+								value={ thumbnailId }
+								render={ ( { open } ) => (
+									<Button
+										__next40pxDefaultSize
+										variant="secondary"
+										onClick={ open }
+										className="godam-audio__add-btn"
+									>
+										{ __( '+ Upload Image', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					) }
+				</PanelBody>
+
+				{ /* Settings */ }
+				<PanelBody title={ __( 'Settings', 'godam' ) } initialOpen={ false } data-test-id="godam-audio-panel-settings">
 					<div data-test-id="godam-audio-control-autoplay">
 						<ToggleControl
 							__nextHasNoMarginBottom
@@ -181,34 +333,49 @@ function AudioEdit( {
 						label={ _x( 'Preload', 'noun; Audio block parameter', 'godam' ) }
 						data-test-id="godam-audio-control-preload"
 						value={ preload || '' }
-						// `undefined` is required for the preload attribute to be unset.
 						onChange={ ( value ) =>
-							setAttributes( {
-								preload: value || undefined,
-							} )
+							setAttributes( { preload: value || undefined } )
 						}
 						options={ [
 							{ value: '', label: __( 'Browser default', 'godam' ) },
 							{ value: 'auto', label: __( 'Auto', 'godam' ) },
 							{ value: 'metadata', label: __( 'Metadata', 'godam' ) },
-							{
-								value: 'none',
-								label: _x( 'None', 'Preload value', 'godam' ),
-							},
+							{ value: 'none', label: _x( 'None', 'Preload value', 'godam' ) },
 						] }
 					/>
 				</PanelBody>
+
 			</InspectorControls>
+
+			{ /* ── Block canvas ─────────────────────────────────────────────── */ }
 			<figure { ...blockProps } data-test-id="godam-audio-canvas">
-				{ /*
-				Disable the audio tag if the block is not selected
-				so the user clicking on it won't play the
-				file or change the position slider when the controls are enabled.
-				*/ }
-				<Disabled isDisabled={ ! isSingleSelected }>
-					<audio controls="controls" src={ src ?? temporaryURL } />
-				</Disabled>
-				{ !! temporaryURL && <Spinner /> }
+				<div className="godam-audio-card">
+					{ /* Thumbnail */ }
+					<div className="godam-audio-card__cover">
+						{ thumbnail ? (
+							<img src={ thumbnail } alt={ audioTitle || __( 'Audio thumbnail', 'godam' ) } />
+						) : (
+							<div className="godam-audio-card__cover-placeholder">
+								<span className="dashicons dashicons-media-audio" />
+							</div>
+						) }
+					</div>
+
+					{ /* Info + player */ }
+					<div className="godam-audio-card__body">
+						{ audioTitle && (
+							<p className="godam-audio-card__title">{ audioTitle }</p>
+						) }
+						{ description && (
+							<p className="godam-audio-card__description">{ description }</p>
+						) }
+						<Disabled isDisabled={ ! isSingleSelected }>
+							<audio controls src={ src ?? temporaryURL } style={ { width: '100%' } } />
+						</Disabled>
+						{ !! temporaryURL && <Spinner /> }
+					</div>
+				</div>
+
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -122,11 +122,23 @@ function AudioEdit( {
 			id: undefined,
 			caption: undefined,
 			blob: undefined,
+			audioTitle: '',
+			description: '',
+			thumbnail: '',
+			thumbnailId: undefined,
 		} );
 	}
 
 	function onSelectThumbnail( media ) {
 		if ( ! media || ! media.url ) {
+			return;
+		}
+		const mediaType = media.type || ( media.mime || media.mime_type || '' ).split( '/' )[ 0 ];
+		if ( mediaType && mediaType !== 'image' ) {
+			createErrorNotice(
+				__( 'Only image files are allowed for the GoDAM Audio thumbnail.', 'godam' ),
+				{ type: 'snackbar' },
+			);
 			return;
 		}
 		setAttributes( { thumbnail: media.url, thumbnailId: media.id } );
@@ -156,6 +168,7 @@ function AudioEdit( {
 								onSelect={ onSelectAudio }
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								accept="audio/*"
+								onError={ onUploadError }
 								render={ ( { open } ) => (
 									<Button
 										__next40pxDefaultSize
@@ -184,6 +197,7 @@ function AudioEdit( {
 								onSelect={ onSelectAudio }
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								accept="audio/*"
+								onError={ onUploadError }
 								render={ ( { open } ) => (
 									<Button
 										variant="primary"
@@ -245,7 +259,7 @@ function AudioEdit( {
 						__nextHasNoMarginBottom
 						label={ __( 'Audio Title', 'godam' ) }
 						value={ audioTitle }
-						placeholder={ __( 'Placeholder', 'godam' ) }
+						placeholder={ __( 'Add a title…', 'godam' ) }
 						onChange={ ( value ) => setAttributes( { audioTitle: value } ) }
 					/>
 
@@ -253,7 +267,7 @@ function AudioEdit( {
 						__nextHasNoMarginBottom
 						label={ __( 'Description', 'godam' ) }
 						value={ description }
-						placeholder={ __( 'This is a sample description.', 'godam' ) }
+						placeholder={ __( 'Add a short description…', 'godam' ) }
 						rows={ 4 }
 						onChange={ ( value ) => setAttributes( { description: value } ) }
 					/>

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -20,6 +20,7 @@ import {
 import {
 	BlockControls,
 	InspectorControls,
+	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadCheck,
 	MediaReplaceFlow,
@@ -149,7 +150,7 @@ function AudioEdit( {
 	}
 
 	const hasAudio = !! ( src || temporaryURL );
-	const fileName = src ? src.split( '/' ).pop().split( '?' )[ 0 ] : '';
+	const fileName = src ? decodeURIComponent( src.split( '/' ).pop().split( '?' )[ 0 ] ) : '';
 
 	const classes = clsx( className, {
 		'is-transient': !! temporaryURL,
@@ -160,60 +161,20 @@ function AudioEdit( {
 	// ── Empty state ───────────────────────────────────────────────────────────
 	if ( ! hasAudio ) {
 		return (
-			<>
-				<InspectorControls>
-					<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true }>
-						<MediaUploadCheck>
-							<MediaUpload
-								onSelect={ onSelectAudio }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								accept="audio/*"
-								onError={ onUploadError }
-								render={ ( { open } ) => (
-									<Button
-										__next40pxDefaultSize
-										variant="secondary"
-										onClick={ open }
-										className="godam-audio__add-btn"
-										data-test-id="godam-audio-button-select"
-									>
-										{ __( '+ Add Audio File', 'godam' ) }
-									</Button>
-								) }
-							/>
-						</MediaUploadCheck>
-					</PanelBody>
-				</InspectorControls>
-
-				<figure { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
-					<div className="godam-audio-empty">
-						<h3 className="godam-audio-empty__title">
-							{ __( 'Add an audio file', 'godam' ) }
-						</h3>
-						<p className="godam-audio-empty__subtitle">
-							{ __( 'Upload an audio file to embed a player on your page or post.', 'godam' ) }
-						</p>
-						<MediaUploadCheck>
-							<MediaUpload
-								onSelect={ onSelectAudio }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								accept="audio/*"
-								onError={ onUploadError }
-								render={ ( { open } ) => (
-									<Button
-										variant="primary"
-										onClick={ open }
-										className="godam-audio-empty__btn"
-										data-test-id="godam-audio-button-upload"
-									>
-										{ __( '+ Upload Audio', 'godam' ) }
-									</Button>
-								) }
-							/>
-						</MediaUploadCheck>
-					</div>
-				</figure>
-			</>
+			<figure { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
+				<MediaPlaceholder
+					icon="media-audio"
+					labels={ {
+						title: __( 'GoDAM Audio', 'godam' ),
+						instructions: __( 'Upload an audio file or pick one from your media library.', 'godam' ),
+					} }
+					onSelect={ onSelectAudio }
+					onError={ onUploadError }
+					accept="audio/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					data-test-id="godam-audio-button-upload"
+				/>
+			</figure>
 		);
 	}
 

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -20,7 +20,6 @@ import {
 import {
 	BlockControls,
 	InspectorControls,
-	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadCheck,
 	MediaReplaceFlow,
@@ -161,20 +160,60 @@ function AudioEdit( {
 	// ── Empty state ───────────────────────────────────────────────────────────
 	if ( ! hasAudio ) {
 		return (
-			<figure { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
-				<MediaPlaceholder
-					icon="media-audio"
-					labels={ {
-						title: __( 'GoDAM Audio', 'godam' ),
-						instructions: __( 'Upload an audio file or pick one from your media library.', 'godam' ),
-					} }
-					onSelect={ onSelectAudio }
-					onError={ onUploadError }
-					accept="audio/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					data-test-id="godam-audio-button-upload"
-				/>
-			</figure>
+			<>
+				<InspectorControls>
+					<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true }>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectAudio }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								accept="audio/*"
+								onError={ onUploadError }
+								render={ ( { open } ) => (
+									<Button
+										__next40pxDefaultSize
+										variant="secondary"
+										onClick={ open }
+										className="godam-audio__add-btn"
+										data-test-id="godam-audio-button-select"
+									>
+										{ __( '+ Add Audio File', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</PanelBody>
+				</InspectorControls>
+
+				<figure { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
+					<div className="godam-audio-empty">
+						<h3 className="godam-audio-empty__title">
+							{ __( 'Add an audio file', 'godam' ) }
+						</h3>
+						<p className="godam-audio-empty__subtitle">
+							{ __( 'Upload an audio file to embed a player on your page or post.', 'godam' ) }
+						</p>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectAudio }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								accept="audio/*"
+								onError={ onUploadError }
+								render={ ( { open } ) => (
+									<Button
+										variant="primary"
+										onClick={ open }
+										className="godam-audio-empty__btn"
+										data-test-id="godam-audio-button-upload"
+									>
+										{ __( '+ Upload Audio', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</div>
+				</figure>
+			</>
 		);
 	}
 

--- a/assets/src/blocks/godam-audio/editor.scss
+++ b/assets/src/blocks/godam-audio/editor.scss
@@ -11,10 +11,12 @@
 	margin-right: 0;
 	position: relative;
 
-	padding: 30px;
-    border: 3px dotted #B2AEFF;
-    background: #F2F2FF;
-    border-radius: 6px;
+	&:not(:has(.godam-audio-empty)) {
+		padding: 30px;
+		border: 3px dotted #b2aeff;
+		background: #f2f2ff;
+		border-radius: 6px;
+	}
 
 	&.is-transient audio {
 		opacity: 0.3;
@@ -58,14 +60,6 @@
 
 	&__btn {
 		margin-top: 8px;
-		background: #6366f1 !important;
-		border-color: #6366f1 !important;
-		color: #fff !important;
-
-		&:hover {
-			background: #4f46e5 !important;
-			border-color: #4f46e5 !important;
-		}
 	}
 }
 

--- a/assets/src/blocks/godam-audio/editor.scss
+++ b/assets/src/blocks/godam-audio/editor.scss
@@ -32,6 +32,38 @@
 	}
 }
 
+// ── Empty state ──────────────────────────────────────────────────────────────
+.godam-audio-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 40px 24px;
+	background: #eef2ff;
+	border: 2px dashed #a5b4fc;
+	border-radius: 6px;
+	text-align: center;
+
+	&__title {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--wp-components-color-foreground, #1e1e1e);
+	}
+
+	&__subtitle {
+		margin: 0;
+		font-size: 13px;
+		color: var(--wp-components-color-foreground-muted, #757575);
+	}
+
+	&__btn {
+		margin-top: 8px;
+		letter-spacing: 1px;
+	}
+}
+
 // ── Inspector: full-width add buttons ────────────────────────────────────────
 .godam-audio__add-btn {
 	width: 100%;

--- a/assets/src/blocks/godam-audio/editor.scss
+++ b/assets/src/blocks/godam-audio/editor.scss
@@ -32,37 +32,6 @@
 	}
 }
 
-// ── Empty state ──────────────────────────────────────────────────────────────
-.godam-audio-empty {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	padding: 40px 24px;
-	background: #eef2ff;
-	border: 2px dashed #a5b4fc;
-	border-radius: 6px;
-	text-align: center;
-
-	&__title {
-		margin: 0;
-		font-size: 16px;
-		font-weight: 600;
-		color: var(--wp-components-color-foreground, #1e1e1e);
-	}
-
-	&__subtitle {
-		margin: 0;
-		font-size: 13px;
-		color: var(--wp-components-color-foreground-muted, #757575);
-	}
-
-	&__btn {
-		margin-top: 8px;
-	}
-}
-
 // ── Inspector: full-width add buttons ────────────────────────────────────────
 .godam-audio__add-btn {
 	width: 100%;
@@ -163,7 +132,7 @@
 
 		audio {
 			width: 100%;
-			height: 15px;
+			height: 25px;
 			margin-top: auto;
 			margin-left: -8px;
 
@@ -191,6 +160,7 @@
 		color: var(--wp-components-color-foreground-muted, #757575);
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
+		line-clamp: 2;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}

--- a/assets/src/blocks/godam-audio/editor.scss
+++ b/assets/src/blocks/godam-audio/editor.scss
@@ -11,6 +11,11 @@
 	margin-right: 0;
 	position: relative;
 
+	padding: 30px;
+    border: 3px dotted #B2AEFF;
+    background: #F2F2FF;
+    border-radius: 6px;
+
 	&.is-transient audio {
 		opacity: 0.3;
 	}
@@ -22,5 +27,177 @@
 		left: 50%;
 		margin-top: -9px;
 		margin-left: -9px;
+	}
+}
+
+// ── Empty state ──────────────────────────────────────────────────────────────
+.godam-audio-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 40px 24px;
+	background: #eef2ff;
+	border: 2px dashed #a5b4fc;
+	border-radius: 6px;
+	text-align: center;
+
+	&__title {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--wp-components-color-foreground, #1e1e1e);
+	}
+
+	&__subtitle {
+		margin: 0;
+		font-size: 13px;
+		color: var(--wp-components-color-foreground-muted, #757575);
+	}
+
+	&__btn {
+		margin-top: 8px;
+		background: #6366f1 !important;
+		border-color: #6366f1 !important;
+		color: #fff !important;
+
+		&:hover {
+			background: #4f46e5 !important;
+			border-color: #4f46e5 !important;
+		}
+	}
+}
+
+// ── Inspector: full-width add buttons ────────────────────────────────────────
+.godam-audio__add-btn {
+	width: 100%;
+	justify-content: center;
+}
+
+// ── Inspector: file row ───────────────────────────────────────────────────────
+.godam-audio-file-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-bottom: 12px;
+	padding: 6px 8px;
+	background: #f0f0f0;
+	border-radius: 4px;
+
+	&__icon {
+		flex-shrink: 0;
+		font-size: 16px;
+		color: var(--wp-components-color-foreground-muted, #757575);
+	}
+
+	&__name {
+		flex: 1;
+		font-size: 12px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--wp-components-color-foreground, #1e1e1e);
+	}
+}
+
+// ── Inspector: thumbnail preview ──────────────────────────────────────────────
+.godam-audio-thumbnail-preview {
+	img {
+		display: block;
+		width: 100%;
+		height: 120px;
+		object-fit: cover;
+		border-radius: 4px;
+		margin-bottom: 8px;
+	}
+
+	&__actions {
+		display: flex;
+		gap: 8px;
+	}
+}
+
+// ── Editor canvas: card ───────────────────────────────────────────────────────
+.godam-audio-card {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 16px;
+	background: #fff;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+
+	&__cover {
+		flex-shrink: 0;
+		width: 123px;
+		height: 98px;
+		border-radius: 6px;
+		overflow: hidden;
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	&__cover-placeholder {
+		width: 100%;
+		height: 100%;
+		background: #eef2ff;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 6px;
+
+		.dashicons {
+			font-size: 36px;
+			width: 36px;
+			height: 36px;
+			color: #a5b4fc;
+		}
+	}
+
+	&__body {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		min-width: 0;
+		justify-content: center;
+
+		audio {
+			width: 100%;
+			height: 15px;
+			margin-top: auto;
+			margin-left: -8px;
+
+			&::-webkit-media-controls-panel {
+				background: #fff;
+				padding: 0;
+				margin: 0;
+			}
+		}
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
+		color: var(--wp-components-color-foreground, #1e1e1e);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__description {
+		margin: 0;
+		font-size: 13px;
+		color: var(--wp-components-color-foreground-muted, #757575);
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
 	}
 }

--- a/assets/src/blocks/godam-audio/editor.scss
+++ b/assets/src/blocks/godam-audio/editor.scss
@@ -132,7 +132,7 @@
 
 		audio {
 			width: 100%;
-			height: 25px;
+			height: 15px;
 			margin-top: auto;
 			margin-left: -8px;
 

--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -45,7 +45,7 @@ if ( ! $godam_attachment_id && ! empty( $godam_src ) ) {
 			<?php if ( $godam_thumbnail ) : ?>
 				<img
 					src="<?php echo esc_url( $godam_thumbnail ); ?>"
-					alt="<?php echo esc_attr( $godam_audio_title ); ?>"
+					alt="<?php echo esc_attr( $godam_audio_title ? $godam_audio_title : __( 'Audio thumbnail', 'godam' ) ); ?>"
 				/>
 			<?php else : ?>
 				<div class="godam-audio-card__cover-placeholder">

--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -17,7 +17,13 @@ $godam_loop          = ! empty( $attributes['loop'] ) ? 'loop' : '';
 $godam_preload       = ! empty( $attributes['preload'] ) ? esc_attr( $attributes['preload'] ) : 'metadata';
 $godam_audio_title   = ! empty( $attributes['audioTitle'] ) ? $attributes['audioTitle'] : '';
 $godam_description   = ! empty( $attributes['description'] ) ? $attributes['description'] : '';
-$godam_thumbnail     = ! empty( $attributes['thumbnail'] ) ? esc_url( $attributes['thumbnail'] ) : '';
+// Resolve thumbnail from attachment ID for robustness (survives domain migration / image regeneration).
+// Fall back to the stored URL if the attachment no longer exists.
+$godam_thumbnail_id  = ! empty( $attributes['thumbnailId'] ) ? intval( $attributes['thumbnailId'] ) : 0;
+$godam_thumbnail     = $godam_thumbnail_id ? wp_get_attachment_image_url( $godam_thumbnail_id, 'medium' ) : '';
+if ( ! $godam_thumbnail && ! empty( $attributes['thumbnail'] ) ) {
+	$godam_thumbnail = esc_url( $attributes['thumbnail'] );
+}
 
 if ( ! $godam_attachment_id && empty( $godam_src ) ) {
 	return;

--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -41,7 +41,7 @@ if ( ! $godam_attachment_id && ! empty( $godam_src ) ) {
 	<div class="godam-audio-card">
 
 		<?php /* Thumbnail */ ?>
-		<div class="godam-audio-card__cover">
+		<div class="godam-audio-card__cover" data-test-id="godam-audio-render-cover">
 			<?php if ( $godam_thumbnail ) : ?>
 				<img
 					src="<?php echo esc_url( $godam_thumbnail ); ?>"
@@ -57,15 +57,16 @@ if ( ! $godam_attachment_id && ! empty( $godam_src ) ) {
 		<?php /* Info + player */ ?>
 		<div class="godam-audio-card__body">
 			<?php if ( $godam_audio_title ) : ?>
-				<p class="godam-audio-card__title"><?php echo esc_html( $godam_audio_title ); ?></p>
+				<p class="godam-audio-card__title" data-test-id="godam-audio-render-title"><?php echo esc_html( $godam_audio_title ); ?></p>
 			<?php endif; ?>
 
 			<?php if ( $godam_description ) : ?>
-				<p class="godam-audio-card__description"><?php echo esc_html( $godam_description ); ?></p>
+				<p class="godam-audio-card__description" data-test-id="godam-audio-render-description"><?php echo esc_html( $godam_description ); ?></p>
 			<?php endif; ?>
 
 			<audio
 				class="godam-audio-card__player"
+				data-test-id="godam-audio-render-player"
 				controls
 				<?php echo esc_attr( $godam_autoplay ); ?>
 				<?php echo esc_attr( $godam_loop ); ?>

--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -15,7 +15,9 @@ $godam_caption       = ! empty( $attributes['caption'] ) ? $attributes['caption'
 $godam_autoplay      = ! empty( $attributes['autoplay'] ) ? 'autoplay' : '';
 $godam_loop          = ! empty( $attributes['loop'] ) ? 'loop' : '';
 $godam_preload       = ! empty( $attributes['preload'] ) ? esc_attr( $attributes['preload'] ) : 'metadata';
-$godam_css_class     = ! empty( $attributes['css_class'] ) ? esc_attr( $attributes['css_class'] ) : '';
+$godam_audio_title   = ! empty( $attributes['audioTitle'] ) ? $attributes['audioTitle'] : '';
+$godam_description   = ! empty( $attributes['description'] ) ? $attributes['description'] : '';
+$godam_thumbnail     = ! empty( $attributes['thumbnail'] ) ? esc_url( $attributes['thumbnail'] ) : '';
 
 if ( ! $godam_attachment_id && empty( $godam_src ) ) {
 	return;
@@ -33,23 +35,55 @@ if ( ! $godam_attachment_id && ! empty( $godam_src ) ) {
 		return;
 	}
 }
-
-$godam_block_wrapper_attributes = get_block_wrapper_attributes();
-$godam_css_classes              = trim( $godam_block_wrapper_attributes . ' ' . $godam_css_class );
 ?>
 
-<figure data-test-id="godam-audio-render" <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => $godam_css_classes ) ) ); ?>>
-	<audio style="display: block; width: 100%;" controls <?php echo esc_attr( $godam_autoplay ); ?> <?php echo esc_attr( $godam_loop ); ?> preload="<?php echo esc_attr( $godam_preload ); ?>">
-		<?php if ( ! empty( $godam_primary_audio ) ) : ?>
-			<source src="<?php echo esc_url( $godam_primary_audio ); ?>" type="audio/mpeg" />
-		<?php endif; ?>
+<figure data-test-id="godam-audio-render" <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
+	<div class="godam-audio-card">
 
-		<?php if ( ! empty( $godam_backup_audio ) ) : ?>
-			<source src="<?php echo esc_url( $godam_backup_audio ); ?>" type="audio/mpeg" />
-		<?php endif; ?>
+		<?php /* Thumbnail */ ?>
+		<div class="godam-audio-card__cover">
+			<?php if ( $godam_thumbnail ) : ?>
+				<img
+					src="<?php echo esc_url( $godam_thumbnail ); ?>"
+					alt="<?php echo esc_attr( $godam_audio_title ); ?>"
+				/>
+			<?php else : ?>
+				<div class="godam-audio-card__cover-placeholder">
+					<span class="dashicons dashicons-media-audio"></span>
+				</div>
+			<?php endif; ?>
+		</div>
 
-		<?php esc_html_e( 'Your browser does not support the audio element.', 'godam' ); ?>
-	</audio>
+		<?php /* Info + player */ ?>
+		<div class="godam-audio-card__body">
+			<?php if ( $godam_audio_title ) : ?>
+				<p class="godam-audio-card__title"><?php echo esc_html( $godam_audio_title ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $godam_description ) : ?>
+				<p class="godam-audio-card__description"><?php echo esc_html( $godam_description ); ?></p>
+			<?php endif; ?>
+
+			<audio
+				class="godam-audio-card__player"
+				controls
+				<?php echo esc_attr( $godam_autoplay ); ?>
+				<?php echo esc_attr( $godam_loop ); ?>
+				preload="<?php echo esc_attr( $godam_preload ); ?>"
+			>
+				<?php if ( ! empty( $godam_primary_audio ) ) : ?>
+					<source src="<?php echo esc_url( $godam_primary_audio ); ?>" type="audio/mpeg" />
+				<?php endif; ?>
+
+				<?php if ( ! empty( $godam_backup_audio ) ) : ?>
+					<source src="<?php echo esc_url( $godam_backup_audio ); ?>" type="audio/mpeg" />
+				<?php endif; ?>
+
+				<?php esc_html_e( 'Your browser does not support the audio element.', 'godam' ); ?>
+			</audio>
+		</div>
+
+	</div>
 
 	<?php if ( $godam_caption ) : ?>
 		<figcaption class="wp-element-caption">

--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -17,13 +17,7 @@ $godam_loop          = ! empty( $attributes['loop'] ) ? 'loop' : '';
 $godam_preload       = ! empty( $attributes['preload'] ) ? esc_attr( $attributes['preload'] ) : 'metadata';
 $godam_audio_title   = ! empty( $attributes['audioTitle'] ) ? $attributes['audioTitle'] : '';
 $godam_description   = ! empty( $attributes['description'] ) ? $attributes['description'] : '';
-// Resolve thumbnail from attachment ID for robustness (survives domain migration / image regeneration).
-// Fall back to the stored URL if the attachment no longer exists.
-$godam_thumbnail_id  = ! empty( $attributes['thumbnailId'] ) ? intval( $attributes['thumbnailId'] ) : 0;
-$godam_thumbnail     = $godam_thumbnail_id ? wp_get_attachment_image_url( $godam_thumbnail_id, 'medium' ) : '';
-if ( ! $godam_thumbnail && ! empty( $attributes['thumbnail'] ) ) {
-	$godam_thumbnail = esc_url( $attributes['thumbnail'] );
-}
+$godam_thumbnail     = ! empty( $attributes['thumbnail'] ) ? esc_url( $attributes['thumbnail'] ) : '';
 
 if ( ! $godam_attachment_id && empty( $godam_src ) ) {
 	return;

--- a/assets/src/blocks/godam-audio/style.scss
+++ b/assets/src/blocks/godam-audio/style.scss
@@ -76,6 +76,7 @@
 		color: #757575;
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
+		line-clamp: 2;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}
@@ -96,19 +97,26 @@
 
 	// Mobile: stack vertically
 	@media ( max-width: 480px ) {
-		.godam-audio-card {
-			&__player {
+		flex-direction: column;
+		align-items: stretch;
 
-				&::-webkit-media-controls-timeline {
-					padding: 1px;
-					width: 100%;
-				}
+		&__cover {
+			width: 100%;
+			height: 160px;
+		}
 
-				&::-webkit-media-controls-volume-control-container,
-				&::-webkit-media-controls-mute-button,
-				&::-webkit-media-controls-fullscreen-button {
-					display: none;
-				}
+		&__player {
+			margin-left: 0;
+
+			&::-webkit-media-controls-timeline {
+				padding: 1px;
+				width: 100%;
+			}
+
+			&::-webkit-media-controls-volume-control-container,
+			&::-webkit-media-controls-mute-button,
+			&::-webkit-media-controls-fullscreen-button {
+				display: none;
 			}
 		}
 	}

--- a/assets/src/blocks/godam-audio/style.scss
+++ b/assets/src/blocks/godam-audio/style.scss
@@ -95,19 +95,9 @@
 		}
 	}
 
-	// Mobile: stack vertically
+	// Mobile: compact media controls
 	@media ( max-width: 480px ) {
-		flex-direction: column;
-		align-items: stretch;
-
-		&__cover {
-			width: 100%;
-			height: 160px;
-		}
-
 		&__player {
-			margin-left: 0;
-
 			&::-webkit-media-controls-timeline {
 				padding: 1px;
 				width: 100%;

--- a/assets/src/blocks/godam-audio/style.scss
+++ b/assets/src/blocks/godam-audio/style.scss
@@ -1,23 +1,106 @@
 .wp-block-godam-audio {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
-	// Supply caption styles to audio blocks, even if the theme hasn't opted in.
-	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
-	// so we supply the styles so as to not appear broken or unstyled in those themes.
-	
+
 	figcaption {
 		margin-top: 0.5em;
 		color: #555d66;
 		text-align: center;
 		font-size: 13px;
 	}
+}
 
-	// Show full-width when not aligned.
-	audio {
+// ── Frontend card ─────────────────────────────────────────────────────────────
+.godam-audio-card {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 16px;
+	background: #fff;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+
+	&__cover {
+		flex-shrink: 0;
+		width: 123px;
+		height: 98px;
+		border-radius: 6px;
+		overflow: hidden;
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	&__cover-placeholder {
 		width: 100%;
+		height: 100%;
+		background: #eef2ff;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 6px;
 
-		// The browser natively applies a 300px width to the audio block.
-		// We restore this as a min-width instead, for alignments.
-		min-width: 300px;
+		.dashicons {
+			font-size: 36px;
+			width: 36px;
+			height: 36px;
+			color: #a5b4fc;
+		}
+	}
+
+	&__body {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		min-width: 0;
+		justify-content: center;
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
+		color: #1e1e1e;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__description {
+		margin: 0;
+		font-size: 13px;
+		color: #757575;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	&__player {
+		width: 100%;
+		min-width: 0;
+		height: 25px;
+		margin-top: auto;
+		margin-left: -8px;
+
+		&::-webkit-media-controls-panel {
+			background: #fff;
+			padding: 0;
+			margin: 0;
+		}
+	}
+
+	// Mobile: stack vertically
+	@media ( max-width: 480px ) {
+		flex-direction: column;
+
+		&__cover {
+			width: 100%;
+			height: 160px;
+		}
 	}
 }

--- a/assets/src/blocks/godam-audio/style.scss
+++ b/assets/src/blocks/godam-audio/style.scss
@@ -96,11 +96,20 @@
 
 	// Mobile: stack vertically
 	@media ( max-width: 480px ) {
-		flex-direction: column;
+		.godam-audio-card {
+			&__player {
 
-		&__cover {
-			width: 100%;
-			height: 160px;
+				&::-webkit-media-controls-timeline {
+					padding: 1px;
+					width: 100%;
+				}
+
+				&::-webkit-media-controls-volume-control-container,
+				&::-webkit-media-controls-mute-button,
+				&::-webkit-media-controls-fullscreen-button {
+					display: none;
+				}
+			}
 		}
 	}
 }

--- a/assets/src/blocks/godam-audio/style.scss
+++ b/assets/src/blocks/godam-audio/style.scss
@@ -74,6 +74,11 @@
 		margin: 0;
 		font-size: 13px;
 		color: #757575;
+	}
+
+	// Double-class specificity (.godam-audio-card .godam-audio-card__description = 0,2,0)
+	// beats theme/WP rules like .entry-content p (0,1,1) that override display.
+	& &__description {
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
 		line-clamp: 2;
@@ -98,6 +103,7 @@
 	// Mobile: compact media controls
 	@media ( max-width: 480px ) {
 		&__player {
+
 			&::-webkit-media-controls-timeline {
 				padding: 1px;
 				width: 100%;


### PR DESCRIPTION
# Audio Block — UI Revamp

## Summary
Complete UI overhaul of the GoDAM Audio block to match the updated Figma design. The block now renders a polished horizontal card layout in both the editor and frontend, replacing the bare native `<audio>` element.

## What changed

**block.json**
Added four new content attributes: `audioTitle`, `description`, `thumbnail`, and `thumbnailId` to support the card metadata.

**edit.js**
- Empty state replaced with a lavender dashed container (`#eef2ff` background, dashed `#a5b4fc` border) containing a heading, subtitle, and primary upload button — matching Figma exactly.
- Inspector reorganised into three panels:
  - **Audio Selection** — shows a file row (filename + remove button) once audio is selected, plus `AUDIO TITLE` text input and `DESCRIPTION` textarea.
  - **Thumbnail** — upload, replace, or remove a cover image.
  - **Settings** — existing autoplay, loop, and preload controls, now collapsed by default.
- Editor canvas renders a horizontal card: square-ish cover image on the left (166×130 px, lavender placeholder with audio icon if no image), title + description + native `<audio>` on the right.
- `MediaReplaceFlow` added to toolbar when block is selected.
- Non-audio file selections are rejected with a snackbar error notice.

**render.php**
Frontend now outputs the same horizontal card structure: thumbnail (or lavender placeholder) on the left, title, 2-line clamped description, and `<audio>` player on the right. Falls back gracefully when title/description/thumbnail are not set.

**editor.scss / style.scss**
- Editor wrapper gets the lavender dotted border from Figma.
- Card styles: flexbox horizontal layout, fixed cover dimensions, body content vertically centered, audio element height reduced to avoid excess whitespace.
- `::-webkit-media-controls-panel` background set to white to blend with the card.
- Mobile breakpoint (≤480 px) stacks the card vertically with a full-width cover.

## Testing
- Add audio block → empty state shown ✓
- Upload audio → card renders with filename, default placeholder cover ✓
- Add title/description/thumbnail via inspector → card updates live ✓
- Toggle autoplay/loop/preload → persists on save ✓
- Frontend renders card correctly with and without thumbnail ✓
- Replace audio via toolbar → works ✓

## Things not implemented as FIGMA

- Transcript and Chapter Feature
- UI for transcript and Chapter feature
- Still has Caption enabled as the previous version (can be turner off by the user if they don't want it)

## Demo

https://github.com/user-attachments/assets/5e7d1f84-efb5-4b57-94db-45bccb6614d3

