### PR TITLE
Release 2.0.0: layer-editor exit confirm + integration-toggle gating + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog #
 
+## v2.0.0 (July 2, 2026) ##
+
+- Feat: GoDAM 2.0 brings a complete visual redesign across the admin and front end, with refreshed branding, new logos, and updated block icons.
+- Feat: Rebuilt the Video Editor with a streamlined layout for managing layers, hotspots, CTAs, and forms.
+- Feat: Added a guided onboarding experience, embedded in the plugin and integrated with GoDAM Central.
+- Feat: Redesigned the analytics dashboard with a cleaner layout, a Layer Timeline range control, and Top Videos improvements.
+- Feat: Redesigned the Video Player, Video Gallery, Audio, and Document blocks.
+- Tweak: The admin UI now follows the WordPress admin colour scheme, and the front end follows the configured brand colour.
+- Tweak: The Video Layer editor now warns before leaving with unsaved changes.
+- Tweak: The WooCommerce integration toggle is disabled when no valid API key is present, as it is a Pro feature.
+- Fix: Various QA fixes across blocks, the video editor, and the media gallery.
+
 ## v1.13.0 (June 18, 2026) ##
 
 - Feat: Track GoDAM media usage across post content, blocks, shortcodes, Elementor, block widgets, and featured images — recording where each asset is used and notifying GoDAM Central.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested up to: 7.0
 
 Requires PHP: 7.4
 
-Stable tag: 1.13.0
+Stable tag: 2.0.0
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 1.13.0
+ * Version: 2.0.0
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '1.13.0' );
+	define( 'RTGODAM_VERSION', '2.0.0' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "1.13.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "1.13.0",
+			"version": "2.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "1.13.0",
+	"version": "2.0.0",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx
@@ -39,7 +39,7 @@ const IntegrationToggle = ( {
 					{ isToggling && <Spinner /> }
 				</>
 			}
-			checked={ enabled }
+			checked={ hasValidAPIKey && enabled }
 			help={
 				! hasValidAPIKey
 					? (

--- a/pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx
+++ b/pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx
@@ -65,7 +65,7 @@ const IntegrationToggle = ( {
 						label,
 					)
 			}
-			disabled={ isToggling || ( ! hasValidAPIKey && ! enabled ) }
+			disabled={ isToggling || ! hasValidAPIKey }
 			onChange={ onChange }
 		/>
 	);

--- a/pages/onboarding/components/screens/WorkspaceScreen.jsx
+++ b/pages/onboarding/components/screens/WorkspaceScreen.jsx
@@ -56,7 +56,9 @@ const WorkspaceScreen = () => {
 	};
 
 	if ( ! organizations.length ) {
-		const appUrl = `${ config.appOrigin || 'https://app.godam.io' }/web/`;
+		// Workspace creation starts from picking a plan, so send the user to the
+		// plans page (same path the upgrade flow uses), not the app root.
+		const plansUrl = `${ config.appOrigin || 'https://app.godam.io' }/web/billing?tab=Plans`;
 		return (
 			<>
 				<h1 className="godam-onboarding__title">{ __( 'No workspaces yet', 'godam' ) }</h1>
@@ -65,7 +67,7 @@ const WorkspaceScreen = () => {
 						__( 'This account has no workspaces. <a>Create one in the GoDAM app</a>, then come back.', 'godam' ),
 						{
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							a: <a className="godam-onboarding__link" href={ appUrl } target="_blank" rel="noreferrer" data-test-id="godam-onboarding-link-create-workspace" />,
+							a: <a className="godam-onboarding__link" href={ plansUrl } target="_blank" rel="noreferrer" data-test-id="godam-onboarding-link-create-workspace" />,
 						},
 					) }
 				</p>

--- a/pages/video-editor/App.js
+++ b/pages/video-editor/App.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -13,7 +13,8 @@ import '../../assets/src/css/godam-player.scss';
 /**
  * WordPress dependencies
  */
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { __ } from '@wordpress/i18n';
 import VideoEditorDataView from './components/video-dataview/VideoEditorDataView.jsx';
 import GodamHeader from '../godam/components/GoDAMHeader.jsx';
 import ProductGuide from './onboarding/ProductGuide.jsx';
@@ -38,6 +39,20 @@ const App = () => {
 	const dispatch = useDispatch();
 	const [ attachmentID, setAttachmentID ] = useState( null );
 	const [ rawID, setRawID ] = useState( null );
+
+	// Track the latest dirty state + current video so the (once-registered)
+	// popstate listener can read them without a stale closure.
+	const isChanged = useSelector( ( state ) => state.videoReducer.isChanged );
+	const isChangedRef = useRef( isChanged );
+	const attachmentIDRef = useRef( attachmentID );
+
+	useEffect( () => {
+		isChangedRef.current = isChanged;
+	}, [ isChanged ] );
+
+	useEffect( () => {
+		attachmentIDRef.current = attachmentID;
+	}, [ attachmentID ] );
 	const {
 		data: resolvedAttachment,
 		isSuccess,
@@ -101,6 +116,21 @@ const App = () => {
 
 		// Handle back/forward navigation
 		const handlePopState = () => {
+			// SPA history navigation (browser back/forward) does not fire the
+			// beforeunload guard, so confirm here before discarding unsaved layer
+			// changes. On cancel, re-push the current video URL to stay put.
+			if ( attachmentIDRef.current && isChangedRef.current ) {
+				// eslint-disable-next-line no-alert
+				const leave = window.confirm( __( 'You have unsaved changes. Are you sure you want to leave?', 'godam' ) );
+
+				if ( ! leave ) {
+					const restoredUrl = new URL( window.location );
+					restoredUrl.searchParams.set( 'id', attachmentIDRef.current );
+					window.history.pushState( {}, '', restoredUrl );
+					return;
+				}
+			}
+
 			resetStore();
 
 			const newParams = new URLSearchParams( window.location.search );

--- a/pages/video-editor/components/editor-shell/ConfigurationPanel.js
+++ b/pages/video-editor/components/editor-shell/ConfigurationPanel.js
@@ -27,9 +27,21 @@ import Layer from '../layers/Layer';
  */
 const ConfigurationPanel = ( { duration } ) => {
 	const dispatch = useDispatch();
-	const currentLayer = useSelector( ( state ) => state.videoReducer.currentLayer );
 
-	if ( ! currentLayer ) {
+	// Resolve the selection against the live layers array rather than trusting
+	// `currentLayer` alone: it can point at a layer that no longer exists (e.g.
+	// after the layer set is re-initialized, or an unsaved layer is dropped),
+	// and the layer editors dereference the layer without guarding. Treating a
+	// stale selection as "nothing selected" keeps every layer type from
+	// crashing the whole editor.
+	const selectedLayer = useSelector( ( state ) => {
+		const current = state.videoReducer.currentLayer;
+		return current
+			? state.videoReducer.layers.find( ( layer ) => layer.id === current.id )
+			: undefined;
+	} );
+
+	if ( ! selectedLayer ) {
 		return (
 			<>
 				<div className="godam-video-editor__config-header">
@@ -46,7 +58,7 @@ const ConfigurationPanel = ( { duration } ) => {
 
 	return (
 		<Layer
-			layer={ currentLayer }
+			layer={ selectedLayer }
 			goBack={ () => dispatch( setCurrentLayer( null ) ) }
 			duration={ duration }
 		/>

--- a/pages/video-editor/components/editor-shell/EditorTopBar.js
+++ b/pages/video-editor/components/editor-shell/EditorTopBar.js
@@ -43,6 +43,25 @@ const EditorTopBar = ( {
 	const previewUrl = `${ homeUrl }?godam_page=video-preview&id=${ attachmentID }`;
 	const analyticsUrl = `${ homeUrl }/wp-admin/admin.php?page=rtgodam_analytics&id=${ attachmentID }`;
 
+	/**
+	 * Leaving the editor via the back button discards any unsaved layer changes,
+	 * so confirm first when there are unsaved changes. Mirrors the native
+	 * `beforeunload` guard in VideoEditor (tab close / reload / browser back) so
+	 * every exit path warns consistently.
+	 */
+	const handleBack = () => {
+		if ( isChanged ) {
+			// eslint-disable-next-line no-alert
+			const leave = window.confirm( __( 'You have unsaved changes. Are you sure you want to leave?', 'godam' ) );
+
+			if ( ! leave ) {
+				return;
+			}
+		}
+
+		onBack();
+	};
+
 	return (
 		<div className="godam-video-editor__topbar">
 			<Flex justify="flex-start" align="center" gap={ 2 } expanded={ false }>
@@ -50,7 +69,8 @@ const EditorTopBar = ( {
 					<Button
 						icon={ arrowLeft }
 						label={ __( 'Back to media library', 'godam' ) }
-						onClick={ onBack }
+						onClick={ handleBack }
+						data-test-id="godam-video-editor-button-back"
 					/>
 				</FlexItem>
 				<FlexItem>

--- a/pages/video-editor/components/editor-shell/EditorTopBar.js
+++ b/pages/video-editor/components/editor-shell/EditorTopBar.js
@@ -45,9 +45,10 @@ const EditorTopBar = ( {
 
 	/**
 	 * Leaving the editor via the back button discards any unsaved layer changes,
-	 * so confirm first when there are unsaved changes. Mirrors the native
-	 * `beforeunload` guard in VideoEditor (tab close / reload / browser back) so
-	 * every exit path warns consistently.
+	 * so confirm first when there are unsaved changes. Complements the other two
+	 * guards: the native `beforeunload` in VideoEditor (tab close / reload /
+	 * cross-page navigation) and the `popstate` confirm in App.js (browser
+	 * back/forward within the editor), so every exit path warns consistently.
 	 */
 	const handleBack = () => {
 		if ( isChanged ) {

--- a/pages/whats-new/components/Features.js
+++ b/pages/whats-new/components/Features.js
@@ -13,7 +13,9 @@ const Features = ( { releaseData } ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ activeFeatureId, setActiveFeatureId ] = useState( null );
 
-	const version = releaseData.version ? releaseData.version : window.headerData?.version;
+	// Banner badge shows the INSTALLED plugin version (localized as headerData),
+	// not the release feed's newest entry; the feed version is only a fallback.
+	const version = window.headerData?.version || releaseData.version;
 	const primaryUpdates = releaseData.features ? releaseData.features.slice( 0, 3 ) : [];
 	const otherUpdates = releaseData.features ? releaseData.features.slice( 3 ) : [];
 

--- a/pages/whats-new/components/Header.js
+++ b/pages/whats-new/components/Header.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import GoDAMIcon from '../../../assets/src/images/godam-icon.svg';
+import GoDAMIcon from '../../../assets/src/images/godam-logo-gradient.svg';
 import BannerImage from '../images/banner.webp';
 
 const Header = ( { version } ) => {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.13.0
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -219,6 +219,18 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 
 == Changelog ==
 
+= v2.0.0 (July 2, 2026) =
+
+- Feat: GoDAM 2.0 brings a complete visual redesign across the admin and front end, with refreshed branding, new logos, and updated block icons.
+- Feat: Rebuilt the Video Editor with a streamlined layout for managing layers, hotspots, CTAs, and forms.
+- Feat: Added a guided onboarding experience, embedded in the plugin and integrated with GoDAM Central.
+- Feat: Redesigned the analytics dashboard with a cleaner layout, a Layer Timeline range control, and Top Videos improvements.
+- Feat: Redesigned the Video Player, Video Gallery, Audio, and Document blocks.
+- Tweak: The admin UI now follows the WordPress admin colour scheme, and the front end follows the configured brand colour.
+- Tweak: The Video Layer editor now warns before leaving with unsaved changes.
+- Tweak: The WooCommerce integration toggle is disabled when no valid API key is present, as it is a Pro feature.
+- Fix: Various QA fixes across blocks, the video editor, and the media gallery.
+
 = v1.13.0 (June 18, 2026) =
 
 - Feat: Track GoDAM media usage across post content, blocks, shortcodes, Elementor, block widgets, and featured images — recording where each asset is used and notifying GoDAM Central.
@@ -238,10 +250,6 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 = v1.12.1 (June 12, 2026) =
 
 - Fix: Resolved security issues.
-
-= v1.12.0 (June 11, 2026) =
-
-- Feat: Added Layer Analytics feature to track how viewers interact with video layers (CTAs, hotspots, forms, and more), with per-layer engagement and conversion metrics in the analytics dashboard.
 
 [CHECK THE FULL CHANGELOG](https://github.com/rtCamp/godam/blob/main/CHANGELOG.md)
 


### PR DESCRIPTION
## Summary

Prepares the **GoDAM 2.0.0** release: three QA fixes + version bump, plus adversarial-review follow-ups.

## QA fixes

- **Video Layer editor: confirm on exit with unsaved changes.** The in-app Back button **and** browser Back/forward (popstate) now both confirm before discarding unsaved layer changes; tab-close/reload was already covered by the existing `beforeunload` guard. (`EditorTopBar.js`, `App.js`)
- **WooCommerce integration toggle: gated on a valid API key.** With no valid key the toggle renders **off and disabled**, so a Pro feature never reads as active without entitlement. (`IntegrationToggle.jsx`)
- **Onboarding: create-workspace link goes to the plans page.** The "Create one in the GoDAM app" link on the no-workspaces screen pointed at the app root; it now opens the plans page (`{appOrigin}/web/billing?tab=Plans`, the same path the upgrade flow uses). (`pages/onboarding/components/screens/WorkspaceScreen.jsx`)
- **Video editor: no crash when the selected layer is gone.** `ConfigurationPanel` rendered `<Layer>` whenever `currentLayer` was truthy without checking it still exists in `layers`; a stranded selection (e.g. `initializeStore` re-running on an attachment refetch without reconciling `currentLayer`, or an unsaved layer being dropped) made the layer editors deref a missing layer (`CTALayer` `layer.id`, `PollLayer` `layer.poll_id`) and white-screen the editor. It now resolves the selection against the live `layers` and degrades to the empty state. (`pages/video-editor/components/editor-shell/ConfigurationPanel.js`)
- **What's New banner: brand mark + installed version.** The banner rendered `godam-icon.svg` (the old horizontal-bars mark); it now uses `godam-logo-gradient.svg`, the diagonal paper-plane brand mark the video-grid badge already uses. The version badge next to it now shows the installed plugin version (`RTGODAM_VERSION` via `headerData`) instead of the release feed's newest entry, with the feed version as fallback. (`pages/whats-new/components/Header.js`, `Features.js`)

## Version bump (2.0.0)

- `godam.php` Version + `RTGODAM_VERSION`; `readme.txt` + `README.md` stable tag; `package.json` + `package-lock.json`; v2.0.0 changelog (July 2, 2026) in `readme.txt` + `CHANGELOG.md`; oldest `readme.txt` entry (v1.12.0) dropped. No `@since n.e.x.t` present.

## Verification

- PHPCS + ESLint clean (pre-commit hooks).
- Chrome (godam-dev.local): in-app **Back** confirmation fires on unsaved changes; integration toggle **disabled + "Pro feature"** in the no-key state; What's New banner shows the diagonal brand mark and the installed version (v2.0.0).
- Video-editor layer crash: reproduced the exact `TypeError: Cannot read properties of undefined (reading 'id')` in CTALayer by stranding `currentLayer` on a layer absent from `layers`, then confirmed the fix degrades to "No layers selected" with no console error, while normal layer selection still renders the editor (Chrome, godam-dev.local).
- Onboarding create-workspace link: rebuilt bundle verified to carry the plans URL (the no-workspaces state needs an account without workspaces, so it was not re-rendered live).
- Browser Back/forward (popstate) guard: verified by code review + successful build (uses the same `window.confirm` path as the live-verified in-app confirm).

## Adversarial review

Ran a multi-agent adversarial review (find, then refute). Addressed: the popstate exit gap (fixed here), and the toggle "stuck on when key lapses" concern (now renders off + disabled). Noted for later: `window.confirm` will need `page.on('dialog', d => d.accept())` in any future e2e that clicks Back mid-edit (no such tests today).

## Automation impact

- The Back button shows a native confirmation on unsaved changes; e2e that clicks Back mid-edit must accept the dialog.
- Added `data-test-id="godam-video-editor-button-back"` on the back button.
- The What's New banner `img` src changed from `godam-icon.svg` to `godam-logo-gradient.svg`; update any selector asserting on the old filename.

## Screenshots
<img width="274" height="134" alt="Screenshot 2026-07-02 at 11 43 49 AM" src="https://github.com/user-attachments/assets/88c4383a-e719-475b-a044-53673cd810fe" />
<img width="493" height="326" alt="Screenshot 2026-07-02 at 11 42 57 AM" src="https://github.com/user-attachments/assets/37aae71d-5a13-4c8b-8bd4-0de4beaa34ef" />
<img width="1244" height="850" alt="Screenshot 2026-07-02 at 11 41 10 AM" src="https://github.com/user-attachments/assets/0fcf9245-60a2-4261-9693-bbed016b07b4" />
<img width="1233" height="812" alt="Screenshot 2026-07-02 at 11 40 57 AM" src="https://github.com/user-attachments/assets/458e89ad-84af-4139-b3a9-4b53dc8c2882" />

<img width="472" height="173" alt="Screenshot 2026-07-02 at 12 52 13 PM" src="https://github.com/user-attachments/assets/e41fee6b-3883-4003-8015-e2abd4ca9399" />



