### PR TITLE
feat(video-editor): inline title editing + attachment metadata popup

### DIFF
--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -689,6 +689,12 @@ class Pages {
 			wp_set_script_translations( 'transcoder-page-script-video-editor', 'godam', RTGODAM_PATH . 'languages' );
 			wp_enqueue_script( 'transcoder-page-script-video-editor' );
 
+			// The "Edit metadata" action reuses the native two-column attachment
+			// details modal (wp.media.view.MediaFrame.EditAttachments), which is
+			// defined in core's media-grid script. wp_enqueue_media() does not
+			// pull it in, so enqueue it explicitly on the video editor screen.
+			wp_enqueue_script( 'media-grid' );
+
 			/**
 			 * Fires after the video editor scripts are enqueued.
 			 * Add-ons can use this to enqueue their own scripts on the video editor page.

--- a/pages/onboarding/components/screens/EntryScreen.jsx
+++ b/pages/onboarding/components/screens/EntryScreen.jsx
@@ -31,7 +31,7 @@ const EntryScreen = () => {
 		<>
 			<BrandLogo markOnly />
 			<h1 className="godam-onboarding__title godam-onboarding__title--lg">
-				{ isWoo ? __( "You've Unlocked Woo-Specific GoDAM", 'godam' ) : __( 'Welcome to GoDAM Pro!', 'godam' ) }
+				{ isWoo ? __( 'You have unlocked GoDAM for Woo', 'godam' ) : __( 'Welcome to GoDAM Pro!', 'godam' ) }
 			</h1>
 			<p className="godam-onboarding__subtitle">
 				{ isWoo

--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -45,9 +45,29 @@ import Transcription from './components/transcription/Transcription';
 import { formatBytes } from './components/transcription/utils';
 import Timeline from './components/timeline/Timeline';
 import { copyGoDAMVideoBlock, prefetchMediaDataForCopy } from './utils/index';
+import { openAttachmentDetailsModal } from './utils/openAttachmentDetails';
 import { getFormIdFromLayer } from './utils/formUtils';
 import { canManageAttachment } from '../../assets/src/js/media-library/utility.js';
 import { ensureAddonLayersRegistered } from './utils/loadAddonLayers';
+
+/**
+ * Decode HTML entities in a string (e.g. `&amp;` → `&`).
+ *
+ * The REST API returns the attachment title as `title.rendered`, which is
+ * entity-encoded. We decode it so the editable input shows the human-readable
+ * title rather than raw entities.
+ *
+ * @param {string} str Possibly entity-encoded string.
+ * @return {string} Decoded string.
+ */
+const decodeHtmlEntities = ( str ) => {
+	if ( ! str ) {
+		return '';
+	}
+	const textarea = document.createElement( 'textarea' );
+	textarea.innerHTML = str;
+	return textarea.value;
+};
 
 const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 	const [ currentTime, setCurrentTime ] = useState( 0 );
@@ -57,6 +77,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 	const [ snackbarMessage, setSnackbarMessage ] = useState( '' );
 	const [ showSnackbar, setShowSnackbar ] = useState( false );
 	const [ aspectRatio, setAspectRatio ] = useState( '16:9' );
+	const [ videoTitle, setVideoTitle ] = useState( '' );
 
 	// Pre-fetch data on mount to ensure copy always works
 	useEffect( () => {
@@ -81,6 +102,9 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 
 	const { data: attachmentConfig, isLoading: isAttachmentConfigLoading } = useGetAttachmentMetaQuery( attachmentID );
 	const [ saveAttachmentMeta, { isLoading: isSavingMeta } ] = useSaveAttachmentMetaMutation();
+	// A separate mutation instance so saving the title doesn't flip the
+	// "Save Video" button into its busy state.
+	const [ saveTitle ] = useSaveAttachmentMetaMutation();
 
 	const { gravityForms, wpForms, cf7Forms, sureforms, forminatorForms, fluentForms, everestForms, ninjaForms, metforms, isFetching } = useFetchForms();
 
@@ -178,6 +202,18 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 
 		setSources( videoSources );
 	}, [ attachmentConfig, dispatch, onBackToAttachmentPicker ] );
+
+	// Seed the editable title from the fetched attachment. `title.raw` is only
+	// present in edit context; otherwise decode the entity-encoded rendered
+	// title so the input shows plain text.
+	useEffect( () => {
+		if ( ! attachmentConfig ) {
+			return;
+		}
+		const rawTitle = attachmentConfig?.title?.raw;
+		const renderedTitle = attachmentConfig?.title?.rendered ?? attachmentConfig?.title;
+		setVideoTitle( rawTitle ?? decodeHtmlEntities( renderedTitle ) );
+	}, [ attachmentConfig ] );
 
 	/**
 	 * Update the store with the fetched forms.
@@ -403,6 +439,56 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 		setShowSnackbar( false );
 	};
 
+	// Opens the same attachment-details popup used in the media library, so
+	// core metadata (title, alt text, caption, description) can be edited
+	// without leaving the editor. Title edits made in the popup are mirrored
+	// back to the editor's top bar so the two stay in sync.
+	const handleEditMetadata = () => {
+		openAttachmentDetailsModal( attachmentID, {
+			onChange: ( attributes ) => {
+				const nextTitle = attributes?.title;
+				if ( typeof nextTitle === 'string' ) {
+					setVideoTitle( decodeHtmlEntities( nextTitle ) );
+				}
+			},
+		} );
+	};
+
+	// Label the "Edit metadata" action by the attachment's media type. In the
+	// video editor this is always a video, but derive it generically so the
+	// wording stays correct if other media types are ever edited here.
+	const getEditMetadataLabel = () => {
+		const mimeGroup = ( attachmentConfig?.mime_type || '' ).split( '/' )[ 0 ];
+
+		switch ( mimeGroup ) {
+			case 'video':
+				return __( 'Edit video metadata', 'godam' );
+			case 'image':
+				return __( 'Edit image metadata', 'godam' );
+			case 'audio':
+				return __( 'Edit audio metadata', 'godam' );
+			default:
+				return __( 'Edit metadata', 'godam' );
+		}
+	};
+
+	// Persist an edited video title to the attachment. Updates the display
+	// optimistically and reverts if the request fails.
+	const handleSaveTitle = async ( newTitle ) => {
+		const previousTitle = videoTitle;
+		setVideoTitle( newTitle );
+
+		try {
+			await saveTitle( { id: attachmentID, data: { title: newTitle } } ).unwrap();
+			setSnackbarMessage( __( 'Video title updated', 'godam' ) );
+			setShowSnackbar( true );
+		} catch ( error ) {
+			setVideoTitle( previousTitle );
+			setSnackbarMessage( __( 'Failed to update video title', 'godam' ) );
+			setShowSnackbar( true );
+		}
+	};
+
 	// Switch the active section and reflect it in the URL so a refresh or
 	// bookmark preserves the user's place. `replaceState` is used so each tab
 	// switch doesn't push a new browser-history entry.
@@ -417,15 +503,12 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 		return <EditorSkeleton />;
 	}
 
-	const videoTitle =
-		attachmentConfig?.title?.rendered ||
-		attachmentConfig?.title ||
-		__( 'Untitled video', 'godam' );
+	const displayTitle = videoTitle || __( 'Untitled video', 'godam' );
 
 	return (
 		<div className="godam-video-editor">
 			<EditorTopBar
-				title={ videoTitle }
+				title={ displayTitle }
 				layerCount={ layers.length }
 				attachmentID={ attachmentID }
 				isChanged={ isChanged }
@@ -433,6 +516,9 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 				onBack={ onBackToAttachmentPicker }
 				onSave={ handleSaveAttachmentMeta }
 				onCopy={ handleCopyGoDAMVideoBlock }
+				onEditMetadata={ handleEditMetadata }
+				editMetadataLabel={ getEditMetadataLabel() }
+				onSaveTitle={ handleSaveTitle }
 			/>
 
 			<EditorStatsRow attachmentID={ attachmentID } />

--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -90,6 +90,8 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 	}, [] );
 
 	const playerRef = useRef( null );
+	// Teardown for the "Edit metadata" popup's title-sync listener; called on unmount.
+	const detachTitleSyncRef = useRef( null );
 
 	const dispatch = useDispatch();
 
@@ -444,7 +446,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 	// without leaving the editor. Title edits made in the popup are mirrored
 	// back to the editor's top bar so the two stay in sync.
 	const handleEditMetadata = () => {
-		openAttachmentDetailsModal( attachmentID, {
+		const teardown = openAttachmentDetailsModal( attachmentID, {
 			onChange: ( attributes ) => {
 				const nextTitle = attributes?.title;
 				if ( typeof nextTitle === 'string' ) {
@@ -452,7 +454,18 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 				}
 			},
 		} );
+		detachTitleSyncRef.current = typeof teardown === 'function' ? teardown : null;
 	};
+
+	// The wp.media attachment model is cached globally and outlives this
+	// component, so unbind the popup's title-sync listener on unmount to avoid
+	// retaining a stale reference to this instance's setVideoTitle.
+	useEffect( () => {
+		return () => {
+			detachTitleSyncRef.current?.();
+			detachTitleSyncRef.current = null;
+		};
+	}, [] );
 
 	// Label the "Edit metadata" action by the attachment's media type. In the
 	// video editor this is always a video, but derive it generically so the

--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -480,6 +480,20 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 
 		try {
 			await saveTitle( { id: attachmentID, data: { title: newTitle } } ).unwrap();
+
+			// Keep the wp.media Backbone model — the data layer the "Edit
+			// metadata" popup reads — in sync so the two don't drift.
+			//
+			// We deliberately do NOT invalidate/refetch the getAttachmentMeta
+			// RTK query: that same query seeds the layer store via the init
+			// effect, so a refetch would re-run initializeStore() and discard
+			// unsaved layer edits (and reload the video). The title display is
+			// driven by local `videoTitle` state, which we already updated.
+			const attachmentModel = window.wp?.media?.attachment?.( attachmentID );
+			if ( attachmentModel && attachmentModel.get( 'title' ) !== newTitle ) {
+				attachmentModel.set( 'title', newTitle );
+			}
+
 			setSnackbarMessage( __( 'Video title updated', 'godam' ) );
 			setShowSnackbar( true );
 		} catch ( error ) {

--- a/pages/video-editor/_editor-shell.scss
+++ b/pages/video-editor/_editor-shell.scss
@@ -48,6 +48,66 @@ $ve-faint: color-mix(in srgb, currentcolor 5%, transparent);
 		line-height: 1.4;
 	}
 
+	// Click-to-edit affordance: the title text is a bare button that reveals a
+	// subtle hover background so it reads as editable.
+	&__title-button {
+		display: block;
+		max-width: 32ch;
+		margin: 0;
+		padding: 0.125rem 0.375rem;
+		overflow: hidden;
+		font: inherit;
+		color: inherit;
+		font-size: 1rem;
+		font-weight: 600;
+		text-align: left;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		background: transparent;
+		border: 1px solid transparent;
+		border-radius: 4px;
+		line-height: 1;
+		cursor: text;
+
+		&:hover {
+			background: $ve-faint;
+		}
+
+		&:focus-visible {
+			outline: none;
+			border-color: $ve-accent;
+			box-shadow: 0 0 0 1px $ve-accent;
+		}
+	}
+
+	// Inline title editor. Nested under the topbar so the two-class specificity
+	// (0,2,0) beats wp-admin's global `input[type="text"]` rules (0,1,1), which
+	// otherwise force a 40px min-height and shift the layout on focus. Its box
+	// (line-height, padding and 1px border) mirrors the display button exactly,
+	// so switching between view and edit modes never changes the row height.
+	&__topbar &__title-input {
+		box-sizing: border-box;
+		width: 100%;
+		max-width: 32ch;
+		min-width: 16ch;
+		min-height: 0;
+		margin: 0;
+		padding: 0.125rem 0.375rem;
+		font-family: inherit;
+		font-size: 1rem;
+		font-weight: 600;
+		line-height: 1.4;
+		color: inherit;
+		background: var(--wp-components-color-background, #fff);
+		border: 1px solid $ve-accent;
+		border-radius: 4px;
+
+		&:focus {
+			outline: none;
+			box-shadow: 0 0 0 1px $ve-accent;
+		}
+	}
+
 	&__subtitle {
 		margin: 0;
 		font-size: 0.75rem;

--- a/pages/video-editor/components/editor-shell/EditorTopBar.js
+++ b/pages/video-editor/components/editor-shell/EditorTopBar.js
@@ -136,6 +136,7 @@ const EditorTopBar = ( {
 	onSaveTitle,
 } ) => {
 	const homeUrl = window?.godamRestRoute?.homeUrl || '';
+	const hasValidApiKey = Boolean( window?.userData?.validApiKey );
 	const previewUrl = `${ homeUrl }?godam_page=video-preview&id=${ attachmentID }`;
 	const analyticsUrl = `${ homeUrl }/wp-admin/admin.php?page=rtgodam_analytics&id=${ attachmentID }`;
 
@@ -249,14 +250,16 @@ const EditorTopBar = ( {
 					>
 						{ ( { onClose } ) => (
 							<MenuGroup>
-								<MenuItem
-									icon={ chartBar }
-									href={ analyticsUrl }
-									target="_blank"
-									data-test-id="godam-video-editor-button-analytics"
-								>
-									{ __( 'Analytics', 'godam' ) }
-								</MenuItem>
+								{ hasValidApiKey && (
+									<MenuItem
+										icon={ chartBar }
+										href={ analyticsUrl }
+										target="_blank"
+										data-test-id="godam-video-editor-button-analytics"
+									>
+										{ __( 'Analytics', 'godam' ) }
+									</MenuItem>
+								) }
 								<MenuItem
 									icon={ pencil }
 									onClick={ () => {

--- a/pages/video-editor/components/editor-shell/EditorTopBar.js
+++ b/pages/video-editor/components/editor-shell/EditorTopBar.js
@@ -28,6 +28,12 @@ const EditableTitle = ( { title, onSave } ) => {
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ draft, setDraft ] = useState( title );
 	const inputRef = useRef( null );
+	const buttonRef = useRef( null );
+	// `editingRef` guards commit/cancel against a double-invocation (the input's
+	// blur can fire as it unmounts right after Enter). `refocusRef` records
+	// whether focus should return to the trigger button once edit mode ends.
+	const editingRef = useRef( false );
+	const refocusRef = useRef( false );
 
 	// Keep the draft aligned with upstream title changes while not editing
 	// (e.g. after a successful save or an external refresh).
@@ -37,16 +43,32 @@ const EditableTitle = ( { title, onSave } ) => {
 		}
 	}, [ title, isEditing ] );
 
-	// Focus and select the field when entering edit mode.
+	// Move focus with the mode change: to the field when editing starts, and
+	// back to the trigger button when it ends — otherwise blur/Enter/Escape
+	// leaves focus on <body> and breaks keyboard flow.
 	useEffect( () => {
-		if ( isEditing && inputRef.current ) {
-			inputRef.current.focus();
-			inputRef.current.select();
+		if ( isEditing ) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		} else if ( refocusRef.current ) {
+			refocusRef.current = false;
+			buttonRef.current?.focus();
 		}
 	}, [ isEditing ] );
 
-	const commit = () => {
+	const startEditing = () => {
+		editingRef.current = true;
+		setIsEditing( true );
+	};
+
+	const commit = ( refocus ) => {
+		if ( ! editingRef.current ) {
+			return;
+		}
+		editingRef.current = false;
+		refocusRef.current = refocus;
 		setIsEditing( false );
+
 		const trimmed = draft.trim();
 		if ( trimmed && trimmed !== title ) {
 			onSave( trimmed );
@@ -56,6 +78,11 @@ const EditableTitle = ( { title, onSave } ) => {
 	};
 
 	const cancel = () => {
+		if ( ! editingRef.current ) {
+			return;
+		}
+		editingRef.current = false;
+		refocusRef.current = true;
 		setDraft( title );
 		setIsEditing( false );
 	};
@@ -63,11 +90,18 @@ const EditableTitle = ( { title, onSave } ) => {
 	const handleKeyDown = ( event ) => {
 		if ( event.key === 'Enter' ) {
 			event.preventDefault();
-			commit();
+			commit( true );
 		} else if ( event.key === 'Escape' ) {
 			event.preventDefault();
 			cancel();
 		}
+	};
+
+	// On blur, only pull focus back to the button when it would otherwise fall
+	// to <body>; if the user clicked another control, let focus go there.
+	const handleBlur = ( event ) => {
+		const goingNowhere = ! event.relatedTarget || event.relatedTarget === document.body;
+		commit( goingNowhere );
 	};
 
 	if ( isEditing ) {
@@ -78,7 +112,7 @@ const EditableTitle = ( { title, onSave } ) => {
 				className="godam-video-editor__title-input"
 				value={ draft }
 				onChange={ ( event ) => setDraft( event.target.value ) }
-				onBlur={ commit }
+				onBlur={ handleBlur }
 				onKeyDown={ handleKeyDown }
 				aria-label={ __( 'Video title', 'godam' ) }
 				data-test-id="godam-video-editor-title-input"
@@ -89,9 +123,10 @@ const EditableTitle = ( { title, onSave } ) => {
 	return (
 		<h1 className="godam-video-editor__title">
 			<button
+				ref={ buttonRef }
 				type="button"
 				className="godam-video-editor__title-button"
-				onClick={ () => setIsEditing( true ) }
+				onClick={ startEditing }
 				title={ __( 'Click to edit title', 'godam' ) }
 				data-test-id="godam-video-editor-title"
 			>
@@ -247,6 +282,7 @@ const EditorTopBar = ( {
 					<DropdownMenu
 						icon={ moreVertical }
 						label={ __( 'More options', 'godam' ) }
+						toggleProps={ { 'data-test-id': 'godam-video-editor-button-more-options' } }
 					>
 						{ ( { onClose } ) => (
 							<MenuGroup>

--- a/pages/video-editor/components/editor-shell/EditorTopBar.js
+++ b/pages/video-editor/components/editor-shell/EditorTopBar.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { Button, Flex, FlexItem, DropdownMenu, MenuGroup, MenuItem, Tooltip } from '@wordpress/components';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { arrowLeft, copy, seen, chartBar, moreVertical } from '@wordpress/icons';
+import { arrowLeft, copy, seen, chartBar, moreVertical, pencil } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -11,21 +12,114 @@ import { arrowLeft, copy, seen, chartBar, moreVertical } from '@wordpress/icons'
 import { notify as notifyGuide } from '../../onboarding/productGuide';
 
 /**
+ * Click-to-edit video title.
+ *
+ * Shows the title as a heading; clicking it (or focusing + Enter/Space) swaps in
+ * a text input. Committing on Enter or blur calls `onSave` with the trimmed
+ * value; Escape cancels and restores the original. An unchanged or empty value
+ * is treated as a no-op so we never persist a blank title.
+ *
+ * @param {Object}   props
+ * @param {string}   props.title  Current title to display/edit.
+ * @param {Function} props.onSave Called with the new title when the edit commits.
+ * @return {JSX.Element} The editable title.
+ */
+const EditableTitle = ( { title, onSave } ) => {
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ draft, setDraft ] = useState( title );
+	const inputRef = useRef( null );
+
+	// Keep the draft aligned with upstream title changes while not editing
+	// (e.g. after a successful save or an external refresh).
+	useEffect( () => {
+		if ( ! isEditing ) {
+			setDraft( title );
+		}
+	}, [ title, isEditing ] );
+
+	// Focus and select the field when entering edit mode.
+	useEffect( () => {
+		if ( isEditing && inputRef.current ) {
+			inputRef.current.focus();
+			inputRef.current.select();
+		}
+	}, [ isEditing ] );
+
+	const commit = () => {
+		setIsEditing( false );
+		const trimmed = draft.trim();
+		if ( trimmed && trimmed !== title ) {
+			onSave( trimmed );
+		} else {
+			setDraft( title );
+		}
+	};
+
+	const cancel = () => {
+		setDraft( title );
+		setIsEditing( false );
+	};
+
+	const handleKeyDown = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			commit();
+		} else if ( event.key === 'Escape' ) {
+			event.preventDefault();
+			cancel();
+		}
+	};
+
+	if ( isEditing ) {
+		return (
+			<input
+				ref={ inputRef }
+				type="text"
+				className="godam-video-editor__title-input"
+				value={ draft }
+				onChange={ ( event ) => setDraft( event.target.value ) }
+				onBlur={ commit }
+				onKeyDown={ handleKeyDown }
+				aria-label={ __( 'Video title', 'godam' ) }
+				data-test-id="godam-video-editor-title-input"
+			/>
+		);
+	}
+
+	return (
+		<h1 className="godam-video-editor__title">
+			<button
+				type="button"
+				className="godam-video-editor__title-button"
+				onClick={ () => setIsEditing( true ) }
+				title={ __( 'Click to edit title', 'godam' ) }
+				data-test-id="godam-video-editor-title"
+			>
+				{ title }
+			</button>
+		</h1>
+	);
+};
+
+/**
  * Top bar for the video editor shell.
  *
  * Renders the back button, video title + layer count, and the primary
- * actions (Copy, Preview, Save Video) plus a kebab menu (Analytics).
- * All handlers are passed in from `VideoEditor` so behaviour is unchanged.
+ * actions (Copy, Preview, Save Video) plus a kebab menu (Edit metadata,
+ * Analytics). All handlers are passed in from `VideoEditor`.
  *
  * @param {Object}   props
- * @param {string}   props.title        Video title.
- * @param {number}   props.layerCount   Number of layers.
- * @param {number}   props.attachmentID Attachment ID for Preview/Analytics links.
- * @param {boolean}  props.isChanged    Whether there are unsaved changes.
- * @param {boolean}  props.isSaving     Whether a save is in progress.
- * @param {Function} props.onBack       Back-to-picker handler.
- * @param {Function} props.onSave       Save handler.
- * @param {Function} props.onCopy       Copy-block handler.
+ * @param {string}   props.title             Video title.
+ * @param {number}   props.layerCount        Number of layers.
+ * @param {number}   props.attachmentID      Attachment ID for Preview/Analytics links.
+ * @param {boolean}  props.isChanged         Whether there are unsaved changes.
+ * @param {boolean}  props.isSaving          Whether a save is in progress.
+ * @param {Function} props.onBack            Back-to-picker handler.
+ * @param {Function} props.onSave            Save handler.
+ * @param {Function} props.onCopy            Copy-block handler.
+ * @param {Function} props.onEditMetadata    Opens the attachment details popup.
+ * @param {string}   props.editMetadataLabel Label for the "Edit metadata" menu item.
+ * @param {Function} props.onSaveTitle       Persists an edited video title.
  * @return {JSX.Element} The top bar.
  */
 const EditorTopBar = ( {
@@ -37,9 +131,11 @@ const EditorTopBar = ( {
 	onBack,
 	onSave,
 	onCopy,
+	onEditMetadata,
+	editMetadataLabel,
+	onSaveTitle,
 } ) => {
 	const homeUrl = window?.godamRestRoute?.homeUrl || '';
-	const hasValidApiKey = Boolean( window?.userData?.validApiKey );
 	const previewUrl = `${ homeUrl }?godam_page=video-preview&id=${ attachmentID }`;
 	const analyticsUrl = `${ homeUrl }/wp-admin/admin.php?page=rtgodam_analytics&id=${ attachmentID }`;
 
@@ -75,7 +171,7 @@ const EditorTopBar = ( {
 					/>
 				</FlexItem>
 				<FlexItem>
-					<h1 className="godam-video-editor__title">{ title }</h1>
+					<EditableTitle title={ title } onSave={ onSaveTitle } />
 					<p className="godam-video-editor__subtitle">
 						{ sprintf(
 							// translators: %d is the number of layers.
@@ -146,27 +242,35 @@ const EditorTopBar = ( {
 						{ isSaving ? __( 'Saving…', 'godam' ) : __( 'Save Video', 'godam' ) }
 					</Button>
 				</FlexItem>
-				{ hasValidApiKey && (
-					<FlexItem>
-						<DropdownMenu
-							icon={ moreVertical }
-							label={ __( 'More options', 'godam' ) }
-						>
-							{ () => (
-								<MenuGroup>
-									<MenuItem
-										icon={ chartBar }
-										href={ analyticsUrl }
-										target="_blank"
-										data-test-id="godam-video-editor-button-analytics"
-									>
-										{ __( 'Analytics', 'godam' ) }
-									</MenuItem>
-								</MenuGroup>
-							) }
-						</DropdownMenu>
-					</FlexItem>
-				) }
+				<FlexItem>
+					<DropdownMenu
+						icon={ moreVertical }
+						label={ __( 'More options', 'godam' ) }
+					>
+						{ ( { onClose } ) => (
+							<MenuGroup>
+								<MenuItem
+									icon={ chartBar }
+									href={ analyticsUrl }
+									target="_blank"
+									data-test-id="godam-video-editor-button-analytics"
+								>
+									{ __( 'Analytics', 'godam' ) }
+								</MenuItem>
+								<MenuItem
+									icon={ pencil }
+									onClick={ () => {
+										onEditMetadata();
+										onClose();
+									} }
+									data-test-id="godam-video-editor-button-edit-metadata"
+								>
+									{ editMetadataLabel }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+				</FlexItem>
 			</Flex>
 		</div>
 	);

--- a/pages/video-editor/components/video-dataview/video-dataview.scss
+++ b/pages/video-editor/components/video-dataview/video-dataview.scss
@@ -337,7 +337,7 @@ $godam-border: rgba(246, 246, 246, 1);
 			max-height: 1.25rem;
 			min-width: 1.25rem;
 			min-height: 1.25rem;
-			object-fit: contain;
+			object-fit: contain !important;
 			position: relative;
 			right: 2px; // optical centering for the GoDAM logo
 		}

--- a/pages/video-editor/utils/openAttachmentDetails.js
+++ b/pages/video-editor/utils/openAttachmentDetails.js
@@ -1,0 +1,86 @@
+/* global Backbone */
+
+/**
+ * Open the native WordPress "attachment details" popup for a given attachment.
+ *
+ * This reuses the exact same two-column modal shown in the media library when an
+ * attachment is clicked — including GoDAM's overrides (Edit Video / Analytics
+ * buttons, video thumbnail picker, transcoding info, EXIF). The modal is a
+ * Backbone `wp.media` view, so we drive it through `wp.media` rather than
+ * rebuilding it in React.
+ *
+ * This relies on three things already present on the video editor screen:
+ * `wp_enqueue_media()` (the `wp.media` framework), the core `media-grid` script
+ * (which defines the `EditAttachments` frame that renders the two-column view),
+ * and GoDAM's `easydam-media-library` bundle (which globally overrides
+ * `wp.media.view.Attachment.Details.TwoColumn` so the popup matches the library).
+ *
+ * @param {number}   attachmentID       The attachment ID to edit.
+ * @param {Object}   [options]          Optional settings.
+ * @param {Function} [options.onChange] Called with the attachment's attributes whenever the modal mutates the model (e.g. a title edit), so the editor can stay in sync.
+ * @return {boolean} `true` if the modal could be opened, `false` otherwise.
+ */
+export function openAttachmentDetailsModal( attachmentID, { onChange } = {} ) {
+	const wp = window.wp;
+
+	if (
+		! attachmentID ||
+		typeof Backbone === 'undefined' ||
+		! wp?.media?.attachment ||
+		! wp?.media?.view?.MediaFrame?.EditAttachments ||
+		! wp?.media?.model?.Attachments
+	) {
+		return false;
+	}
+
+	const model = wp.media.attachment( attachmentID );
+
+	// Keep the editor in sync with edits made inside the modal. WordPress saves
+	// each field through this Backbone model, so its `change` event fires as soon
+	// as a field (e.g. the title) is saved. Replace any prior listener we added
+	// so repeat opens don't stack callbacks.
+	if ( typeof onChange === 'function' ) {
+		if ( model._godamOnChange ) {
+			model.off( 'change', model._godamOnChange );
+		}
+		model._godamOnChange = () => onChange( model.attributes );
+		model.on( 'change', model._godamOnChange );
+	}
+
+	// Prevent the EditAttachments frame from rewriting the browser URL (its
+	// grid router expects the `upload.php` grid). We also hand it a no-op
+	// router shim below, so the editor's own `?tab=` URL state is untouched.
+	model.set( 'skipHistory', true );
+
+	// Fetch fresh so the details view renders with complete metadata.
+	model.fetch().always( () => {
+		wp.media.frames = wp.media.frames || {};
+
+		// Reuse the frame across clicks (mirrors core's grid behaviour): the
+		// editor always targets the same attachment, so a refresh is enough.
+		if ( wp.media.frames.godamAttachmentEdit ) {
+			wp.media.frames.godamAttachmentEdit.open();
+			wp.media.frames.godamAttachmentEdit.trigger( 'refresh', model );
+			return;
+		}
+
+		// The EditAttachments frame normally lives inside the media-grid "Manage"
+		// controller and talks to its `gridRouter`. Off the grid there is no such
+		// controller, so we supply a minimal event-emitting router shim that
+		// satisfies the calls the frame makes (`navigate`, `baseUrl`, and the
+		// `route:search` listener) without touching the URL.
+		const gridRouter = Object.assign( {}, Backbone.Events, {
+			navigate() {},
+			baseUrl: ( url ) => url,
+		} );
+
+		wp.media.frames.godamAttachmentEdit = new wp.media.view.MediaFrame.EditAttachments( {
+			controller: { gridRouter },
+			// A single-item library hides the prev/next navigation arrows.
+			library: new wp.media.model.Attachments( [ model ] ),
+			model,
+		} );
+	} );
+
+	return true;
+}

--- a/pages/video-editor/utils/openAttachmentDetails.js
+++ b/pages/video-editor/utils/openAttachmentDetails.js
@@ -17,8 +17,8 @@
  *
  * @param {number}   attachmentID       The attachment ID to edit.
  * @param {Object}   [options]          Optional settings.
- * @param {Function} [options.onChange] Called with the attachment's attributes whenever the modal mutates the model (e.g. a title edit), so the editor can stay in sync.
- * @return {boolean} `true` if the modal could be opened, `false` otherwise.
+ * @param {Function} [options.onChange] Called with the attachment's attributes when the title is edited in the modal, so the editor can stay in sync.
+ * @return {Function|boolean} A teardown that unbinds the title listener, or `false` if the modal could not be opened.
  */
 export function openAttachmentDetailsModal( attachmentID, { onChange } = {} ) {
 	const wp = window.wp;
@@ -35,18 +35,32 @@ export function openAttachmentDetailsModal( attachmentID, { onChange } = {} ) {
 
 	const model = wp.media.attachment( attachmentID );
 
-	// Keep the editor in sync with edits made inside the modal. WordPress saves
-	// each field through this Backbone model, so its `change` event fires as soon
-	// as a field (e.g. the title) is saved. Replace any prior listener we added
-	// so repeat opens don't stack callbacks.
-	if ( model._godamOnChange ) {
-		model.off( 'change', model._godamOnChange );
-		delete model._godamOnChange;
+	// Keep the editor's title in sync with edits made inside the modal.
+	// WordPress saves each field through this Backbone model, so `change:title`
+	// fires when the title is saved. We scope to `change:title` (not the broad
+	// `change`) so unrelated field edits and internal sets like `skipHistory`
+	// don't trigger it. Replace any prior listener so repeat opens don't stack.
+	if ( model._godamOnTitleChange ) {
+		model.off( 'change:title', model._godamOnTitleChange );
+		delete model._godamOnTitleChange;
 	}
+
+	let listener = null;
 	if ( typeof onChange === 'function' ) {
-		model._godamOnChange = () => onChange( model.attributes );
-		model.on( 'change', model._godamOnChange );
+		listener = () => onChange( model.attributes );
+		model._godamOnTitleChange = listener;
+		model.on( 'change:title', listener );
 	}
+
+	// The model is cached globally by wp.media and outlives the React component,
+	// so hand back a teardown the caller unbinds on unmount. The guard ensures a
+	// stale teardown can't remove a newer listener bound by a later open.
+	const teardown = () => {
+		if ( listener && model._godamOnTitleChange === listener ) {
+			model.off( 'change:title', listener );
+			delete model._godamOnTitleChange;
+		}
+	};
 
 	// Prevent the EditAttachments frame from rewriting the browser URL (its
 	// grid router expects the `upload.php` grid). We also hand it a no-op
@@ -83,5 +97,5 @@ export function openAttachmentDetailsModal( attachmentID, { onChange } = {} ) {
 		} );
 	} );
 
-	return true;
+	return teardown;
 }

--- a/pages/video-editor/utils/openAttachmentDetails.js
+++ b/pages/video-editor/utils/openAttachmentDetails.js
@@ -39,10 +39,11 @@ export function openAttachmentDetailsModal( attachmentID, { onChange } = {} ) {
 	// each field through this Backbone model, so its `change` event fires as soon
 	// as a field (e.g. the title) is saved. Replace any prior listener we added
 	// so repeat opens don't stack callbacks.
+	if ( model._godamOnChange ) {
+		model.off( 'change', model._godamOnChange );
+		delete model._godamOnChange;
+	}
 	if ( typeof onChange === 'function' ) {
-		if ( model._godamOnChange ) {
-			model.off( 'change', model._godamOnChange );
-		}
 		model._godamOnChange = () => onChange( model.attributes );
 		model.on( 'change', model._godamOnChange );
 	}


### PR DESCRIPTION
Add 'Edit metadata' kebab action opening the native wp.media attachment modal (enqueues core media-grid), make the title click-to-edit with popup↔title sync, always show the Analytics link, and fix the title-focus layout shift caused by wp-admin's input min-height.

- Add 'Edit metadata' action that opens the native wp.media attachment modal by enqueuing core media-grid
- Make the title click-to-edit with two-way sync between the inline editor and attachment metadata popup
- Always display the Analytics link
- Fix the title focus layout shift caused by wp-admin's default input min-height


https://github.com/user-attachments/assets/5a580994-1223-419b-9fc5-c6b4ceb151ce

