### PR TITLE
Fix the demo video MPD source mapping

### DIFF
--- a/inc/classes/class-demo-assets.php
+++ b/inc/classes/class-demo-assets.php
@@ -191,6 +191,7 @@ class Demo_Assets {
 	 */
 	private static function create_from_payload( $key, $file_name, $payload ) {
 		$mp4 = ! empty( $payload['transcoded_mp4_url'] ) ? $payload['transcoded_mp4_url'] : '';
+		$mpd = ! empty( $payload['transcoded_file_path'] ) ? $payload['transcoded_file_path'] : '';
 		$hls = ! empty( $payload['transcoded_hls_path'] ) ? $payload['transcoded_hls_path'] : '';
 
 		$data = array(
@@ -199,7 +200,7 @@ class Demo_Assets {
 			'url'      => $mp4 ? $mp4 : $hls,
 			'mime'     => 'video/mp4',
 			'type'     => 'video',
-			'mpd_url'  => $mp4,
+			'mpd_url'  => $mpd,
 			'hls_url'  => $hls,
 			'icon'     => ! empty( $payload['thumbnail_url'] ) ? $payload['thumbnail_url'] : '',
 			'filename' => ! empty( $payload['orignal_file_name'] ) ? $payload['orignal_file_name'] : ( $file_name . '.mp4' ),


### PR DESCRIPTION
This pull request makes a small but important correction to how demo video asset URLs are handled in the `class-demo-assets.php` file. The change ensures that the correct MPD (MPEG-DASH) URL is used for demo video assets, improving the accuracy of asset metadata.

- Corrected the assignment of the `mpd_url` field in the asset data array to use the `transcoded_file_path` from the payload, rather than incorrectly using the MP4 URL. [[1]](diffhunk://#diff-4a06d33c38ee5fbe292d182a8f02ef33a3c25d4fd910b49f5a56e32738f084d3R194) [[2]](diffhunk://#diff-4a06d33c38ee5fbe292d182a8f02ef33a3c25d4fd910b49f5a56e32738f084d3L202-R203)

## Demo

https://github.com/user-attachments/assets/535ab6b1-496a-46f1-8a35-77e6ea484cdb

