### PR TITLE
Analytics polish: Layer Timeline range dropdown + Top Videos heading alignment

### DIFF
--- a/pages/analytics/timeline/DateRangePicker.js
+++ b/pages/analytics/timeline/DateRangePicker.js
@@ -6,60 +6,69 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
+import { Dropdown, Button, MenuGroup, MenuItem, Icon } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Pill-toggle for the timeline's global date range. 7D / 30D / 90D / 1Y / All.
+ * Date-range dropdown for the timeline's global range. 7D / 30D / 90D / 1Y / All.
  *
- * Plain unstyled radio group via buttons — matches the mockup. Selected
- * pill gets a soft pink-tinted background so it reads as the active
- * filter; remaining pills are neutral. "All" mirrors the Playback
- * Performance chart's all-time option — it maps to no `days` param so the
- * microservice returns the full history (see rangeToDays in
- * useVideoLayerData).
+ * Mirrors the Playback Performance chart's range dropdown (same `Dropdown` +
+ * secondary `Button` + `MenuGroup` pattern and `godam-period-dropdown` styling)
+ * so both range pickers on the analytics page look and behave identically and
+ * follow the WP admin colour scheme. "All" maps to no `days` param so the
+ * microservice returns the full history (see rangeToDays in useVideoLayerData).
  *
  * @param {Object}   props
- * @param {string}   props.value    Currently selected key.
+ * @param {string}   props.value    Currently selected key ('7d' | '30d' | '90d' | '1y' | 'all').
  * @param {Function} props.onChange (next) => void.
- * @return {JSX.Element} Toggle group.
+ * @return {JSX.Element} Range dropdown.
  */
 const DateRangePicker = ( { value, onChange } ) => {
 	const options = [
-		{ id: '7d', label: __( '7D', 'godam' ), aria: __( 'Last 7 days', 'godam' ) },
-		{ id: '30d', label: __( '30D', 'godam' ), aria: __( 'Last 30 days', 'godam' ) },
-		{ id: '90d', label: __( '90D', 'godam' ), aria: __( 'Last 90 days', 'godam' ) },
-		{ id: '1y', label: __( '1Y', 'godam' ), aria: __( 'Last year', 'godam' ) },
-		{ id: 'all', label: __( 'All', 'godam' ), aria: __( 'All time', 'godam' ) },
+		{ id: '7d', label: __( 'Last 7 days', 'godam' ) },
+		{ id: '30d', label: __( 'Last 30 days', 'godam' ) },
+		{ id: '90d', label: __( 'Last 90 days', 'godam' ) },
+		{ id: '1y', label: __( 'Last year', 'godam' ) },
+		{ id: 'all', label: __( 'All time', 'godam' ) },
 	];
 
+	const currentLabel =
+		options.find( ( o ) => o.id === value )?.label || options[ 0 ].label;
+
 	return (
-		<div
-			role="radiogroup"
-			aria-label={ __( 'Date range', 'godam' ) }
-			className="inline-flex flex-wrap rounded-lg border border-zinc-200 bg-white p-0.5"
-		>
-			{ options.map( ( opt ) => {
-				const active = value === opt.id;
-				return (
-					<button
-						key={ opt.id }
-						type="button"
-						role="radio"
-						aria-checked={ active }
-						aria-label={ opt.aria }
-						onClick={ () => onChange( opt.id ) }
-						className="text-sm font-medium px-3 py-1.5 cursor-pointer border-0 rounded-md tabular-nums"
-						style={ {
-							background: active ? '#FCE7F3' : 'transparent',
-							color: active ? '#BE185D' : '#475569',
-							transition: 'background-color 140ms ease-out, color 140ms ease-out',
-						} }
-					>
-						{ opt.label }
-					</button>
-				);
-			} ) }
-		</div>
+		<Dropdown
+			className="godam-period-dropdown"
+			popoverProps={ { placement: 'bottom-end' } }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					variant="secondary"
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					aria-label={ __( 'Date range', 'godam' ) }
+					className="godam-period-dropdown__toggle"
+				>
+					{ currentLabel }
+					<Icon icon={ chevronDown } size={ 20 } />
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<MenuGroup>
+					{ options.map( ( opt ) => (
+						<MenuItem
+							key={ opt.id }
+							isSelected={ value === opt.id }
+							onClick={ () => {
+								onChange( opt.id );
+								onClose();
+							} }
+						>
+							{ opt.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
+		/>
 	);
 };
 

--- a/pages/analytics/timeline/DateRangePicker.js
+++ b/pages/analytics/timeline/DateRangePicker.js
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import { Dropdown, Button, MenuGroup, MenuItem, Icon } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Date-range dropdown for the timeline's global range. 7D / 30D / 90D / 1Y / All.
@@ -36,6 +36,14 @@ const DateRangePicker = ( { value, onChange } ) => {
 	const currentLabel =
 		options.find( ( o ) => o.id === value )?.label || options[ 0 ].label;
 
+	// Fold the current selection into the toggle's accessible name so screen
+	// readers keep it (a bare aria-label="Date range" overrode it — Copilot note).
+	const rangeAriaLabel = sprintf(
+		/* translators: %s: the selected range label, e.g. "Last 7 days". */
+		__( 'Date range: %s', 'godam' ),
+		currentLabel,
+	);
+
 	return (
 		<Dropdown
 			className="godam-period-dropdown"
@@ -45,7 +53,7 @@ const DateRangePicker = ( { value, onChange } ) => {
 					variant="secondary"
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
-					aria-label={ __( 'Date range', 'godam' ) }
+					aria-label={ rangeAriaLabel }
 					className="godam-period-dropdown__toggle"
 				>
 					{ currentLabel }

--- a/pages/dashboard/index.scss
+++ b/pages/dashboard/index.scss
@@ -78,7 +78,9 @@
 		font-weight: 600;
 		margin: 0;
 		display: flex;
-		align-items: center;
+		// Baseline (not center) so a trailing count/badge shares the heading's
+		// text baseline instead of floating against its vertical centre.
+		align-items: baseline;
 	}
 
 	&__head {


### PR DESCRIPTION
## Analytics design polish (follow-ups to [godam#1969](https://github.com/rtCamp/godam/pull/1969))

Two small UI follow-ups to the merged GoDAM 2.0 analytics reskin. They were accidentally pushed onto #1969's branch after it merged, so they're broken out into this PR off `develop`.

### What changed
1. **Layer Timeline range control → dropdown.** The "Video Layer Timeline" range filter (7D / 30D / 90D / 1Y / All) was a pill-toggle; it now uses the **same dropdown** as the Playback Performance chart on the same page (`Dropdown` + secondary `Button` + `MenuGroup`, `.godam-period-dropdown` styling) for a consistent control. This also **drops the hardcoded pink** (`#FCE7F3` / `#BE185D`) the pills used, so it follows the **WP admin colour scheme** like the rest of the analytics surface.
2. **Top Videos heading alignment.** The result-count badge ("N videos") sat in a center-aligned flexbox `h2`, so it floated ~2px above the title's baseline. Switched `.top-media-container__head h2` to `align-items: baseline` so the count shares the heading's baseline.

### Automation impact (E2E)
- **Layer Timeline range control changed type:** was a `role="radiogroup"` of `role="radio"` pill buttons (aria-labels "Last 7 days"…); now a WP `Dropdown` (a button toggle + menu items). Selectors on the old radio pills no longer apply. No `data-test-id` (matches the sibling Playback Performance dropdown — both range dropdowns currently lack one).
- Heading change is **CSS-only** — no DOM/selector change.
- No new popups; no REST/route changes.

Part of GoDAM 2.0 Analytics — see [godam-plugin-wp#2](https://github.com/rtCamp/godam-plugin-wp/issues/2).
