### PR TITLE
feat: add data-test-id hooks for E2E on redesigned Video player block controls

### DIFF
--- a/assets/src/blocks/godam-player/components/ThumbnailPanel.js
+++ b/assets/src/blocks/godam-player/components/ThumbnailPanel.js
@@ -223,6 +223,7 @@ export default function ThumbnailPanel( {
 								onClick={ open }
 								icon={ edit }
 								className="godam-thumbnail-actions__btn"
+								data-test-id="godam-video-button-thumbnail-edit"
 							>
 								{ __( 'Edit', 'godam' ) }
 							</Button>
@@ -234,6 +235,7 @@ export default function ThumbnailPanel( {
 					onClick={ handleRemoveCustom }
 					disabled={ ! poster }
 					className="godam-thumbnail-actions__btn"
+					data-test-id="godam-video-button-thumbnail-reset"
 				>
 					{ __( 'Reset', 'godam' ) }
 				</Button>

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -97,6 +97,7 @@ export const PlaybackControls = ( { setAttributes, attributes } ) => {
 			{ showShareButtonSetting && (
 				<ToggleControl
 					__nextHasNoMarginBottom
+					data-test-id="godam-video-control-show-share-button"
 					label={ __( 'Show share button', 'godam' ) }
 					onChange={ toggleFactory.showShareButton }
 					checked={ !! showShareButton }
@@ -106,12 +107,13 @@ export const PlaybackControls = ( { setAttributes, attributes } ) => {
 			{ /* TODO: Add "Show transcription" toggle control here when it is ready. */ }
 			<ToggleControl
 				__nextHasNoMarginBottom
+				data-test-id="godam-video-control-show-subtitles"
 				label={ __( 'Show subtitles', 'godam' ) }
 				onChange={ toggleFactory.showSubtitles }
 				checked={ !! showSubtitles }
 			/>
 			{ showSubtitles && hasNoTracks && ( id || cmmId ) && (
-				<div className="godam-subtitle-notice notice notice-warning">
+				<div className="godam-subtitle-notice notice notice-warning" data-test-id="godam-video-element-subtitle-notice">
 					<p>
 						{ __( 'No subtitle file uploaded.', 'godam' ) }
 						{ ' ' }
@@ -191,6 +193,7 @@ export const LikesAndComments = ( { setAttributes, attributes, isInsideQueryLoop
 	const toggleControl = (
 		<ToggleControl
 			__nextHasNoMarginBottom
+			data-test-id="godam-video-control-engagements"
 			label={ __( 'Enable Likes & Comments', 'godam' ) }
 			onChange={ toggleEngagements }
 			checked={ !! engagements }

--- a/assets/src/blocks/godam-player/edit-common-settings.js
+++ b/assets/src/blocks/godam-player/edit-common-settings.js
@@ -95,23 +95,25 @@ export const PlaybackControls = ( { setAttributes, attributes } ) => {
 				/>
 			</div>
 			{ showShareButtonSetting && (
-				<ToggleControl
-					__nextHasNoMarginBottom
-					data-test-id="godam-video-control-show-share-button"
-					label={ __( 'Show share button', 'godam' ) }
-					onChange={ toggleFactory.showShareButton }
-					checked={ !! showShareButton }
-					help={ __( 'Adds a share button on the video player for transcoded videos', 'godam' ) }
-				/>
+				<div data-test-id="godam-video-control-show-share-button">
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show share button', 'godam' ) }
+						onChange={ toggleFactory.showShareButton }
+						checked={ !! showShareButton }
+						help={ __( 'Adds a share button on the video player for transcoded videos', 'godam' ) }
+					/>
+				</div>
 			) }
 			{ /* TODO: Add "Show transcription" toggle control here when it is ready. */ }
-			<ToggleControl
-				__nextHasNoMarginBottom
-				data-test-id="godam-video-control-show-subtitles"
-				label={ __( 'Show subtitles', 'godam' ) }
-				onChange={ toggleFactory.showSubtitles }
-				checked={ !! showSubtitles }
-			/>
+			<div data-test-id="godam-video-control-show-subtitles">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Show subtitles', 'godam' ) }
+					onChange={ toggleFactory.showSubtitles }
+					checked={ !! showSubtitles }
+				/>
+			</div>
 			{ showSubtitles && hasNoTracks && ( id || cmmId ) && (
 				<div className="godam-subtitle-notice notice notice-warning" data-test-id="godam-video-element-subtitle-notice">
 					<p>
@@ -191,14 +193,15 @@ export const LikesAndComments = ( { setAttributes, attributes, isInsideQueryLoop
 	}
 
 	const toggleControl = (
-		<ToggleControl
-			__nextHasNoMarginBottom
-			data-test-id="godam-video-control-engagements"
-			label={ __( 'Enable Likes & Comments', 'godam' ) }
-			onChange={ toggleEngagements }
-			checked={ !! engagements }
-			help={ __( 'Engagement will only be visible for transcoded videos', 'godam' ) }
-		/>
+		<div data-test-id="godam-video-control-engagements">
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Enable Likes & Comments', 'godam' ) }
+				onChange={ toggleEngagements }
+				checked={ !! engagements }
+				help={ __( 'Engagement will only be visible for transcoded videos', 'godam' ) }
+			/>
+		</div>
 	);
 
 	return (

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -748,6 +748,7 @@ function VideoEdit( {
 							onClick={ open }
 							icon={ plus }
 							className="godam-video-selection__add-btn"
+							data-test-id="godam-video-button-add-video"
 						>
 							{ __( 'Add Video', 'godam' ) }
 						</Button>
@@ -761,6 +762,7 @@ function VideoEdit( {
 						className="godam-video-selection__customize-btn"
 						icon={ CustomizeVideoIcon }
 						iconSize={ 14 }
+						data-test-id="godam-video-button-customize"
 					>
 						{ __( 'Customize Video', 'godam' ) }
 					</Button>
@@ -783,6 +785,7 @@ function VideoEdit( {
 							label={ __( 'Remove video', 'godam' ) }
 							onClick={ () => onSelectVideo( undefined ) }
 							className="godam-video-selection__item-delete"
+							data-test-id="godam-video-button-remove-video"
 						/>
 					</div>
 				</>
@@ -949,6 +952,7 @@ function VideoEdit( {
 							target="_blank"
 							rel="noopener noreferrer"
 							className="godam-upgrade-notice__button"
+							data-test-id="godam-video-button-upgrade"
 						>
 							{ __( 'Upgrade Now', 'godam' ) }
 						</Button>


### PR DESCRIPTION
## What & why
The Video player 2.0 redesign (#1970) is already well-instrumented, but its **new** inspector controls ship without test-ids our E2E suite needs. This fills the gap. Targets `feat/video-player-redesign` so the hooks ship with the redesign.

**Scope:** source-only. No behavioural changes — `data-test-id` only; existing hooks untouched; IDs verified unique.

## Hooks added (`godam-video-*`)
- `control-show-subtitles`, `element-subtitle-notice`, `control-show-share-button`, `control-engagements` (`edit-common-settings.js`)
- `button-add-video` (Video Selection panel — distinct from the canvas placeholder's existing `button-select-video`), `button-customize`, `button-remove-video`, `button-upgrade` (`edit.js`)
- `button-thumbnail-edit`, `button-thumbnail-reset` (`ThumbnailPanel.js`)

## Notes for reviewers
- ToggleControls forward the id to their wrapper — the suite scopes `${TID} input`.
- `button-add-video` (inspector) and the existing `button-select-video` (canvas placeholder) are two distinct `<Button>`s that share the "Add Video" label; both are kept.
- Independent of the open review threads on #1970 (those are dev-side); the "GoDAM suite" typo is already fixed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)