### PR TITLE
fix: allow native browser shortcuts to pass through in keyboard event handling

### DIFF
--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -315,6 +315,13 @@ export default class PlayerManager {
 	 * @return {boolean} True if event should be skipped
 	 */
 	shouldSkipKeyboardEvent( event ) {
+		// Let native browser shortcuts (Cmd+F, Ctrl+F, Ctrl+arrows, etc.) pass
+		// through untouched. The player only handles unmodified keystrokes, so a
+		// modified key must never be captured or preventDefault()-ed.
+		if ( event.metaKey || event.ctrlKey || event.altKey ) {
+			return true;
+		}
+
 		const skipTags = [ 'INPUT', 'TEXTAREA' ];
 		return skipTags.includes( event.target.tagName ) || event.target.isContentEditable;
 	}


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-plugin-wp/issues/16

This pull request updates the keyboard event handling logic in the `PlayerManager` class to improve user experience and prevent interference with native browser shortcuts.

**Keyboard event handling improvements:**

* Updated the `shouldSkipKeyboardEvent` method in `playerManager.js` to allow native browser shortcuts (such as Cmd+F, Ctrl+F, Ctrl+arrows) to pass through by skipping events with modifier keys (`metaKey`, `ctrlKey`, or `altKey`). This ensures the player only handles unmodified keystrokes and avoids capturing or preventing default behavior for modified keys.

Self-tested on Safari and Chrome Browsers ✅