### PR TITLE
feat: add data-test-id hooks for E2E (Video Editor 2.0 + Settings redesign)

### DIFF
--- a/pages/godam/components/ConfirmModal.jsx
+++ b/pages/godam/components/ConfirmModal.jsx
@@ -39,6 +39,7 @@ const ConfirmModal = ( {
 	onCancel,
 	isBusy = false,
 	isDestructive = false,
+	...rest
 } ) => {
 	if ( ! isOpen ) {
 		return null;
@@ -71,6 +72,7 @@ const ConfirmModal = ( {
 					isBusy={ isBusy }
 					icon={ isBusy && <Spinner /> }
 					disabled={ isBusy }
+					{ ...rest }
 				>
 					{ confirmLabel }
 				</Button>

--- a/pages/godam/components/ConfirmModal.jsx
+++ b/pages/godam/components/ConfirmModal.jsx
@@ -26,6 +26,7 @@ import './confirm-modal.scss';
  * @param {Function}    param0.onCancel      - Called when the modal is dismissed or cancelled.
  * @param {boolean}     param0.isBusy        - Whether the confirm action is in progress.
  * @param {boolean}     param0.isDestructive - Whether the confirm action is destructive.
+ * @param {string}      [param0.testId]      - data-test-id for the confirm button (E2E hook).
  *
  * @return {JSX.Element|null} The rendered modal or null when closed.
  */
@@ -39,7 +40,7 @@ const ConfirmModal = ( {
 	onCancel,
 	isBusy = false,
 	isDestructive = false,
-	...rest
+	'data-test-id': testId,
 } ) => {
 	if ( ! isOpen ) {
 		return null;
@@ -72,7 +73,7 @@ const ConfirmModal = ( {
 					isBusy={ isBusy }
 					icon={ isBusy && <Spinner /> }
 					disabled={ isBusy }
-					{ ...rest }
+					data-test-id={ testId }
 				>
 					{ confirmLabel }
 				</Button>

--- a/pages/godam/components/ConfirmModal.jsx
+++ b/pages/godam/components/ConfirmModal.jsx
@@ -26,7 +26,7 @@ import './confirm-modal.scss';
  * @param {Function}    param0.onCancel      - Called when the modal is dismissed or cancelled.
  * @param {boolean}     param0.isBusy        - Whether the confirm action is in progress.
  * @param {boolean}     param0.isDestructive - Whether the confirm action is destructive.
- * @param {string}      [param0.testId]      - data-test-id for the confirm button (E2E hook).
+ * @param {string}      [param0.'data-test-id'] - data-test-id forwarded to the confirm button (E2E hook).
  *
  * @return {JSX.Element|null} The rendered modal or null when closed.
  */

--- a/pages/godam/components/tabs/APIKey/APIKey.jsx
+++ b/pages/godam/components/tabs/APIKey/APIKey.jsx
@@ -46,6 +46,7 @@ const APIKey = () => {
 								href={ `https://godam.io/pricing?utm_campaign=buy-plan&utm_source=${ window?.location?.host || '' }&utm_medium=plugin&utm_content=settings` }
 								target="_blank"
 								variant="primary"
+								data-test-id="godam-settings-api-key-button-choose-plan"
 							>
 								{ __( 'Choose GoDAM Plan', 'godam' ) }
 							</Button>

--- a/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
+++ b/pages/godam/components/tabs/AdsSettings/AdsSettings.jsx
@@ -93,18 +93,21 @@ const AdsSettings = () => {
 			<div>
 				<Panel header={ __( 'Video Ads Settings', 'godam' ) } className="godam-panel">
 					<PanelBody opened>
-						<ToggleControl
-							className="mb-4"
-							label={ __( 'Enable Global Video Ads', 'godam' ) }
-							help={ __( 'Enable or disable video ads on all videos across the site', 'godam' ) }
-							checked={ mediaSettings?.ads_settings?.enable_global_video_ads }
-							onChange={ ( value ) => handleSettingChange( 'enable_global_video_ads', value ) }
-						/>
+						<div data-test-id="godam-settings-ads-control-enable">
+							<ToggleControl
+								className="mb-4"
+								label={ __( 'Enable Global Video Ads', 'godam' ) }
+								help={ __( 'Enable or disable video ads on all videos across the site', 'godam' ) }
+								checked={ mediaSettings?.ads_settings?.enable_global_video_ads }
+								onChange={ ( value ) => handleSettingChange( 'enable_global_video_ads', value ) }
+							/>
+						</div>
 
 						{
 							mediaSettings?.ads_settings?.enable_global_video_ads &&
 							<TextareaControl
 								className="mb-4"
+								data-test-id="godam-settings-ads-control-tag-url"
 								label={ __( 'Ad Tag URL', 'godam' ) }
 								help={
 									<div>
@@ -126,6 +129,7 @@ const AdsSettings = () => {
 						icon={ saveMediaSettingsLoading && <Spinner /> }
 						isBusy={ saveMediaSettingsLoading }
 						disabled={ saveMediaSettingsLoading || ! isChanged }
+						data-test-id="godam-settings-ads-button-save"
 					>
 						{ saveMediaSettingsLoading ? __( 'Saving…', 'godam' ) : __( 'Save', 'godam' ) }
 					</Button>

--- a/pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx
@@ -107,6 +107,7 @@ const BrandImageSelector = ( { mediaSettings, handleSettingChange } ) => {
 					onClick={ openBrandMediaPicker }
 					variant="secondary"
 					disabled={ isBubbleOrClassic }
+					data-test-id="godam-settings-player-button-logo-upload"
 				>
 					{ mediaSettings?.video_player?.brand_image ? __( 'Replace', 'godam' ) : __( 'Upload', 'godam' ) }
 				</Button>
@@ -116,6 +117,7 @@ const BrandImageSelector = ( { mediaSettings, handleSettingChange } ) => {
 						variant="secondary"
 						isDestructive
 						disabled={ isBubbleOrClassic }
+						data-test-id="godam-settings-player-button-logo-remove"
 					>
 						{ __( 'Remove', 'godam' ) }
 					</Button>

--- a/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
+++ b/pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx
@@ -133,6 +133,7 @@ const GeneralSettings = () => {
 						checked={ folderOrgEnabled }
 						disabled={ mediaLibraryUICodeManaged }
 						onChange={ ( value ) => handleSettingChange( 'enable_folder_organization', value ) }
+						data-test-id="godam-settings-general-control-folder-org"
 					/>
 
 					<ToggleControl
@@ -142,6 +143,7 @@ const GeneralSettings = () => {
 						help={ __( 'Enable Google Tag Manager video tracking for analytics and conversion tracking.', 'godam' ) }
 						checked={ mediaSettings?.general?.enable_gtm_tracking }
 						onChange={ ( value ) => handleSettingChange( 'enable_gtm_tracking', value ) }
+						data-test-id="godam-settings-general-control-gtm"
 					/>
 
 				</PanelBody>
@@ -171,6 +173,7 @@ const GeneralSettings = () => {
 					icon={ saveMediaSettingsLoading && <Spinner /> }
 					isBusy={ saveMediaSettingsLoading }
 					disabled={ saveMediaSettingsLoading || ! isChanged }
+					data-test-id="godam-settings-general-button-save"
 				>
 					{ saveMediaSettingsLoading ? __( 'Saving…', 'godam' ) : __( 'Save', 'godam' ) }
 				</Button>
@@ -183,6 +186,7 @@ const GeneralSettings = () => {
 				cancelLabel={ __( 'Cancel', 'godam' ) }
 				onCancel={ () => setIsResetOnboardingOpen( false ) }
 				onConfirm={ handleResetOnboarding }
+				data-test-id="godam-settings-general-button-confirm-reset"
 			>
 				{ __( 'We’ll restart the guided tour. The next time you open your dashboard, you’ll see the welcome screen where you can pick a guide and step through it again. This won’t sign you out or affect your media, settings, or content.', 'godam' ) }
 			</ConfirmModal>

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx
@@ -355,6 +355,7 @@ const IntegrationSettings = () => {
 					icon={ saveMediaSettingsLoading && <Spinner /> }
 					isBusy={ saveMediaSettingsLoading }
 					disabled={ saveMediaSettingsLoading || ! isChanged || ! hasValidAPIKey }
+					data-test-id="godam-settings-integrations-button-save"
 				>
 					{ saveMediaSettingsLoading ? __( 'Saving…', 'godam' ) : __( 'Save', 'godam' ) }
 				</Button>

--- a/pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx
+++ b/pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx
@@ -409,7 +409,7 @@ const VideoPlayer = () => {
 				<PanelBody opened>
 					<div ref={ wrapperRef } className="max-w-[650px] shadow-xl rounded-lg overflow-hidden mb-6"></div>
 
-					<div className="godam-form-group max-w-[520px]">
+					<div className="godam-form-group max-w-[520px]" data-test-id="godam-settings-player-control-skin">
 						<label className="label-text" htmlFor="player_skin">
 							{ __( 'Player Skin', 'godam' ) }
 						</label>
@@ -428,16 +428,19 @@ const VideoPlayer = () => {
 				<PanelBody opened>
 					<div className="godam-form-group godam-margin-bottom">
 						<div className="flex items-center gap-2 flex-wrap">
-							<ColorPickerButton
-								label={ __( 'Brand color', 'godam' ) }
-								value={ mediaSettings?.video_player?.brand_color }
-								onChange={ ( value ) => handleSettingChange( 'brand_color', value ) }
-								disabled={ isMinimalOrClassic }
-							/>
+							<div data-test-id="godam-settings-player-control-brand-color">
+								<ColorPickerButton
+									label={ __( 'Brand color', 'godam' ) }
+									value={ mediaSettings?.video_player?.brand_color }
+									onChange={ ( value ) => handleSettingChange( 'brand_color', value ) }
+									disabled={ isMinimalOrClassic }
+								/>
+							</div>
 							{ mediaSettings?.video_player?.brand_color && ! isMinimalOrClassic && (
 								<Button
 									variant="tertiary"
 									onClick={ () => handleSettingChange( 'brand_color', '' ) }
+									data-test-id="godam-settings-player-button-brand-color-clear"
 								>
 									{ __( 'Clear', 'godam' ) }
 								</Button>
@@ -467,7 +470,7 @@ const VideoPlayer = () => {
 
 			<Panel header={ __( 'Custom CSS', 'godam' ) } className="godam-panel godam-margin-bottom">
 				<PanelBody opened>
-					<div className="godam-form-group godam-settings__container__custom-css">
+					<div className="godam-form-group godam-settings__container__custom-css" data-test-id="godam-settings-player-editor-custom-css">
 						<CustomVideoPlayerCSS handleSettingChange={ handleSettingChange } />
 						<div className="text-[0.75rem] leading-[1.2] text-[#777] mt-2">
 							{ __( 'Any custom CSS you add will be applied to all player skins. It\'s global and not tied to a specific skin style.', 'godam' ) }
@@ -483,6 +486,7 @@ const VideoPlayer = () => {
 					icon={ saveMediaSettingsLoading && <Spinner /> }
 					isBusy={ saveMediaSettingsLoading }
 					disabled={ saveMediaSettingsLoading || ! isChanged }
+					data-test-id="godam-settings-player-button-save"
 				>
 					{ saveMediaSettingsLoading ? __( 'Saving…', 'godam' ) : __( 'Save', 'godam' ) }
 				</Button>

--- a/pages/godam/components/tabs/VideoSettings/APISettings.jsx
+++ b/pages/godam/components/tabs/VideoSettings/APISettings.jsx
@@ -150,6 +150,7 @@ const APISettings = ( { setNotice } ) => {
 								disabled={ ! hasAPIKey }
 								label={ __( 'Copy API key', 'godam' ) }
 								showTooltip
+								data-test-id="godam-settings-api-key-button-copy"
 							/>
 							<Button
 								icon={ trash }
@@ -171,7 +172,7 @@ const APISettings = ( { setNotice } ) => {
 							disabled={ isAPIKeyLoading || hasAPIKey || ! apiKey.trim() }
 							variant="primary"
 							isBusy={ isAPIKeyLoading }
-							data-test-id="godam-settings-video-button-save-api-key"
+							data-test-id="godam-settings-api-key-button-save"
 						>
 							{ isAPIKeyLoading ? __( 'Saving…', 'godam' ) : __( 'Save API Key', 'godam' ) }
 						</Button>
@@ -181,6 +182,7 @@ const APISettings = ( { setNotice } ) => {
 								disabled={ isRefreshLoading }
 								variant="secondary"
 								isBusy={ isRefreshLoading }
+								data-test-id="godam-settings-api-key-button-refresh"
 							>
 								{ isRefreshLoading ? __( 'Refreshing…', 'godam' ) : __( 'Refresh Status', 'godam' ) }
 							</Button>
@@ -227,6 +229,7 @@ const APISettings = ( { setNotice } ) => {
 				isBusy={ isDeactivateLoading }
 				onCancel={ () => setIsRemoveModalOpen( false ) }
 				onConfirm={ handleDeactivateAPIKey }
+				data-test-id="godam-settings-api-key-button-confirm-remove"
 			>
 				{ __( 'If you remove the API key, your account will be deactivated and you’ll lose access to the platform.', 'godam' ) }
 			</ConfirmModal>

--- a/pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx
@@ -22,7 +22,7 @@ const VideoCompressQuality = ( { handleSettingChange } ) => {
 	const selectedOption = QUALITY_OPTIONS.find( ( option ) => option.key === String( videoQuality ) ) || QUALITY_OPTIONS[ 0 ];
 
 	return (
-		<div className="godam-form-group">
+		<div className="godam-form-group" data-test-id="godam-settings-video-control-quality">
 			<CustomSelectControl
 				__next40pxDefaultSize
 				label={ __( 'Video Quality', 'godam' ) }

--- a/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx
@@ -22,23 +22,27 @@ const VideoEngagement = ( { handleSettingChange } ) => {
 	return (
 		<div className="flex flex-col gap-2 relative">
 			{ engagementFeatureEnabled && (
+				<div data-test-id="godam-settings-video-control-engagement">
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Enable video engagement globally', 'godam' ) }
+						checked={ enableGlobalEngagement }
+						onChange={ ( value ) => handleSettingChange( 'enable_global_video_engagement', value ) }
+						disabled={ ! hasAPIKey }
+						help={ __( 'If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel.', 'godam' ) }
+					/>
+				</div>
+			) }
+			<div data-test-id="godam-settings-video-control-share">
 				<ToggleControl
 					__nextHasNoMarginBottom
-					label={ __( 'Enable video engagement globally', 'godam' ) }
-					checked={ enableGlobalEngagement }
-					onChange={ ( value ) => handleSettingChange( 'enable_global_video_engagement', value ) }
+					label={ __( 'Enable video share globally', 'godam' ) }
+					checked={ enableGlobalShare }
+					onChange={ ( value ) => handleSettingChange( 'enable_global_video_share', value ) }
 					disabled={ ! hasAPIKey }
-					help={ __( 'If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel.', 'godam' ) }
+					help={ __( 'If disabled, sharing options (such as social sharing buttons) will not be available for GoDAM videos. If enabled, it can be overridden in the block settings panel.', 'godam' ) }
 				/>
-			) }
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Enable video share globally', 'godam' ) }
-				checked={ enableGlobalShare }
-				onChange={ ( value ) => handleSettingChange( 'enable_global_video_share', value ) }
-				disabled={ ! hasAPIKey }
-				help={ __( 'If disabled, sharing options (such as social sharing buttons) will not be available for GoDAM videos. If enabled, it can be overridden in the block settings panel.', 'godam' ) }
-			/>
+			</div>
 		</div>
 	);
 };

--- a/pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx
@@ -49,6 +49,7 @@ const VideoThumbnails = ( { handleSettingChange } ) => {
 			</label>
 			<TextControl
 				id="video_thumbnails_count"
+				data-test-id="godam-settings-video-control-thumbnails-count"
 				type="number"
 				min="1"
 				max="10"

--- a/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
+++ b/pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx
@@ -119,6 +119,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 									<Button
 										variant="primary"
 										onClick={ openMediaPicker }
+										data-test-id="godam-settings-video-button-watermark-select"
 									>
 										{ selectedMedia
 											? __( 'Change Watermark', 'godam' )
@@ -132,6 +133,7 @@ const VideoWatermark = ( { handleSettingChange } ) => {
 												handleSettingChange( 'watermark_image_id', null );
 											} }
 											variant="secondary"
+											data-test-id="godam-settings-video-button-watermark-remove"
 										>
 											{ __( 'Remove Watermark', 'godam' ) }
 										</Button>

--- a/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx
+++ b/pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx
@@ -106,6 +106,7 @@ const PasswordFieldWithToggle = ( { hasValidAPIKey, hasAPIKey, apiKey, setAPIKey
 			className={ `godam-input__api-key godam-form-group ${ ( validationError || ( hasAPIKey && ! hasValidAPIKey ) ) ? 'invalid-api-key' : '' }` }
 			disabled={ hasAPIKey }
 			type="text"
+			data-test-id="godam-settings-api-key-control-key"
 		/>
 	);
 };

--- a/pages/video-editor/components/SidebarLayers.js
+++ b/pages/video-editor/components/SidebarLayers.js
@@ -180,6 +180,7 @@ const AddLayerSubmenuItem = ( { opt, onParentClose } ) => {
 		<div className="godam-ve-add-menu__submenu" ref={ anchorRef }>
 			<MenuItem
 				className="godam-ve-add-menu__item"
+				data-test-id={ `godam-video-editor-control-add-${ opt.key }` }
 				aria-haspopup="menu"
 				aria-expanded={ isSubOpen }
 				onClick={ () => setSubOpen( ( value ) => ! value ) }
@@ -213,6 +214,7 @@ const AddLayerSubmenuItem = ( { opt, onParentClose } ) => {
 							<MenuItem
 								key={ sub.key }
 								className="godam-ve-add-menu__item"
+								data-test-id={ `godam-video-editor-control-add-form-${ sub.key }` }
 								onClick={ () => {
 									sub.onSelect();
 									setSubOpen( false );
@@ -543,6 +545,7 @@ const SidebarLayers = ( { currentTime, onSelectLayer, onPauseVideo, duration } )
 									className="godam-ve-layers__add-button"
 									iconPosition="left"
 									id="add-layer-btn"
+									data-test-id="godam-video-editor-button-add-layer"
 									onClick={ handleToggle }
 									aria-expanded={ menuOpen }
 									disabled={ isAddDisabled }
@@ -578,6 +581,7 @@ const SidebarLayers = ( { currentTime, onSelectLayer, onPauseVideo, duration } )
 								const item = (
 									<MenuItem
 										className="godam-ve-add-menu__item"
+										data-test-id={ `godam-video-editor-control-add-${ opt.key }` }
 										disabled={ opt.disabled }
 										onClick={ () => {
 											opt.onSelect?.();

--- a/pages/video-editor/components/appearance/Appearance.js
+++ b/pages/video-editor/components/appearance/Appearance.js
@@ -119,7 +119,7 @@ const Appearance = ( { attachmentID } ) => {
 	const hasLogo = controlBar.customBrandImg?.length > 0;
 
 	return (
-		<div id="easydam-player-settings" className="godam-ve-settings">
+		<div id="easydam-player-settings" className="godam-ve-settings" data-test-id="godam-video-editor-panel-player-settings">
 			<div className="godam-ve-settings__head">
 				<h2 className="godam-ve-settings__title">{ __( 'Settings', 'godam' ) }</h2>
 			</div>
@@ -128,16 +128,19 @@ const Appearance = ( { attachmentID } ) => {
 
 				<VeSection title={ __( 'Display Settings', 'godam' ) }>
 					<VeToggle
+						data-test-id="godam-video-editor-control-volume"
 						label={ __( 'Show volume slider', 'godam' ) }
 						checked={ controlBar.volumePanel }
 						onChange={ handleVolumeToggle }
 					/>
 					<VeToggle
+						data-test-id="godam-video-editor-control-captions"
 						label={ __( 'Display captions', 'godam' ) }
 						checked={ controlBar.subsCapsButton }
 						onChange={ handleCaptionsToggle }
 					/>
 					<VeCustomSelect
+						data-test-id="godam-video-editor-control-skip-duration"
 						label={ __( 'Adjust Skip Duration', 'godam' ) }
 						help={ __( 'Number of seconds the skip-forward / skip-backward buttons jump.', 'godam' ) }
 						value={ controlBar.skipButtons?.forward?.toString() || '10' }
@@ -153,6 +156,7 @@ const Appearance = ( { attachmentID } ) => {
 				<VeSection title={ __( 'Customisation Settings', 'godam' ) }>
 					{ ! hasLogo ? (
 						<Button
+							data-test-id="godam-video-editor-button-logo"
 							className="godam-ve-media-select"
 							variant="secondary"
 							icon={ plus }
@@ -164,6 +168,7 @@ const Appearance = ( { attachmentID } ) => {
 						<div className="godam-ve-media">
 							<button
 								type="button"
+								data-test-id="godam-video-editor-button-replace-logo"
 								className="godam-ve-media__main"
 								onClick={ openBrandLogoPicker }
 								aria-label={ __( 'Replace logo', 'godam' ) }
@@ -175,7 +180,7 @@ const Appearance = ( { attachmentID } ) => {
 								</span>
 							</button>
 							<Tooltip text={ __( 'Remove logo', 'godam' ) } placement="top">
-								<Button className="godam-ve-media__remove" icon={ trash } isDestructive onClick={ removeBrandLogo } />
+								<Button data-test-id="godam-video-editor-button-remove-logo" className="godam-ve-media__remove" icon={ trash } isDestructive onClick={ removeBrandLogo } />
 							</Tooltip>
 						</div>
 					) }
@@ -207,6 +212,7 @@ const Appearance = ( { attachmentID } ) => {
 
 				<VeSection title={ __( 'Ad Server', 'godam' ) }>
 					<VeToggle
+						data-test-id="godam-video-editor-control-ad-server"
 						label={ __( 'Use ad server\'s ad', 'godam' ) }
 						help={ __( 'Enable this option to use ads from the ad server. This option will disable the ads layer', 'godam' ) }
 						checked={ videoConfig.adServer === 'ad-server' }
@@ -214,6 +220,7 @@ const Appearance = ( { attachmentID } ) => {
 					/>
 					{ videoConfig.adServer === 'ad-server' && (
 						<VeTextInput
+							data-test-id="godam-video-editor-control-ad-tag-url"
 							label={ __( 'Ad Tag URL', 'godam' ) }
 							type="url"
 							value={ videoConfig.adTagURL }

--- a/pages/video-editor/components/appearance/ThumbnailSelector.jsx
+++ b/pages/video-editor/components/appearance/ThumbnailSelector.jsx
@@ -115,10 +115,11 @@ const ThumbnailSelector = ( { attachmentID } ) => {
 		return null;
 	}
 
-	const renderTile = ( url, isCustom ) => (
+	const renderTile = ( url, isCustom, index ) => (
 		<div key={ url } className="godam-ve-thumb-tile-wrap">
 			<button
 				type="button"
+				data-test-id={ `godam-video-editor-element-thumbnail-${ index }` }
 				className={ `godam-ve-thumb-tile${ selected === url ? ' is-selected' : '' }` }
 				onClick={ () => selectThumbnail( url ) }
 				aria-pressed={ selected === url }
@@ -132,6 +133,7 @@ const ThumbnailSelector = ( { attachmentID } ) => {
 			{ isCustom && (
 				<button
 					type="button"
+					data-test-id={ `godam-video-editor-button-delete-thumbnail-${ index }` }
 					className="godam-ve-thumb-tile__delete"
 					onClick={ () => deleteCustom( url ) }
 					aria-label={ __( 'Remove custom thumbnail', 'godam' ) }
@@ -150,14 +152,15 @@ const ThumbnailSelector = ( { attachmentID } ) => {
 				<div className="godam-ve-thumb-grid">
 					<button
 						type="button"
+						data-test-id="godam-video-editor-button-upload-thumbnail"
 						className="godam-ve-thumb-tile godam-ve-thumb-upload"
 						onClick={ uploadCustom }
 						aria-label={ __( 'Upload custom thumbnail', 'godam' ) }
 					>
 						<span aria-hidden="true">+</span>
 					</button>
-					{ customThumbnails.map( ( url ) => renderTile( url, true ) ) }
-					{ autoThumbnails.map( ( url ) => renderTile( url, false ) ) }
+					{ customThumbnails.map( ( url, index ) => renderTile( url, true, index ) ) }
+					{ autoThumbnails.map( ( url, index ) => renderTile( url, false, index ) ) }
 				</div>
 			) }
 		</div>

--- a/pages/video-editor/components/appearance/ThumbnailSelector.jsx
+++ b/pages/video-editor/components/appearance/ThumbnailSelector.jsx
@@ -119,7 +119,7 @@ const ThumbnailSelector = ( { attachmentID } ) => {
 		<div key={ url } className="godam-ve-thumb-tile-wrap">
 			<button
 				type="button"
-				data-test-id={ `godam-video-editor-element-thumbnail-${ index }` }
+				data-test-id={ `godam-video-editor-element-thumbnail-${ isCustom ? 'custom' : 'auto' }-${ index }` }
 				className={ `godam-ve-thumb-tile${ selected === url ? ' is-selected' : '' }` }
 				onClick={ () => selectThumbnail( url ) }
 				aria-pressed={ selected === url }
@@ -133,7 +133,7 @@ const ThumbnailSelector = ( { attachmentID } ) => {
 			{ isCustom && (
 				<button
 					type="button"
-					data-test-id={ `godam-video-editor-button-delete-thumbnail-${ index }` }
+					data-test-id={ `godam-video-editor-button-delete-thumbnail-custom-${ index }` }
 					className="godam-ve-thumb-tile__delete"
 					onClick={ () => deleteCustom( url ) }
 					aria-label={ __( 'Remove custom thumbnail', 'godam' ) }

--- a/pages/video-editor/components/chapters/ChapterForm.js
+++ b/pages/video-editor/components/chapters/ChapterForm.js
@@ -127,6 +127,7 @@ const ChapterForm = ( { rows, duration, formatTimeForInput, editingRow, onSubmit
 			</div>
 
 			<VeTextInput
+				data-test-id="godam-video-editor-control-chapter-title"
 				label={ __( 'Chapter title', 'godam' ) }
 				placeholder={ __( 'e.g. Introduction', 'godam' ) }
 				value={ title }
@@ -135,6 +136,7 @@ const ChapterForm = ( { rows, duration, formatTimeForInput, editingRow, onSubmit
 
 			<div className="godam-ve-chapters__times">
 				<VeTextInput
+					data-test-id="godam-video-editor-control-chapter-start"
 					label={ __( 'Start time', 'godam' ) }
 					value={ startInput }
 					placeholder="0:00"
@@ -142,6 +144,7 @@ const ChapterForm = ( { rows, duration, formatTimeForInput, editingRow, onSubmit
 					onChange={ setStartInput }
 				/>
 				<VeTextInput
+					data-test-id="godam-video-editor-control-chapter-end"
 					label={ __( 'End time', 'godam' ) }
 					value={ endInput }
 					placeholder={ durationLabel }
@@ -151,6 +154,7 @@ const ChapterForm = ( { rows, duration, formatTimeForInput, editingRow, onSubmit
 			</div>
 
 			<Button
+				data-test-id="godam-video-editor-button-chapter-submit"
 				variant="secondary"
 				className="godam-ve-chapters__submit"
 				icon={ editingId ? undefined : plus }

--- a/pages/video-editor/components/chapters/Chapters.js
+++ b/pages/video-editor/components/chapters/Chapters.js
@@ -72,7 +72,7 @@ const Chapters = ( { duration, formatTimeForInput, onSelectChapter } ) => {
 	};
 
 	return (
-		<div className="godam-ve-chapters">
+		<div className="godam-ve-chapters" data-test-id="godam-video-editor-panel-chapters">
 			<div className="godam-ve-chapters__head">
 				<h2 className="godam-ve-chapters__title">
 					{ sprintf(
@@ -117,7 +117,7 @@ const Chapters = ( { duration, formatTimeForInput, onSelectChapter } ) => {
 						}
 
 						return (
-							<li key={ row.id } className="godam-ve-chapter-row">
+							<li key={ row.id } className="godam-ve-chapter-row" data-test-id={ `godam-video-editor-element-chapter-${ row.id }` }>
 								<Button
 									className="godam-ve-chapter-row__main"
 									onClick={ () => handleEdit( row ) }
@@ -136,12 +136,14 @@ const Chapters = ( { duration, formatTimeForInput, onSelectChapter } ) => {
 									</span>
 								</Button>
 								<Button
+									data-test-id={ `godam-video-editor-button-edit-chapter-${ row.id }` }
 									className="godam-ve-chapter-row__edit"
 									icon={ edit }
 									label={ __( 'Edit chapter', 'godam' ) }
 									onClick={ () => handleEdit( row ) }
 								/>
 								<Button
+									data-test-id={ `godam-video-editor-button-delete-chapter-${ row.id }` }
 									className="godam-ve-chapter-row__delete"
 									icon={ trash }
 									isDestructive

--- a/pages/video-editor/components/controls/index.js
+++ b/pages/video-editor/components/controls/index.js
@@ -29,8 +29,8 @@ import { useState } from '@wordpress/element';
  * @param {JSX.Element} props.children    Section body.
  * @return {JSX.Element} Section element.
  */
-export const VeSection = ( { title, className = '', children } ) => (
-	<section className={ `godam-ve-section ${ className }`.trim() }>
+export const VeSection = ( { title, className = '', children, ...rest } ) => (
+	<section className={ `godam-ve-section ${ className }`.trim() } { ...rest }>
 		{ title && <h3 className="godam-ve-section__title">{ title }</h3> }
 		{ children }
 	</section>
@@ -48,8 +48,8 @@ export const VeSection = ( { title, className = '', children } ) => (
  * @param {JSX.Element} props.children    The grouped controls.
  * @return {JSX.Element} Field element.
  */
-export const VeField = ( { label, help, className = '', children } ) => (
-	<div className={ `godam-ve-field ${ className }`.trim() }>
+export const VeField = ( { label, help, className = '', children, ...rest } ) => (
+	<div className={ `godam-ve-field ${ className }`.trim() } { ...rest }>
 		{ label && <span className="godam-ve-field__label">{ label }</span> }
 		{ children }
 		{ help && <p className="godam-ve-field__help">{ help }</p> }
@@ -103,7 +103,7 @@ export const VeTextInput = ( { label, help, error, value = '', onChange, placeho
  * @param {string}   [props.className]   Extra class names.
  * @return {JSX.Element} Textarea control.
  */
-export const VeTextarea = ( { label, help, value = '', onChange, placeholder, rows = 4, maxLength, className = '' } ) => (
+export const VeTextarea = ( { label, help, value = '', onChange, placeholder, rows = 4, maxLength, className = '', ...rest } ) => (
 	<TextareaControl
 		__nextHasNoMarginBottom
 		className={ `godam-ve-control godam-ve-control--textarea ${ className }`.trim() }
@@ -115,6 +115,7 @@ export const VeTextarea = ( { label, help, value = '', onChange, placeholder, ro
 		placeholder={ placeholder }
 		maxLength={ maxLength }
 		onChange={ onChange }
+		{ ...rest }
 	/>
 );
 
@@ -133,7 +134,7 @@ export const VeTextarea = ( { label, help, value = '', onChange, placeholder, ro
  * @param {string}   [props.className] Extra class names.
  * @return {JSX.Element} Range control.
  */
-export const VeSlider = ( { label, help, value = 0, onChange, min = 0, max = 100, step = 1, className = '' } ) => (
+export const VeSlider = ( { label, help, value = 0, onChange, min = 0, max = 100, step = 1, className = '', ...rest } ) => (
 	<RangeControl
 		__next40pxDefaultSize
 		__nextHasNoMarginBottom
@@ -146,6 +147,7 @@ export const VeSlider = ( { label, help, value = 0, onChange, min = 0, max = 100
 		min={ min }
 		max={ max }
 		step={ step }
+		{ ...rest }
 	/>
 );
 
@@ -162,7 +164,7 @@ export const VeSlider = ( { label, help, value = 0, onChange, min = 0, max = 100
  * @param {string}   [props.className] Extra class names.
  * @return {JSX.Element} Select control.
  */
-export const VeSelect = ( { label, help, value, onChange, options = [], disabled = false, className = '' } ) => (
+export const VeSelect = ( { label, help, value, onChange, options = [], disabled = false, className = '', ...rest } ) => (
 	<SelectControl
 		__next40pxDefaultSize
 		__nextHasNoMarginBottom
@@ -173,6 +175,7 @@ export const VeSelect = ( { label, help, value, onChange, options = [], disabled
 		options={ options }
 		onChange={ onChange }
 		disabled={ disabled }
+		{ ...rest }
 	/>
 );
 
@@ -196,12 +199,12 @@ export const VeSelect = ( { label, help, value, onChange, options = [], disabled
  * @param {string}   [props.className] Extra class names.
  * @return {JSX.Element} Custom select control.
  */
-export const VeCustomSelect = ( { label, help, value, onChange, options = [], disabled = false, className = '' } ) => {
+export const VeCustomSelect = ( { label, help, value, onChange, options = [], disabled = false, className = '', ...rest } ) => {
 	const items = options.map( ( opt ) => ( { key: String( opt.value ), name: opt.label } ) );
 	const selected = items.find( ( item ) => item.key === String( value ) ) ?? items[ 0 ];
 
 	return (
-		<div className={ `godam-ve-custom-select-field ${ disabled ? 'is-disabled' : '' } ${ className }`.trim() }>
+		<div className={ `godam-ve-custom-select-field ${ disabled ? 'is-disabled' : '' } ${ className }`.trim() } { ...rest }>
 			<CustomSelectControl
 				__next40pxDefaultSize
 				className="godam-ve-control godam-ve-custom-select"
@@ -227,7 +230,7 @@ export const VeCustomSelect = ( { label, help, value, onChange, options = [], di
  * @param {string}   [props.className] Extra class names.
  * @return {JSX.Element} Toggle control.
  */
-export const VeToggle = ( { label, help, checked, onChange, disabled = false, className = '' } ) => (
+export const VeToggle = ( { label, help, checked, onChange, disabled = false, className = '', ...rest } ) => (
 	<ToggleControl
 		__nextHasNoMarginBottom
 		className={ `godam-ve-control godam-ve-toggle ${ className }`.trim() }
@@ -236,6 +239,7 @@ export const VeToggle = ( { label, help, checked, onChange, disabled = false, cl
 		checked={ checked }
 		onChange={ onChange }
 		disabled={ disabled }
+		{ ...rest }
 	/>
 );
 
@@ -250,14 +254,15 @@ export const VeToggle = ( { label, help, checked, onChange, disabled = false, cl
  * @param {Function} props.onChange Receives the chosen value.
  * @return {JSX.Element} Segmented control.
  */
-export const VeSegmented = ( { options = [], value, onChange } ) => (
-	<div className="godam-ve-segmented">
+export const VeSegmented = ( { options = [], value, onChange, ...rest } ) => (
+	<div className="godam-ve-segmented" { ...rest }>
 		{ options.map( ( opt ) => (
 			<button
 				key={ opt.value }
 				type="button"
 				disabled={ opt.disabled }
 				aria-pressed={ value === opt.value }
+				data-test-id={ opt.testId }
 				className={ `godam-ve-segmented__option${ value === opt.value ? ' is-selected' : '' }` }
 				onClick={ () => onChange?.( opt.value ) }
 			>
@@ -283,8 +288,8 @@ export const VeSegmented = ( { options = [], value, onChange } ) => (
  * @param {Function} props.onChange Receives the chosen value.
  * @return {JSX.Element} Grid control.
  */
-export const VeLayoutGrid = ( { options = [], value, onChange } ) => (
-	<div className="godam-ve-layout-grid">
+export const VeLayoutGrid = ( { options = [], value, onChange, ...rest } ) => (
+	<div className="godam-ve-layout-grid" { ...rest }>
 		{ options.map( ( opt ) => {
 			const ItemIcon = opt.Icon;
 			return (
@@ -294,6 +299,7 @@ export const VeLayoutGrid = ( { options = [], value, onChange } ) => (
 					aria-label={ opt.label }
 					aria-pressed={ value === opt.value }
 					title={ opt.label }
+					data-test-id={ opt.testId }
 					className={ `godam-ve-layout-grid__item${ value === opt.value ? ' is-selected' : '' }` }
 					onClick={ () => onChange?.( opt.value ) }
 				>
@@ -320,8 +326,8 @@ export const VeLayoutGrid = ( { options = [], value, onChange } ) => (
  * @param {Function} props.onChange Receives the chosen value.
  * @return {JSX.Element} Radio group.
  */
-export const VeRadioGroup = ( { name, options = [], value, onChange } ) => (
-	<div className="godam-ve-radio-group" role="radiogroup">
+export const VeRadioGroup = ( { name, options = [], value, onChange, ...rest } ) => (
+	<div className="godam-ve-radio-group" role="radiogroup" { ...rest }>
 		{ options.map( ( opt ) => {
 			const selected = value === opt.value;
 			const optionId = `${ name }-${ opt.value }`;
@@ -339,6 +345,7 @@ export const VeRadioGroup = ( { name, options = [], value, onChange } ) => (
 							value={ opt.value }
 							checked={ selected }
 							disabled={ opt.disabled }
+							data-test-id={ opt.testId }
 							onChange={ () => onChange?.( opt.value ) }
 						/>
 						<span className="godam-ve-radio__text">
@@ -368,10 +375,10 @@ export const VeRadioGroup = ( { name, options = [], value, onChange } ) => (
  * @param {JSX.Element} props.children      Body content.
  * @return {JSX.Element} Collapsible section.
  */
-export const VeCollapsible = ( { title, defaultOpen = true, children } ) => {
+export const VeCollapsible = ( { title, defaultOpen = true, children, ...rest } ) => {
 	const [ open, setOpen ] = useState( defaultOpen );
 	return (
-		<div className={ `godam-ve-collapsible${ open ? ' is-open' : '' }` }>
+		<div className={ `godam-ve-collapsible${ open ? ' is-open' : '' }` } { ...rest }>
 			<button
 				type="button"
 				className="godam-ve-collapsible__head"
@@ -397,6 +404,6 @@ export const VeCollapsible = ( { title, defaultOpen = true, children } ) => {
  * @param {JSX.Element} props.children `ColorPickerButton` rows.
  * @return {JSX.Element} Colour list.
  */
-export const VeColorList = ( { children } ) => (
-	<div className="godam-ve-color-list">{ children }</div>
+export const VeColorList = ( { children, ...rest } ) => (
+	<div className="godam-ve-color-list" { ...rest }>{ children }</div>
 );

--- a/pages/video-editor/components/controls/index.js
+++ b/pages/video-editor/components/controls/index.js
@@ -248,7 +248,7 @@ export const VeToggle = ( { label, help, checked, onChange, disabled = false, cl
  * `ToggleGroupControl` can't render the two-line option design.
  *
  * @param {Object}   props          Props.
- * @param {Array}    props.options  `[{ value, label, description, icon, disabled }]`. `icon` is an optional JSX element rendered above the label.
+ * @param {Array}    props.options  `[{ value, label, description, icon, disabled, testId }]`. `icon` is an optional JSX element rendered above the label; `testId` is rendered as `data-test-id` on the option button.
  *
  * @param {string}   props.value    Selected value.
  * @param {Function} props.onChange Receives the chosen value.
@@ -283,7 +283,7 @@ export const VeSegmented = ( { options = [], value, onChange, ...rest } ) => (
  * component renders a selectable icon grid.
  *
  * @param {Object}   props          Props.
- * @param {Array}    props.options  `[{ value, label, Icon }]` where `Icon` is a component.
+ * @param {Array}    props.options  `[{ value, label, Icon, testId }]` where `Icon` is a component; `testId` is rendered as `data-test-id` on the grid button.
  * @param {string}   props.value    Selected value.
  * @param {Function} props.onChange Receives the chosen value.
  * @return {JSX.Element} Grid control.
@@ -321,7 +321,7 @@ export const VeLayoutGrid = ( { options = [], value, onChange, ...rest } ) => (
  *
  * @param {Object}   props          Props.
  * @param {string}   props.name     Shared radio group name (unique per layer).
- * @param {Array}    props.options  `[{ value, label, description, disabled, content }]`.
+ * @param {Array}    props.options  `[{ value, label, description, disabled, content, testId }]`. `testId` is rendered as `data-test-id` on the option's `<input>`.
  * @param {string}   props.value    Selected value.
  * @param {Function} props.onChange Receives the chosen value.
  * @return {JSX.Element} Radio group.

--- a/pages/video-editor/components/cta/CardCTA.js
+++ b/pages/video-editor/components/cta/CardCTA.js
@@ -291,14 +291,14 @@ const CardCTA = ( { layerID, triggerSlot } ) => {
 
 	// Layout options
 	const layoutOptions = [
-		{ label: __( 'Image Left, Text Right (Full Height)', 'godam' ), value: 'card-layout--imagecover-text', Icon: LayoutIcons.MediaTextCover },
-		{ label: __( 'Text Left, Image Right (Full Height)', 'godam' ), value: 'card-layout--text-imagecover', Icon: LayoutIcons.TextMediaCover },
-		{ label: __( 'Image Left, Text Right', 'godam' ), value: 'card-layout--image-text', Icon: LayoutIcons.MediaText },
-		{ label: __( 'Text Left, Image Right', 'godam' ), value: 'card-layout--text-image', Icon: LayoutIcons.TextMedia },
-		{ label: __( 'Image Top, Text Bottom', 'godam' ), value: 'card-layout--image-top', Icon: LayoutIcons.MediaTop },
-		{ label: __( 'Text Top, Image Bottom', 'godam' ), value: 'card-layout--image-bottom', Icon: LayoutIcons.MediaBottom },
-		{ label: __( 'Image Background', 'godam' ), value: 'card-layout--image-background', Icon: LayoutIcons.TextCoverMedia },
-		{ label: __( 'Text Only (No Image)', 'godam' ), value: 'desktop-text-only', Icon: LayoutIcons.TextOnly },
+		{ label: __( 'Image Left, Text Right (Full Height)', 'godam' ), value: 'card-layout--imagecover-text', Icon: LayoutIcons.MediaTextCover, testId: 'godam-cta-button-layout-imagecover-text' },
+		{ label: __( 'Text Left, Image Right (Full Height)', 'godam' ), value: 'card-layout--text-imagecover', Icon: LayoutIcons.TextMediaCover, testId: 'godam-cta-button-layout-text-imagecover' },
+		{ label: __( 'Image Left, Text Right', 'godam' ), value: 'card-layout--image-text', Icon: LayoutIcons.MediaText, testId: 'godam-cta-button-layout-image-text' },
+		{ label: __( 'Text Left, Image Right', 'godam' ), value: 'card-layout--text-image', Icon: LayoutIcons.TextMedia, testId: 'godam-cta-button-layout-text-image' },
+		{ label: __( 'Image Top, Text Bottom', 'godam' ), value: 'card-layout--image-top', Icon: LayoutIcons.MediaTop, testId: 'godam-cta-button-layout-image-top' },
+		{ label: __( 'Text Top, Image Bottom', 'godam' ), value: 'card-layout--image-bottom', Icon: LayoutIcons.MediaBottom, testId: 'godam-cta-button-layout-image-bottom' },
+		{ label: __( 'Image Background', 'godam' ), value: 'card-layout--image-background', Icon: LayoutIcons.TextCoverMedia, testId: 'godam-cta-button-layout-image-background' },
+		{ label: __( 'Text Only (No Image)', 'godam' ), value: 'desktop-text-only', Icon: LayoutIcons.TextOnly, testId: 'godam-cta-button-layout-text-only' },
 	];
 
 	const layoutsWithWidth = [ 'card-layout--text-imagecover', 'card-layout--imagecover-text', 'card-layout--text-image', 'card-layout--image-text' ];
@@ -432,6 +432,7 @@ const CardCTA = ( { layerID, triggerSlot } ) => {
 					onChange={ ( value ) => updateField( 'imageDescription', value ) }
 					placeholder={ __( 'Your description', 'godam' ) }
 					maxLength={ DESCRIPTION_LIMIT }
+					data-test-id="godam-cta-control-description"
 				/>
 			</VeSection>
 

--- a/pages/video-editor/components/layers/CTALayer.js
+++ b/pages/video-editor/components/layers/CTALayer.js
@@ -53,8 +53,8 @@ const CTALayer = ( { layerID, goBack, duration } ) => {
 
 	// Two CTA styles in the new design: a card builder and a raw-HTML editor.
 	const ctaTypeOptions = [
-		{ value: 'image', label: __( 'Card Style', 'godam' ), description: __( 'Perfect for everyone', 'godam' ) },
-		{ value: 'html', label: __( 'HTML', 'godam' ), description: __( 'Great for developers', 'godam' ) },
+		{ value: 'image', label: __( 'Card Style', 'godam' ), description: __( 'Perfect for everyone', 'godam' ), testId: 'godam-cta-control-type-image' },
+		{ value: 'html', label: __( 'HTML', 'godam' ), description: __( 'Great for developers', 'godam' ), testId: 'godam-cta-control-type-html' },
 	];
 
 	// Normalize legacy / unknown types (e.g. the removed "text" type) to "image".

--- a/pages/video-editor/components/video-dataview/VideoEditorDataView.jsx
+++ b/pages/video-editor/components/video-dataview/VideoEditorDataView.jsx
@@ -109,8 +109,10 @@ const DEFAULT_VIEW = {
  * @param {Object}   props
  * @param {string}   props.label    Accessible label / aria for the control.
  * @param {Array}    props.options  `{ key, label }` options.
- * @param {string}   props.value    Currently selected option key.
- * @param {Function} props.onChange Called with the selected option key.
+ * @param {string}   props.value              Currently selected option key.
+ * @param {Function} props.onChange           Called with the selected option key.
+ * @param {string}   [props.toggleTestId]     data-test-id for the toggle button (E2E hook).
+ * @param {string}   [props.itemTestIdPrefix] Prefix for each menu item's data-test-id; the option key is appended.
  * @return {JSX.Element} Dropdown control.
  */
 const ToolbarDropdown = ( { label, options, value, onChange, toggleTestId, itemTestIdPrefix } ) => {

--- a/pages/video-editor/components/video-dataview/VideoEditorDataView.jsx
+++ b/pages/video-editor/components/video-dataview/VideoEditorDataView.jsx
@@ -113,7 +113,7 @@ const DEFAULT_VIEW = {
  * @param {Function} props.onChange Called with the selected option key.
  * @return {JSX.Element} Dropdown control.
  */
-const ToolbarDropdown = ( { label, options, value, onChange } ) => {
+const ToolbarDropdown = ( { label, options, value, onChange, toggleTestId, itemTestIdPrefix } ) => {
 	const selected = options.find( ( o ) => o.key === value ) || options[ 0 ];
 
 	return (
@@ -124,6 +124,7 @@ const ToolbarDropdown = ( { label, options, value, onChange } ) => {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					className="godam-ve-toolbar__dropdown-toggle"
+					data-test-id={ toggleTestId }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 					aria-label={ label }
@@ -138,6 +139,7 @@ const ToolbarDropdown = ( { label, options, value, onChange } ) => {
 						{ options.map( ( option ) => (
 							<MenuItem
 								key={ option.key }
+								data-test-id={ `${ itemTestIdPrefix }${ option.key }` }
 								role="menuitemradio"
 								isSelected={ option.key === value }
 								icon={ option.key === value ? check : undefined }
@@ -360,7 +362,10 @@ const VideoEditorDataView = ( { onEdit } ) => {
 
 					return (
 						<>
-							<div className="godam-ve-card__media-frame">
+							<div
+								className="godam-ve-card__media-frame"
+								data-test-id={ `godam-video-editor-element-card-${ item.id }` }
+							>
 								<img
 									src={ isFallback ? NoThumbnailImage : item.thumbnail }
 									alt={ item.title || '' }
@@ -376,6 +381,7 @@ const VideoEditorDataView = ( { onEdit } ) => {
 										<Button
 											variant="primary"
 											icon={ editIcon }
+											data-test-id={ `godam-video-editor-button-edit-${ item.id }` }
 											className="godam-ve-card__edit-button"
 											onClick={ ( event ) => {
 												event.stopPropagation();
@@ -489,11 +495,12 @@ const VideoEditorDataView = ( { onEdit } ) => {
 				</a>
 			</div>
 
-			<div className="godam-ve-toolbar">
+			<div className="godam-ve-toolbar" data-test-id="godam-video-editor-toolbar-list">
 				<div className="godam-ve-toolbar__search">
 					<Icon icon={ searchIcon } size={ 20 } />
 					<input
 						type="text"
+						data-test-id="godam-video-editor-control-search"
 						value={ search }
 						placeholder={ __( 'Search', 'godam' ) }
 						onChange={ handleSearchChange }
@@ -507,18 +514,22 @@ const VideoEditorDataView = ( { onEdit } ) => {
 						options={ FILTER_OPTIONS }
 						value={ filter }
 						onChange={ handleFilterChange }
+						toggleTestId="godam-video-editor-button-filter"
+						itemTestIdPrefix="godam-video-editor-control-filter-"
 					/>
 					<ToolbarDropdown
 						label={ __( 'Sort videos', 'godam' ) }
 						options={ SORT_OPTIONS }
 						value={ sortKey }
 						onChange={ handleSortChange }
+						toggleTestId="godam-video-editor-button-sort"
+						itemTestIdPrefix="godam-video-editor-control-sort-"
 					/>
 				</div>
 			</div>
 
 			{ isEmpty ? (
-				<div className="godam-ve-list__empty">
+				<div className="godam-ve-list__empty" data-test-id="godam-video-editor-content-empty">
 					<Icon icon={ mediaIcon } size={ 120 } />
 					<h2>{ __( 'You have no media yet!', 'godam' ) }</h2>
 					<p>
@@ -535,6 +546,7 @@ const VideoEditorDataView = ( { onEdit } ) => {
 				</div>
 			) : (
 				<DataViews
+					data-test-id="godam-video-editor-content-list"
 					data={ items }
 					fields={ fields }
 					view={ view }
@@ -556,7 +568,7 @@ const VideoEditorDataView = ( { onEdit } ) => {
 			{ /* "Showing X of Y" count + manual Load more button. */ }
 			{ items.length > 0 && (
 				<div className="godam-ve-list__loadmore">
-					<p className="godam-ve-list__count">
+					<p className="godam-ve-list__count" data-test-id="godam-video-editor-element-count">
 						{ sprintf(
 							/* translators: 1: number of loaded media items, 2: total media items. */
 							__( 'Showing %1$d of %2$d media items', 'godam' ),
@@ -567,6 +579,7 @@ const VideoEditorDataView = ( { onEdit } ) => {
 					{ hasMore && (
 						<Button
 							variant="secondary"
+							data-test-id="godam-video-editor-button-load-more"
 							className="godam-ve-list__loadmore-button"
 							onClick={ loadMore }
 							isBusy={ fetching }


### PR DESCRIPTION
## What & why
Adds stable `data-test-id` hooks for the Playwright E2E suite across the **Video Editor 2.0** surfaces and the merged **Settings redesign** (#1982). Targets `feat/video-editor-2.0` so the hooks ship as part of 2.0. The redesigned screens currently expose almost no test-ids, blocking automation coverage of search/filter, per-video settings, chapters, and every settings tab.

**Scope:** source-only (`pages/…`). No behavioural changes — `data-test-id` attributes plus the prop-forwarding noted below. Build artifacts / zip to be regenerated.

## Keystone: `Ve*` controls now forward `data-test-id`
`pages/video-editor/components/controls/index.js` — the reusable wrappers (`VeToggle`, `VeSelect`, `VeCustomSelect`, `VeTextarea`, `VeSlider`, `VeSegmented`, `VeLayoutGrid`, `VeRadioGroup`, `VeCollapsible`, `VeSection`, `VeField`, `VeColorList`) previously dropped unknown props, so call-site test-ids never reached the DOM. They now spread `...rest`; `VeSegmented`/`VeLayoutGrid`/`VeRadioGroup` also accept a per-option `testId`. `ConfirmModal` forwards `data-test-id` too (distinct ids per call site).

## Coverage added
**Video Editor (`video-editor` area):** list `-control-search` / `-content-list` / `-toolbar-list` / `-element-count` / `-content-empty` / `-button-load-more` / `-element-card-${id}` / `-button-edit-${id}`; `-button-filter` / `-button-sort` + `-control-filter-${key}` / `-control-sort-${key}`; per-video settings `-panel-player-settings` / `-control-volume` / `-captions` / `-skip-duration` / `-ad-server` / `-control-ad-tag-url` / `-button-logo` / `-button-replace-logo` / `-button-remove-logo` / `-button-upload-thumbnail` / `-element-thumbnail-{custom|auto}-${i}` / `-button-delete-thumbnail-custom-${i}`; chapters `-panel-chapters` / `-element-chapter-${id}` / `-button-edit-chapter-${id}` / `-button-delete-chapter-${id}` / `-control-chapter-{title,start,end}` / `-button-chapter-submit`; add-layer `-button-add-layer` / `-control-add-${type}` / `-control-add-form-${formType}`.
**CTA:** `godam-cta-control-type-{image,html}`, `godam-cta-button-layout-${suffix}` (×8), `godam-cta-control-description`.
**Settings page:** `settings-api-key-*` (control-key, button-copy/save/refresh/choose-plan/confirm-remove), `settings-general-*` (folder-org, gtm, save, confirm-reset), `settings-video-*` (quality, thumbnails-count, watermark-select/remove, engagement, share), `settings-player-*` (skin, brand-color + clear, logo-upload/remove, editor-custom-css, save), `settings-ads-*` (enable, tag-url, save), `settings-integrations-button-save`.

## Notes for reviewers
- **ID renamed:** the API-key Save button id `godam-settings-video-button-save-api-key` → `godam-settings-api-key-button-save` (API Key is now its own tab). Flag if the old id must be preserved.
- A few settings controls that don't forward props (`CustomSelectControl`, `ToggleControl`, `ColorPickerButton`, Monaco CSS editor) are wrapped in a `<div>` carrying the id — scope inward (`… input` / trigger `button`).
- All ids verified globally unique (no new duplicates).
- Source-only; needs a build/lint pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)