### PR TITLE
Fix: adversarial review findings — IDOR, audio crash, player/editor bugs

### DIFF
--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -111,21 +111,27 @@ function AudioEdit( {
 			return;
 		}
 
-		// Normalize the description to a string. Library selections expose it as
-		// a plain string, but freshly uploaded files come from the REST API where
-		// `description` is an object ( { raw, rendered } ). Storing the object
-		// would make React throw "Objects are not valid as a React child" when
-		// the description is rendered.
+		// Normalize the description/title/caption to strings. Library selections
+		// expose them as plain strings, but freshly uploaded files come from the
+		// REST API where each is an object ( { raw, rendered } ). Storing the
+		// object would make React throw "Objects are not valid as a React child"
+		// when the value is rendered (and PHP `esc_html()` warns on the frontend).
 		const mediaDescription = typeof media.description === 'string'
 			? media.description
 			: ( media.description?.raw ?? '' );
+		const mediaTitle = typeof media.title === 'string'
+			? media.title
+			: ( media.title?.raw ?? '' );
+		const mediaCaption = typeof media.caption === 'string'
+			? media.caption
+			: ( media.caption?.raw ?? '' );
 
 		setAttributes( {
 			blob: undefined,
 			src: media.url,
 			id: media.id,
-			caption: media.caption || media.title,
-			audioTitle: media.title || '',
+			caption: mediaCaption || mediaTitle,
+			audioTitle: mediaTitle,
 			description: mediaDescription,
 		} );
 		setTemporaryURL();

--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -118,13 +118,13 @@ function AudioEdit( {
 		// when the value is rendered (and PHP `esc_html()` warns on the frontend).
 		const mediaDescription = typeof media.description === 'string'
 			? media.description
-			: ( media.description?.raw ?? '' );
+			: ( media.description?.raw ?? media.description?.rendered ?? '' );
 		const mediaTitle = typeof media.title === 'string'
 			? media.title
-			: ( media.title?.raw ?? '' );
+			: ( media.title?.raw ?? media.title?.rendered ?? '' );
 		const mediaCaption = typeof media.caption === 'string'
 			? media.caption
-			: ( media.caption?.raw ?? '' );
+			: ( media.caption?.raw ?? media.caption?.rendered ?? '' );
 
 		setAttributes( {
 			blob: undefined,

--- a/assets/src/blocks/godam-gallery-v2/edit.js
+++ b/assets/src/blocks/godam-gallery-v2/edit.js
@@ -960,45 +960,31 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 				{ /* ── Interaction ──────────────────────────────────────────── */ }
 				<PanelBody title={ __( 'Interaction', 'godam' ) } initialOpen={ true } data-test-id="godam-gallery-v2-panel-interaction">
-					<div className="godam-gallery-v2__radio-group">
-						{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
-						<label className="godam-gallery-v2__radio-option">
-							<input
-								type="radio"
-								name={ `godam-gallery-interaction-${ clientId }` }
-								value="autoplay"
-								checked={ !! autoplay }
-								onChange={ () =>
-									setAttributes( { autoplay: true, playOnHover: false } )
-								}
-								data-test-id="godam-gallery-v2-control-autoplay"
-							/>
-							<span className="godam-gallery-v2__radio-label">
-								{ __( 'Autoplay all videos', 'godam' ) }
-							</span>
-							<span className="godam-gallery-v2__radio-hint">
-								{ __( 'Visible videos autoplay one at a time and continue through the full video.', 'godam' ) }
-							</span>
-						</label>
-						{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
-						<label className="godam-gallery-v2__radio-option">
-							<input
-								type="radio"
-								name={ `godam-gallery-interaction-${ clientId }` }
-								value="hover"
-								checked={ ! autoplay }
-								onChange={ () =>
-									setAttributes( { autoplay: false, playOnHover: true } )
-								}
-								data-test-id="godam-gallery-v2-control-play-on-hover"
-							/>
-							<span className="godam-gallery-v2__radio-label">
-								{ __( 'Play on hover', 'godam' ) }
-							</span>
-							<span className="godam-gallery-v2__radio-hint">
-								{ __( 'Videos will play when hovered over', 'godam' ) }
-							</span>
-						</label>
+					<div data-test-id="godam-gallery-v2-control-interaction">
+						<RadioControl
+							className="godam-gallery-v2__interaction-radio"
+							label={ __( 'Interaction', 'godam' ) }
+							hideLabelFromVision
+							selected={ autoplay ? 'autoplay' : 'hover' }
+							options={ [
+								{
+									label: __( 'Autoplay all videos', 'godam' ),
+									value: 'autoplay',
+									description: __( 'Visible videos autoplay one at a time and continue through the full video.', 'godam' ),
+								},
+								{
+									label: __( 'Play on hover', 'godam' ),
+									value: 'hover',
+									description: __( 'Videos will play when hovered over', 'godam' ),
+								},
+							] }
+							onChange={ ( value ) =>
+								setAttributes( {
+									autoplay: value === 'autoplay',
+									playOnHover: value === 'hover',
+								} )
+							}
+						/>
 					</div>
 
 					<ToggleControl

--- a/assets/src/blocks/godam-gallery-v2/editor.scss
+++ b/assets/src/blocks/godam-gallery-v2/editor.scss
@@ -126,61 +126,6 @@
 		justify-content: center;
 	}
 
-	// ── Interaction panel custom radio group ──────────────────────────────────
-
-	&__radio-group {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-		margin-bottom: 16px;
-	}
-
-	&__radio-option {
-		display: flex;
-		align-items: flex-start;
-		gap: 10px;
-		padding: 10px 12px;
-		border-radius: 6px;
-		border: 1px solid #e0e0e0;
-		cursor: pointer;
-		transition: border-color 0.15s ease, background 0.15s ease;
-
-		input[type="radio"] {
-			flex: 0 0 auto;
-			margin-top: 2px;
-			cursor: pointer;
-		}
-
-		&:has(input:checked) {
-			border-color: var(--wp-admin-theme-color, #007cba);
-			background: #f0f7fb;
-		}
-
-		&:hover:not(:has(input:checked)) {
-			border-color: #b0b0b0;
-			background: #fafafa;
-		}
-	}
-
-	&__radio-content {
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-	}
-
-	&__radio-label {
-		font-size: 13px;
-		font-weight: 500;
-		color: var(--wp-components-color-foreground, #1e1e1e);
-		line-height: 1.4;
-	}
-
-	&__radio-hint {
-		font-size: 11px;
-		color: var(--wp-components-color-foreground-muted, #757575);
-		line-height: 1.4;
-	}
-
 	// ── Empty state (handpicked, no videos selected) ──────────────────────────
 
 	&__empty-state {
@@ -296,6 +241,10 @@
 
 .godam-gallery-v2__date-range-picker {
 	margin: 10px 0;
+}
+
+.godam-gallery-v2__interaction-radio {
+	margin-bottom: 1rem;
 }
 
 .godam-gallery-v2__query-row {

--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -461,13 +461,21 @@ export default class GodamVideoPlayer {
 			return;
 		}
 
+		// Auto-enable at most once. After the first track is turned on (or one is
+		// already showing), a viewer who turns captions back off must be respected
+		// even when a late-loading track (the async AI transcript) fires `addtrack`.
+		let hasAutoEnabled = false;
 		const enableFirstSubtitle = () => {
+			if ( hasAutoEnabled ) {
+				return;
+			}
 			const subtitleTracks = [];
 			for ( let i = 0; i < textTracks.length; i++ ) {
 				const track = textTracks[ i ];
 				if ( track.kind === 'subtitles' || track.kind === 'captions' ) {
 					// A subtitle track is already active — respect the viewer's choice.
 					if ( track.mode === 'showing' ) {
+						hasAutoEnabled = true;
 						return;
 					}
 					subtitleTracks.push( track );
@@ -475,11 +483,14 @@ export default class GodamVideoPlayer {
 			}
 			if ( subtitleTracks.length > 0 ) {
 				subtitleTracks[ 0 ].mode = 'showing';
+				hasAutoEnabled = true;
 			}
 		};
 
 		enableFirstSubtitle();
 		textTracks.addEventListener( 'addtrack', enableFirstSubtitle );
+		// Avoid leaking the listener on SPA / infinite-scroll teardowns.
+		this.player.one( 'dispose', () => textTracks.removeEventListener( 'addtrack', enableFirstSubtitle ) );
 	}
 
 	/**

--- a/inc/classes/rest-api/class-video-editor.php
+++ b/inc/classes/rest-api/class-video-editor.php
@@ -218,7 +218,12 @@ class Video_Editor extends Base {
 		// Not on this page — prepare it directly if it's a valid video attachment.
 		if ( null === $pinned ) {
 			$post = get_post( $prioritize_id );
-			if ( $post && 'attachment' === $post->post_type && 0 === strpos( (string) get_post_mime_type( $post ), 'video/' ) ) {
+			// Enforce the same author scoping as the list query: users who can't
+			// edit others' content may only surface their own uploads, otherwise
+			// this becomes an IDOR that leaks other users' private video metadata.
+			$owned = $post
+				&& ( current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $post->post_author );
+			if ( $owned && 'attachment' === $post->post_type && 0 === strpos( (string) get_post_mime_type( $post ), 'video/' ) ) {
 				$pinned = $this->prepare_video_item( $post );
 			}
 		}

--- a/inc/classes/rest-api/class-video-editor.php
+++ b/inc/classes/rest-api/class-video-editor.php
@@ -221,8 +221,7 @@ class Video_Editor extends Base {
 			// Enforce the same author scoping as the list query: users who can't
 			// edit others' content may only surface their own uploads, otherwise
 			// this becomes an IDOR that leaks other users' private video metadata.
-			$owned = $post
-				&& ( current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $post->post_author );
+			$owned = $post && ( current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $post->post_author || 1 === (int) get_post_meta( $post->ID, 'rtgodam_is_demo_attachment', true ) );
 			if ( $owned && 'attachment' === $post->post_type && 0 === strpos( (string) get_post_mime_type( $post ), 'video/' ) ) {
 				$pinned = $this->prepare_video_item( $post );
 			}

--- a/pages/onboarding/utils/use-google-signin.js
+++ b/pages/onboarding/utils/use-google-signin.js
@@ -71,12 +71,15 @@ export const useGoogleSignIn = () => {
 
 		let settled = false;
 		let poll = null;
+		// Tear down listeners/timers only. Loading state is cleared explicitly by
+		// each terminal path — critically, the success path keeps `isLoading` true
+		// across the code exchange so the button can't be re-clicked mid-flow and
+		// start a duplicate OAuth popup.
 		const cleanup = () => {
 			window.removeEventListener( 'message', onMessage );
 			if ( poll ) {
 				clearInterval( poll );
 			}
-			setIsLoading( false );
 		};
 		const fail = ( message ) => {
 			if ( settled ) {
@@ -84,6 +87,7 @@ export const useGoogleSignIn = () => {
 			}
 			settled = true;
 			cleanup();
+			setIsLoading( false );
 			if ( ! popup.closed ) {
 				popup.close();
 			}
@@ -108,6 +112,8 @@ export const useGoogleSignIn = () => {
 				await proceedToWorkspace( session );
 			} catch ( error ) {
 				dispatch( setNotice( { status: 'error', message: error?.data?.message || __( 'Google sign-in failed.', 'godam' ) } ) );
+			} finally {
+				setIsLoading( false );
 			}
 		}
 

--- a/pages/video-editor/components/cta/CardCTA.js
+++ b/pages/video-editor/components/cta/CardCTA.js
@@ -288,14 +288,18 @@ const CardCTA = ( { layerID, triggerSlot } ) => {
 	};
 
 	// prevent color picker flickering.
-	const colorDebounceRef = useRef();
+	// Timers are keyed per-field so editing two colors (text + background)
+	// within the debounce window doesn't make the second edit's clearTimeout
+	// cancel the first, silently dropping one color update.
+	const colorDebounceRef = useRef( {} );
 	const debouncedColorUpdate = useCallback(
 		( field, value ) => {
-			if ( colorDebounceRef.current ) {
-				clearTimeout( colorDebounceRef.current );
+			if ( colorDebounceRef.current[ field ] ) {
+				clearTimeout( colorDebounceRef.current[ field ] );
 			}
-			colorDebounceRef.current = setTimeout( () => {
+			colorDebounceRef.current[ field ] = setTimeout( () => {
 				dispatch( updateLayerField( { id: layerID, field, value } ) );
+				delete colorDebounceRef.current[ field ];
 			}, 150 );
 		},
 		[ dispatch, layerID ],


### PR DESCRIPTION
Scope prioritize_id to the current user (IDOR); normalize audio title/caption to strings (upload crash); fix Google sign-in double-popup; auto-enable subtitles once + remove listener on dispose; per-field CardCTA color debounce.

This pull request introduces several improvements and bug fixes across the codebase, focusing on data normalization, security, event handling, UI responsiveness, and code robustness. The most important changes are grouped below by theme:

**Data Normalization and Handling:**

* Normalized `description`, `title`, and `caption` fields to always be strings in `AudioEdit` to prevent React errors and frontend warnings when handling media objects from the REST API.

**Security and Access Control:**

* Tightened access control in the video editor REST API (`class-video-editor.php`) to ensure that users without the `edit_others_posts` capability can only surface their own uploads, preventing IDOR vulnerabilities that could leak private video metadata.

**Event Handling and Resource Management:**

* Improved subtitle auto-enabling logic in `GodamVideoPlayer` to ensure it only auto-enables once per session and properly cleans up event listeners to prevent memory leaks during SPA/infinite-scroll teardowns.

**UI Responsiveness and State Management:**

* Refined loading state handling in the Google sign-in flow to ensure the loading indicator (`isLoading`) remains accurate, preventing duplicate OAuth popups and ensuring proper cleanup on both success and failure. [[1]](diffhunk://#diff-661bfd2489492ab0561354dc4af6c0a39dc9b78dd3a36abc50ef376994ebafafR74-R90) [[2]](diffhunk://#diff-661bfd2489492ab0561354dc4af6c0a39dc9b78dd3a36abc50ef376994ebafafR115-R116)

**Debounce Logic Robustness:**

* Updated color picker debounce logic in `CardCTA` to use per-field timers, preventing one field's timer from interfering with another and ensuring reliable color updates when editing multiple fields in quick succession.