### PR TITLE
feat: add data-test-id hooks for E2E on the redesigned Audio block

### DIFF
--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -175,6 +175,7 @@ function AudioEdit( {
 										variant="secondary"
 										onClick={ open }
 										className="godam-audio__add-btn"
+										data-test-id="godam-audio-button-select"
 									>
 										{ __( '+ Add Audio File', 'godam' ) }
 									</Button>
@@ -184,7 +185,7 @@ function AudioEdit( {
 					</PanelBody>
 				</InspectorControls>
 
-				<figure { ...blockProps }>
+				<figure { ...blockProps } data-test-id="godam-audio-canvas-placeholder">
 					<div className="godam-audio-empty">
 						<h3 className="godam-audio-empty__title">
 							{ __( 'Add an audio file', 'godam' ) }
@@ -203,6 +204,7 @@ function AudioEdit( {
 										variant="primary"
 										onClick={ open }
 										className="godam-audio-empty__btn"
+										data-test-id="godam-audio-button-upload"
 									>
 										{ __( '+ Upload Audio', 'godam' ) }
 									</Button>
@@ -237,7 +239,7 @@ function AudioEdit( {
 			<InspectorControls>
 
 				{ /* Audio Selection */ }
-				<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Audio Selection', 'godam' ) } initialOpen={ true } data-test-id="godam-audio-panel-selection">
 					{ fileName && (
 						<div className="godam-audio-file-row">
 							<span className="godam-audio-file-row__icon dashicons dashicons-media-audio" />
@@ -250,6 +252,7 @@ function AudioEdit( {
 								isDestructive
 								size="small"
 								onClick={ onRemoveAudio }
+								data-test-id="godam-audio-button-remove"
 							/>
 						</div>
 					) }
@@ -258,6 +261,7 @@ function AudioEdit( {
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 						label={ __( 'Audio Title', 'godam' ) }
+						data-test-id="godam-audio-control-title"
 						value={ audioTitle }
 						placeholder={ __( 'Add a title…', 'godam' ) }
 						onChange={ ( value ) => setAttributes( { audioTitle: value } ) }
@@ -266,6 +270,7 @@ function AudioEdit( {
 					<TextareaControl
 						__nextHasNoMarginBottom
 						label={ __( 'Description', 'godam' ) }
+						data-test-id="godam-audio-control-description"
 						value={ description }
 						placeholder={ __( 'Add a short description…', 'godam' ) }
 						rows={ 4 }
@@ -274,7 +279,7 @@ function AudioEdit( {
 				</PanelBody>
 
 				{ /* Thumbnail */ }
-				<PanelBody title={ __( 'Thumbnail', 'godam' ) } initialOpen={ true }>
+				<PanelBody title={ __( 'Thumbnail', 'godam' ) } initialOpen={ true } data-test-id="godam-audio-panel-thumbnail">
 					{ thumbnail ? (
 						<div className="godam-audio-thumbnail-preview">
 							<img src={ thumbnail } alt={ __( 'Audio thumbnail', 'godam' ) } />
@@ -285,7 +290,7 @@ function AudioEdit( {
 										allowedTypes={ ALLOWED_THUMBNAIL_TYPES }
 										value={ thumbnailId }
 										render={ ( { open } ) => (
-											<Button variant="secondary" size="small" onClick={ open }>
+											<Button variant="secondary" size="small" onClick={ open } data-test-id="godam-audio-button-replace-thumbnail">
 												{ __( 'Replace', 'godam' ) }
 											</Button>
 										) }
@@ -296,6 +301,7 @@ function AudioEdit( {
 									size="small"
 									isDestructive
 									onClick={ onRemoveThumbnail }
+									data-test-id="godam-audio-button-remove-thumbnail"
 								>
 									{ __( 'Remove', 'godam' ) }
 								</Button>
@@ -313,6 +319,7 @@ function AudioEdit( {
 										variant="secondary"
 										onClick={ open }
 										className="godam-audio__add-btn"
+										data-test-id="godam-audio-button-upload-thumbnail"
 									>
 										{ __( '+ Upload Image', 'godam' ) }
 									</Button>
@@ -365,7 +372,7 @@ function AudioEdit( {
 			<figure { ...blockProps } data-test-id="godam-audio-canvas">
 				<div className="godam-audio-card">
 					{ /* Thumbnail */ }
-					<div className="godam-audio-card__cover">
+					<div className="godam-audio-card__cover" data-test-id="godam-audio-element-cover">
 						{ thumbnail ? (
 							<img src={ thumbnail } alt={ audioTitle || __( 'Audio thumbnail', 'godam' ) } />
 						) : (
@@ -378,10 +385,10 @@ function AudioEdit( {
 					{ /* Info + player */ }
 					<div className="godam-audio-card__body">
 						{ audioTitle && (
-							<p className="godam-audio-card__title">{ audioTitle }</p>
+							<p className="godam-audio-card__title" data-test-id="godam-audio-element-title">{ audioTitle }</p>
 						) }
 						{ description && (
-							<p className="godam-audio-card__description">{ description }</p>
+							<p className="godam-audio-card__description" data-test-id="godam-audio-element-description">{ description }</p>
 						) }
 						<Disabled isDisabled={ ! isSingleSelected }>
 							<audio controls src={ src ?? temporaryURL } style={ { width: '100%' } } />

--- a/assets/src/blocks/godam-audio/render.php
+++ b/assets/src/blocks/godam-audio/render.php
@@ -41,7 +41,7 @@ if ( ! $godam_attachment_id && ! empty( $godam_src ) ) {
 	<div class="godam-audio-card">
 
 		<?php /* Thumbnail */ ?>
-		<div class="godam-audio-card__cover">
+		<div class="godam-audio-card__cover" data-test-id="godam-audio-render-cover">
 			<?php if ( $godam_thumbnail ) : ?>
 				<img
 					src="<?php echo esc_url( $godam_thumbnail ); ?>"
@@ -57,15 +57,16 @@ if ( ! $godam_attachment_id && ! empty( $godam_src ) ) {
 		<?php /* Info + player */ ?>
 		<div class="godam-audio-card__body">
 			<?php if ( $godam_audio_title ) : ?>
-				<p class="godam-audio-card__title"><?php echo esc_html( $godam_audio_title ); ?></p>
+				<p class="godam-audio-card__title" data-test-id="godam-audio-render-title"><?php echo esc_html( $godam_audio_title ); ?></p>
 			<?php endif; ?>
 
 			<?php if ( $godam_description ) : ?>
-				<p class="godam-audio-card__description"><?php echo esc_html( $godam_description ); ?></p>
+				<p class="godam-audio-card__description" data-test-id="godam-audio-render-description"><?php echo esc_html( $godam_description ); ?></p>
 			<?php endif; ?>
 
 			<audio
 				class="godam-audio-card__player"
+				data-test-id="godam-audio-render-player"
 				controls
 				<?php echo esc_attr( $godam_autoplay ); ?>
 				<?php echo esc_attr( $godam_loop ); ?>


### PR DESCRIPTION
## What & why
The audio-block card-layout revamp (#1980) replaced `MediaPlaceholder` with `MediaUpload` and added title/description/thumbnail controls + a card frontend. That **orphaned** two hooks our E2E suite relies on (`godam-audio-button-select`, `godam-audio-canvas-placeholder`) and left the new UI uninstrumented. This restores those and adds hooks for the new surfaces. Targets `redesign/audio-block` so they ship with the revamp.

**Scope:** source-only (`assets/src`). No behavioural changes — `data-test-id` only. IDs verified globally unique.

## Hooks added (`godam-audio-*`)
**Editor (`edit.js`):** `-canvas-placeholder` (re-add), `-button-upload` (canvas "+ Upload Audio"), `-button-select` (re-add, inspector "+ Add Audio File"), `-panel-selection`, `-panel-thumbnail`, `-button-remove`, `-control-title`, `-control-description`, `-button-upload-thumbnail`, `-button-replace-thumbnail`, `-button-remove-thumbnail`, `-element-cover`, `-element-title`, `-element-description`.
**Frontend (`render.php`):** `-render-cover`, `-render-title`, `-render-description`, `-render-player` (complementing the existing `godam-audio-render` wrapper).
Existing `-canvas` / `-panel-settings` / `-control-autoplay|loop|preload` are untouched.

## Notes for reviewers
- Title/Description use `TextControl`/`TextareaControl` (forward the id to the input). The two media openers (inspector vs canvas) and the two thumbnail states (upload vs replace) get distinct ids.
- Mirrors the PDF 2.0 hook conventions (MediaUpload flow, `*-render-<part>` anchors) for cross-block consistency.
- Independent of the open Copilot/review comments on #1980 (those are dev-side and don't affect these attributes); the title/description placeholder stubs noted in early review are already fixed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)