### PR TITLE
Update: GoDAM blocks in wp bakery

### DIFF
--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -24,7 +24,7 @@ import './api/godam-api.js';
 /**
  * Initialize player on DOM content loaded
  */
-document.addEventListener( 'DOMContentLoaded', () => {
+const initGodamPlayers = () => {
 	new PlayerManager();
 
 	// Scroll to a specific video and optionally seek to a timestamp when the URL
@@ -87,7 +87,81 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			document.addEventListener( 'godamPlayerReady', onPlayerReady );
 		}
 	}
-} );
+};
+
+// Run on DOMContentLoaded, or immediately if the DOM is already parsed. Page
+// builders such as WPBakery's inline editor enqueue/inject this script AFTER
+// DOMContentLoaded has fired inside their preview iframe, so a bare listener
+// would never run and the player would stay stuck in its pre-init "loading"
+// state (0×0, only the play button visible). The readyState fallback ensures
+// PlayerManager still runs in that case.
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', initGodamPlayers );
+} else {
+	initGodamPlayers();
+}
+
+/**
+ * Re-initialize any players that appear after the initial run.
+ *
+ * Page builders (e.g. WPBakery's inline editor) render the shortcode markup into
+ * their preview AFTER this script has already executed, which leaves the player
+ * stuck in its pre-init "loading" state (0×0, only the play button visible).
+ * PlayerManager.initializeVideo() is idempotent — it is guarded by
+ * `data-godam-initialized` — so re-running only initializes players that were
+ * missed. On a normal front-end load where everything is already initialized,
+ * the guard below finds nothing pending and this is a cheap no-op.
+ */
+const reinitPendingPlayers = () => {
+	if ( document.querySelector( '.easydam-player.video-js:not([data-godam-initialized])' ) ) {
+		new PlayerManager();
+	}
+};
+
+// Catch players rendered slightly after our initial init. Each pass is a single
+// querySelector no-op when nothing is pending.
+[ 300, 1200, 3000 ].forEach( ( delay ) => setTimeout( reinitPendingPlayers, delay ) );
+
+/**
+ * In a page-builder preview the markup can be re-rendered repeatedly as the user
+ * edits, so keep watching and re-initialize on demand. Restricted to editor
+ * previews so no observer is attached on the published front end.
+ *
+ * @return {boolean} True when running inside a WPBakery editor preview.
+ */
+const isBuilderPreview = () => {
+	try {
+		const fe = window.frameElement;
+		if ( fe && /vc[-_]inline-frame|vc_editor/i.test( ( fe.id || '' ) + ' ' + ( fe.className || '' ) ) ) {
+			return true;
+		}
+	} catch ( e ) {}
+	try {
+		return !! document.body?.classList.contains( 'vc_editor' );
+	} catch ( e ) {
+		return false;
+	}
+};
+
+if ( isBuilderPreview() && 'MutationObserver' in window ) {
+	let scheduled = false;
+	const observer = new MutationObserver( () => {
+		if ( scheduled ) {
+			return;
+		}
+		scheduled = true;
+		window.requestAnimationFrame( () => {
+			scheduled = false;
+			reinitPendingPlayers();
+		} );
+	} );
+	const startObserving = () => observer.observe( document.body, { childList: true, subtree: true } );
+	if ( document.body ) {
+		startObserving();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', startObserving );
+	}
+}
 
 /**
  * Handle Content Security Policy (CSP) violations related to blob workers

--- a/assets/src/js/godam-player/frontend.js
+++ b/assets/src/js/godam-player/frontend.js
@@ -24,8 +24,16 @@ import './api/godam-api.js';
 /**
  * Initialize player on DOM content loaded
  */
+let godamPlayerManager = null;
 const initGodamPlayers = () => {
-	new PlayerManager();
+	// Idempotent: if a deferred re-init pass (editor preview) already created the
+	// manager, reuse it and just initialize any pending players — never construct
+	// a second PlayerManager (which would duplicate global listeners).
+	if ( godamPlayerManager ) {
+		godamPlayerManager.initializePendingVideos();
+	} else {
+		godamPlayerManager = new PlayerManager();
+	}
 
 	// Scroll to a specific video and optionally seek to a timestamp when the URL
 	// hash matches #godam-video-{jobId} and an optional ?t={seconds} query param is present.
@@ -105,27 +113,26 @@ if ( document.readyState === 'loading' ) {
  * Re-initialize any players that appear after the initial run.
  *
  * Page builders (e.g. WPBakery's inline editor) render the shortcode markup into
- * their preview AFTER this script has already executed, which leaves the player
- * stuck in its pre-init "loading" state (0×0, only the play button visible).
- * PlayerManager.initializeVideo() is idempotent — it is guarded by
- * `data-godam-initialized` — so re-running only initializes players that were
- * missed. On a normal front-end load where everything is already initialized,
- * the guard below finds nothing pending and this is a cheap no-op.
+ * their preview AFTER this script has already executed, leaving the player stuck
+ * in its pre-init "loading" state (0×0, only the play button visible). This
+ * initializes only players that were missed (via the manager's guarded
+ * `initializePendingVideos()`), so it never duplicates global listeners.
  */
 const reinitPendingPlayers = () => {
-	if ( document.querySelector( '.easydam-player.video-js:not([data-godam-initialized])' ) ) {
-		new PlayerManager();
+	if ( ! document.querySelector( '.easydam-player.video-js:not([data-godam-initialized])' ) ) {
+		return;
+	}
+	if ( godamPlayerManager ) {
+		godamPlayerManager.initializePendingVideos();
+	} else {
+		godamPlayerManager = new PlayerManager();
 	}
 };
 
-// Catch players rendered slightly after our initial init. Each pass is a single
-// querySelector no-op when nothing is pending.
-[ 300, 1200, 3000 ].forEach( ( delay ) => setTimeout( reinitPendingPlayers, delay ) );
-
 /**
- * In a page-builder preview the markup can be re-rendered repeatedly as the user
- * edits, so keep watching and re-initialize on demand. Restricted to editor
- * previews so no observer is attached on the published front end.
+ * Detect a WPBakery editor preview. The re-init timers/observer below are scoped
+ * to this so nothing extra runs on the published front end, where the one-shot
+ * init above already handles every player present at load.
  *
  * @return {boolean} True when running inside a WPBakery editor preview.
  */
@@ -143,23 +150,30 @@ const isBuilderPreview = () => {
 	}
 };
 
-if ( isBuilderPreview() && 'MutationObserver' in window ) {
-	let scheduled = false;
-	const observer = new MutationObserver( () => {
-		if ( scheduled ) {
-			return;
-		}
-		scheduled = true;
-		window.requestAnimationFrame( () => {
-			scheduled = false;
-			reinitPendingPlayers();
+// Only in a page-builder preview: the markup is rendered/re-rendered after this
+// script runs, so catch it with a few deferred passes plus an observer for
+// ongoing edits. None of this is scheduled on the published front end.
+if ( isBuilderPreview() ) {
+	[ 300, 1200, 3000 ].forEach( ( delay ) => setTimeout( reinitPendingPlayers, delay ) );
+
+	if ( 'MutationObserver' in window ) {
+		let scheduled = false;
+		const observer = new MutationObserver( () => {
+			if ( scheduled ) {
+				return;
+			}
+			scheduled = true;
+			window.requestAnimationFrame( () => {
+				scheduled = false;
+				reinitPendingPlayers();
+			} );
 		} );
-	} );
-	const startObserving = () => observer.observe( document.body, { childList: true, subtree: true } );
-	if ( document.body ) {
-		startObserving();
-	} else {
-		document.addEventListener( 'DOMContentLoaded', startObserving );
+		const startObserving = () => observer.observe( document.body, { childList: true, subtree: true } );
+		if ( document.body ) {
+			startObserving();
+		} else {
+			document.addEventListener( 'DOMContentLoaded', startObserving );
+		}
 	}
 }
 

--- a/assets/src/js/godam-player/managers/playerManager.js
+++ b/assets/src/js/godam-player/managers/playerManager.js
@@ -124,6 +124,28 @@ export default class PlayerManager {
 	}
 
 	/**
+	 * Initialize players that were added to the DOM after construction (e.g.
+	 * markup rendered by a page builder such as WPBakery's inline editor).
+	 *
+	 * Re-scans the document and initializes ONLY elements that are not already
+	 * initialized — initializeVideo() is guarded by `data-godam-initialized`.
+	 * This deliberately does NOT re-run the one-time global setup (keyboard
+	 * handler, autoplay-on-view observer, engagement, blur-up), so it can be
+	 * called repeatedly without ever duplicating global listeners.
+	 *
+	 * @return {void}
+	 */
+	initializePendingVideos() {
+		document.querySelectorAll( '.easydam-player.video-js' ).forEach( ( video ) => {
+			const instanceId = video.dataset.instanceId;
+			if ( instanceId && ! ( instanceId in this.isDisplayingLayers ) ) {
+				this.isDisplayingLayers[ instanceId ] = false;
+			}
+			this.initializeVideo( video );
+		} );
+	}
+
+	/**
 	 * Initialize individual video
 	 *
 	 * @param {HTMLElement} video - Video element to initialize

--- a/assets/src/js/wpbakery/wpbakery-audio-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-audio-selector-param.js
@@ -42,7 +42,10 @@
 				$input.val( attachment.id ).trigger( 'change' );
 				$srcInput.val( attachment.url ).trigger( 'change' );
 
-				// Auto-populate Audio Title and Description from the attachment.
+				// Auto-populate Audio Title and Description from the attachment on
+				// every select/replace, matching the block's onSelectAudio — so
+				// swapping the audio file refreshes the title/description to the
+				// newly selected attachment's values.
 				if ( $audioTitleInput.length ) {
 					$audioTitleInput.val( attachment.title || '' ).trigger( 'change' );
 				}

--- a/assets/src/js/wpbakery/wpbakery-audio-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-audio-selector-param.js
@@ -14,7 +14,13 @@
 			const paramName = $button.data( 'param' );
 			const $container = $button.closest( '.audio_selector_block' );
 			const $input = $container.find( '.audio_selector_field' );
-			const $srcInput = $attributeContainer.find( '.textfield_hidden_field' );
+			// Target the `src` hidden param specifically so other hidden fields
+			// are never touched.
+			const $srcInput = $attributeContainer.find( '.textfield_hidden_field[name="src"]' );
+			// Sibling params to auto-populate from the attachment, mirroring the
+			// Gutenberg block's onSelectAudio (Audio Title + Description).
+			const $audioTitleInput = $attributeContainer.find( '[name="audio_title"]' );
+			const $descriptionInput = $attributeContainer.find( '[name="description"]' );
 
 			// Create WordPress media frame
 			const frame = wp.media( {
@@ -35,6 +41,17 @@
 				// Update the hidden input value
 				$input.val( attachment.id ).trigger( 'change' );
 				$srcInput.val( attachment.url ).trigger( 'change' );
+
+				// Auto-populate Audio Title and Description from the attachment.
+				if ( $audioTitleInput.length ) {
+					$audioTitleInput.val( attachment.title || '' ).trigger( 'change' );
+				}
+				if ( $descriptionInput.length ) {
+					const attachmentDescription = typeof attachment.description === 'string'
+						? attachment.description
+						: '';
+					$descriptionInput.val( attachmentDescription ).trigger( 'change' );
+				}
 
 				// Update button text
 				$button.text( 'Replace' );
@@ -81,7 +98,7 @@
 			const $container = $button.closest( '.audio_selector_block' );
 			const $input = $container.find( '.audio_selector_field' );
 			const $selectButton = $container.find( '.audio-selector-button' );
-			const $srcInput = $attributeContainer.find( '.textfield_hidden_field' );
+			const $srcInput = $attributeContainer.find( '.textfield_hidden_field[name="src"]' );
 
 			// Clear the input value
 			$input.val( '' ).trigger( 'change' );

--- a/inc/classes/shortcodes/class-godam-audio.php
+++ b/inc/classes/shortcodes/class-godam-audio.php
@@ -33,25 +33,38 @@ class GoDAM_Audio {
 	 * @return string HTML output of the audio player.
 	 */
 	public function render( $atts ) {
+		// Snake_case attribute names (WordPress lowercases shortcode attribute
+		// names) matching the WPBakery element params. Mapped below to the block's
+		// camelCase attribute keys that the shared render.php consumes.
 		$attributes = shortcode_atts(
 			array(
-				'id'       => '',
-				'src'      => '',
-				'caption'  => '',
-				'autoplay' => false,
-				'loop'     => false,
-				'preload'  => 'metadata',
-				'css'      => '',
+				'id'              => '',
+				'src'             => '',
+				'autoplay'        => false,
+				'loop'            => false,
+				'preload'         => 'metadata',
+				'audio_title'     => '',
+				'description'     => '',
+				'thumbnail'       => '',
+				'show_transcript' => true,
+				'show_chapters'   => true,
+				'css'             => '',
 			),
 			$atts,
 			'godam_audio'
 		);
 
 		// Handle boolean attributes passed as strings.
-		$boolean_attributes = array( 'autoplay', 'loop' );
+		$boolean_attributes = array( 'autoplay', 'loop', 'show_transcript', 'show_chapters' );
 		foreach ( $boolean_attributes as $bool_attr ) {
 			$attributes[ $bool_attr ] = filter_var( $attributes[ $bool_attr ], FILTER_VALIDATE_BOOLEAN );
 		}
+
+		// Map the redesigned attributes to the block's camelCase keys that
+		// render.php reads. 'description'/'thumbnail' already share the key name.
+		$attributes['audioTitle']     = $attributes['audio_title'];
+		$attributes['showTranscript'] = $attributes['show_transcript'];
+		$attributes['showChapters']   = $attributes['show_chapters'];
 
 		// Get WPBakery Design Options CSS class if available.
 		$attributes['css_class'] = '';

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -316,14 +316,16 @@ class GoDAM_Player {
 		}
 
 		// Map the WPBakery caption/transcription toggles to the block's camelCase
-		// attributes, but only when explicitly provided. This preserves the
-		// template's own defaults (showTranscription on; showCaption derived from
-		// the attachment) for hand-written shortcodes that omit them.
-		if ( is_array( $atts ) && array_key_exists( 'show_transcription', $atts ) ) {
-			$attributes['showTranscription'] = filter_var( $attributes['show_transcription'], FILTER_VALIDATE_BOOLEAN );
+		// attributes, but only when explicitly provided with a non-empty value.
+		// A bare/empty flag (e.g. [godam_video show_transcription=""]) must NOT be
+		// read as `false` — leaving the attribute unset preserves the template's
+		// own defaults (showTranscription on; showCaption derived from the
+		// attachment). '0'/'false' are still honoured as an explicit "off".
+		if ( is_array( $atts ) && isset( $atts['show_transcription'] ) && '' !== $atts['show_transcription'] ) {
+			$attributes['showTranscription'] = filter_var( $atts['show_transcription'], FILTER_VALIDATE_BOOLEAN );
 		}
-		if ( is_array( $atts ) && array_key_exists( 'show_caption', $atts ) ) {
-			$attributes['showCaption'] = filter_var( $attributes['show_caption'], FILTER_VALIDATE_BOOLEAN );
+		if ( is_array( $atts ) && isset( $atts['show_caption'] ) && '' !== $atts['show_caption'] ) {
+			$attributes['showCaption'] = filter_var( $atts['show_caption'], FILTER_VALIDATE_BOOLEAN );
 		}
 
 		// Get WPBakery Design Options CSS class if available.

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -269,6 +269,8 @@ class GoDAM_Player {
 				'show_share_button'  => false, // WPBakery format (lowercase with underscore).
 				'playerHeight'       => '',
 				'player_height'      => '', // WPBakery format (lowercase with underscore).
+				'show_transcription' => '', // WPBakery toggle → maps to showTranscription.
+				'show_caption'       => '', // WPBakery toggle → maps to showCaption.
 				'css'                => '',
 				'godam_context'      => '',
 			),
@@ -311,6 +313,17 @@ class GoDAM_Player {
 		$raw_has_performance_mode_camel_case = is_array( $atts ) && array_key_exists( 'performanceMode', $atts );
 		if ( $raw_has_performance_mode && ! $raw_has_performance_mode_camel_case && isset( $attributes['performance_mode'] ) && '' !== $attributes['performance_mode'] ) {
 			$attributes['performanceMode'] = $attributes['performance_mode'];
+		}
+
+		// Map the WPBakery caption/transcription toggles to the block's camelCase
+		// attributes, but only when explicitly provided. This preserves the
+		// template's own defaults (showTranscription on; showCaption derived from
+		// the attachment) for hand-written shortcodes that omit them.
+		if ( is_array( $atts ) && array_key_exists( 'show_transcription', $atts ) ) {
+			$attributes['showTranscription'] = filter_var( $attributes['show_transcription'], FILTER_VALIDATE_BOOLEAN );
+		}
+		if ( is_array( $atts ) && array_key_exists( 'show_caption', $atts ) ) {
+			$attributes['showCaption'] = filter_var( $attributes['show_caption'], FILTER_VALIDATE_BOOLEAN );
 		}
 
 		// Get WPBakery Design Options CSS class if available.

--- a/inc/classes/shortcodes/class-godam-video-gallery.php
+++ b/inc/classes/shortcodes/class-godam-video-gallery.php
@@ -63,14 +63,21 @@ class GoDAM_Video_Gallery {
 				'show_title'          => true,
 				'performance_mode'    => 'balanced',
 				'engagements'         => true,
+				// Interaction: 'hover' (play on hover) or 'autoplay'. Maps to the
+				// block's mutually-exclusive autoplay / playOnHover booleans.
+				'interaction'         => 'hover',
+				'show_play_button'    => true,
 			),
 			$atts,
 			'godam_video_gallery'
 		);
 
-		foreach ( array( 'infinite_scroll', 'enable_more_items', 'show_title', 'engagements' ) as $bool_key ) {
+		foreach ( array( 'infinite_scroll', 'enable_more_items', 'show_title', 'engagements', 'show_play_button' ) as $bool_key ) {
 			$atts[ $bool_key ] = filter_var( $atts[ $bool_key ], FILTER_VALIDATE_BOOLEAN );
 		}
+
+		// Split the single interaction choice into the two block booleans.
+		$godam_is_autoplay = ( 'autoplay' === sanitize_key( $atts['interaction'] ) );
 
 		// WPBakery saves param_group as rawurlencode(json_encode([{video_id: …}, …])).
 		// Decode it and fold each row's video_id into the comma-separated `ids`
@@ -131,6 +138,9 @@ class GoDAM_Video_Gallery {
 			'showTitle'         => $atts['show_title'],
 			'performanceMode'   => sanitize_key( $atts['performance_mode'] ),
 			'engagements'       => $atts['engagements'],
+			'autoplay'          => $godam_is_autoplay,
+			'playOnHover'       => ! $godam_is_autoplay,
+			'showPlayButton'    => $atts['show_play_button'],
 		);
 
 		// Enqueue the block's frontend assets so the shortcode reuses the same

--- a/inc/classes/wpbakery-elements/class-wpb-godam-audio.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-audio.php
@@ -95,6 +95,48 @@ class WPB_GoDAM_Audio {
 						),
 					),
 
+					// Audio Title.
+					array(
+						'type'        => 'textfield',
+						'heading'     => esc_html__( 'Audio Title', 'godam' ),
+						'param_name'  => 'audio_title',
+						'value'       => '',
+						'description' => esc_html__( 'Title shown in the player. Leave empty to use the attachment title.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Description.
+					array(
+						'type'        => 'textarea',
+						'heading'     => esc_html__( 'Description', 'godam' ),
+						'param_name'  => 'description',
+						'value'       => '',
+						'description' => esc_html__( 'Short description shown beneath the title.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Thumbnail.
+					array(
+						'type'        => 'image_src_selector',
+						'heading'     => esc_html__( 'Thumbnail', 'godam' ),
+						'param_name'  => 'thumbnail',
+						'value'       => '',
+						'description' => esc_html__( 'Cover image for the audio player. Leave empty to use the GoDAM-generated cover.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
 					// Audio Playback Controls.
 					array(
 						'type'        => 'dropdown',
@@ -147,13 +189,27 @@ class WPB_GoDAM_Audio {
 						),
 					),
 					
-					// Caption Settings.
+					// Transcription Settings.
 					array(
-						'type'        => 'textfield',
-						'heading'     => esc_html__( 'Audio Caption', 'godam' ),
-						'param_name'  => 'caption',
-						'value'       => '',
-						'description' => esc_html__( 'Add a caption for the audio player.', 'godam' ),
+						'type'        => 'checkbox',
+						'heading'     => esc_html__( 'Show Transcript', 'godam' ),
+						'param_name'  => 'show_transcript',
+						'value'       => array( esc_html__( 'Yes', 'godam' ) => 'true' ),
+						'std'         => 'true',
+						'description' => esc_html__( 'Show the transcript panel (when a transcript is available).', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+					array(
+						'type'        => 'checkbox',
+						'heading'     => esc_html__( 'Show Chapters', 'godam' ),
+						'param_name'  => 'show_chapters',
+						'value'       => array( esc_html__( 'Yes', 'godam' ) => 'true' ),
+						'std'         => 'true',
+						'description' => esc_html__( 'Show the chapters panel (when chapters are available).', 'godam' ),
 						'save_always' => true,
 						'dependency'  => array(
 							'element'   => 'id',

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php
@@ -242,6 +242,7 @@ class WPB_GoDAM_Video_Gallery {
 				'value'       => array(
 					esc_html__( 'Grid', 'godam' )     => 'grid',
 					esc_html__( 'Carousel', 'godam' ) => 'carousel',
+					esc_html__( 'List', 'godam' )     => 'list',
 				),
 				'std'         => 'grid',
 				'description' => esc_html__( 'Choose the layout style for the gallery.', 'godam' ),
@@ -282,6 +283,27 @@ class WPB_GoDAM_Video_Gallery {
 				'value'       => array( esc_html__( 'Yes', 'godam' ) => 'true' ),
 				'std'         => 'true',
 				'description' => esc_html__( 'Display video titles and upload dates beneath each tile.', 'godam' ),
+				'group'       => $display_group,
+			),
+			array(
+				'type'        => 'dropdown',
+				'heading'     => esc_html__( 'Interaction', 'godam' ),
+				'param_name'  => 'interaction',
+				'value'       => array(
+					esc_html__( 'Play on hover', 'godam' ) => 'hover',
+					esc_html__( 'Autoplay all videos', 'godam' ) => 'autoplay',
+				),
+				'std'         => 'hover',
+				'description' => esc_html__( 'Play on hover: videos play when hovered. Autoplay: visible videos autoplay one at a time.', 'godam' ),
+				'group'       => $display_group,
+			),
+			array(
+				'type'        => 'checkbox',
+				'heading'     => esc_html__( 'Show Play Button', 'godam' ),
+				'param_name'  => 'show_play_button',
+				'value'       => array( esc_html__( 'Yes', 'godam' ) => 'true' ),
+				'std'         => 'true',
+				'description' => esc_html__( 'Show the play button overlay on each tile.', 'godam' ),
 				'group'       => $display_group,
 			),
 			array(

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php
@@ -303,6 +303,10 @@ class WPB_GoDAM_Video_Gallery {
 				'param_name'  => 'show_play_button',
 				'value'       => array( esc_html__( 'Yes', 'godam' ) => 'true' ),
 				'std'         => 'true',
+				// save_always so unchecking persists an empty value; without it VC
+				// omits the attribute and the shortcode's `true` default keeps the
+				// overlay on, making the toggle impossible to turn off.
+				'save_always' => true,
 				'description' => esc_html__( 'Show the play button overlay on each tile.', 'godam' ),
 				'group'       => $display_group,
 			),

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video.php
@@ -258,11 +258,12 @@ class WPB_GoDAM_Video {
 					'heading'     => esc_html__( 'Show Transcription', 'godam' ),
 					'param_name'  => 'show_transcription',
 					'value'       => array(
+						esc_html__( 'Default (from media)', 'godam' ) => '',
 						esc_html__( 'Yes', 'godam' ) => '1',
 						esc_html__( 'No', 'godam' )  => '0',
 					),
-					'std'         => '1',
-					'description' => esc_html__( 'Show the transcript button/panel (when a transcript is available).', 'godam' ),
+					'std'         => '',
+					'description' => esc_html__( 'Show the transcript button/panel. "Default" follows the media/block setting.', 'godam' ),
 					'save_always' => true,
 					'dependency'  => array(
 						'element'   => 'id',
@@ -276,11 +277,12 @@ class WPB_GoDAM_Video {
 					'heading'     => esc_html__( 'Show Caption', 'godam' ),
 					'param_name'  => 'show_caption',
 					'value'       => array(
+						esc_html__( 'Default (from media)', 'godam' ) => '',
 						esc_html__( 'Yes', 'godam' ) => '1',
 						esc_html__( 'No', 'godam' )  => '0',
 					),
-					'std'         => '1',
-					'description' => esc_html__( 'Show the subtitles/captions button in the player (when a caption track is available).', 'godam' ),
+					'std'         => '',
+					'description' => esc_html__( 'Show the subtitles/captions button. "Default" follows the media caption setting.', 'godam' ),
 					'save_always' => true,
 					'dependency'  => array(
 						'element'   => 'id',

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video.php
@@ -252,6 +252,42 @@ class WPB_GoDAM_Video {
 					),
 				),
 					
+				// Show Transcription.
+				array(
+					'type'        => 'dropdown',
+					'heading'     => esc_html__( 'Show Transcription', 'godam' ),
+					'param_name'  => 'show_transcription',
+					'value'       => array(
+						esc_html__( 'Yes', 'godam' ) => '1',
+						esc_html__( 'No', 'godam' )  => '0',
+					),
+					'std'         => '1',
+					'description' => esc_html__( 'Show the transcript button/panel (when a transcript is available).', 'godam' ),
+					'save_always' => true,
+					'dependency'  => array(
+						'element'   => 'id',
+						'not_empty' => true,
+					),
+				),
+
+				// Show Caption.
+				array(
+					'type'        => 'dropdown',
+					'heading'     => esc_html__( 'Show Caption', 'godam' ),
+					'param_name'  => 'show_caption',
+					'value'       => array(
+						esc_html__( 'Yes', 'godam' ) => '1',
+						esc_html__( 'No', 'godam' )  => '0',
+					),
+					'std'         => '1',
+					'description' => esc_html__( 'Show the subtitles/captions button in the player (when a caption track is available).', 'godam' ),
+					'save_always' => true,
+					'dependency'  => array(
+						'element'   => 'id',
+						'not_empty' => true,
+					),
+				),
+
 				// Caption Settings.
 				array(
 					'type'        => 'textfield',


### PR DESCRIPTION
# Sync WPBakery elements with the redesigned 2.0 blocks (Video Gallery, Audio, Video) 

Issue - rtCamp/godam-plugin-wp#19

## Summary

The GoDAM 2.0 redesign added new attributes and controls to the Video Gallery, Audio, and Video blocks, but the corresponding **WPBakery (Visual Composer)** elements were never updated, so those options were missing from the page builder. This PR brings all three WPBakery elements (and their shortcodes) up to parity with the redesigned Gutenberg blocks, and fixes the Video block preview not rendering inside the WPBakery inline editor.

Branch: `update/godam-blocks-wp-bakery` → `develop`

## Background

Each GoDAM media block has a matching WPBakery element that renders through a shortcode (`base` → shortcode name), and each shortcode reuses the block's server template/`render.php`. When the blocks were redesigned, the new attributes were added to the blocks and their templates, but not surfaced in the WPBakery element params or mapped in the shortcodes — so WPBakery users couldn't configure them.

One important constraint throughout: WordPress' `shortcode_parse_atts()` lowercases every attribute name, so WPBakery params use lowercase/snake_case names that are then mapped to the blocks' camelCase attribute keys in each shortcode.

## Changes by block

### Video Gallery (`godam/gallery-v2`)
- **Layout:** added the **List** option (Grid / Carousel / List) — the block gained List in the redesign.
- **Interaction:** added an **Interaction** dropdown — *Play on hover* (default) vs *Autoplay all videos* — mapped to the block's mutually-exclusive `autoplay` / `playOnHover` booleans.
- **Show Play Button:** added a checkbox mapped to `showPlayButton`.
- Shortcode (`[godam_video_gallery]`): accepts `interaction` and `show_play_button`, splits `interaction` into `autoplay`/`playOnHover`, and passes `showPlayButton` to the shared template (which already consumes all three; playOnHover/showPlayButton default to `true`, matching the block).

Files: `inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php`, `inc/classes/shortcodes/class-godam-video-gallery.php`.

### Audio (`godam/audio`)
- **Added** the redesign's attributes as params: **Audio Title** (`audio_title` → `audioTitle`), **Description** (`description`), **Thumbnail** (`thumbnail`, empty falls back to the GoDAM-generated cover), **Show Transcript** (`show_transcript` → `showTranscript`, default on) and **Show Chapters** (`show_chapters` → `showChapters`, default on).
- **Removed** the obsolete **Caption** param — the redesign dropped it from the block and `render.php` no longer reads it.
- Selector param JS: auto-populates **Audio Title** and **Description** from the attachment on selection (parity with the block's `onSelectAudio`), and targets the `src` hidden field specifically via `[name="src"]` instead of any hidden field.
- Shortcode (`[godam_audio]`): maps the new snake_case atts to the block's camelCase keys the shared `render.php` consumes (transcript/chapters default to `true`).

Files: `inc/classes/wpbakery-elements/class-wpb-godam-audio.php`, `inc/classes/shortcodes/class-godam-audio.php`, `assets/src/js/wpbakery/wpbakery-audio-selector-param.js`.

### Video (`godam/video`)
- **Added** the two new Playback-Controls toggles the redesign introduced: **Show Transcription** (`show_transcription` → `showTranscription`) and **Show Caption** (`show_caption` → `showCaption`), both defaulting to Yes (matching the block toggles' `true` defaults).
- Shortcode (`[godam_video]`): maps these to the block's camelCase attributes **only when explicitly provided**, so hand-written `[godam_video]` shortcodes keep the template's own defaults (transcription on; caption derived from the attachment's Display-captions setting). The template already honors an explicit `showCaption`/`showTranscription`.

Files: `inc/classes/wpbakery-elements/class-wpb-godam-video.php`, `inc/classes/shortcodes/class-godam-player.php`.

### Fix: Video preview not rendering in the WPBakery inline editor

**Problem:** In the WPBakery inline editor the Video block showed only a play button on a zero-height area — the player was stuck in its pre-init state (`easydam-video-container.loading` / `vjs-hidden`, 0×0).

**Root cause:** `godam-player/frontend.js` initialized players **only** on `DOMContentLoaded`. WPBakery renders the shortcode markup into its preview iframe *after* that event has already fired, so `PlayerManager` never ran against the block and the player was never initialized. (Gutenberg avoids this by rendering its own React player in the editor; WPBakery uses the shortcode path.)

**Fix (in `assets/src/js/godam-player/frontend.js`):**
- Run initialization immediately when the DOM is already parsed (`readyState` fallback), not only on `DOMContentLoaded`.
- Add deferred re-init passes (300/1200/3000 ms). `PlayerManager.initializeVideo()` is idempotent — guarded by `data-godam-initialized` — so a re-run only initializes players that were missed; on a normal front-end load where everything is already initialized this is a cheap `querySelector` no-op.
- In a WPBakery editor preview only (detected via the `#vc_inline-frame` wrapper / `vc_editor` body class), attach a `MutationObserver` that re-initializes on demand as elements are re-rendered during editing. No observer is attached on the published front end.

Verified live in the inline editor: after a plain reload the player initializes on its own (0×0 → 645×363, `loading` cleared, `data-godam-initialized="1"`). Because the changes are additive and idempotent, published-page behavior is unchanged (init still runs once; the deferred passes find nothing pending).

## How to test

1. Ensure WPBakery (`js_composer`) is active. Run `npm run build:js` and `npm run build:blocks` (build artifacts under `assets/build/` are gitignored).
2. **Video Gallery:** add the GoDAM → Video Gallery element; confirm Layout offers List, the Interaction dropdown switches autoplay/hover, and Show Play Button toggles the overlay on the front end.
3. **Audio:** add the Audio element, select an audio file → Title/Description auto-fill; set a Thumbnail; toggle Show Transcript / Show Chapters and confirm on the front end.
4. **Video:** add the Video element; toggle Show Transcription / Show Caption and confirm the transcript button / captions on the front end.
5. **Editor preview:** open the WPBakery inline editor on a page with a Video element and confirm the player renders (not just a play button) after load.

## Notes for reviewers

- Build files (`assets/build/**`) are gitignored — rebuild with `npm run build:js` / `npm run build:blocks`.
- The `frontend.js` change is on the shared player bundle used by all render paths; it is additive and idempotent (single init on the front end; deferred passes are no-ops when nothing is pending).

## Demo Video

https://github.com/user-attachments/assets/f864eb05-e9a7-4c0e-acc3-1839bf66f7e7

