### PR TITLE
Feat/video editor transcript

### DIFF
--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -38,6 +38,7 @@ use RTGODAM\Inc\REST_API\Media_Library;
 use RTGODAM\Inc\REST_API\Video_Editor;
 use RTGODAM\Inc\REST_API\Ads;
 use RTGODAM\Inc\REST_API\Transcoding;
+use RTGODAM\Inc\REST_API\Transcription;
 use RTGODAM\Inc\REST_API\Analytics;
 use RTGODAM\Inc\REST_API\Polls;
 use RTGODAM\Inc\REST_API\Dynamic_Shortcode;
@@ -182,6 +183,7 @@ class Plugin {
 		Video_Editor::get_instance();
 		Ads::get_instance();
 		Transcoding::get_instance();
+		Transcription::get_instance();
 		Analytics::get_instance();
 		Deactivation::get_instance();
 		Polls::get_instance();

--- a/inc/classes/rest-api/class-transcription.php
+++ b/inc/classes/rest-api/class-transcription.php
@@ -34,6 +34,16 @@ class Transcription extends Base {
 	const STATUS_META = 'rtgodam_transcript_status';
 
 	/**
+	 * Meta flag set when the user deletes the transcript. While set, the GET
+	 * endpoint will NOT auto-resurrect the transcript from the SaaS (otherwise
+	 * `godam_get_transcript_path()` re-caches it and the delete is undone). It
+	 * is cleared on generate / upload so a fresh transcript can replace it.
+	 *
+	 * @var string
+	 */
+	const DELETED_META = 'rtgodam_transcript_deleted';
+
+	/**
 	 * Register custom REST API.
 	 *
 	 * @return array Array of registered REST API routes.
@@ -123,12 +133,14 @@ class Transcription extends Base {
 	public function get_transcription( \WP_REST_Request $request ) {
 		$attachment_id = absint( $request->get_param( 'attachment_id' ) );
 
-		// `godam_get_transcript_path()` returns the cached meta when present,
-		// otherwise fetches + caches it from the SaaS.
-		$path = godam_get_transcript_path( $attachment_id );
+		// Locally-stored transcript takes precedence.
+		$path = get_post_meta( $attachment_id, 'rtgodam_transcript_path', true );
 
-		if ( empty( $path ) ) {
-			$path = get_post_meta( $attachment_id, 'rtgodam_transcript_path', true );
+		// Auto-discover from the SaaS only when the user has NOT deleted the
+		// transcript. Otherwise `godam_get_transcript_path()` would re-cache it
+		// and silently undo the delete.
+		if ( empty( $path ) && ! get_post_meta( $attachment_id, self::DELETED_META, true ) ) {
+			$path = godam_get_transcript_path( $attachment_id );
 		}
 
 		$status = $path ? 'Transcribed' : (string) get_post_meta( $attachment_id, self::STATUS_META, true );
@@ -197,12 +209,16 @@ class Transcription extends Base {
 		$current_status = isset( $payload['current_status'] ) ? sanitize_text_field( $payload['current_status'] ) : '';
 
 		if ( ! empty( $path ) ) {
+			// A (re)generated transcript supersedes any prior delete.
+			delete_post_meta( $attachment_id, self::DELETED_META );
 			update_post_meta( $attachment_id, 'rtgodam_transcript_path', $path );
 			update_post_meta( $attachment_id, self::STATUS_META, 'Transcribed' );
-		} else {
-			// No path yet — remember whatever in-flight status the SaaS reported
-			// so the editor keeps polling.
-			$track = $current_status ? $current_status : ( $status ? $status : 'Transcribing' );
+		} elseif ( '' !== $current_status || '' !== $status ) {
+			// A job is genuinely in progress — clear the delete marker and
+			// remember the in-flight status so the editor keeps polling. On a
+			// hard error we leave the delete marker intact.
+			delete_post_meta( $attachment_id, self::DELETED_META );
+			$track = $current_status ? $current_status : $status;
 			update_post_meta( $attachment_id, self::STATUS_META, $track );
 		}
 
@@ -237,6 +253,8 @@ class Transcription extends Base {
 			);
 		}
 
+		// An uploaded transcript supersedes any prior delete.
+		delete_post_meta( $attachment_id, self::DELETED_META );
 		update_post_meta( $attachment_id, 'rtgodam_transcript_path', $url );
 		update_post_meta( $attachment_id, self::STATUS_META, 'Transcribed' );
 
@@ -254,6 +272,8 @@ class Transcription extends Base {
 
 		delete_post_meta( $attachment_id, 'rtgodam_transcript_path' );
 		delete_post_meta( $attachment_id, self::STATUS_META );
+		// Mark as deleted so GET won't auto-resurrect it from the SaaS.
+		update_post_meta( $attachment_id, self::DELETED_META, '1' );
 
 		return rest_ensure_response( $this->shape( '', '' ) );
 	}

--- a/inc/classes/rest-api/class-transcription.php
+++ b/inc/classes/rest-api/class-transcription.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * REST API class for the AI transcript feature in the video editor.
+ *
+ * Provides same-origin proxies the React editor can call (with a WP nonce) so
+ * the GoDAM SaaS licence key never reaches the browser. The transcript itself
+ * is stored on the attachment as the `rtgodam_transcript_path` meta.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\REST_API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Transcription
+ */
+class Transcription extends Base {
+
+	/**
+	 * REST route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'transcription';
+
+	/**
+	 * Meta key holding the last known SaaS transcription status, used so the
+	 * editor can poll between "Transcribing" and "Transcribed".
+	 *
+	 * @var string
+	 */
+	const STATUS_META = 'rtgodam_transcript_status';
+
+	/**
+	 * Register custom REST API.
+	 *
+	 * @return array Array of registered REST API routes.
+	 */
+	public function get_rest_routes() {
+		$attachment_arg = array(
+			'attachment_id' => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'description'       => __( 'The video attachment ID.', 'godam' ),
+				'sanitize_callback' => 'absint',
+			),
+		);
+
+		return array(
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base,
+				'args'      => array(
+					array(
+						'methods'             => \WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_transcription' ),
+						'permission_callback' => array( $this, 'edit_permission' ),
+						'args'                => $attachment_arg,
+					),
+					array(
+						'methods'             => \WP_REST_Server::DELETABLE,
+						'callback'            => array( $this, 'delete_transcription' ),
+						'permission_callback' => array( $this, 'edit_permission' ),
+						'args'                => $attachment_arg,
+					),
+				),
+			),
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/generate',
+				'args'      => array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'generate_transcription' ),
+					'permission_callback' => array( $this, 'edit_permission' ),
+					'args'                => $attachment_arg,
+				),
+			),
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/upload',
+				'args'      => array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'upload_transcription' ),
+					'permission_callback' => array( $this, 'edit_permission' ),
+					'args'                => array_merge(
+						$attachment_arg,
+						array(
+							'url' => array(
+								'required'          => true,
+								'type'              => 'string',
+								'description'       => __( 'URL of the uploaded .vtt / .srt caption file.', 'godam' ),
+								'sanitize_callback' => 'esc_url_raw',
+							),
+						)
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission: the caller must be able to edit the target attachment.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return bool Whether the request is allowed.
+	 */
+	public function edit_permission( \WP_REST_Request $request ) {
+		$attachment_id = absint( $request->get_param( 'attachment_id' ) );
+		if ( empty( $attachment_id ) ) {
+			return current_user_can( 'upload_files' );
+		}
+		return current_user_can( 'edit_post', $attachment_id );
+	}
+
+	/**
+	 * Return the current transcript path + status for an attachment.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return \WP_REST_Response
+	 */
+	public function get_transcription( \WP_REST_Request $request ) {
+		$attachment_id = absint( $request->get_param( 'attachment_id' ) );
+
+		// `godam_get_transcript_path()` returns the cached meta when present,
+		// otherwise fetches + caches it from the SaaS.
+		$path = godam_get_transcript_path( $attachment_id );
+
+		if ( empty( $path ) ) {
+			$path = get_post_meta( $attachment_id, 'rtgodam_transcript_path', true );
+		}
+
+		$status = $path ? 'Transcribed' : (string) get_post_meta( $attachment_id, self::STATUS_META, true );
+
+		return rest_ensure_response( $this->shape( $path, $status ) );
+	}
+
+	/**
+	 * Start (or re-run) AI transcription via the SaaS `process_transcription`
+	 * endpoint.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function generate_transcription( \WP_REST_Request $request ) {
+		$attachment_id = absint( $request->get_param( 'attachment_id' ) );
+
+		$job_id = get_post_meta( $attachment_id, 'rtgodam_transcoding_job_id', true );
+		if ( empty( $job_id ) ) {
+			$job_id = get_post_meta( $attachment_id, '_godam_original_id', true );
+		}
+
+		if ( empty( $job_id ) ) {
+			return new \WP_Error(
+				'rtgodam_no_job',
+				__( 'This video has not been transcoded yet, so it cannot be transcribed.', 'godam' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$api_key = get_option( 'rtgodam-api-key', '' );
+		if ( empty( $api_key ) ) {
+			return new \WP_Error(
+				'rtgodam_no_api_key',
+				__( 'Connect your GoDAM account to generate transcriptions.', 'godam' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$response = wp_remote_post(
+			RTGODAM_API_BASE . '/api/method/godam_core.api.process.process_transcription',
+			array(
+				'timeout' => 15, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+				'body'    => array(
+					'job_name' => sanitize_text_field( $job_id ),
+					'api_key'  => sanitize_text_field( $api_key ),
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error(
+				'rtgodam_request_failed',
+				__( 'Could not reach the transcription service. Please try again.', 'godam' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		// Frappe wraps `@frappe.whitelist` method results in a `message` key.
+		$payload = ( is_array( $data ) && isset( $data['message'] ) ) ? $data['message'] : $data;
+		$payload = is_array( $payload ) ? $payload : array();
+
+		$path           = isset( $payload['transcript_path'] ) ? esc_url_raw( $payload['transcript_path'] ) : '';
+		$status         = isset( $payload['status'] ) ? sanitize_text_field( $payload['status'] ) : '';
+		$current_status = isset( $payload['current_status'] ) ? sanitize_text_field( $payload['current_status'] ) : '';
+
+		if ( ! empty( $path ) ) {
+			update_post_meta( $attachment_id, 'rtgodam_transcript_path', $path );
+			update_post_meta( $attachment_id, self::STATUS_META, 'Transcribed' );
+		} else {
+			// No path yet — remember whatever in-flight status the SaaS reported
+			// so the editor keeps polling.
+			$track = $current_status ? $current_status : ( $status ? $status : 'Transcribing' );
+			update_post_meta( $attachment_id, self::STATUS_META, $track );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success'         => ! empty( $payload['success'] ),
+				'status'          => $status,
+				'current_status'  => $current_status,
+				'transcript_path' => $path,
+				'error'           => isset( $payload['error'] ) ? sanitize_text_field( $payload['error'] ) : '',
+				'message'         => isset( $payload['message'] ) ? sanitize_text_field( $payload['message'] ) : '',
+			)
+		);
+	}
+
+	/**
+	 * Attach an uploaded caption file as the transcript.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function upload_transcription( \WP_REST_Request $request ) {
+		$attachment_id = absint( $request->get_param( 'attachment_id' ) );
+		$url           = esc_url_raw( $request->get_param( 'url' ) );
+
+		$ext = strtolower( pathinfo( wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION ) );
+		if ( ! in_array( $ext, array( 'vtt', 'srt' ), true ) ) {
+			return new \WP_Error(
+				'rtgodam_bad_file',
+				__( 'Only .vtt or .srt caption files are supported.', 'godam' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		update_post_meta( $attachment_id, 'rtgodam_transcript_path', $url );
+		update_post_meta( $attachment_id, self::STATUS_META, 'Transcribed' );
+
+		return rest_ensure_response( $this->shape( $url, 'Transcribed' ) );
+	}
+
+	/**
+	 * Remove the transcript from an attachment.
+	 *
+	 * @param \WP_REST_Request $request REST request object.
+	 * @return \WP_REST_Response
+	 */
+	public function delete_transcription( \WP_REST_Request $request ) {
+		$attachment_id = absint( $request->get_param( 'attachment_id' ) );
+
+		delete_post_meta( $attachment_id, 'rtgodam_transcript_path' );
+		delete_post_meta( $attachment_id, self::STATUS_META );
+
+		return rest_ensure_response( $this->shape( '', '' ) );
+	}
+
+	/**
+	 * Build the response shape the editor consumes.
+	 *
+	 * @param string $path   Transcript URL (may be empty).
+	 * @param string $status Transcription status.
+	 * @return array Response body.
+	 */
+	private function shape( $path, $status ) {
+		return array(
+			'transcript_path' => $path,
+			'status'          => $status,
+			'file_name'       => $path ? basename( wp_parse_url( $path, PHP_URL_PATH ) ) : '',
+		);
+	}
+}

--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -41,6 +41,8 @@ import './video-editor.scss';
 import { useGetAttachmentMetaQuery, useSaveAttachmentMetaMutation } from './redux/api/attachment';
 import { useFetchForms } from './components/forms/fetchForms';
 import Chapters from './components/chapters/Chapters';
+import Transcription from './components/transcription/Transcription';
+import { formatBytes } from './components/transcription/utils';
 import Timeline from './components/timeline/Timeline';
 import { copyGoDAMVideoBlock, prefetchMediaDataForCopy } from './utils/index';
 import { getFormIdFromLayer } from './utils/formUtils';
@@ -424,6 +426,13 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 						/>
 					) }
 					{ currentTab === 'player-settings' && <Appearance attachmentID={ attachmentID } /> }
+					{ currentTab === 'transcription' && (
+						<Transcription
+							attachmentID={ attachmentID }
+							duration={ duration }
+							fileSize={ formatBytes( attachmentConfig?.media_details?.filesize ) }
+						/>
+					) }
 					{ currentTab === 'chapters' && (
 						<Chapters
 							duration={ duration }

--- a/pages/video-editor/_transcription.scss
+++ b/pages/video-editor/_transcription.scss
@@ -205,15 +205,6 @@ $ve-faint: color-mix(in srgb, currentcolor 4%, transparent);
 			color: $ve-muted;
 			text-align: center;
 		}
-
-		// Success toast (Flow 34) — centred near the bottom of the editor.
-		&__toast.components-snackbar {
-			position: fixed;
-			bottom: 2rem;
-			left: 50%;
-			transform: translateX(-50%);
-			z-index: 1000;
-		}
 	}
 }
 

--- a/pages/video-editor/_transcription.scss
+++ b/pages/video-editor/_transcription.scss
@@ -1,0 +1,229 @@
+// =============================================================
+// Video Editor — Transcription tab.
+// Scoped under `.godam-video-editor`. Mirrors the Chapters / Settings
+// tab primitives (sticky head, `$ve-*` neutrals, accent from the
+// WordPress component accent variable).
+// =============================================================
+
+$ve-border: #E0E0E0;
+$ve-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+$ve-muted: #0000008c;
+$ve-faint: color-mix(in srgb, currentcolor 4%, transparent);
+
+.godam-video-editor {
+
+	.godam-ve-transcription {
+
+		&__head {
+			padding: 1rem;
+			border-bottom: 1px solid $ve-border;
+			position: sticky;
+			top: 0;
+			background: #fff;
+			z-index: 10;
+		}
+
+		&__title {
+			margin: 0;
+			font-size: 0.9375rem;
+			font-weight: 600;
+			line-height: 1.4;
+		}
+
+		&__subtitle {
+			margin: 0.25rem 0 0;
+			font-size: 0.75rem;
+			color: $ve-muted;
+		}
+
+		&__body {
+			padding: 1rem;
+		}
+
+		// ---- Empty / busy state (Flow 32 + 33) ----
+		&__generate {
+			display: flex;
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.75rem;
+		}
+
+		&__help {
+			margin: 0;
+			font-size: 0.8125rem;
+			line-height: 1.5;
+			color: $ve-muted;
+			text-align: center;
+		}
+
+		&__generate-btn.components-button,
+		&__upload-btn.components-button {
+			width: 100%;
+			justify-content: center;
+			height: 44px;
+		}
+
+		// Accent-tinted primary action (the "Generate" call to action).
+		&__generate-btn.components-button.is-secondary {
+			color: $ve-accent;
+			box-shadow: inset 0 0 0 1px $ve-accent;
+			background: color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 6%, transparent);
+
+			&:hover:not(:disabled) {
+				background: color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
+			}
+		}
+
+		// "OR" divider with rules either side.
+		&__divider {
+			display: flex;
+			align-items: center;
+			gap: 0.75rem;
+			color: $ve-muted;
+			font-size: 0.75rem;
+
+			&::before,
+			&::after {
+				content: '';
+				flex: 1 1 auto;
+				height: 1px;
+				background: $ve-border;
+			}
+		}
+
+		// In-progress block (spinner + copy + indeterminate bar).
+		&__progress {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem 0 0.25rem;
+			text-align: center;
+		}
+
+		&__progress-title {
+			margin: 0;
+			font-size: 0.875rem;
+			font-weight: 600;
+		}
+
+		&__progress-note {
+			margin: 0;
+			font-size: 0.75rem;
+			line-height: 1.4;
+			color: $ve-muted;
+		}
+
+		&__progress-bar {
+			position: relative;
+			width: 100%;
+			height: 3px;
+			margin-top: 0.5rem;
+			overflow: hidden;
+			background: $ve-border;
+			border-radius: 2px;
+
+			&::after {
+				content: '';
+				position: absolute;
+				inset: 0;
+				width: 40%;
+				background: $ve-accent;
+				border-radius: 2px;
+				animation: godam-ve-transcription-indeterminate 1.4s ease-in-out infinite;
+			}
+		}
+
+		// ---- Ready state (Flow 35) ----
+		&__file {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 0.5rem;
+			margin-bottom: 0.75rem;
+		}
+
+		&__file-name {
+			overflow: hidden;
+			font-size: 0.875rem;
+			font-weight: 600;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		&__file-actions {
+			display: flex;
+			flex: 0 0 auto;
+			gap: 0.25rem;
+		}
+
+		&__loader {
+			display: flex;
+			justify-content: center;
+			padding: 2rem 0;
+		}
+
+		// Scrollable cue list.
+		&__cues {
+			margin: 0;
+			padding: 0;
+			list-style: none;
+			max-height: calc(100vh - 320px);
+			overflow-y: auto;
+			border: 1px solid $ve-border;
+			border-radius: 8px;
+		}
+
+		&__cue {
+			padding: 0.75rem 1rem;
+
+			&:not(:last-child) {
+				border-bottom: 1px solid $ve-border;
+			}
+
+			&:hover {
+				background: $ve-faint;
+			}
+		}
+
+		&__cue-time {
+			display: block;
+			margin-bottom: 0.25rem;
+			font-size: 0.75rem;
+			color: $ve-muted;
+		}
+
+		&__cue-text {
+			margin: 0;
+			font-size: 0.875rem;
+			line-height: 1.5;
+		}
+
+		&__cue-empty {
+			padding: 1rem;
+			font-size: 0.8125rem;
+			color: $ve-muted;
+			text-align: center;
+		}
+
+		// Success toast (Flow 34) — centred near the bottom of the editor.
+		&__toast.components-snackbar {
+			position: fixed;
+			bottom: 2rem;
+			left: 50%;
+			transform: translateX(-50%);
+			z-index: 1000;
+		}
+	}
+}
+
+@keyframes godam-ve-transcription-indeterminate {
+
+	0% {
+		left: -40%;
+	}
+
+	100% {
+		left: 100%;
+	}
+}

--- a/pages/video-editor/components/editor-shell/EditorTabRail.js
+++ b/pages/video-editor/components/editor-shell/EditorTabRail.js
@@ -7,15 +7,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { LayersTabIcon, SettingsTabIcon, ChaptersTabIcon } from './icons';
+import { LayersTabIcon, SettingsTabIcon, TranscriptTabIcon, ChaptersTabIcon } from './icons';
 
 /**
  * Vertical icon rail that switches the active editor section.
  *
  * Replaces the previous horizontal `TabPanel`. The internal tab names are
  * kept identical to the existing Redux `currentTab` values so no behaviour
- * changes (`layers`, `player-settings`, `chapters`). The Transcript tab is
- * added in a later step.
+ * changes (`layers`, `player-settings`, `transcription`, `chapters`).
  *
  * @param {Object}   props
  * @param {string}   props.currentTab Active tab name.
@@ -26,6 +25,7 @@ const EditorTabRail = ( { currentTab, onSelect } ) => {
 	const tabs = [
 		{ name: 'layers', label: __( 'Layers', 'godam' ), icon: LayersTabIcon },
 		{ name: 'player-settings', label: __( 'Settings', 'godam' ), icon: SettingsTabIcon },
+		{ name: 'transcription', label: __( 'Transcription', 'godam' ), icon: TranscriptTabIcon },
 		{ name: 'chapters', label: __( 'Chapters', 'godam' ), icon: ChaptersTabIcon },
 	];
 

--- a/pages/video-editor/components/transcription/Transcription.js
+++ b/pages/video-editor/components/transcription/Transcription.js
@@ -1,0 +1,326 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Spinner, Notice, Snackbar, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plus, update, trash } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useGetTranscriptionQuery,
+	useGenerateTranscriptionMutation,
+	useUploadTranscriptionMutation,
+	useDeleteTranscriptionMutation,
+} from '../../redux/api/transcription';
+import { parseCaptions, formatClock, formatBytes, isTranscribingStatus } from './utils';
+
+const BoltIcon = (
+	<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+		<path d="M10.8334 1.66699L3.41671 10.5673C3.12614 10.916 2.98086 11.0904 2.97864 11.2376C2.97672 11.3656 3.03377 11.4874 3.13355 11.5677C3.24834 11.6601 3.4754 11.6601 3.92952 11.6601H10L9.16671 18.3337L16.5834 9.4333C16.8739 9.08457 17.0192 8.91021 17.0214 8.76304C17.0234 8.63503 16.9663 8.51319 16.8665 8.43288C16.7517 8.34049 16.5247 8.34049 16.0706 8.34049H10L10.8334 1.66699Z" stroke="currentColor" strokeWidth="1.66667" strokeLinecap="round" strokeLinejoin="round" />
+	</svg>
+);
+
+/**
+ * Transcription tab panel.
+ *
+ * Drives the four design states off the SaaS job status: an empty state with
+ * "Generate" / "Upload" actions, a busy state with progress copy, a success
+ * toast, and the ready state showing the file meta and a timestamped cue list.
+ *
+ * The transcript is stored on the attachment (not in `rtgodam_meta`), so this
+ * panel owns its data via the transcription API rather than the editor store.
+ *
+ * @param {Object} props              Props.
+ * @param {number} props.attachmentID WordPress attachment id.
+ * @param {number} props.duration     Video duration in seconds (for the header).
+ * @param {string} [props.fileSize]   Pre-formatted media size shown beside the duration.
+ * @return {JSX.Element} The Transcription panel.
+ */
+const Transcription = ( { attachmentID, duration, fileSize } ) => {
+	const [ busyKind, setBusyKind ] = useState( null ); // 'generate' | 'upload' | null
+	const [ cues, setCues ] = useState( [] );
+	const [ cuesLoading, setCuesLoading ] = useState( false );
+	const [ error, setError ] = useState( '' );
+	const [ toast, setToast ] = useState( false );
+	const [ confirmDelete, setConfirmDelete ] = useState( false );
+
+	const { data: transcription } = useGetTranscriptionQuery( attachmentID, {
+		// Poll while a generation job is running so the panel flips to "ready"
+		// on its own once the SaaS finishes.
+		pollingInterval: busyKind === 'generate' ? 8000 : 0,
+	} );
+
+	const [ generateTranscription ] = useGenerateTranscriptionMutation();
+	const [ uploadTranscription ] = useUploadTranscriptionMutation();
+	const [ deleteTranscription, { isLoading: isDeleting } ] = useDeleteTranscriptionMutation();
+
+	const transcriptPath = transcription?.transcript_path || '';
+	const status = transcription?.status || '';
+	const isReady = Boolean( transcriptPath );
+
+	// Once a job we're polling for resolves, drop out of the busy state.
+	useEffect( () => {
+		if ( busyKind === 'generate' && ( isReady || status === 'Failed' ) ) {
+			setBusyKind( null );
+			if ( status === 'Failed' ) {
+				setError( __( 'Transcription failed. Please try again.', 'godam' ) );
+			}
+		}
+	}, [ busyKind, isReady, status ] );
+
+	// Fetch and parse the caption file whenever the path changes.
+	useEffect( () => {
+		let cancelled = false;
+		if ( ! transcriptPath ) {
+			setCues( [] );
+			return undefined;
+		}
+		setCuesLoading( true );
+		fetch( transcriptPath )
+			.then( ( res ) => ( res.ok ? res.text() : Promise.reject( res ) ) )
+			.then( ( text ) => {
+				if ( ! cancelled ) {
+					setCues( parseCaptions( text ) );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setCues( [] );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setCuesLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ transcriptPath ] );
+
+	const handleGenerate = async () => {
+		setError( '' );
+		setBusyKind( 'generate' );
+		try {
+			const result = await generateTranscription( attachmentID ).unwrap();
+			// SaaS may answer synchronously when the transcript already exists.
+			if ( result?.transcript_path ) {
+				setBusyKind( null );
+			} else if ( result?.success === false && result?.error && ! isTranscribingStatus( result?.current_status ) ) {
+				// Anything other than "already in progress" surfaces as an error.
+				setBusyKind( null );
+				setError( result.error );
+			}
+		} catch ( err ) {
+			setBusyKind( null );
+			setError( err?.data?.message || __( 'Could not start transcription. Please try again.', 'godam' ) );
+		}
+	};
+
+	const handleUpload = () => {
+		setError( '' );
+		const frame = wp.media( {
+			title: __( 'Select a caption file', 'godam' ),
+			button: { text: __( 'Use this file', 'godam' ) },
+			library: { type: [ 'text/vtt', 'application/x-subrip', 'text/plain' ] },
+			multiple: false,
+		} );
+
+		frame.on( 'select', async () => {
+			const attachment = frame.state().get( 'selection' ).first().toJSON();
+			const url = attachment?.url || '';
+			if ( ! /\.(vtt|srt)$/i.test( url ) ) {
+				setError( __( 'Please choose a .vtt or .srt caption file.', 'godam' ) );
+				return;
+			}
+			setBusyKind( 'upload' );
+			try {
+				await uploadTranscription( { attachmentID, url } ).unwrap();
+				setToast( true );
+			} catch ( err ) {
+				setError( err?.data?.message || __( 'Could not attach the caption file.', 'godam' ) );
+			} finally {
+				setBusyKind( null );
+			}
+		} );
+
+		frame.open();
+	};
+
+	const handleDelete = async () => {
+		setConfirmDelete( false );
+		setError( '' );
+		try {
+			await deleteTranscription( attachmentID ).unwrap();
+			setCues( [] );
+		} catch ( err ) {
+			setError( err?.data?.message || __( 'Could not remove the transcript.', 'godam' ) );
+		}
+	};
+
+	const durationLabel = formatClock( duration );
+	const sizeLabel = fileSize || formatBytes( transcription?.file_size );
+	const fileName = transcription?.file_name || __( 'Transcript', 'godam' );
+	const showReady = isReady && busyKind !== 'generate';
+
+	return (
+		<div className="godam-ve-transcription">
+			<div className="godam-ve-transcription__head">
+				<h2 className="godam-ve-transcription__title">{ __( 'Transcription', 'godam' ) }</h2>
+				{ showReady && (
+					<p className="godam-ve-transcription__subtitle">
+						{ [ durationLabel, sizeLabel ].filter( Boolean ).join( ' • ' ) }
+					</p>
+				) }
+			</div>
+
+			<div className="godam-ve-transcription__body">
+				{ error && (
+					<Notice status="error" isDismissible onRemove={ () => setError( '' ) }>
+						{ error }
+					</Notice>
+				) }
+
+				{ showReady ? (
+					/* ---- Ready: file row + cue list (Flow 35) ---- */
+					<>
+						<div className="godam-ve-transcription__file">
+							<span className="godam-ve-transcription__file-name">{ fileName }</span>
+							<div className="godam-ve-transcription__file-actions">
+								<Button
+									icon={ update }
+									label={ __( 'Regenerate transcription', 'godam' ) }
+									showTooltip
+									onClick={ handleGenerate }
+								/>
+								<Button
+									icon={ trash }
+									label={ __( 'Delete transcription', 'godam' ) }
+									showTooltip
+									isDestructive
+									isBusy={ isDeleting }
+									onClick={ () => setConfirmDelete( true ) }
+								/>
+							</div>
+						</div>
+
+						{ cuesLoading ? (
+							<div className="godam-ve-transcription__loader">
+								<Spinner />
+							</div>
+						) : (
+							<ul className="godam-ve-transcription__cues">
+								{ cues.map( ( cue, index ) => (
+									<li key={ index } className="godam-ve-transcription__cue">
+										<span className="godam-ve-transcription__cue-time">{ formatClock( cue.start ) }</span>
+										<p className="godam-ve-transcription__cue-text">{ cue.text }</p>
+									</li>
+								) ) }
+								{ cues.length === 0 && (
+									<li className="godam-ve-transcription__cue-empty">
+										{ __( 'No cues found in this caption file.', 'godam' ) }
+									</li>
+								) }
+							</ul>
+						) }
+					</>
+				) : (
+					/* ---- Empty / Busy (Flow 32 + 33) ---- */
+					<div className="godam-ve-transcription__generate">
+						<p className="godam-ve-transcription__help">
+							{ __( "Automatically transcribe the audio using GoDAM's AI engine", 'godam' ) }
+						</p>
+						<Button
+							className="godam-ve-transcription__generate-btn"
+							variant="secondary"
+							icon={ BoltIcon }
+							disabled={ Boolean( busyKind ) }
+							onClick={ handleGenerate }
+						>
+							{ __( 'Generate Transcription', 'godam' ) }
+						</Button>
+
+						<div className="godam-ve-transcription__divider">
+							<span>{ __( 'OR', 'godam' ) }</span>
+						</div>
+
+						{ busyKind ? (
+							<div className="godam-ve-transcription__progress">
+								<Spinner />
+								<p className="godam-ve-transcription__progress-title">
+									{ busyKind === 'upload'
+										? __( 'Uploading transcript…', 'godam' )
+										: __( 'Generating transcription…', 'godam' ) }
+								</p>
+								<p className="godam-ve-transcription__progress-note">
+									{ __( "This usually takes 10–15 minutes. We'll notify you once it's ready", 'godam' ) }
+								</p>
+								<span className="godam-ve-transcription__progress-bar" aria-hidden="true" />
+							</div>
+						) : (
+							<>
+								<p className="godam-ve-transcription__help">
+									{ __( 'Use an existing .srt or .vtt caption file', 'godam' ) }
+								</p>
+								<Button
+									className="godam-ve-transcription__upload-btn"
+									variant="secondary"
+									icon={ plus }
+									onClick={ handleUpload }
+								>
+									{ __( 'Upload File', 'godam' ) }
+								</Button>
+							</>
+						) }
+					</div>
+				) }
+			</div>
+
+			{ /* ---- Success toast (Flow 34) ---- */ }
+			{ toast && (
+				<Snackbar
+					className="godam-ve-transcription__toast"
+					actions={ [ { label: __( 'Review', 'godam' ), onClick: () => setToast( false ) } ] }
+					onRemove={ () => setToast( false ) }
+				>
+					{ __( 'Transcription file added successfully', 'godam' ) }
+				</Snackbar>
+			) }
+
+			{ confirmDelete && (
+				<Modal
+					title={ __( 'Delete transcription', 'godam' ) }
+					onRequestClose={ () => setConfirmDelete( false ) }
+				>
+					<p>{ __( 'Delete this transcription? This cannot be undone.', 'godam' ) }</p>
+					<div className="flex justify-between items-center gap-3">
+						<Button
+							variant="tertiary"
+							className="w-full justify-center"
+							onClick={ () => setConfirmDelete( false ) }
+						>
+							{ __( 'Cancel', 'godam' ) }
+						</Button>
+						<Button
+							variant="primary"
+							className="w-full justify-center"
+							isDestructive
+							onClick={ handleDelete }
+						>
+							{ __( 'Delete', 'godam' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</div>
+	);
+};
+
+export default Transcription;

--- a/pages/video-editor/components/transcription/Transcription.js
+++ b/pages/video-editor/components/transcription/Transcription.js
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 /**
  * WordPress dependencies
  */
-import { Button, Spinner, Notice, Snackbar, Modal } from '@wordpress/components';
+import { Button, Spinner, Notice, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { plus, update, trash } from '@wordpress/icons';
 
@@ -30,9 +30,11 @@ const BoltIcon = (
 /**
  * Transcription tab panel.
  *
- * Drives the four design states off the SaaS job status: an empty state with
- * "Generate" / "Upload" actions, a busy state with progress copy, a success
- * toast, and the ready state showing the file meta and a timestamped cue list.
+ * Drives the design states off the SaaS job status: an empty state with
+ * "Generate" / "Upload" actions, a busy state with progress copy while AI
+ * transcription runs, and the ready state showing the file meta + cue list
+ * (with Replace / Delete actions). Uploading a caption file is a quiet action
+ * — it just opens the media picker and swaps the transcript in.
  *
  * The transcript is stored on the attachment (not in `rtgodam_meta`), so this
  * panel owns its data via the transcription API rather than the editor store.
@@ -44,17 +46,16 @@ const BoltIcon = (
  * @return {JSX.Element} The Transcription panel.
  */
 const Transcription = ( { attachmentID, duration, fileSize } ) => {
-	const [ busyKind, setBusyKind ] = useState( null ); // 'generate' | 'upload' | null
+	const [ isGenerating, setIsGenerating ] = useState( false );
 	const [ cues, setCues ] = useState( [] );
 	const [ cuesLoading, setCuesLoading ] = useState( false );
 	const [ error, setError ] = useState( '' );
-	const [ toast, setToast ] = useState( false );
 	const [ confirmDelete, setConfirmDelete ] = useState( false );
 
 	const { data: transcription } = useGetTranscriptionQuery( attachmentID, {
 		// Poll while a generation job is running so the panel flips to "ready"
 		// on its own once the SaaS finishes.
-		pollingInterval: busyKind === 'generate' ? 8000 : 0,
+		pollingInterval: isGenerating ? 8000 : 0,
 	} );
 
 	const [ generateTranscription ] = useGenerateTranscriptionMutation();
@@ -65,15 +66,15 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 	const status = transcription?.status || '';
 	const isReady = Boolean( transcriptPath );
 
-	// Once a job we're polling for resolves, drop out of the busy state.
+	// Once a generation job we're polling for resolves, drop out of the busy state.
 	useEffect( () => {
-		if ( busyKind === 'generate' && ( isReady || status === 'Failed' ) ) {
-			setBusyKind( null );
+		if ( isGenerating && ( isReady || status === 'Failed' ) ) {
+			setIsGenerating( false );
 			if ( status === 'Failed' ) {
 				setError( __( 'Transcription failed. Please try again.', 'godam' ) );
 			}
 		}
-	}, [ busyKind, isReady, status ] );
+	}, [ isGenerating, isReady, status ] );
 
 	// Fetch and parse the caption file whenever the path changes.
 	useEffect( () => {
@@ -107,23 +108,26 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 
 	const handleGenerate = async () => {
 		setError( '' );
-		setBusyKind( 'generate' );
+		setIsGenerating( true );
 		try {
 			const result = await generateTranscription( attachmentID ).unwrap();
 			// SaaS may answer synchronously when the transcript already exists.
 			if ( result?.transcript_path ) {
-				setBusyKind( null );
+				setIsGenerating( false );
 			} else if ( result?.success === false && result?.error && ! isTranscribingStatus( result?.current_status ) ) {
 				// Anything other than "already in progress" surfaces as an error.
-				setBusyKind( null );
+				setIsGenerating( false );
 				setError( result.error );
 			}
 		} catch ( err ) {
-			setBusyKind( null );
+			setIsGenerating( false );
 			setError( err?.data?.message || __( 'Could not start transcription. Please try again.', 'godam' ) );
 		}
 	};
 
+	// Open the media picker and attach the chosen .vtt / .srt as the transcript.
+	// Used by both "Upload File" (empty state) and "Replace" (ready state) — a
+	// quiet action with no progress/success messaging; the panel just updates.
 	const handleUpload = () => {
 		setError( '' );
 		const frame = wp.media( {
@@ -140,14 +144,10 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 				setError( __( 'Please choose a .vtt or .srt caption file.', 'godam' ) );
 				return;
 			}
-			setBusyKind( 'upload' );
 			try {
 				await uploadTranscription( { attachmentID, url } ).unwrap();
-				setToast( true );
 			} catch ( err ) {
 				setError( err?.data?.message || __( 'Could not attach the caption file.', 'godam' ) );
-			} finally {
-				setBusyKind( null );
 			}
 		} );
 
@@ -168,7 +168,7 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 	const durationLabel = formatClock( duration );
 	const sizeLabel = fileSize || formatBytes( transcription?.file_size );
 	const fileName = transcription?.file_name || __( 'Transcript', 'godam' );
-	const showReady = isReady && busyKind !== 'generate';
+	const showReady = isReady && ! isGenerating;
 
 	return (
 		<div className="godam-ve-transcription">
@@ -196,9 +196,9 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 							<div className="godam-ve-transcription__file-actions">
 								<Button
 									icon={ update }
-									label={ __( 'Regenerate transcription', 'godam' ) }
+									label={ __( 'Replace transcription file', 'godam' ) }
 									showTooltip
-									onClick={ handleGenerate }
+									onClick={ handleUpload }
 								/>
 								<Button
 									icon={ trash }
@@ -232,7 +232,7 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 						) }
 					</>
 				) : (
-					/* ---- Empty / Busy (Flow 32 + 33) ---- */
+					/* ---- Empty / Generating (Flow 32 + 33) ---- */
 					<div className="godam-ve-transcription__generate">
 						<p className="godam-ve-transcription__help">
 							{ __( "Automatically transcribe the audio using GoDAM's AI engine", 'godam' ) }
@@ -241,7 +241,7 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 							className="godam-ve-transcription__generate-btn"
 							variant="secondary"
 							icon={ BoltIcon }
-							disabled={ Boolean( busyKind ) }
+							disabled={ isGenerating }
 							onClick={ handleGenerate }
 						>
 							{ __( 'Generate Transcription', 'godam' ) }
@@ -251,13 +251,11 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 							<span>{ __( 'OR', 'godam' ) }</span>
 						</div>
 
-						{ busyKind ? (
+						{ isGenerating ? (
 							<div className="godam-ve-transcription__progress">
 								<Spinner />
 								<p className="godam-ve-transcription__progress-title">
-									{ busyKind === 'upload'
-										? __( 'Uploading transcript…', 'godam' )
-										: __( 'Generating transcription…', 'godam' ) }
+									{ __( 'Generating transcription…', 'godam' ) }
 								</p>
 								<p className="godam-ve-transcription__progress-note">
 									{ __( "This usually takes 10–15 minutes. We'll notify you once it's ready", 'godam' ) }
@@ -265,34 +263,18 @@ const Transcription = ( { attachmentID, duration, fileSize } ) => {
 								<span className="godam-ve-transcription__progress-bar" aria-hidden="true" />
 							</div>
 						) : (
-							<>
-								<p className="godam-ve-transcription__help">
-									{ __( 'Use an existing .srt or .vtt caption file', 'godam' ) }
-								</p>
-								<Button
-									className="godam-ve-transcription__upload-btn"
-									variant="secondary"
-									icon={ plus }
-									onClick={ handleUpload }
-								>
-									{ __( 'Upload File', 'godam' ) }
-								</Button>
-							</>
+							<Button
+								className="godam-ve-transcription__upload-btn"
+								variant="secondary"
+								icon={ plus }
+								onClick={ handleUpload }
+							>
+								{ __( 'Upload File', 'godam' ) }
+							</Button>
 						) }
 					</div>
 				) }
 			</div>
-
-			{ /* ---- Success toast (Flow 34) ---- */ }
-			{ toast && (
-				<Snackbar
-					className="godam-ve-transcription__toast"
-					actions={ [ { label: __( 'Review', 'godam' ), onClick: () => setToast( false ) } ] }
-					onRemove={ () => setToast( false ) }
-				>
-					{ __( 'Transcription file added successfully', 'godam' ) }
-				</Snackbar>
-			) }
 
 			{ confirmDelete && (
 				<Modal

--- a/pages/video-editor/components/transcription/utils.js
+++ b/pages/video-editor/components/transcription/utils.js
@@ -1,0 +1,124 @@
+/**
+ * Helpers for the Transcription tab: parsing WebVTT / SRT caption files into
+ * cue objects and formatting clocks / file sizes for display.
+ */
+
+/**
+ * Parse a single timestamp (`HH:MM:SS.mmm`, `MM:SS.mmm`, or the SRT comma
+ * variant) into seconds.
+ *
+ * @param {string} stamp Raw timestamp.
+ * @return {number} Seconds (float), or NaN when unparseable.
+ */
+const parseTimestamp = ( stamp ) => {
+	if ( ! stamp ) {
+		return NaN;
+	}
+	// SRT uses a comma before milliseconds; normalise to a dot.
+	const parts = stamp.trim().replace( ',', '.' ).split( ':' );
+	if ( parts.length < 2 || parts.length > 3 ) {
+		return NaN;
+	}
+	const nums = parts.map( ( part ) => parseFloat( part ) );
+	if ( nums.some( ( num ) => Number.isNaN( num ) ) ) {
+		return NaN;
+	}
+	if ( nums.length === 3 ) {
+		return ( nums[ 0 ] * 3600 ) + ( nums[ 1 ] * 60 ) + nums[ 2 ];
+	}
+	return ( nums[ 0 ] * 60 ) + nums[ 1 ];
+};
+
+/**
+ * Parse WebVTT or SRT text into an array of cues. Cue identifiers, the
+ * `WEBVTT` header, NOTE blocks and styling are ignored — only timed text is
+ * returned.
+ *
+ * @param {string} raw The caption file contents.
+ * @return {Array<{start:number,end:number,text:string}>} Ordered cues.
+ */
+export const parseCaptions = ( raw ) => {
+	if ( ! raw || typeof raw !== 'string' ) {
+		return [];
+	}
+
+	const cues = [];
+	// Blocks are separated by one or more blank lines. Normalise line endings.
+	const blocks = raw.replace( /\r\n/g, '\n' ).replace( /\r/g, '\n' ).split( /\n{2,}/ );
+
+	for ( const block of blocks ) {
+		const lines = block.split( '\n' ).filter( ( line ) => line.trim() !== '' );
+		const arrowIndex = lines.findIndex( ( line ) => line.includes( '-->' ) );
+		if ( arrowIndex === -1 ) {
+			continue;
+		}
+
+		const [ rawStart, rawRest ] = lines[ arrowIndex ].split( '-->' );
+		// The end timestamp may be followed by cue settings (e.g. `align:start`).
+		const rawEnd = ( rawRest || '' ).trim().split( /\s+/ )[ 0 ];
+
+		const start = parseTimestamp( rawStart );
+		const end = parseTimestamp( rawEnd );
+		if ( Number.isNaN( start ) ) {
+			continue;
+		}
+
+		const text = lines.slice( arrowIndex + 1 ).join( ' ' ).trim();
+		if ( text === '' ) {
+			continue;
+		}
+
+		cues.push( { start, end: Number.isNaN( end ) ? start : end, text } );
+	}
+
+	return cues;
+};
+
+/**
+ * Format seconds as a clock (`m:ss`, or `h:mm:ss` past an hour).
+ *
+ * @param {number} seconds Seconds.
+ * @return {string} Clock string.
+ */
+export const formatClock = ( seconds ) => {
+	if ( seconds === null || seconds === undefined || Number.isNaN( seconds ) ) {
+		return '0:00';
+	}
+	const total = Math.max( 0, Math.floor( seconds ) );
+	const hrs = Math.floor( total / 3600 );
+	const mins = Math.floor( ( total % 3600 ) / 60 );
+	const secs = total % 60;
+	const pad = ( value ) => String( value ).padStart( 2, '0' );
+	if ( hrs > 0 ) {
+		return `${ hrs }:${ pad( mins ) }:${ pad( secs ) }`;
+	}
+	return `${ mins }:${ pad( secs ) }`;
+};
+
+/**
+ * Human-readable file size.
+ *
+ * @param {number} bytes Byte count.
+ * @return {string} e.g. `56.2 MB`, or '' when unknown.
+ */
+export const formatBytes = ( bytes ) => {
+	if ( ! bytes || Number.isNaN( bytes ) ) {
+		return '';
+	}
+	const units = [ 'B', 'KB', 'MB', 'GB' ];
+	let value = bytes;
+	let unit = 0;
+	while ( value >= 1024 && unit < units.length - 1 ) {
+		value /= 1024;
+		unit += 1;
+	}
+	return `${ value.toFixed( unit === 0 ? 0 : 1 ) } ${ units[ unit ] }`;
+};
+
+/**
+ * Whether a SaaS transcription status string means a job is still running.
+ *
+ * @param {string} status Status from the API.
+ * @return {boolean} True while transcribing.
+ */
+export const isTranscribingStatus = ( status ) => status === 'Transcribing' || status === 'Transcoding';

--- a/pages/video-editor/redux/api/transcription.js
+++ b/pages/video-editor/redux/api/transcription.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const restURL = window.godamRestRoute?.url || window.wpApiSettings?.root || '/wp-json/';
+
+/**
+ * RTK Query API for the AI transcript feature.
+ *
+ * All endpoints are same-origin WordPress REST proxies (under `godam/v1`) that
+ * forward to the GoDAM SaaS using the server-side licence key — the React app
+ * never sees the API key. See `class-transcription.php` for the PHP side.
+ */
+export const transcriptionAPI = createApi( {
+	reducerPath: 'transcriptionAPI',
+	baseQuery: fetchBaseQuery( {
+		baseUrl: restURL,
+		prepareHeaders: ( headers ) => {
+			headers.set( 'X-WP-Nonce', window.videoData.nonce );
+			return headers;
+		},
+	} ),
+	tagTypes: [ 'Transcription' ],
+	endpoints: ( builder ) => ( {
+		// Current transcript status / path for an attachment. Polled while a
+		// job is in progress.
+		getTranscription: builder.query( {
+			query: ( attachmentID ) => ( {
+				url: `/godam/v1/transcription`,
+				method: 'GET',
+				params: { attachment_id: attachmentID },
+			} ),
+			providesTags: ( result, error, attachmentID ) => [ { type: 'Transcription', id: attachmentID } ],
+		} ),
+
+		// Kick off (or re-run) AI transcription for the attachment's transcoding job.
+		generateTranscription: builder.mutation( {
+			query: ( attachmentID ) => ( {
+				url: `/godam/v1/transcription/generate`,
+				method: 'POST',
+				body: { attachment_id: attachmentID },
+			} ),
+			invalidatesTags: ( result, error, attachmentID ) => [ { type: 'Transcription', id: attachmentID } ],
+		} ),
+
+		// Attach an existing caption file (.vtt / .srt) as the transcript.
+		uploadTranscription: builder.mutation( {
+			query: ( { attachmentID, url } ) => ( {
+				url: `/godam/v1/transcription/upload`,
+				method: 'POST',
+				body: { attachment_id: attachmentID, url },
+			} ),
+			invalidatesTags: ( result, error, { attachmentID } ) => [ { type: 'Transcription', id: attachmentID } ],
+		} ),
+
+		// Remove the transcript from the attachment.
+		deleteTranscription: builder.mutation( {
+			query: ( attachmentID ) => ( {
+				url: `/godam/v1/transcription`,
+				method: 'DELETE',
+				body: { attachment_id: attachmentID },
+			} ),
+			invalidatesTags: ( result, error, attachmentID ) => [ { type: 'Transcription', id: attachmentID } ],
+		} ),
+	} ),
+} );
+
+export const {
+	useGetTranscriptionQuery,
+	useGenerateTranscriptionMutation,
+	useUploadTranscriptionMutation,
+	useDeleteTranscriptionMutation,
+} = transcriptionAPI;

--- a/pages/video-editor/redux/slice/videoSlice.js
+++ b/pages/video-editor/redux/slice/videoSlice.js
@@ -130,8 +130,8 @@ const slice = createSlice( {
 			state.currentLayer = action.payload;
 		},
 		setCurrentTab: ( state, action ) => {
-			// check if action.payload is either 'layers' or 'player-settings'.
-			if ( action.payload === 'layers' || action.payload === 'player-settings' || action.payload === 'chapters' ) {
+			// Only accept known editor tab names.
+			if ( [ 'layers', 'player-settings', 'transcription', 'chapters' ].includes( action.payload ) ) {
 				state.currentTab = action.payload;
 			}
 		},

--- a/pages/video-editor/redux/store.js
+++ b/pages/video-editor/redux/store.js
@@ -11,6 +11,7 @@ import { videosAPI } from './api/video';
 import { videoEditorAPI } from './api/video-editor';
 import { pollsAPI } from './api/polls';
 import { attachmentAPI } from './api/attachment';
+import { transcriptionAPI } from './api/transcription';
 import { gravityFormsAPI } from './api/gravity-forms';
 import { contactForm7Api } from './api/cf7-forms';
 import { wpFormsApi } from './api/wpforms';
@@ -30,6 +31,7 @@ export default configureStore( {
 		[ videoEditorAPI.reducerPath ]: videoEditorAPI.reducer,
 		[ pollsAPI.reducerPath ]: pollsAPI.reducer,
 		[ attachmentAPI.reducerPath ]: attachmentAPI.reducer,
+		[ transcriptionAPI.reducerPath ]: transcriptionAPI.reducer,
 		[ gravityFormsAPI.reducerPath ]: gravityFormsAPI.reducer,
 		[ contactForm7Api.reducerPath ]: contactForm7Api.reducer,
 		[ wpFormsApi.reducerPath ]: wpFormsApi.reducer,
@@ -47,6 +49,7 @@ export default configureStore( {
 		videoEditorAPI.middleware,
 		pollsAPI.middleware,
 		attachmentAPI.middleware,
+		transcriptionAPI.middleware,
 		gravityFormsAPI.middleware,
 		contactForm7Api.middleware,
 		wpFormsApi.middleware,

--- a/pages/video-editor/video-editor.scss
+++ b/pages/video-editor/video-editor.scss
@@ -14,6 +14,7 @@
 @use 'controls';
 @use 'layers';
 @use 'chapters';
+@use 'transcription';
 @use 'timeline';
 
 // Hide layer controls fallback when portal target is not available


### PR DESCRIPTION
This pull request introduces a new AI-powered transcription feature to the video editor, adding both backend REST API support and a new frontend "Transcription" tab. Users can now generate, upload, and manage video transcriptions directly within the editor interface. The main changes are grouped below:

**Backend: REST API for Transcription**
- Added a new `Transcription` REST API class (`class-transcription.php`) that supports generating AI transcriptions, uploading caption files, fetching current transcription status, and deleting transcriptions for video attachments. This ensures secure handling of SaaS credentials and transcript metadata.
- Registered the new `Transcription` REST API in the plugin's main loader to ensure endpoints are available. [[1]](diffhunk://#diff-0beca18a469ce0ef11130f3a94b2f7f6997eecfa5f4f414442e163a0230e131cR41) [[2]](diffhunk://#diff-0beca18a469ce0ef11130f3a94b2f7f6997eecfa5f4f414442e163a0230e131cR186)

**Frontend: Video Editor Integration**
- Introduced a new "Transcription" tab in the video editor UI, including the tab icon and navigation logic, so users can access transcription features alongside layers, settings, and chapters. [[1]](diffhunk://#diff-2d227a735881884c63071a3e5d58d3056564026d18f0a0a4379c0ca4c70d33e8L10-R17) [[2]](diffhunk://#diff-2d227a735881884c63071a3e5d58d3056564026d18f0a0a4379c0ca4c70d33e8R28)
- Integrated the `Transcription` React component into the editor, passing necessary props such as `attachmentID`, `duration`, and formatted file size. [[1]](diffhunk://#diff-0559daddab966567cf8d9f589b35d6c35f4a44b62c60586606523dd0cbcb3494R44-R45) [[2]](diffhunk://#diff-0559daddab966567cf8d9f589b35d6c35f4a44b62c60586606523dd0cbcb3494R429-R435)

**Styling**
- Added a dedicated SCSS file (`_transcription.scss`) to style the new transcription tab, including layouts for empty, busy, and ready states, as well as cue list presentation.


## Demo

https://github.com/user-attachments/assets/b8e1456e-ffb6-4570-9f66-741648e9aa0b