### PR TITLE
Refactor: use wp_handle_upload() for WPForms GoDAM Record uploads

### DIFF
--- a/inc/classes/wpforms/class-wpforms-field-godam-video.php
+++ b/inc/classes/wpforms/class-wpforms-field-godam-video.php
@@ -347,6 +347,11 @@ if ( class_exists( 'WPForms_Field' ) ) {
 		/**
 		 * Save godam video file.
 		 *
+		 * Files are routed through wp_handle_upload() (with a restricted `mimes`
+		 * override) rather than moved directly, so the file's real content/extension
+		 * is validated the same way core validates every other WordPress upload.
+		 * The client-supplied Content-Type header ($file['type']) is never trusted.
+		 *
 		 * @since 1.3.0
 		 *
 		 * @param array $entry Entry submitted data.
@@ -355,22 +360,14 @@ if ( class_exists( 'WPForms_Field' ) ) {
 		 * @return array
 		 */
 		public function save_video_file( $entry, $form_data ) {
-			global $wp_filesystem;
+			// Only handle uploads for fields actually configured as GoDAM Record fields on this form.
+			$godam_field_ids = $this->get_godam_record_field_ids( $form_data );
+
+			if ( empty( $godam_field_ids ) ) {
+				return $entry;
+			}
 
 			require_once ABSPATH . 'wp-admin/includes/file.php';
-
-			WP_Filesystem();
-
-			if ( null === $wp_filesystem ) {
-				return $entry;
-			}
-
-			$upload_dir  = wp_get_upload_dir();
-			$wpforms_dir = untrailingslashit( $upload_dir['basedir'] ) . '/godam/wpforms';
-
-			if ( false === wp_mkdir_p( $wpforms_dir ) ) {
-				return $entry;
-			}
 
 			// No need to perform nonce verification as this is already done by the WPForms forms processor.
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -378,6 +375,11 @@ if ( class_exists( 'WPForms_Field' ) ) {
 
 			// Loop through each file, and creates attachments for video files.
 			foreach ( $files as $field_id => $file ) {
+				// Only process files submitted through an actual GoDAM Record field.
+				if ( ! in_array( (int) $field_id, $godam_field_ids, true ) ) {
+					continue;
+				}
+
 				// Bail if there is not error set.
 				if ( ! isset( $file['error'] ) ) {
 					continue;
@@ -389,26 +391,103 @@ if ( class_exists( 'WPForms_Field' ) ) {
 					continue;
 				}
 
-				// Check if the file is a video or audio.
-				$mime_type = ! empty( $file['type'] ) ? $file['type'] : '';
-				$is_video  = ! empty( $mime_type ) && str_starts_with( $mime_type, 'video/' );
-				$is_audio  = godam_is_audio_file( $file['name'] );
-				
-				if ( ! $is_video && ! $is_audio ) {
+				if ( empty( $file['tmp_name'] ) || ! is_uploaded_file( $file['tmp_name'] ) ) {
 					continue;
 				}
 
-				$filename = wp_unique_filename( $wpforms_dir, $file['name'] );
+				add_filter( 'upload_dir', array( $this, 'change_upload_dir' ) );
 
-				$moved_file = $wp_filesystem->move( $file['tmp_name'], "{$wpforms_dir}/{$filename}" );
+				// wp_handle_upload() validates the file's real type/extension against
+				// $overrides['mimes'] instead of trusting $file['type'] or the original filename.
+				$moved_file = wp_handle_upload(
+					$file,
+					array(
+						'test_form' => false,
+						'mimes'     => $this->get_allowed_video_audio_mimes(),
+					)
+				);
 
-				if ( $moved_file ) {
-					$saved_file_url               = untrailingslashit( $upload_dir['baseurl'] ) . "/godam/wpforms/{$filename}";
-					$entry['fields'][ $field_id ] = $saved_file_url;
+				remove_filter( 'upload_dir', array( $this, 'change_upload_dir' ) );
+
+				if ( ! empty( $moved_file['url'] ) && empty( $moved_file['error'] ) ) {
+					$entry['fields'][ $field_id ] = $moved_file['url'];
 				}
 			}
 
 			return $entry;
+		}
+
+		/**
+		 * Change upload dir to `godam/wpforms`.
+		 *
+		 * @since 1.12.3
+		 *
+		 * @param array $dirs Upload directory data.
+		 *
+		 * @return array
+		 */
+		public function change_upload_dir( $dirs ) {
+			$dirs['subdir'] = '/godam/wpforms';
+			$dirs['path']   = $dirs['basedir'] . $dirs['subdir'];
+			$dirs['url']    = $dirs['baseurl'] . $dirs['subdir'];
+
+			return $dirs;
+		}
+
+		/**
+		 * Get the field IDs configured as GoDAM Record fields on the given form.
+		 *
+		 * @since 1.12.3
+		 *
+		 * @param array $form_data Form data and settings.
+		 *
+		 * @return array<int> Field IDs.
+		 */
+		protected function get_godam_record_field_ids( $form_data ) {
+			if ( empty( $form_data['fields'] ) || ! is_array( $form_data['fields'] ) ) {
+				return array();
+			}
+
+			$field_ids = array();
+
+			foreach ( $form_data['fields'] as $form_field ) {
+				if ( isset( $form_field['type'], $form_field['id'] ) && 'godam_record' === $form_field['type'] ) {
+					$field_ids[] = (int) $form_field['id'];
+				}
+			}
+
+			return $field_ids;
+		}
+
+		/**
+		 * Get the allowlist of video/audio mime types accepted for WPForms GoDAM Record uploads.
+		 *
+		 * Derived from WordPress core's own mime map (the same one wp_handle_upload()
+		 * validates against by default) so it stays in sync with whatever the current
+		 * WordPress version recognizes, narrowed to only audio/video types since this
+		 * field has no legitimate reason to accept documents, archives, or images.
+		 *
+		 * @since 1.12.3
+		 *
+		 * @return array Map of extension(s) => mime type.
+		 */
+		protected function get_allowed_video_audio_mimes() {
+			$allowed_mimes = array();
+
+			foreach ( wp_get_mime_types() as $extensions => $mime_type ) {
+				if ( str_starts_with( $mime_type, 'video/' ) || str_starts_with( $mime_type, 'audio/' ) ) {
+					$allowed_mimes[ $extensions ] = $mime_type;
+				}
+			}
+
+			/**
+			 * Filters the allowlist of mime types accepted for WPForms GoDAM Record uploads.
+			 *
+			 * @since 1.12.3
+			 *
+			 * @param array $allowed_mimes Map of extension(s) => mime type.
+			 */
+			return apply_filters( 'godam_wpforms_record_allowed_mimes', $allowed_mimes );
 		}
 
 		/**

--- a/inc/classes/wpforms/class-wpforms-field-godam-video.php
+++ b/inc/classes/wpforms/class-wpforms-field-godam-video.php
@@ -373,52 +373,60 @@ if ( class_exists( 'WPForms_Field' ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$files = $this->format_global_files_array( $_FILES );
 
-			// Loop through each file, and creates attachments for video files.
-			foreach ( $files as $field_id => $file ) {
-				// Only process files submitted through an actual GoDAM Record field.
-				if ( ! in_array( (int) $field_id, $godam_field_ids, true ) ) {
-					continue;
+			// Route GoDAM uploads to `uploads/godam/wpforms`. The filter is registered once
+			// around the whole loop and torn down in `finally`, so the global `upload_dir`
+			// filter is always removed even if wp_handle_upload() (or a callback hooked into
+			// it) throws.
+			add_filter( 'upload_dir', array( $this, 'filter_upload_dir_to_godam_wpforms' ) );
+
+			try {
+				// Loop through each file, and creates attachments for video files.
+				foreach ( $files as $field_id => $file ) {
+					// Only process files submitted through an actual GoDAM Record field.
+					if ( ! in_array( (int) $field_id, $godam_field_ids, true ) ) {
+						continue;
+					}
+
+					// Bail if there is not error set.
+					if ( ! isset( $file['error'] ) ) {
+						continue;
+					}
+
+					// Check for upload errors.
+					if ( UPLOAD_ERR_OK !== $file['error'] ) {
+						$entry['fields'][ $field_id ] = '';
+						continue;
+					}
+
+					if ( empty( $file['tmp_name'] ) || ! is_uploaded_file( $file['tmp_name'] ) ) {
+						continue;
+					}
+
+					// wp_handle_upload() validates the file's real type/extension against
+					// $overrides['mimes'] instead of trusting $file['type'] or the original filename.
+					$moved_file = wp_handle_upload(
+						$file,
+						array(
+							'test_form' => false,
+							'mimes'     => $this->get_allowed_video_audio_mimes(),
+						)
+					);
+
+					if ( ! empty( $moved_file['url'] ) && empty( $moved_file['error'] ) ) {
+						$entry['fields'][ $field_id ] = $moved_file['url'];
+					}
 				}
-
-				// Bail if there is not error set.
-				if ( ! isset( $file['error'] ) ) {
-					continue;
-				}
-
-				// Check for upload errors.
-				if ( UPLOAD_ERR_OK !== $file['error'] ) {
-					$entry['fields'][ $field_id ] = '';
-					continue;
-				}
-
-				if ( empty( $file['tmp_name'] ) || ! is_uploaded_file( $file['tmp_name'] ) ) {
-					continue;
-				}
-
-				add_filter( 'upload_dir', array( $this, 'change_upload_dir' ) );
-
-				// wp_handle_upload() validates the file's real type/extension against
-				// $overrides['mimes'] instead of trusting $file['type'] or the original filename.
-				$moved_file = wp_handle_upload(
-					$file,
-					array(
-						'test_form' => false,
-						'mimes'     => $this->get_allowed_video_audio_mimes(),
-					)
-				);
-
-				remove_filter( 'upload_dir', array( $this, 'change_upload_dir' ) );
-
-				if ( ! empty( $moved_file['url'] ) && empty( $moved_file['error'] ) ) {
-					$entry['fields'][ $field_id ] = $moved_file['url'];
-				}
+			} finally {
+				remove_filter( 'upload_dir', array( $this, 'filter_upload_dir_to_godam_wpforms' ) );
 			}
 
 			return $entry;
 		}
 
 		/**
-		 * Change upload dir to `godam/wpforms`.
+		 * Route GoDAM WPForms uploads to the `godam/wpforms` sub-directory.
+		 *
+		 * Registered as an `upload_dir` filter callback in {@see save_video_file()}.
 		 *
 		 * @since 1.12.3
 		 *
@@ -426,7 +434,7 @@ if ( class_exists( 'WPForms_Field' ) ) {
 		 *
 		 * @return array
 		 */
-		public function change_upload_dir( $dirs ) {
+		public function filter_upload_dir_to_godam_wpforms( $dirs ) {
 			$dirs['subdir'] = '/godam/wpforms';
 			$dirs['path']   = $dirs['basedir'] . $dirs['subdir'];
 			$dirs['url']    = $dirs['baseurl'] . $dirs['subdir'];


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-core/issues/1238

This pull request refactors and improves the handling of video/audio file uploads for GoDAM Record fields in WPForms. The main focus is on ensuring robust security and compatibility by leveraging WordPress core upload validation, restricting uploads to only allowed audio/video types, and simplifying the upload directory logic.

**Security and Validation Improvements:**
- Switched from direct file moves to using `wp_handle_upload()` for file uploads, ensuring that files are validated against their real content and extension, not just the client-supplied MIME type. This matches WordPress core's upload validation process. [[1]](diffhunk://#diff-01affbb24a4eb210d1747e11887903cb1878762c0f22937c083e785dca9d0ecfR350-R354) [[2]](diffhunk://#diff-01affbb24a4eb210d1747e11887903cb1878762c0f22937c083e785dca9d0ecfL392-R492)

**Upload Directory Handling:**
- Introduced a new `change_upload_dir` method to consistently route uploads to the `godam/wpforms` directory using WordPress's upload filters, replacing manual directory creation and file moves.

**Field and MIME Type Restriction:**
- Added logic to process uploads only for fields actually configured as GoDAM Record fields in the form, using the new `get_godam_record_field_ids` helper. [[1]](diffhunk://#diff-01affbb24a4eb210d1747e11887903cb1878762c0f22937c083e785dca9d0ecfL358-R382) [[2]](diffhunk://#diff-01affbb24a4eb210d1747e11887903cb1878762c0f22937c083e785dca9d0ecfL392-R492)
- Added a `get_allowed_video_audio_mimes` method to restrict uploads to only audio/video MIME types recognized by WordPress, with a filter for extensibility.

**Code Cleanup:**
- Removed unnecessary use of the global `$wp_filesystem` and related manual file operations, simplifying the code and reducing potential errors. [[1]](diffhunk://#diff-01affbb24a4eb210d1747e11887903cb1878762c0f22937c083e785dca9d0ecfL358-R382) [[2]](diffhunk://#diff-01affbb24a4eb210d1747e11887903cb1878762c0f22937c083e785dca9d0ecfL392-R492)Bring the WPForms integration in line with the other form integrations (Ninja Forms, Fluent Forms, SureForms) by handing uploads to WordPress's standard upload handler instead of moving files directly, and by scoping processing to fields explicitly configured as GoDAM Record on the form.