### PR TITLE
fix: eliminate broken-image flash on no-thumbnail video gallery tiles

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -102,16 +102,25 @@
 }
 
 // Preview video — shared by both handpicked and query tiles.
+// Hidden by default so it never flashes over a real thumbnail.
+// Revealed only when hovering/autoplay (is-previewing) or when the tile
+// has no server-side thumbnail and uses the first video frame instead (--no-thumb).
 .godam-gallery-v2-item__preview-video {
 	position: absolute;
 	inset: 0;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
-	opacity: 1;
+	opacity: 0;
 	pointer-events: none;
 	transition: opacity 0.3s ease;
 	z-index: 1;
+}
+
+// No-thumbnail tiles: video first frame IS the thumbnail.
+// Must come before .is-previewing (lower specificity → must precede higher).
+.godam-gallery-v2-item--no-thumb .godam-gallery-v2-item__preview-video {
+	opacity: 1;
 }
 
 .godam-gallery-v2__query-button.is-previewing,
@@ -229,6 +238,7 @@
 		// only for items that have a placeholder image.
 	}
 
+	// stylelint-disable-next-line no-descending-specificity
 	&__play-icon {
 		position: absolute;
 		width: 52px;
@@ -409,6 +419,7 @@
 // ── Show play button toggle ───────────────────────────────────────────────────
 // When the editor sets data-show-play-button="false" on the gallery wrapper,
 // hide the play icon overlays on all tile types.
+// stylelint-disable no-descending-specificity
 [data-show-play-button="false"] {
 
 	.godam-gallery-v2__play-icon,
@@ -416,6 +427,7 @@
 		display: none;
 	}
 }
+// stylelint-enable no-descending-specificity
 
 @keyframes godam_gallery_v2_blur_pulse {
 

--- a/inc/classes/rest-api/class-dynamic-gallery.php
+++ b/inc/classes/rest-api/class-dynamic-gallery.php
@@ -165,19 +165,21 @@ class Dynamic_Gallery extends Base {
 				);
 
 				echo '<div class="godam-gallery-v2__query-item godam-gallery-v2__query-item--ratio-' . esc_attr( $ratio_class ) . '">';
+				$no_thumb_class = ( empty( $item['thumbnail'] ) && ! empty( $item['video_url'] ) ) ? ' godam-gallery-v2-item--no-thumb' : '';
 				/* translators: %s: video title. */
-				echo '<button type="button" class="godam-gallery-v2__query-button" data-godam-gallery-v2-trigger="true" data-video-id="' . esc_attr( $item['id'] ) . '" aria-label="' . esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $item['title'] ) ) . '">';
+				echo '<button type="button" class="godam-gallery-v2__query-button' . esc_attr( $no_thumb_class ) . '" data-godam-gallery-v2-trigger="true" data-video-id="' . esc_attr( $item['id'] ) . '" aria-label="' . esc_attr( sprintf( __( 'Open video: %s', 'godam' ), $item['title'] ) ) . '">';
 				echo '<div class="godam-gallery-v2__query-thumb' . ( ! empty( $item['placeholder'] ) ? ' godam-gallery-blurred-img' : '' ) . '"' . ( ! empty( $item['placeholder'] ) ? ' style="background-image: url(\'' . esc_url( $item['placeholder'] ) . '\')"' : '' ) . '>';
 
 				if ( ! empty( $item['thumbnail'] ) ) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $thumbnail_attributes comes from rtgodam_format_html_attributes() which pre-sanitizes.
 					echo '<img src="' . esc_url( $item['thumbnail'] ) . '" alt="' . esc_attr( $item['title'] ) . '" class="godam-gallery-v2__thumbnail"' . ( $thumbnail_attributes ? ' ' . $thumbnail_attributes : '' ) . ' />';
 				} else {
-					echo '<img class="godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending" alt="' . esc_attr( $item['title'] ) . '" aria-hidden="true" />';
+					echo '<span class="godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending" aria-hidden="true" hidden></span>';
 				}
 
 				if ( ! empty( $item['video_url'] ) ) {
-					echo '<video class="godam-gallery-v2-item__preview-video" src="' . esc_url( $item['video_url'] ) . '" muted playsinline preload="none" aria-hidden="true" tabindex="-1"></video>';
+					$preload_val = empty( $item['thumbnail'] ) ? 'metadata' : 'none';
+					echo '<video class="godam-gallery-v2-item__preview-video" src="' . esc_url( $item['video_url'] ) . '" muted playsinline preload="' . esc_attr( $preload_val ) . '" aria-hidden="true" tabindex="-1"></video>';
 				}
 
 				echo '<div class="godam-gallery-v2__play-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z" /></svg></div>';

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1741,16 +1741,10 @@ function rtgodam_get_video_thumbnail_sources( $attachment_id, $thumbnail_url = '
 		}
 	}
 
-	if ( empty( $resolved_thumbnail ) ) {
-		$icon = wp_mime_type_icon( $attachment_id );
-		if ( $icon ) {
-			$resolved_thumbnail = esc_url_raw( $icon );
-		}
-	}
-
-	if ( empty( $resolved_thumbnail ) && defined( 'RTGODAM_URL' ) ) {
-		$resolved_thumbnail = trailingslashit( RTGODAM_URL ) . 'assets/src/images/video-thumbnail-default.png';
-	}
+	// Do NOT fall back to wp_mime_type_icon() or a generic default image here.
+	// When no real thumbnail is available, returning '' lets the gallery template
+	// emit a --pending sentinel instead, which the frontend JS replaces with the
+	// video's first frame via initFirstFrameThumbnails().
 
 	return array(
 		'thumbnail'   => $resolved_thumbnail,

--- a/inc/templates/godam-video-gallery.php
+++ b/inc/templates/godam-video-gallery.php
@@ -432,7 +432,7 @@ if ( 'query' === $godam_gallery_mode ) {
 										src="<?php echo esc_url( $godam_item['video_url'] ); ?>"
 										muted
 										playsinline
-										preload="<?php echo empty( $godam_item['thumbnail'] ) ? 'metadata' : 'none'; ?>"
+										preload="<?php echo esc_attr( empty( $godam_item['thumbnail'] ) ? 'metadata' : 'none' ); ?>"
 										aria-hidden="true"
 										tabindex="-1"
 									></video>
@@ -507,7 +507,7 @@ if ( 'query' === $godam_gallery_mode ) {
 										src="<?php echo esc_url( $godam_item['video_url'] ); ?>"
 										muted
 										playsinline
-										preload="<?php echo empty( $godam_item['thumbnail'] ) ? 'metadata' : 'none'; ?>"
+										preload="<?php echo esc_attr( empty( $godam_item['thumbnail'] ) ? 'metadata' : 'none' ); ?>"
 										aria-hidden="true"
 										tabindex="-1"
 									></video>

--- a/inc/templates/godam-video-gallery.php
+++ b/inc/templates/godam-video-gallery.php
@@ -414,7 +414,7 @@ if ( 'query' === $godam_gallery_mode ) {
 					<div class="<?php echo esc_attr( sprintf( 'godam-gallery-v2__query-item godam-gallery-v2__query-item--ratio-%s', $godam_ratio_class ) ); ?>">
 						<button
 							type="button"
-							class="godam-gallery-v2__query-button"
+							class="godam-gallery-v2__query-button<?php echo ( empty( $godam_item['thumbnail'] ) && ! empty( $godam_item['video_url'] ) ) ? ' godam-gallery-v2-item--no-thumb' : ''; ?>"
 							data-godam-gallery-v2-trigger="true"
 							data-video-id="<?php echo esc_attr( $godam_item['id'] ); ?>"
 							<?php /* translators: %s: video title. */ ?>
@@ -424,7 +424,7 @@ if ( 'query' === $godam_gallery_mode ) {
 								<?php if ( ! empty( $godam_item['thumbnail'] ) ) : ?>
 									<img src="<?php echo esc_url( $godam_item['thumbnail'] ); ?>" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" class="godam-gallery-v2__thumbnail" <?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?> />
 								<?php else : ?>
-									<img class="godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending" alt="<?php echo esc_attr( $godam_item['title'] ); ?>" aria-hidden="true" />
+									<span class="godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending" aria-hidden="true" hidden></span>
 								<?php endif; ?>
 								<?php if ( ! empty( $godam_item['video_url'] ) ) : ?>
 									<video
@@ -432,7 +432,7 @@ if ( 'query' === $godam_gallery_mode ) {
 										src="<?php echo esc_url( $godam_item['video_url'] ); ?>"
 										muted
 										playsinline
-										preload="none"
+										preload="<?php echo empty( $godam_item['thumbnail'] ) ? 'metadata' : 'none'; ?>"
 										aria-hidden="true"
 										tabindex="-1"
 									></video>
@@ -480,7 +480,7 @@ if ( 'query' === $godam_gallery_mode ) {
 					<div class="<?php echo esc_attr( sprintf( 'godam-gallery-v2-item godam-gallery-v2-item--%s godam-gallery-v2-item--ratio-%s', $godam_layout, $godam_ratio_class ) ); ?>">
 						<button
 							type="button"
-							class="godam-gallery-v2-item__button"
+							class="godam-gallery-v2-item__button<?php echo ( empty( $godam_item['thumbnail'] ) && ! empty( $godam_item['video_url'] ) ) ? ' godam-gallery-v2-item--no-thumb' : ''; ?>"
 							data-godam-gallery-v2-trigger="true"
 							data-video-id="<?php echo esc_attr( $godam_item['id'] ); ?>"
 							<?php /* translators: %s: video title. */ ?>
@@ -495,11 +495,11 @@ if ( 'query' === $godam_gallery_mode ) {
 										<?php echo $godam_thumbnail_attributes ? wp_kses_data( $godam_thumbnail_attributes ) : ''; ?>
 									/>
 								<?php else : ?>
-									<img
+									<span
 										class="godam-gallery-v2-item__thumbnail godam-gallery-v2__thumbnail godam-gallery-v2__thumbnail--pending"
-										alt="<?php echo esc_attr( $godam_item['title'] ); ?>"
 										aria-hidden="true"
-									/>
+										hidden
+									></span>
 								<?php endif; ?>
 								<?php if ( ! empty( $godam_item['video_url'] ) ) : ?>
 									<video
@@ -507,7 +507,7 @@ if ( 'query' === $godam_gallery_mode ) {
 										src="<?php echo esc_url( $godam_item['video_url'] ); ?>"
 										muted
 										playsinline
-										preload="none"
+										preload="<?php echo empty( $godam_item['thumbnail'] ) ? 'metadata' : 'none'; ?>"
 										aria-hidden="true"
 										tabindex="-1"
 									></video>


### PR DESCRIPTION
- Remove wp_mime_type_icon() and default PNG fallbacks in rtgodam_get_video_thumbnail_sources() so tiles with no real thumbnail emit a --pending sentinel instead of a generic icon

- Change --pending placeholder from src-less <img> to <span hidden> in both template modes (query/handpicked) and the REST load-more path, eliminating the browser broken-image glyph

- CSS: set preview video default opacity to 0; add --no-thumb rule to keep it visible at opacity 1 when the tile has no server-side thumbnail

- PHP: emit godam-gallery-v2-item--no-thumb class and preload=metadata directly in server-rendered HTML for no-thumbnail tiles so the first video frame is visible on first paint with no JS delay and no gray flash

Make it similar to how it is handled in Shoppable Video Block

https://github.com/user-attachments/assets/9baa6d66-04a8-46e4-b0a4-d7dd549e5626
