### PR TITLE
fix: render GoDAM Record player on Everest Forms entry view

### DIFF
--- a/inc/classes/everest-forms/class-everest-forms-field-godam-video.php
+++ b/inc/classes/everest-forms/class-everest-forms-field-godam-video.php
@@ -202,7 +202,7 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 		 * On older Everest Forms builds this filter simply never fires and the entry
 		 * view echoes the value unescaped, so this is a no-op there.
 		 *
-		 * @since 1.4.0
+		 * @since n.e.x.t
 		 *
 		 * @param array  $types     Field types whose entry value may contain HTML.
 		 * @param string $meta_key  Meta key of the field currently being rendered.
@@ -213,6 +213,13 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 		public function allow_godam_html_in_entry_view( $types, $meta_key = '', $form_data = array() ) {
 			if ( is_string( $meta_key ) && false !== strpos( $meta_key, 'godam_record' ) ) {
 				$types[] = $this->type;
+
+				// Everest Forms exposes no per-field "after echo" hook, so the tag
+				// allow-list is intentionally left active until remove_player_kses_filter()
+				// detaches it on everest_forms_entry_details_content (after the whole
+				// field loop). Any field rendered after this one in the same loop
+				// therefore also sees the expanded tags — benign on this admin-gated,
+				// plugin-generated view.
 				add_filter( 'wp_kses_allowed_html', array( $this, 'allow_player_tags_in_kses' ), 10, 2 );
 			}
 
@@ -228,7 +235,7 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 		 * text). <source> (audio/video), <svg> and <path> (the play-button icon) are
 		 * likewise not allowed in the 'post' context.
 		 *
-		 * @since 1.4.0
+		 * @since n.e.x.t
 		 *
 		 * @param array  $allowed_tags Allowed tags.
 		 * @param string $context      Context.
@@ -252,7 +259,7 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 			);
 
 			$allowed_tags['svg'] = array(
-				'xlmns'   => true,
+				'xmlns'   => true,
 				'width'   => true,
 				'height'  => true,
 				'src'     => true,
@@ -275,7 +282,7 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 		 * Detach the player wp_kses_allowed_html filter once the single-entry view
 		 * has finished rendering, so it does not affect other requests/contexts.
 		 *
-		 * @since 1.4.0
+		 * @since n.e.x.t
 		 *
 		 * @return void
 		 */

--- a/inc/classes/everest-forms/class-everest-forms-field-godam-video.php
+++ b/inc/classes/everest-forms/class-everest-forms-field-godam-video.php
@@ -76,6 +76,10 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 
 			// To display field HTML in the entry meta.
 			add_filter( 'everest_forms_html_field_value', array( $this, 'update_entry_meta_display_godam_recorder' ), 10, 4 );
+
+			// Allow the player markup to survive the single-entry view sanitization.
+			add_filter( 'everest_forms_entry_view_field_types_allowing_html', array( $this, 'allow_godam_html_in_entry_view' ), 10, 3 );
+			add_action( 'everest_forms_entry_details_content', array( $this, 'remove_player_kses_filter' ), 20 );
 		}
 
 		/**
@@ -179,6 +183,104 @@ if ( class_exists( 'EVF_Form_Fields_Upload' ) ) {
 			$output = $style . $download_url . $transcoded_url_output . $media_output;
 
 			return $output;
+		}
+
+		/**
+		 * Allow the GoDAM Record field value to output HTML on the Everest Forms
+		 * single-entry view.
+		 *
+		 * Recent Everest Forms versions route each entry field value through one of
+		 * three sinks based on its field type: wp_kses_post() for HTML-allowed types,
+		 * make_clickable() for file/media types, or esc_html() for everything else.
+		 * The GoDAM Record field is not in either allow-list, so it falls through to
+		 * esc_html(), which escapes the whole video/audio player markup and renders it
+		 * as a literal HTML string. Registering the field type here switches it to the
+		 * wp_kses_post() sink; the companion wp_kses_allowed_html filter (added here so
+		 * it is active for the echo that immediately follows) keeps the player's
+		 * <style>/<source>/<svg>/<path> tags, which wp_kses_post() strips by default.
+		 *
+		 * On older Everest Forms builds this filter simply never fires and the entry
+		 * view echoes the value unescaped, so this is a no-op there.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array  $types     Field types whose entry value may contain HTML.
+		 * @param string $meta_key  Meta key of the field currently being rendered.
+		 * @param mixed  $form_data Form data.
+		 *
+		 * @return array
+		 */
+		public function allow_godam_html_in_entry_view( $types, $meta_key = '', $form_data = array() ) {
+			if ( is_string( $meta_key ) && false !== strpos( $meta_key, 'godam_record' ) ) {
+				$types[] = $this->type;
+				add_filter( 'wp_kses_allowed_html', array( $this, 'allow_player_tags_in_kses' ), 10, 2 );
+			}
+
+			return (array) $types;
+		}
+
+		/**
+		 * Whitelist the tags the GoDAM player emits so they survive wp_kses_post()
+		 * on the Everest Forms single-entry view.
+		 *
+		 * The player wrapper styles are printed as an inline <style> block, which
+		 * wp_kses_post() strips by default (leaking the CSS onto the page as raw
+		 * text). <source> (audio/video), <svg> and <path> (the play-button icon) are
+		 * likewise not allowed in the 'post' context.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array  $allowed_tags Allowed tags.
+		 * @param string $context      Context.
+		 *
+		 * @return array
+		 */
+		public function allow_player_tags_in_kses( $allowed_tags, $context ) {
+			if ( 'post' !== $context ) {
+				return $allowed_tags;
+			}
+
+			$allowed_tags['style'] = array(
+				'id'    => true,
+				'type'  => true,
+				'media' => true,
+			);
+
+			$allowed_tags['source'] = array(
+				'src'  => true,
+				'type' => true,
+			);
+
+			$allowed_tags['svg'] = array(
+				'xlmns'   => true,
+				'width'   => true,
+				'height'  => true,
+				'src'     => true,
+				'style'   => true,
+				'class'   => true,
+				'fill'    => true,
+				'viewbox' => true,
+				'data-*'  => true,
+				'aria-*'  => true,
+			);
+
+			$allowed_tags['path'] = array(
+				'd' => true,
+			);
+
+			return $allowed_tags;
+		}
+
+		/**
+		 * Detach the player wp_kses_allowed_html filter once the single-entry view
+		 * has finished rendering, so it does not affect other requests/contexts.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @return void
+		 */
+		public function remove_player_kses_filter() {
+			remove_filter( 'wp_kses_allowed_html', array( $this, 'allow_player_tags_in_kses' ), 10 );
 		}
 
 		/**

--- a/inc/classes/wpforms/class-wpforms-field-godam-video.php
+++ b/inc/classes/wpforms/class-wpforms-field-godam-video.php
@@ -67,6 +67,17 @@ if ( class_exists( 'WPForms_Field' ) ) {
 				'type' => true,
 			);
 
+			// The GoDAM player template emits its wrapper styles as an inline
+			// <style id="godam-player-wrapper-inline-css"> block. wp_kses_post()
+			// strips <style> by default (keeping only its CSS text, which then
+			// leaks onto the page as a raw string), so it must be whitelisted for
+			// the rendered player to be styled on the entry view page.
+			$allowed_tags['style'] = array(
+				'id'    => true,
+				'type'  => true,
+				'media' => true,
+			);
+
 			$allowed_tags['svg'] = array(
 				'xlmns'   => true,
 				'width'   => true,

--- a/inc/classes/wpforms/class-wpforms-field-godam-video.php
+++ b/inc/classes/wpforms/class-wpforms-field-godam-video.php
@@ -79,7 +79,7 @@ if ( class_exists( 'WPForms_Field' ) ) {
 			);
 
 			$allowed_tags['svg'] = array(
-				'xlmns'   => true,
+				'xmlns'   => true,
 				'width'   => true,
 				'height'  => true,
 				'src'     => true,


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/2013

This pull request improves the display of the GoDAM video/audio player in Everest Forms and WPForms entry views by ensuring the player’s HTML markup and required tags are properly allowed and rendered, rather than being escaped or stripped. The main changes involve whitelisting necessary HTML tags and managing filters to allow the player to display and function correctly.

**Everest Forms:**

* Entry view rendering:
  - Registers the GoDAM field type to allow HTML output in the single-entry view, switching sanitization from `esc_html()` to `wp_kses_post()`. [[1]](diffhunk://#diff-639ca3702364e00212af65dd6fbdbd60cbeb33bf9dd1767c0dd2d86a725c10b7R79-R82) [[2]](diffhunk://#diff-639ca3702364e00212af65dd6fbdbd60cbeb33bf9dd1767c0dd2d86a725c10b7R188-R285)
  - Whitelists player-specific tags (`<style>`, `<source>`, `<svg>`, `<path>`) so the player renders and is styled properly, and removes this filter after rendering to avoid side effects.

**WPForms:**

* Entry view rendering:
  - Adds `<style>` to the list of allowed tags so the player’s inline CSS is preserved and the rendered player is styled correctly.

## Demo

https://github.com/user-attachments/assets/b6c25687-69ba-477d-be7e-9881e6d9a075

