### PR TITLE
Fix old to new video editor layers issues.

### DIFF
--- a/pages/video-editor/App.js
+++ b/pages/video-editor/App.js
@@ -149,16 +149,22 @@ const App = () => {
 		return () => window.removeEventListener( 'popstate', handlePopState );
 	}, [ resetStore ] );
 
-	const handleAttachmentClick = ( id ) => {
+	const handleAttachmentClick = useCallback( ( id ) => {
 		resetStore();
 		setAttachmentID( id );
 		setRawID( id );
 		const newUrl = new URL( window.location );
 		newUrl.searchParams.set( 'id', id );
 		window.history.pushState( {}, '', newUrl );
-	};
+	}, [ resetStore ] );
 
-	const handleBackToAttachmentPicker = () => {
+	// Memoized so its reference is stable across App re-renders. App re-renders
+	// whenever `isChanged` toggles (see the useSelector above), and this callback
+	// is forwarded to <VideoEditor> where it sits in the dependency array of the
+	// effect that calls `initializeStore`. An unstable reference made that effect
+	// re-run on every edit, re-initializing the store from the saved meta and
+	// silently reverting the user's add/update/delete of layers.
+	const handleBackToAttachmentPicker = useCallback( () => {
 		// Leaving the editor mid-tour would strip the editor-specific coachmark
 		// targets, so end the guide cleanly.
 		if ( isGuideActive() ) {
@@ -170,7 +176,7 @@ const App = () => {
 		const newUrl = new URL( window.location );
 		newUrl.searchParams.delete( 'id' );
 		window.history.replaceState( {}, '', newUrl );
-	};
+	}, [ resetStore ] );
 
 	return (
 		<>


### PR DESCRIPTION
This pull request improves the stability and correctness of callback references in the `App` component of the video editor. By memoizing key callback functions with `useCallback`, it prevents unnecessary effect re-runs and unintended state resets during editing, especially when navigating back from the video editor.

**Callback memoization and stability:**

* Updated `handleAttachmentClick` to use `useCallback`, ensuring its reference is stable across re-renders and preventing unnecessary resets of the editor state.
* Memoized `handleBackToAttachmentPicker` with `useCallback`, accompanied by a detailed comment explaining how this prevents unwanted store re-initialization and preserves user edits when toggling between editor and attachment picker. [[1]](diffhunk://#diff-459223d7f6a78beab22f88597ca4eeedf70d1fdc9b40868c0eac482fb3be0a8eL152-R167) [[2]](diffhunk://#diff-459223d7f6a78beab22f88597ca4eeedf70d1fdc9b40868c0eac482fb3be0a8eL173-R179)

https://github.com/user-attachments/assets/847aa579-60aa-4b32-bc74-9a7a04e94c34


