### PR TITLE
fix(deps): security bumps for 12 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"clsx": "^2.1.1",
 				"flv.js": "^1.6.2",
 				"isomorphic-dompurify": "^2.26.0",
-				"posthog-js": "^1.282.0",
+				"posthog-js": "^1.386.8",
 				"quill": "2.0.2",
 				"react": "^18.0.0",
 				"react-bootstrap-icons": "^1.11.6",
@@ -47,7 +47,7 @@
 				"videojs-ima": "2.4.0"
 			},
 			"devDependencies": {
-				"@babel/core": "7.28.0",
+				"@babel/core": "7.29.6",
 				"@tailwindcss/typography": "^0.5.16",
 				"@wordpress/api-fetch": "7.39.0",
 				"@wordpress/babel-preset-default": "8.34.0",
@@ -101,20 +101,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@analytics/cookie-utils": {
@@ -372,13 +358,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -397,22 +383,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-			"integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+			"version": "7.29.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+			"integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.6",
-				"@babel/parser": "^7.28.0",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.0",
-				"@babel/types": "^7.28.0",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.6",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.29.2",
+				"@babel/parser": "^7.29.3",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -447,14 +433,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -680,9 +666,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -690,9 +676,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -725,27 +711,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -2301,15 +2287,15 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2335,14 +2321,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -5257,6 +5243,17 @@
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -5859,6 +5856,7 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.0.0"
@@ -5914,52 +5912,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-http": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
-			"integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.208.0",
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/otlp-exporter-base": "0.208.0",
-				"@opentelemetry/otlp-transformer": "0.208.0",
-				"@opentelemetry/sdk-logs": "0.208.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
@@ -6408,118 +6360,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
-			"integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/otlp-transformer": "0.208.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
-			"integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.208.0",
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0",
-				"@opentelemetry/sdk-logs": "0.208.0",
-				"@opentelemetry/sdk-metrics": "2.2.0",
-				"@opentelemetry/sdk-trace-base": "2.2.0",
-				"protobufjs": "^7.3.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
-			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/redis-common": {
 			"version": "0.36.2",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
@@ -6557,113 +6397,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
-			"integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api-logs": "0.208.0",
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.4.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
-			"integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/resources": "2.2.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.9.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.2.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
@@ -6696,6 +6429,7 @@
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
 			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -7329,12 +7063,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@posthog/core": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.23.2.tgz",
-			"integrity": "sha512-zTDdda9NuSHrnwSOfFMxX/pyXiycF4jtU1kTr8DL61dHhV+7LF6XF1ndRZZTuaGGbfbb/GJYkEsjEX9SXfNZeQ==",
+			"version": "1.39.1",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.1.tgz",
+			"integrity": "sha512-EaeRd1VoZM84yQSqu4cIDHNR93nCV3ojlW+vQLpOyP9UM7CK0rHWgueiYxxymNDDvn6nxCft5k/Vn+onSBgfug==",
 			"license": "MIT",
 			"dependencies": {
-				"cross-spawn": "^7.0.6"
+				"@posthog/types": "^1.392.0"
 			}
 		},
 		"node_modules/@posthog/react": {
@@ -7354,9 +7088,9 @@
 			}
 		},
 		"node_modules/@posthog/types": {
-			"version": "1.360.0",
-			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.360.0.tgz",
-			"integrity": "sha512-roypbiJ49V3jWlV/lzhXGf0cKLLRj69L4H4ZHW6YsITHlnjQ12cgdPhPS88Bb9nW9xZTVSGWWDjfNGsdgAxsNg==",
+			"version": "1.392.0",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.0.tgz",
+			"integrity": "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw==",
 			"license": "MIT"
 		},
 		"node_modules/@prisma/instrumentation": {
@@ -7371,70 +7105,6 @@
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.8"
 			}
-		},
-		"node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/@puppeteer/browsers": {
 			"version": "2.6.1",
@@ -9049,6 +8719,7 @@
 			"version": "20.19.37",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
 			"integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -10335,37 +10006,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/core": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
 		"node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/browserslist-config": {
 			"version": "6.41.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.41.0.tgz",
@@ -11219,37 +10859,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/babel-preset-default/node_modules/@babel/core": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/browserslist-config": {
@@ -12393,37 +12002,6 @@
 				"@wordpress/env": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@babel/core": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@jest/console": {
@@ -16942,6 +16520,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -18496,9 +18075,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -20935,16 +20514,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -21650,9 +21229,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -23022,6 +22601,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -26262,14 +25842,14 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.1.tgz",
-			"integrity": "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+			"integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"picocolors": "^1.1.1",
-				"shell-quote": "^1.8.3"
+				"shell-quote": "^1.8.4"
 			}
 		},
 		"node_modules/lazy-cache": {
@@ -26457,28 +26037,6 @@
 			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
 			"dev": true,
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/lighthouse/node_modules/semver": {
 			"version": "7.7.4",
@@ -27036,12 +26594,6 @@
 				"type": "tidelift",
 				"url": "https://tidelift.com/funding/github/npm/loglevel"
 			}
-		},
-		"node_modules/long": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/lookup-closest-locale": {
 			"version": "6.2.0",
@@ -29368,6 +28920,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -30643,79 +30196,31 @@
 			}
 		},
 		"node_modules/posthog-js": {
-			"version": "1.360.0",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.360.0.tgz",
-			"integrity": "sha512-jkyO+T97yi6RuiexOaXC7AnEGiC+yIfGU5DIUzI5rqBH6MltmtJw/ve2Oxc4jeua2WDr5sXMzo+SS+acbpueAA==",
+			"version": "1.396.2",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.396.2.tgz",
+			"integrity": "sha512-WFdS0JL+r/M7A9XQwIGbw1Xn6W7/V5TEmv1wgrq7GFcPxZ0I3TktNGtGQNmzARbI8nKedAHFkY9UPDDg+NTSQg==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
-				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/api-logs": "^0.208.0",
-				"@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
-				"@opentelemetry/resources": "^2.2.0",
-				"@opentelemetry/sdk-logs": "^0.208.0",
-				"@posthog/core": "1.23.2",
-				"@posthog/types": "1.360.0",
+				"@posthog/core": "^1.38.1",
+				"@posthog/types": "^1.392.0",
 				"core-js": "^3.38.1",
 				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",
-				"preact": "^10.28.2",
+				"preact": "^10.29.2",
 				"query-selector-shadow-dom": "^1.0.1",
-				"web-vitals": "^5.1.0"
-			}
-		},
-		"node_modules/posthog-js/node_modules/@opentelemetry/api-logs": {
-			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/posthog-js/node_modules/@opentelemetry/core": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
-			"integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/posthog-js/node_modules/@opentelemetry/resources": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
-			"integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.6.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+				"web-vitals": "^5.3.0"
 			}
 		},
 		"node_modules/posthog-js/node_modules/web-vitals": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
-			"integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/preact": {
-			"version": "10.28.4",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
-			"integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
+			"version": "10.29.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
+			"integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -30866,30 +30371,6 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"license": "MIT"
-		},
-		"node_modules/protobufjs": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.1",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.1",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -32745,6 +32226,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -32757,6 +32239,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -35726,6 +35209,7 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -36846,6 +36330,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -37103,9 +36588,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"clsx": "^2.1.1",
 		"flv.js": "^1.6.2",
 		"isomorphic-dompurify": "^2.26.0",
-		"posthog-js": "^1.282.0",
+		"posthog-js": "^1.386.8",
 		"quill": "2.0.2",
 		"react": "^18.0.0",
 		"react-bootstrap-icons": "^1.11.6",
@@ -61,7 +61,7 @@
 		"videojs-ima": "2.4.0"
 	},
 	"devDependencies": {
-		"@babel/core": "7.28.0",
+		"@babel/core": "7.29.6",
 		"@tailwindcss/typography": "^0.5.16",
 		"@wordpress/api-fetch": "7.39.0",
 		"@wordpress/babel-preset-default": "8.34.0",
@@ -98,12 +98,13 @@
 		"webpack-remove-empty-scripts": "1.1.1"
 	},
 	"overrides": {
+		"@babel/core": "7.29.6",
 		"@xmldom/xmldom": "0.8.13",
 		"@babel/plugin-transform-modules-systemjs": "7.29.4",
 		"@protobufjs/utf8": "1.1.1",
 		"axios": "1.16.1",
 		"basic-ftp": "5.2.2",
-		"dompurify": "3.4.5",
+		"dompurify": "3.4.11",
 		"fast-uri": "3.1.2",
 		"follow-redirects": "1.16.0",
 		"ip-address": "10.1.1",
@@ -113,13 +114,13 @@
 		"picomatch@<=2.3.1": "2.3.2",
 		"picomatch@>=4.0.0 <=4.0.3": "4.0.4",
 		"postcss": "8.5.15",
-		"protobufjs": "7.5.8",
+		"protobufjs": "7.6.3",
 		"qs": "6.15.2",
 		"serialize-javascript": "7.0.5",
 		"shell-quote": "1.8.4",
 		"simple-git": "3.36.0",
 		"uuid@<11.1.1": "11.1.1",
-		"ws@<8.20.1": "8.20.1",
+		"ws@<8.21.0": "8.21.0",
 		"@wordpress/scripts": {
 			"svgo@>3.0.0 <3.3.3": "3.3.3",
 			"minimatch@<3.1.5": "3.1.5",


### PR DESCRIPTION
## Summary
Lockfile-focused security bumps addressing open Dependabot alerts for the npm ecosystem. All fixes stay within the same major version as installed (no breaking major bumps, no source edits). The repo uses `overrides` to pin transitive security versions; vulnerable pins were advanced to patched same-major releases, and `posthog-js` was bumped (per Dependabot PR #1961) to drop its vulnerable transitive dependencies.

## Fixes
| Package | Old -> New | Alert # | Severity | GHSA |
|---|---|---|---|---|
| dompurify (override) | 3.4.5 -> 3.4.11 | 217,218,219,221,222,223,226 | medium/low | GHSA-r47g-fvhr-h676, -hpcv-96wg-7vj8, -76mc-f452-cxcm, -rp9w-3fw7-7cwq, -gvmj-g25r-r7wr, -vxr8-fq34-vvx9, -cmwh-pvxp-8882 |
| ws (override) | 8.20.1 -> 8.21.0 | 210 | **HIGH** | GHSA-96hv-2xvq-fx4p |
| form-data | 4.0.5 -> 4.0.6 | 214 | **HIGH** | GHSA-hmw2-7cc7-3qxx |
| protobufjs (via posthog-js drop) | 7.5.8 -> removed | 216 | **HIGH** | GHSA-wcpc-wj8m-hjx6 |
| protobufjs (via posthog-js drop) | 7.5.8 -> removed | 215 | medium | GHSA-f38q-mgvj-vph7 |
| @babel/core (devDep + override) | 7.28.0/7.25.7 -> 7.29.6 | 227, 211 | low | GHSA-4x5r-pxfx-6jf8 |
| launch-editor | 2.13.1 -> 2.14.1 | 213 | medium | GHSA-v6wh-96g9-6wx3 |
| @opentelemetry/core 2.x (via posthog-js) | 2.2.0/2.6.0 -> removed | 224 (partial) | medium | GHSA-8988-4f7v-96qf |

## Why
- dompurify/protobufjs/ws are pinned through the existing `overrides` block; bumping the override values to patched same-major versions is the repo's established mechanism for transitive security control.
- `posthog-js` ^1.282.0 -> ^1.386.8 (matching Dependabot PR #1961) eliminates the vulnerable transitive `protobufjs` and the `@opentelemetry/core` 2.x copies entirely.
- `@babel/core` added to `overrides` so the nested dev-only @wordpress copies (7.25.7) dedupe to 7.29.6.

## How tested
Lockfile-only changes generated with `npm install/update --package-lock-only --ignore-scripts`. The lockfile parses as valid JSON. **Build/tests NOT run locally — please verify in CI.**

## Residual risk / not applied
- **Alert 220 — dompurify (low):** No patched version exists (first_patched_version = none). Not fixable.
- **Alert 161 — showdown 1.9.1 (medium):** No patched version exists. Major rewrite would be required. Not fixable.
- **Alert 225 — markdown-it 12.3.2 (medium):** Patch is 14.2.0 — a **major** bump (12 -> 14). Out of safe scope; flagged for manual review.
- **Alert 224 — @opentelemetry/core (medium):** The actively-flagged vulnerable 2.x copies were removed via the posthog-js bump. A residual dev-only `@opentelemetry/core@1.30.1` remains (transitive of `@sentry/node` and the OTel 1.x instrumentation tree, which require ^1.x). The advisory patch is 2.8.0 — a **major** bump of that 1.x tree. Out of safe scope; flagged for manual review.

Do not merge without CI verification.
