### PR TITLE
Feat: Register Document Block in WP Bakery

### DIFF
--- a/assets/src/blocks/godam-pdf/render.php
+++ b/assets/src/blocks/godam-pdf/render.php
@@ -53,8 +53,20 @@ if ( empty( $godam_sources ) ) {
 
 $godam_file_name = basename( $godam_sources[0] );
 
+// Root wrapper: in block context merge WordPress' block-support attributes
+// (align/spacing/etc.). The [godam_document] shortcode (used by the WPBakery
+// element) sets $godam_is_shortcode and runs outside a block, where
+// get_block_wrapper_attributes() would raise a warning, so it instead applies
+// any WPBakery Design Options CSS class passed in via $godam_css_class.
+if ( empty( $godam_is_shortcode ) ) {
+	$godam_wrapper_attributes = get_block_wrapper_attributes();
+} else {
+	$godam_shortcode_class    = trim( 'wp-block-godam-pdf ' . ( isset( $godam_css_class ) ? $godam_css_class : '' ) );
+	$godam_wrapper_attributes = 'class="' . esc_attr( $godam_shortcode_class ) . '"';
+}
+
 ?>
-<figure <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
+<figure <?php echo wp_kses_data( $godam_wrapper_attributes ); ?>>
 
 	<?php if ( 'card' === $godam_preview_mode ) : ?>
 

--- a/assets/src/blocks/godam-pdf/render.php
+++ b/assets/src/blocks/godam-pdf/render.php
@@ -163,7 +163,7 @@ if ( empty( $godam_is_shortcode ) ) {
 			style="height: <?php echo esc_attr( $godam_height ); ?>px;"
 		>
 			<object
-				id="pdfObject"
+				id="<?php echo esc_attr( wp_unique_id( 'godam-pdf-object-' ) ); ?>"
 				type="application/pdf"
 				width="100%"
 				height="100%"

--- a/assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js
@@ -1,0 +1,168 @@
+( function( $ ) {
+	'use strict';
+
+	// Initialize on document ready and when WPBakery reloads the params.
+	$( document ).ready( initDocumentCoverSelector );
+	$( document ).on( 'vc.reload', initDocumentCoverSelector );
+
+	/**
+	 * Resolve the WP REST API root. The document cover meta
+	 * (rtgodam_media_video_thumbnail / rtgodam_media_pdf_thumbnail) is registered
+	 * show_in_rest, so it is readable in the public "view" context — no nonce
+	 * required.
+	 *
+	 * @return {string} REST root URL with trailing slash.
+	 */
+	function restRoot() {
+		if ( window.wpApiSettings && window.wpApiSettings.root ) {
+			return window.wpApiSettings.root;
+		}
+		return window.location.origin + '/wp-json/';
+	}
+
+	function initDocumentCoverSelector() {
+		$( '.document_cover_selector_block' ).each( function() {
+			setupBlock( $( this ) );
+		} );
+	}
+
+	/**
+	 * Read the selected document (attachment) ID from the sibling document
+	 * selector param in the same edit form.
+	 *
+	 * @param {Object} $block The cover selector block element.
+	 * @return {string} The attachment ID, or an empty string.
+	 */
+	function getDocumentId( $block ) {
+		const $formContainer = $block.closest( '.wpb_el_type_document_cover_selector' ).parent();
+		const $idInput = $formContainer.find( '.document_selector_field' );
+		return $idInput.length ? $idInput.val() : '';
+	}
+
+	/**
+	 * Fetch the attachment's auto-generated cover URL from its REST meta.
+	 *
+	 * @param {string}   id The attachment ID.
+	 * @param {Function} cb Callback receiving the cover URL (string, may be empty).
+	 */
+	function fetchAutoCover( id, cb ) {
+		if ( ! id ) {
+			cb( '' );
+			return;
+		}
+		fetch( restRoot() + 'wp/v2/media/' + id )
+			.then( ( res ) => ( res.ok ? res.json() : null ) )
+			.then( ( media ) => {
+				let cover = '';
+				if ( media && media.meta ) {
+					// Mirror render.php: video thumbnail first, then pdf thumbnail.
+					cover = media.meta.rtgodam_media_video_thumbnail ||
+						media.meta.rtgodam_media_pdf_thumbnail || '';
+				}
+				cb( cover );
+			} )
+			.catch( () => cb( '' ) );
+	}
+
+	function setupBlock( $block ) {
+		const $valueInput = $block.find( '.document_cover_selector_field' );
+		const $tiles = $block.find( '.document-cover-tiles' );
+		const $selectBtn = $block.find( '.document-cover-select' );
+
+		let autoCover = '';
+
+		const tileBaseStyle = 'position:relative;width:88px;height:64px;border:2px solid #dcdcde;border-radius:4px;overflow:hidden;cursor:pointer;background:#f0f0f1;display:flex;align-items:center;justify-content:center;';
+		const tileSelectedStyle = 'border-color:var(--wp-admin-theme-color,#3858e9);';
+		const imgStyle = 'width:100%;height:100%;object-fit:cover;';
+
+		function tileHtml( role, imgUrl, selected, label ) {
+			let inner = '';
+			if ( imgUrl ) {
+				inner = '<img src="' + imgUrl + '" alt="" style="' + imgStyle + '" />';
+			} else {
+				inner = '<span class="dashicons dashicons-media-document" style="font-size:28px;color:#8c8f94;"></span>';
+			}
+
+			let badge = '';
+			if ( selected ) {
+				badge = '<span class="godam-cover-tile__check" style="position:absolute;top:2px;right:2px;background:var(--wp-admin-theme-color,#3858e9);color:#fff;border-radius:50%;width:16px;height:16px;line-height:16px;text-align:center;font-size:11px;">&#10003;</span>';
+			}
+
+			let remove = '';
+			if ( 'custom' === role ) {
+				remove = '<button type="button" class="godam-cover-tile__remove" title="Remove" style="position:absolute;bottom:2px;right:2px;background:rgba(0,0,0,0.6);color:#fff;border:none;border-radius:3px;width:16px;height:16px;line-height:14px;cursor:pointer;padding:0;">&times;</button>';
+			}
+
+			return '<div class="godam-cover-tile" data-role="' + role + '" title="' + label + '" style="' + tileBaseStyle + ( selected ? tileSelectedStyle : '' ) + '">' +
+				inner + badge + remove +
+				'</div>';
+		}
+
+		function render() {
+			const custom = $valueInput.val();
+			const autoSelected = ! custom;
+			let html = '';
+
+			// Auto-generated cover tile (default).
+			html += tileHtml( 'auto', autoCover, autoSelected, 'Auto-generated cover' );
+
+			// Custom cover tile (only when a custom image is chosen).
+			if ( custom ) {
+				html += tileHtml( 'custom', custom, true, 'Custom cover' );
+			}
+
+			$tiles.html( html );
+		}
+
+		// Load the auto cover for the currently-selected document, then paint.
+		fetchAutoCover( getDocumentId( $block ), function( cover ) {
+			autoCover = cover;
+			render();
+		} );
+		render();
+
+		// Selecting the auto tile clears the custom value (empty = use auto).
+		$tiles.off( 'click' ).on( 'click', '.godam-cover-tile', function() {
+			if ( 'auto' === $( this ).data( 'role' ) ) {
+				$valueInput.val( '' ).trigger( 'change' );
+				render();
+			}
+		} );
+
+		// Removing the custom cover reverts to the auto-generated cover.
+		$tiles.on( 'click', '.godam-cover-tile__remove', function( e ) {
+			e.stopPropagation();
+			$valueInput.val( '' ).trigger( 'change' );
+			render();
+		} );
+
+		// "Select image" opens the media library (images only) for a custom cover.
+		$selectBtn.off( 'click' ).on( 'click', function( e ) {
+			e.preventDefault();
+			const frame = wp.media( {
+				title: 'Select Cover Image',
+				button: { text: 'Use image' },
+				library: { type: 'image' },
+				multiple: false,
+			} );
+			frame.on( 'select', function() {
+				const attachment = frame.state().get( 'selection' ).first().toJSON();
+				$valueInput.val( attachment.url ).trigger( 'change' );
+				render();
+			} );
+			frame.open();
+		} );
+
+		// When the chosen document changes, reset to auto and refetch its cover.
+		const $formContainer = $block.closest( '.wpb_el_type_document_cover_selector' ).parent();
+		$formContainer.find( '.document_selector_field' ).off( 'change.godamCover' ).on( 'change.godamCover', function() {
+			$valueInput.val( '' ).trigger( 'change' );
+			autoCover = '';
+			render();
+			fetchAutoCover( $( this ).val(), function( cover ) {
+				autoCover = cover;
+				render();
+			} );
+		} );
+	}
+}( window.jQuery ) );

--- a/assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js
@@ -1,23 +1,30 @@
 ( function( $ ) {
 	'use strict';
 
+	// Use WordPress i18n when available so user-facing strings are translatable.
+	const { __ } = ( window.wp && window.wp.i18n ) ? window.wp.i18n : { __: ( s ) => s };
+
 	// Initialize on document ready and when WPBakery reloads the params.
 	$( document ).ready( initDocumentCoverSelector );
 	$( document ).on( 'vc.reload', initDocumentCoverSelector );
 
 	/**
-	 * Resolve the WP REST API root. The document cover meta
-	 * (rtgodam_media_video_thumbnail / rtgodam_media_pdf_thumbnail) is registered
-	 * show_in_rest, so it is readable in the public "view" context — no nonce
-	 * required.
+	 * Resolve the WP REST API root for a given block. The authoritative value is
+	 * printed server-side via rest_url() into the block's data-rest-url attribute,
+	 * which correctly handles subdirectory installs, custom REST prefixes and
+	 * multisite. Falls back to wpApiSettings.root, then to a best-effort guess.
 	 *
-	 * @return {string} REST root URL with trailing slash.
+	 * @param {Object} $block The cover selector block element.
+	 * @return {string} REST root URL with a trailing slash.
 	 */
-	function restRoot() {
-		if ( window.wpApiSettings && window.wpApiSettings.root ) {
-			return window.wpApiSettings.root;
+	function getRestRoot( $block ) {
+		let root = $block.attr( 'data-rest-url' ) ||
+			( window.wpApiSettings && window.wpApiSettings.root ) ||
+			( window.location.origin + '/wp-json/' );
+		if ( root && root.slice( -1 ) !== '/' ) {
+			root += '/';
 		}
-		return window.location.origin + '/wp-json/';
+		return root;
 	}
 
 	function initDocumentCoverSelector() {
@@ -42,15 +49,16 @@
 	/**
 	 * Fetch the attachment's auto-generated cover URL from its REST meta.
 	 *
-	 * @param {string}   id The attachment ID.
-	 * @param {Function} cb Callback receiving the cover URL (string, may be empty).
+	 * @param {string}   restRoot The REST API root URL (trailing slash).
+	 * @param {string}   id       The attachment ID.
+	 * @param {Function} cb       Callback receiving the cover URL (may be empty).
 	 */
-	function fetchAutoCover( id, cb ) {
+	function fetchAutoCover( restRoot, id, cb ) {
 		if ( ! id ) {
 			cb( '' );
 			return;
 		}
-		fetch( restRoot() + 'wp/v2/media/' + id )
+		fetch( restRoot + 'wp/v2/media/' + id )
 			.then( ( res ) => ( res.ok ? res.json() : null ) )
 			.then( ( media ) => {
 				let cover = '';
@@ -68,6 +76,8 @@
 		const $valueInput = $block.find( '.document_cover_selector_field' );
 		const $tiles = $block.find( '.document-cover-tiles' );
 		const $selectBtn = $block.find( '.document-cover-select' );
+		const $formContainer = $block.closest( '.wpb_el_type_document_cover_selector' ).parent();
+		const restRoot = getRestRoot( $block );
 
 		let autoCover = '';
 
@@ -78,7 +88,7 @@
 		function tileHtml( role, imgUrl, selected, label ) {
 			let inner = '';
 			if ( imgUrl ) {
-				inner = '<img src="' + imgUrl + '" alt="" style="' + imgStyle + '" />';
+				inner = '<img src="' + encodeURI( imgUrl ) + '" alt="" style="' + imgStyle + '" />';
 			} else {
 				inner = '<span class="dashicons dashicons-media-document" style="font-size:28px;color:#8c8f94;"></span>';
 			}
@@ -90,7 +100,8 @@
 
 			let remove = '';
 			if ( 'custom' === role ) {
-				remove = '<button type="button" class="godam-cover-tile__remove" title="Remove" style="position:absolute;bottom:2px;right:2px;background:rgba(0,0,0,0.6);color:#fff;border:none;border-radius:3px;width:16px;height:16px;line-height:14px;cursor:pointer;padding:0;">&times;</button>';
+				const removeLabel = __( 'Remove cover', 'godam' );
+				remove = '<button type="button" class="godam-cover-tile__remove" aria-label="' + removeLabel + '" title="' + removeLabel + '" style="position:absolute;bottom:2px;right:2px;background:rgba(0,0,0,0.6);color:#fff;border:none;border-radius:3px;width:16px;height:16px;line-height:14px;cursor:pointer;padding:0;">&times;</button>';
 			}
 
 			return '<div class="godam-cover-tile" data-role="' + role + '" title="' + label + '" style="' + tileBaseStyle + ( selected ? tileSelectedStyle : '' ) + '">' +
@@ -104,25 +115,28 @@
 			let html = '';
 
 			// Auto-generated cover tile (default).
-			html += tileHtml( 'auto', autoCover, autoSelected, 'Auto-generated cover' );
+			html += tileHtml( 'auto', autoCover, autoSelected, __( 'Auto-generated cover', 'godam' ) );
 
 			// Custom cover tile (only when a custom image is chosen).
 			if ( custom ) {
-				html += tileHtml( 'custom', custom, true, 'Custom cover' );
+				html += tileHtml( 'custom', custom, true, __( 'Custom cover', 'godam' ) );
 			}
 
 			$tiles.html( html );
 		}
 
 		// Load the auto cover for the currently-selected document, then paint.
-		fetchAutoCover( getDocumentId( $block ), function( cover ) {
+		fetchAutoCover( restRoot, getDocumentId( $block ), function( cover ) {
 			autoCover = cover;
 			render();
 		} );
 		render();
 
+		// Namespaced delegated handlers, removed before re-binding so repeated
+		// setupBlock() runs (document ready + vc.reload) don't stack listeners.
+
 		// Selecting the auto tile clears the custom value (empty = use auto).
-		$tiles.off( 'click' ).on( 'click', '.godam-cover-tile', function() {
+		$tiles.off( 'click.godamCoverTile' ).on( 'click.godamCoverTile', '.godam-cover-tile', function() {
 			if ( 'auto' === $( this ).data( 'role' ) ) {
 				$valueInput.val( '' ).trigger( 'change' );
 				render();
@@ -130,18 +144,18 @@
 		} );
 
 		// Removing the custom cover reverts to the auto-generated cover.
-		$tiles.on( 'click', '.godam-cover-tile__remove', function( e ) {
+		$tiles.off( 'click.godamCoverRemove' ).on( 'click.godamCoverRemove', '.godam-cover-tile__remove', function( e ) {
 			e.stopPropagation();
 			$valueInput.val( '' ).trigger( 'change' );
 			render();
 		} );
 
 		// "Select image" opens the media library (images only) for a custom cover.
-		$selectBtn.off( 'click' ).on( 'click', function( e ) {
+		$selectBtn.off( 'click.godamCoverSelect' ).on( 'click.godamCoverSelect', function( e ) {
 			e.preventDefault();
 			const frame = wp.media( {
-				title: 'Select Cover Image',
-				button: { text: 'Use image' },
+				title: __( 'Select Cover Image', 'godam' ),
+				button: { text: __( 'Use image', 'godam' ) },
 				library: { type: 'image' },
 				multiple: false,
 			} );
@@ -154,15 +168,26 @@
 		} );
 
 		// When the chosen document changes, reset to auto and refetch its cover.
-		const $formContainer = $block.closest( '.wpb_el_type_document_cover_selector' ).parent();
 		$formContainer.find( '.document_selector_field' ).off( 'change.godamCover' ).on( 'change.godamCover', function() {
 			$valueInput.val( '' ).trigger( 'change' );
 			autoCover = '';
 			render();
-			fetchAutoCover( $( this ).val(), function( cover ) {
+			fetchAutoCover( restRoot, $( this ).val(), function( cover ) {
 				autoCover = cover;
 				render();
 			} );
+		} );
+
+		// WPBakery dependencies only support a single condition, so custom_cover
+		// is gated on show_cover alone. When the view leaves Card, reset both
+		// show_cover and the custom cover value so the cover picker can't linger
+		// with a stale show_cover=1 in Default view.
+		$formContainer.find( '[name="preview_mode"]' ).off( 'change.godamCoverMode' ).on( 'change.godamCoverMode', function() {
+			if ( 'card' !== $( this ).val() ) {
+				$formContainer.find( '[name="show_cover"]' ).val( '0' ).trigger( 'change' );
+				$valueInput.val( '' ).trigger( 'change' );
+				render();
+			}
 		} );
 	}
 }( window.jQuery ) );

--- a/assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js
@@ -179,14 +179,13 @@
 		} );
 
 		// WPBakery dependencies only support a single condition, so custom_cover
-		// is gated on show_cover alone. When the view leaves Card, reset both
-		// show_cover and the custom cover value so the cover picker can't linger
-		// with a stale show_cover=1 in Default view.
+		// is gated on show_cover alone. When the view leaves Card, reset show_cover
+		// to 0 — that already hides the custom cover field via its dependency. Do
+		// NOT clear the stored custom_cover value: the field is only hidden, so a
+		// previously chosen cover must survive peeking at Default and back.
 		$formContainer.find( '[name="preview_mode"]' ).off( 'change.godamCoverMode' ).on( 'change.godamCoverMode', function() {
 			if ( 'card' !== $( this ).val() ) {
 				$formContainer.find( '[name="show_cover"]' ).val( '0' ).trigger( 'change' );
-				$valueInput.val( '' ).trigger( 'change' );
-				render();
 			}
 		} );
 	}

--- a/assets/src/js/wpbakery/wpbakery-document-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-document-selector-param.js
@@ -1,6 +1,10 @@
 ( function( $ ) {
 	'use strict';
 
+	// Use WordPress i18n when available so user-facing strings are translatable;
+	// fall back to identity if wp.i18n is not loaded in the current context.
+	const { __ } = ( window.wp && window.wp.i18n ) ? window.wp.i18n : { __: ( s ) => s };
+
 	// Initialize document selector on document ready and when WPBakery reloads the params
 	$( document ).ready( initDocumentSelector );
 	$( document ).on( 'vc.reload', initDocumentSelector );
@@ -14,7 +18,10 @@
 			const paramName = $button.data( 'param' );
 			const $container = $button.closest( '.document_selector_block' );
 			const $input = $container.find( '.document_selector_field' );
-			const $srcInput = $attributeContainer.find( '.textfield_hidden_field' );
+			// Target the `src` hidden param specifically — a bare
+			// `.textfield_hidden_field` match could update another hidden field
+			// if the element ever gains more of them.
+			const $srcInput = $attributeContainer.find( '.textfield_hidden_field[name="src"]' );
 			// Sibling param fields to auto-populate from the attachment, mirroring
 			// the Gutenberg block's onSelectPdf (Doc Title + Description).
 			const $docTitleInput = $attributeContainer.find( '[name="doc_title"]' );
@@ -22,9 +29,9 @@
 
 			// Create WordPress media frame, restricted to PDF documents.
 			const frame = wp.media( {
-				title: 'Select or Upload Document',
+				title: __( 'Select or Upload Document', 'godam' ),
 				button: {
-					text: 'Select Document',
+					text: __( 'Select Document', 'godam' ),
 				},
 				library: {
 					type: 'application/pdf',
@@ -53,9 +60,9 @@
 				}
 
 				// Update button text
-				$button.text( 'Replace' );
+				$button.text( __( 'Replace', 'godam' ) );
 
-				const fileName = attachment.filename || attachment.title || 'Document';
+				const fileName = attachment.filename || attachment.title || __( 'Document', 'godam' );
 
 				// Add or update preview
 				let $preview = $container.find( '.document-selector-preview' );
@@ -64,16 +71,20 @@
 					$container.append( $preview );
 				}
 
-				$preview.html(
-					'<span class="dashicons dashicons-media-document" style="vertical-align: middle;"></span> ' +
-					'<span class="document-selector-preview__name">' + fileName + '</span>',
-				);
+				// Build the preview via DOM + .text() so the (attachment-derived)
+				// file name is never interpolated into markup — avoids XSS from a
+				// crafted attachment title/filename.
+				const $icon = $( '<span class="dashicons dashicons-media-document" style="vertical-align: middle;"></span>' );
+				const $name = $( '<span class="document-selector-preview__name"></span>' ).text( fileName );
+				$preview.empty().append( $icon, ' ', $name );
 
 				// Add or update remove button in the buttons wrapper
 				const $buttonsWrapper = $container.find( '.document_selector-buttons-wrapper' );
 				let $removeButton = $buttonsWrapper.find( '.document-selector-remove' );
 				if ( $removeButton.length === 0 ) {
-					$removeButton = $( '<button class="button document-selector-remove" data-test-id="godam-wpb-button-remove-document" data-param="' + paramName + '" style="margin-left: 5px;">Remove</button>' );
+					$removeButton = $( '<button type="button" class="button document-selector-remove" data-test-id="godam-wpb-button-remove-document" style="margin-left: 5px;"></button>' )
+						.attr( 'data-param', paramName )
+						.text( __( 'Remove', 'godam' ) );
 					$buttonsWrapper.append( $removeButton );
 				}
 
@@ -98,7 +109,7 @@
 			const $container = $button.closest( '.document_selector_block' );
 			const $input = $container.find( '.document_selector_field' );
 			const $selectButton = $container.find( '.document-selector-button' );
-			const $srcInput = $attributeContainer.find( '.textfield_hidden_field' );
+			const $srcInput = $attributeContainer.find( '.textfield_hidden_field[name="src"]' );
 
 			// Clear the input values
 			$input.val( '' ).trigger( 'change' );
@@ -111,7 +122,7 @@
 			$button.remove();
 
 			// Update button text
-			$selectButton.text( 'Select document' );
+			$selectButton.text( __( 'Select document', 'godam' ) );
 		} );
 	}
 }( window.jQuery ) );

--- a/assets/src/js/wpbakery/wpbakery-document-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-document-selector-param.js
@@ -1,0 +1,117 @@
+( function( $ ) {
+	'use strict';
+
+	// Initialize document selector on document ready and when WPBakery reloads the params
+	$( document ).ready( initDocumentSelector );
+	$( document ).on( 'vc.reload', initDocumentSelector );
+
+	function initDocumentSelector() {
+		$( '.document-selector-button' ).off( 'click' ).on( 'click', function( e ) {
+			e.preventDefault();
+
+			const $button = $( this );
+			const $attributeContainer = $button.closest( '.wpb_el_type_document_selector' ).parent();
+			const paramName = $button.data( 'param' );
+			const $container = $button.closest( '.document_selector_block' );
+			const $input = $container.find( '.document_selector_field' );
+			const $srcInput = $attributeContainer.find( '.textfield_hidden_field' );
+			// Sibling param fields to auto-populate from the attachment, mirroring
+			// the Gutenberg block's onSelectPdf (Doc Title + Description).
+			const $docTitleInput = $attributeContainer.find( '[name="doc_title"]' );
+			const $descriptionInput = $attributeContainer.find( '[name="description"]' );
+
+			// Create WordPress media frame, restricted to PDF documents.
+			const frame = wp.media( {
+				title: 'Select or Upload Document',
+				button: {
+					text: 'Select Document',
+				},
+				library: {
+					type: 'application/pdf',
+				},
+				multiple: false,
+			} );
+
+			// When a document is selected
+			frame.on( 'select', function() {
+				const attachment = frame.state().get( 'selection' ).first().toJSON();
+
+				// Update the hidden input values
+				$input.val( attachment.id ).trigger( 'change' );
+				$srcInput.val( attachment.url ).trigger( 'change' );
+
+				// Auto-populate Doc Title and Description from the attachment, matching
+				// the block. The media library exposes `description` as a plain string.
+				if ( $docTitleInput.length ) {
+					$docTitleInput.val( attachment.title || '' ).trigger( 'change' );
+				}
+				if ( $descriptionInput.length ) {
+					const attachmentDescription = typeof attachment.description === 'string'
+						? attachment.description
+						: '';
+					$descriptionInput.val( attachmentDescription ).trigger( 'change' );
+				}
+
+				// Update button text
+				$button.text( 'Replace' );
+
+				const fileName = attachment.filename || attachment.title || 'Document';
+
+				// Add or update preview
+				let $preview = $container.find( '.document-selector-preview' );
+				if ( $preview.length === 0 ) {
+					$preview = $( '<div class="document-selector-preview" data-test-id="godam-wpb-preview-document" style="margin-top: 10px;"></div>' );
+					$container.append( $preview );
+				}
+
+				$preview.html(
+					'<span class="dashicons dashicons-media-document" style="vertical-align: middle;"></span> ' +
+					'<span class="document-selector-preview__name">' + fileName + '</span>',
+				);
+
+				// Add or update remove button in the buttons wrapper
+				const $buttonsWrapper = $container.find( '.document_selector-buttons-wrapper' );
+				let $removeButton = $buttonsWrapper.find( '.document-selector-remove' );
+				if ( $removeButton.length === 0 ) {
+					$removeButton = $( '<button class="button document-selector-remove" data-test-id="godam-wpb-button-remove-document" data-param="' + paramName + '" style="margin-left: 5px;">Remove</button>' );
+					$buttonsWrapper.append( $removeButton );
+				}
+
+				// Re-attach remove handler
+				initRemoveHandler();
+			} );
+
+			// Open the media frame
+			frame.open();
+		} );
+
+		// Initialize remove handler
+		initRemoveHandler();
+	}
+
+	function initRemoveHandler() {
+		$( '.document-selector-remove' ).off( 'click' ).on( 'click', function( e ) {
+			e.preventDefault();
+
+			const $button = $( this );
+			const $attributeContainer = $button.closest( '.wpb_el_type_document_selector' ).parent();
+			const $container = $button.closest( '.document_selector_block' );
+			const $input = $container.find( '.document_selector_field' );
+			const $selectButton = $container.find( '.document-selector-button' );
+			const $srcInput = $attributeContainer.find( '.textfield_hidden_field' );
+
+			// Clear the input values
+			$input.val( '' ).trigger( 'change' );
+			$srcInput.val( '' ).trigger( 'change' );
+
+			// Remove preview
+			$container.find( '.document-selector-preview' ).remove();
+
+			// Remove the remove button itself
+			$button.remove();
+
+			// Update button text
+			$selectButton.text( 'Select document' );
+		} );
+	}
+}( window.jQuery ) );

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -59,6 +59,7 @@ use RTGODAM\Inc\REST_API\MetForm;
 use RTGODAM\Inc\Shortcodes\GoDAM_Player;
 use RTGODAM\Inc\Shortcodes\GoDAM_Video_Gallery;
 use RTGODAM\Inc\Shortcodes\GoDAM_Audio;
+use RTGODAM\Inc\Shortcodes\GoDAM_Document;
 
 use RTGODAM\Inc\Migrations\Runner as Migrations_Runner;
 use RTGODAM\Inc\Cron_Jobs\Retranscode_Failed_Media;
@@ -78,6 +79,7 @@ use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Params;
 use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Video;
 use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Video_Gallery;
 use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Audio;
+use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Document;
 
 /**
  * Class Plugin.
@@ -115,6 +117,7 @@ class Plugin {
 		GoDAM_Player::get_instance();
 		GoDAM_Video_Gallery::get_instance();
 		GoDAM_Audio::get_instance();
+		GoDAM_Document::get_instance();
 		Video_Engagement::get_instance();
 
 		Video_Editor_Form_Layer_Handler::get_instance()->init();
@@ -249,6 +252,7 @@ class Plugin {
 		WPB_GoDAM_Video::get_instance();
 		WPB_GoDAM_Video_Gallery::get_instance();
 		WPB_GoDAM_Audio::get_instance();
+		WPB_GoDAM_Document::get_instance();
 	}
 
 	/**

--- a/inc/classes/shortcodes/class-godam-document.php
+++ b/inc/classes/shortcodes/class-godam-document.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * GoDAM Document Shortcode Class.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Shortcodes;
+
+defined( 'ABSPATH' ) || exit;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+/**
+ * Class GoDAM_Document.
+ *
+ * This class handles the GoDAM document shortcode functionality. It powers the
+ * WPBakery "Document" element by reusing the Document block's render template.
+ */
+class GoDAM_Document {
+	use Singleton;
+
+	/**
+	 * Constructor.
+	 */
+	final protected function __construct() {
+		add_shortcode( 'godam_document', array( $this, 'render' ) );
+	}
+
+	/**
+	 * Render the GoDAM document shortcode.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string HTML output of the document embed.
+	 */
+	public function render( $atts ) {
+		// NOTE: WordPress' shortcode_parse_atts() lowercases every attribute name,
+		// so the WPBakery element uses lowercase/snake_case param names (doc_title,
+		// preview_mode, show_cover, custom_cover). Defaults below match that casing;
+		// they are then mapped to the block's camelCase attribute shape.
+		$atts = shortcode_atts(
+			array(
+				'id'           => '',
+				'src'          => '',
+				'caption'      => '',
+				'doc_title'    => '',
+				'description'  => '',
+				'preview_mode' => 'default',
+				'height'       => 600,
+				'show_cover'   => '0',
+				'custom_cover' => '',
+				'page_count'   => 0,
+				'css'          => '',
+			),
+			$atts,
+			'godam_document'
+		);
+
+		// A document requires either an attachment ID or a source URL.
+		if ( empty( $atts['id'] ) && empty( $atts['src'] ) ) {
+			return '';
+		}
+
+		// Map the flat shortcode atts to the block attribute shape expected by
+		// the shared render.php (booleans / ints normalized).
+		$attributes = array(
+			'id'          => $atts['id'],
+			'src'         => $atts['src'],
+			'caption'     => $atts['caption'],
+			'docTitle'    => $atts['doc_title'],
+			'description' => $atts['description'],
+			'previewMode' => $atts['preview_mode'],
+			'height'      => intval( $atts['height'] ),
+			'showCover'   => filter_var( $atts['show_cover'], FILTER_VALIDATE_BOOLEAN ),
+			'customCover' => $atts['custom_cover'],
+			'pageCount'   => intval( $atts['page_count'] ),
+		);
+
+		// Get WPBakery Design Options CSS class if available.
+		$godam_css_class = '';
+		if ( ! empty( $atts['css'] ) && function_exists( 'vc_shortcode_custom_css_class' ) ) {
+			$godam_css_class = vc_shortcode_custom_css_class( $atts['css'], ' ' );
+		}
+
+		// Enqueue the block's front-end script + styles so the shortcode gets the
+		// same behaviour and styling as the block. These handles are registered by
+		// register_block_type() (see class-blocks.php); WordPress auto-enqueues them
+		// for the block, but not when the shared render.php is included directly.
+		wp_enqueue_script( 'godam-pdf-view-script' );
+		wp_enqueue_style( 'godam-pdf-style' );
+
+		// Tells the shared render.php it runs outside block context, so it skips
+		// get_block_wrapper_attributes() (which warns without a block).
+		$godam_is_shortcode = true;
+
+		ob_start();
+		require RTGODAM_PATH . 'assets/build/blocks/godam-pdf/render.php';
+		return ob_get_clean();
+	}
+}

--- a/inc/classes/wpbakery-elements/class-wpb-godam-document.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-document.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * WPBakery GoDAM Document Element
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\WPBakery_Elements;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WPB_GoDAM_Document
+ *
+ * @since 2.0.0
+ *
+ * @package GoDAM
+ */
+class WPB_GoDAM_Document {
+	use Singleton;
+
+	/**
+	 * WPB_GoDAM_Document constructor.
+	 *
+	 * @since 2.0.0
+	 */
+	protected function __construct() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$is_wpbakery_active = is_plugin_active( 'js_composer/js_composer.php' );
+
+		if ( $is_wpbakery_active ) {
+			$this->setup_hooks();
+		}
+	}
+
+	/**
+	 * Setup hooks.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+		add_action( 'vc_before_init', array( $this, 'godam_document' ) );
+	}
+
+	/**
+	 * Map document element to WPBakery.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return void
+	 */
+	public function godam_document() {
+		if ( ! function_exists( 'vc_map' ) ) {
+			return;
+		}
+
+		vc_map(
+			array(
+				'name'        => esc_html__( 'Document', 'godam' ),
+				'base'        => 'godam_document',
+				'category'    => esc_html__( 'GoDAM', 'godam' ),
+				'description' => esc_html__( 'Embed a PDF document from GoDAM Media Library', 'godam' ),
+				'icon'        => RTGODAM_URL . 'assets/images/godam-pdf.svg',
+				'params'      => array(
+					// Document Selection.
+					array(
+						'type'        => 'document_selector',
+						'heading'     => esc_html__( 'Select Document', 'godam' ),
+						'param_name'  => 'id',
+						'value'       => '',
+						'description' => esc_html__( 'Select a PDF document from the WordPress Media Library.', 'godam' ),
+						'admin_label' => true,
+						'save_always' => true,
+					),
+
+					// Source URL (auto-filled by the document selector).
+					array(
+						'type'        => 'textfield_hidden',
+						'heading'     => esc_html__( 'Source URL', 'godam' ),
+						'param_name'  => 'src',
+						'value'       => '',
+						'admin_label' => true,
+						'description' => esc_html__( 'The source URL for the document file.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Document Title.
+					array(
+						'type'        => 'textfield',
+						'heading'     => esc_html__( 'Doc Title', 'godam' ),
+						'param_name'  => 'doc_title',
+						'value'       => '',
+						'description' => esc_html__( 'Add a title for the document. Leave empty to use the attachment title.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Description.
+					array(
+						'type'        => 'textarea',
+						'heading'     => esc_html__( 'Description', 'godam' ),
+						'param_name'  => 'description',
+						'value'       => '',
+						'description' => esc_html__( 'Add a document description (shown in card view).', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Preview Mode.
+					array(
+						'type'        => 'dropdown',
+						'heading'     => esc_html__( 'View', 'godam' ),
+						'param_name'  => 'preview_mode',
+						'value'       => array(
+							esc_html__( 'Default View', 'godam' ) => 'default',
+							esc_html__( 'Card View', 'godam' )    => 'card',
+						),
+						'std'         => 'default',
+						'description' => esc_html__( 'Choose how the document is displayed: an embedded PDF viewer or a card with a cover image.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Height (Default View only).
+					array(
+						'type'        => 'textfield',
+						'heading'     => esc_html__( 'Height (px)', 'godam' ),
+						'param_name'  => 'height',
+						'value'       => '600',
+						'description' => esc_html__( 'Height of the embedded PDF viewer in pixels.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element' => 'preview_mode',
+							'value'   => 'default',
+						),
+					),
+
+					// Show Cover (Card View only).
+					array(
+						'type'        => 'dropdown',
+						'heading'     => esc_html__( 'Show Cover', 'godam' ),
+						'param_name'  => 'show_cover',
+						'value'       => array(
+							esc_html__( 'No', 'godam' )  => '0',
+							esc_html__( 'Yes', 'godam' ) => '1',
+						),
+						'std'         => '0',
+						'description' => esc_html__( 'Show a cover image on the document card.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element' => 'preview_mode',
+							'value'   => 'card',
+						),
+					),
+
+					// Custom Cover (Card View + Show Cover only).
+					// Uses a dedicated selector that also previews the attachment's
+					// auto-generated cover (mirroring the block's first cover tile).
+					array(
+						'type'        => 'document_cover_selector',
+						'heading'     => esc_html__( 'Cover Image', 'godam' ),
+						'param_name'  => 'custom_cover',
+						'value'       => '',
+						'description' => esc_html__( 'Leave on the auto-generated cover, or select a custom image. Recommended aspect ratio: 16:9.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element' => 'show_cover',
+							'value'   => '1',
+						),
+					),
+
+					// Caption.
+					array(
+						'type'        => 'textfield',
+						'heading'     => esc_html__( 'Caption', 'godam' ),
+						'param_name'  => 'caption',
+						'value'       => '',
+						'description' => esc_html__( 'Add a caption for the document.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// WPBakery Design Options tab.
+					array(
+						'type'       => 'css_editor',
+						'heading'    => esc_html__( 'Design Options', 'godam' ),
+						'param_name' => 'css',
+						'group'      => esc_html__( 'Design Options', 'godam' ),
+					),
+				),
+			)
+		);
+	}
+}

--- a/inc/classes/wpbakery-elements/class-wpb-godam-params.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-params.php
@@ -66,6 +66,18 @@ class WPB_GoDAM_Params {
 		);
 
 		vc_add_shortcode_param(
+			'document_selector',
+			array( $this, 'document_selector_settings_field' ),
+			RTGODAM_URL . 'assets/build/js/wpbakery-document-selector-param.min.js'
+		);
+
+		vc_add_shortcode_param(
+			'document_cover_selector',
+			array( $this, 'document_cover_selector_settings_field' ),
+			RTGODAM_URL . 'assets/build/js/wpbakery-document-cover-selector-param.min.js'
+		);
+
+		vc_add_shortcode_param(
 			'textfield_hidden',
 			array( $this, 'textfield_hidden_settings_field' ),
 		);
@@ -180,6 +192,71 @@ class WPB_GoDAM_Params {
 			. $remove_button
 			. '</div>'
 			. $preview_html
+			. '</div>';
+	}
+
+	/**
+	 * Document selector settings field.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array  $settings Field settings.
+	 * @param string $value    Field value.
+	 * @return string
+	 */
+	public function document_selector_settings_field( $settings, $value ) {
+		$button_text   = ! empty( $value ) ? esc_html__( 'Replace', 'godam' ) : esc_html__( 'Select document', 'godam' );
+		$preview_html  = '';
+		$remove_button = '';
+
+		// If a document is selected, show preview and remove button.
+		if ( ! empty( $value ) && is_numeric( $value ) ) {
+			$attachment = wp_get_attachment_url( $value );
+			if ( $attachment ) {
+				$file_name     = basename( $attachment );
+				$preview_html  = '<div class="document-selector-preview" data-test-id="godam-wpb-preview-document" style="margin-top: 10px;">
+					<span class="dashicons dashicons-media-document" style="vertical-align: middle;"></span>
+					<span class="document-selector-preview__name">' . esc_html( $file_name ) . '</span>
+				</div>';
+				$remove_button = '<button type="button" class="button document-selector-remove" data-test-id="godam-wpb-button-remove-document" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
+			}
+		}
+
+		return '<div class="document_selector_block">'
+			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-document" class="wpb_vc_param_value wpb-textinput document_selector_field ' .
+			esc_attr( $settings['param_name'] ) . ' ' .
+			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'
+			. '<div class="document_selector-buttons-wrapper" style="display: flex; align-items: center;">'
+			. '<button type="button" class="button document-selector-button" data-test-id="godam-wpb-button-select-document" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
+			. $remove_button
+			. '</div>'
+			. $preview_html
+			. '</div>';
+	}
+
+	/**
+	 * Document cover selector settings field.
+	 *
+	 * Mirrors the block's cover picker: the auto-generated cover (fetched
+	 * client-side from the attachment meta) is the default, with the option to
+	 * override it with a custom image. An empty stored value means "use the
+	 * auto-generated cover" — which the render template already falls back to.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array  $settings Field settings.
+	 * @param string $value    Field value (custom cover URL, empty = auto).
+	 * @return string
+	 */
+	public function document_cover_selector_settings_field( $settings, $value ) {
+		return '<div class="document_cover_selector_block">'
+			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-cover" class="wpb_vc_param_value wpb-textinput document_cover_selector_field ' .
+			esc_attr( $settings['param_name'] ) . ' ' .
+			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'
+			. '<div class="document-cover-tiles" data-test-id="godam-wpb-cover-tiles" style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px;"></div>'
+			. '<div class="document_cover_selector-buttons-wrapper" style="display:flex;align-items:center;">'
+			. '<button type="button" class="button document-cover-select" data-test-id="godam-wpb-button-select-cover">' . esc_html__( 'Select image', 'godam' ) . '</button>'
+			. '</div>'
 			. '</div>';
 	}
 

--- a/inc/classes/wpbakery-elements/class-wpb-godam-params.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-params.php
@@ -249,7 +249,10 @@ class WPB_GoDAM_Params {
 	 * @return string
 	 */
 	public function document_cover_selector_settings_field( $settings, $value ) {
-		return '<div class="document_cover_selector_block">'
+		// Pass the site's REST root (rest_url()) so the JS never has to guess it —
+		// this is correct for subdirectory installs, custom REST prefixes and
+		// multisite, unlike deriving it from window.location.
+		return '<div class="document_cover_selector_block" data-rest-url="' . esc_url( rest_url() ) . '">'
 			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-cover" class="wpb_vc_param_value wpb-textinput document_cover_selector_field ' .
 			esc_attr( $settings['param_name'] ) . ' ' .
 			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -264,6 +264,20 @@ const wpBakeryImageSrcSelectorParam = {
 		'wpbakery-image-src-selector-param': path.resolve( process.cwd(), 'assets', 'src', 'js', 'wpbakery', 'wpbakery-image-src-selector-param.js' ),
 	},
 };
+
+const wpBakeryDocumentSelectorParam = {
+	...sharedConfig,
+	entry: {
+		'wpbakery-document-selector-param': path.resolve( process.cwd(), 'assets', 'src', 'js', 'wpbakery', 'wpbakery-document-selector-param.js' ),
+	},
+};
+
+const wpBakeryDocumentCoverSelectorParam = {
+	...sharedConfig,
+	entry: {
+		'wpbakery-document-cover-selector-param': path.resolve( process.cwd(), 'assets', 'src', 'js', 'wpbakery', 'wpbakery-document-cover-selector-param.js' ),
+	},
+};
 const ninjaFormsSubmissionsList = {
 	...sharedConfig,
 	entry: {
@@ -390,6 +404,8 @@ module.exports = [
 	wpBakeryVideoSelectorParam,
 	wpBakeryAudioSelectorParam,
 	wpBakeryImageSrcSelectorParam,
+	wpBakeryDocumentSelectorParam,
+	wpBakeryDocumentCoverSelectorParam,
 	ninjaFormsSubmissionsList,
 	blockExtensions,
 ];


### PR DESCRIPTION
<html><head></head><body><h1>Register Document (PDF) block in WPBakery</h1>

Issue - rtCamp/godam-plugin-wp#19

<h2>Summary</h2>
<p>The <code>godam/pdf</code> <strong>Document</strong> block was the only GoDAM media block not available in the WPBakery (Visual Composer) page builder — Video, Video Gallery, and Audio were all already mapped. This PR registers a <strong>Document</strong> element under the GoDAM category in WPBakery, wired the same way as the existing elements, and exposes the block's redesigned (2.0) attributes so the WPBakery element reaches feature parity with the Gutenberg block, including <strong>Default (embedded viewer)</strong> and <strong>Card</strong> views with an auto‑generated cover.</p>
<h2>Background</h2>
<p>WPBakery elements render through shortcodes (<code>base</code> → shortcode name), and each existing GoDAM element reuses the corresponding block's <code>render.php</code>. The Document block had no WPBakery element and no shortcode, so it couldn't be added from the builder. It also gained new attributes in the 2.0 redesign (title, description, preview mode, cover, etc.) that needed to be surfaced.</p>
<h2>What changed</h2>
<h3>New files</h3>
<ul>
<li><code>inc/classes/wpbakery-elements/class-wpb-godam-document.php</code> — maps the <code>godam_document</code> element via <code>vc_map()</code> under the <strong>GoDAM</strong> category. Follows the exact pattern of the other elements (WPBakery-active guard, <code>vc_before_init</code> hook, <code>Singleton</code>).</li>
<li><code>inc/classes/shortcodes/class-godam-document.php</code> — registers the <code>[godam_document]</code> shortcode, which reuses the Document block's <code>render.php</code> (same approach as <code>[godam_audio]</code>). Maps the flat shortcode attributes to the block's attribute shape.</li>
<li><code>assets/src/js/wpbakery/wpbakery-document-selector-param.js</code> — custom <code>document_selector</code> param: opens the media library filtered to PDFs, stores the attachment ID + source URL, and <strong>auto-populates Doc Title and Description</strong> from the attachment (matching the block's <code>onSelectPdf</code>).</li>
<li><code>assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js</code> — custom <code>document_cover_selector</code> param: renders the <strong>auto-generated cover</strong> (fetched from the attachment's REST meta) as the default tile, with a "Select image" override, mirroring the block's cover picker.</li>
</ul>
<h3>Modified files</h3>
<ul>
<li><code>inc/classes/wpbakery-elements/class-wpb-godam-params.php</code> — registers the two new custom param types (<code>document_selector</code>, <code>document_cover_selector</code>) and their field renderers.</li>
<li><code>inc/classes/shortcodes/class-godam-document.php</code> <em>(new, listed above)</em> and <code>assets/src/blocks/godam-pdf/render.php</code> — <code>render.php</code> now supports being called outside block context: when <code>$godam_is_shortcode</code> is set it skips <code>get_block_wrapper_attributes()</code> (which warns without an active block) and applies any WPBakery <strong>Design Options</strong> CSS class instead.</li>
<li><code>inc/classes/class-plugin.php</code> — registers <code>GoDAM_Document</code> (shortcode) and <code>WPB_GoDAM_Document</code> (element) alongside the existing ones.</li>
<li><code>webpack.config.js</code> — adds build entries for the two new param scripts.</li>
</ul>
<h2>Attributes exposed in the WPBakery element</h2>

WPBakery param (base: godam_document) | Block attribute | Notes
-- | -- | --
id | id | PDF picker (media library, PDF-only)
src | src | Hidden, auto-filled by the picker
doc_title | docTitle | Auto-populated from attachment; editable
description | description | Auto-populated from attachment; editable
preview_mode | previewMode | Default View / Card View
height | height | Default view only
show_cover | showCover | Card view only
custom_cover | customCover | Card + Show Cover; empty = auto-generated cover
caption | caption |  
css | — | WPBakery Design Options tab


<h2>Key implementation notes</h2>
<ul>
<li><strong>Shortcode attribute casing.</strong> WordPress' <code>shortcode_parse_atts()</code> <strong>lowercases every attribute name</strong>, so WPBakery params must use lowercase/snake_case names (as the existing Video/Audio elements do). Params use <code>doc_title</code>, <code>preview_mode</code>, <code>show_cover</code>, <code>custom_cover</code>, and the shortcode maps them back to the block's camelCase attributes (<code>docTitle</code>, <code>previewMode</code>, …). Using camelCase param names silently breaks Card view because <code>previewmode</code> never matches <code>previewMode</code>.</li>
<li><strong>Auto-generated cover.</strong> The cover meta (<code>rtgodam_media_video_thumbnail</code>, then <code>rtgodam_media_pdf_thumbnail</code>) is registered <code>show_in_rest</code>, so it is readable in the public "view" context without a nonce. The cover param fetches <code>/wp/v2/media/{id}</code> client-side to preview the auto cover; an empty <code>custom_cover</code> value means "use the auto cover", which <code>render.php</code> already resolves on the front end.</li>
<li><strong>Single source of truth for rendering.</strong> No markup was duplicated — the shortcode reuses the block's <code>render.php</code>, so block and WPBakery output stay in sync.</li>
</ul>
<h2>How to test</h2>
<ol>
<li>Ensure WPBakery (<code>js_composer</code>) is active. Run <code>npm run build:js</code> (the two new param scripts are generated into <code>assets/build/js/</code>, which is gitignored).</li>
<li>Edit a page with WPBakery → add the <strong>GoDAM → Document</strong> element.</li>
<li>Select a PDF → confirm <strong>Doc Title</strong> and <strong>Description</strong> auto-populate.</li>
<li><strong>Default View:</strong> adjust Height → confirm the embedded PDF renders on the front end.</li>
<li><strong>Card View:</strong> set View = Card, Show Cover = Yes → the <strong>auto-generated cover</strong> appears as the first tile; optionally override via "Select image". Confirm the card (cover, title, description) renders on the front end.</li>
<li>Verify the <strong>Design Options</strong> tab styling applies on the front end.</li>
</ol>
<h2>Notes for reviewers</h2>
<ul>
<li><code>assets/build/js/*.min.js</code> are build artifacts (gitignored) — rebuild with <code>npm run build:js</code>.</li>
<li>No PHPCS error found.</li>
</ul></body></html>

## Demo

https://github.com/user-attachments/assets/0a8019b4-17b6-4ce6-b1bd-2eaa27d151ee


