### PR TITLE
Add render-time video SEO schema for block templates, parts, and patterns

### DIFF
--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -573,6 +573,10 @@ class Seo {
 	 * excludes admin screens, REST requests (e.g. editor block previews) and
 	 * feeds, none of which output a `wp_footer` document head we can attach to.
 	 *
+	 * The `godam_video_seo_render_context` filter lets integrators narrow this
+	 * scope further (e.g. suppress on archives to avoid repeating the same
+	 * schema across listing pages).
+	 *
 	 * @return bool True on a front-end HTML page render, false otherwise.
 	 */
 	private function is_render_time_seo_context() {
@@ -588,7 +592,33 @@ class Seo {
 			return false;
 		}
 
-		return true;
+		/**
+		 * Filters whether render-time video SEO schema should be collected and
+		 * emitted for the current front-end view.
+		 *
+		 * This runs only for genuine front-end page renders — admin, REST and
+		 * feed requests are already excluded and never reach the filter. Return
+		 * false to suppress the render-time VideoObject output on specific
+		 * views. For example, to keep it on singular content and the front page
+		 * only, and off other archives/search (avoiding the same schema being
+		 * repeated across listing pages):
+		 *
+		 *     add_filter(
+		 *         'godam_video_seo_render_context',
+		 *         function ( $emit ) {
+		 *             return is_singular() || is_front_page();
+		 *         }
+		 *     );
+		 *
+		 * All conditional tags (is_singular(), is_archive(), is_front_page(),
+		 * is_search(), …) are available inside the callback.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param bool $emit Whether to emit render-time video SEO on this view.
+		 *                    Defaults to true for every front-end view.
+		 */
+		return (bool) apply_filters( 'godam_video_seo_render_context', true );
 	}
 
 	/**

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -24,6 +24,33 @@ class Seo {
 	const POST_ATTACHMENTS_META_KEY         = '_godam_seo_attachments';
 
 	/**
+	 * Content URLs already emitted by the cached wp_head schema output.
+	 *
+	 * Lets the render-time collector skip videos that were already output from
+	 * the queried post's content, avoiding duplicate JSON-LD.
+	 *
+	 * @var array<string,bool>
+	 */
+	private $emitted_content_urls = array();
+
+	/**
+	 * Attachment IDs already emitted by the cached wp_head schema output.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $emitted_attachment_ids = array();
+
+	/**
+	 * Video SEO entries collected at render time from block-theme templates,
+	 * template parts and synced patterns (content that is not part of the
+	 * queried post's own post_content). Keyed by contentUrl (or headline) for
+	 * de-duplication.
+	 *
+	 * @var array<string,array>
+	 */
+	private $render_collected_schemas = array();
+
+	/**
 	 * Construct method.
 	 */
 	protected function __construct() {
@@ -40,6 +67,11 @@ class Seo {
 		add_action( 'save_post', array( $this, 'elementor_save_seo_data_as_postmeta' ), 10, 1 );
 		add_filter( 'rest_prepare_attachment', array( $this, 'add_video_duration_for_video_seo' ), 10, 2 );
 		add_action( 'wp_head', array( $this, 'add_video_seo_schema' ) );
+
+		// Render-time capture for videos that live outside the queried post's
+		// content — block-theme templates, template parts and synced patterns.
+		add_filter( 'render_block', array( $this, 'collect_render_time_video_seo' ), 10, 2 );
+		add_action( 'wp_footer', array( $this, 'output_render_time_video_seo_schema' ), 20 );
 
 		// Hook to update SEO when attachment is edited.
 		add_action( 'edit_attachment', array( $this, 'schedule_seo_sync_for_attachment' ) );
@@ -430,37 +462,19 @@ class Seo {
 				$seen_content_urls[ $content_url ] = true;
 			}
 
-			$schema = array(
-				'@context'         => 'https://schema.org',
-				'@type'            => 'VideoObject',
-				'name'             => sanitize_text_field( $video['headline'] ?? '' ),
-				'description'      => wp_strip_all_tags( $video['description'] ?? '' ),
-				'contentUrl'       => esc_url_raw( $video['contentUrl'] ?? '' ),
-				'uploadDate'       => sanitize_text_field( $video['uploadDate'] ?? '' ),
-				'isFamilyFriendly' => isset( $video['isFamilyFriendly'] ) ? (bool) $video['isFamilyFriendly'] : true,
-			);
-
-			if ( ! empty( $video['thumbnailUrl'] ) ) {
-				$schema['thumbnailUrl'] = esc_url_raw( $video['thumbnailUrl'] );
+			$schema = $this->build_video_object_schema( $video, $post_id );
+			if ( empty( $schema ) ) {
+				continue;
 			}
 
-			if ( ! empty( $video['duration'] ) ) {
-				$schema['duration'] = sanitize_text_field( $video['duration'] );
+			// Record what we emit here so the render-time collector (wp_footer)
+			// does not output the same video a second time.
+			if ( $content_url ) {
+				$this->emitted_content_urls[ $content_url ] = true;
 			}
-
-			/**
-			 * Filter an individual video SEO schema entry before output.
-			 *
-			 * Allows add-ons to modify or extend a single VideoObject schema,
-			 * e.g. by adding an associatedProduct for WooCommerce integration.
-			 *
-			 * @since 1.10.0
-			 *
-			 * @param array $schema  The VideoObject schema array.
-			 * @param array $video   The raw cached video SEO data.
-			 * @param int   $post_id The current post ID.
-			 */
-			$schema = apply_filters( 'godam_video_seo_schema', $schema, $video, $post_id );
+			if ( ! empty( $video['attachment_id'] ) ) {
+				$this->emitted_attachment_ids[ (int) $video['attachment_id'] ] = true;
+			}
 
 			$output_schemas[] = $schema;
 		}
@@ -493,6 +507,210 @@ class Seo {
 		}
 
 		// Output a single <script> with all schemas.
+		echo '<script type="application/ld+json">' . wp_json_encode(
+			count( $output_schemas ) === 1 ? $output_schemas[0] : $output_schemas,
+			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
+		) . '</script>';
+	}
+
+	/**
+	 * Build a sanitized VideoObject schema array from a raw video SEO entry.
+	 *
+	 * Shared by the cached wp_head output ({@see add_video_seo_schema}) and the
+	 * render-time output ({@see output_render_time_video_seo_schema}) so both
+	 * paths produce identical schema and fire the same per-entry filter.
+	 *
+	 * @param array $video   Raw video SEO data (headline, contentUrl, etc.).
+	 * @param int   $post_id The current post ID (filter context).
+	 * @return array|null The VideoObject schema array, or null when invalid.
+	 */
+	private function build_video_object_schema( $video, $post_id ) {
+		if ( ! is_array( $video ) || empty( $video['headline'] ) ) {
+			return null;
+		}
+
+		$schema = array(
+			'@context'         => 'https://schema.org',
+			'@type'            => 'VideoObject',
+			'name'             => sanitize_text_field( $video['headline'] ?? '' ),
+			'description'      => wp_strip_all_tags( $video['description'] ?? '' ),
+			'contentUrl'       => esc_url_raw( $video['contentUrl'] ?? '' ),
+			'uploadDate'       => sanitize_text_field( $video['uploadDate'] ?? '' ),
+			'isFamilyFriendly' => isset( $video['isFamilyFriendly'] ) ? (bool) $video['isFamilyFriendly'] : true,
+		);
+
+		if ( ! empty( $video['thumbnailUrl'] ) ) {
+			$schema['thumbnailUrl'] = esc_url_raw( $video['thumbnailUrl'] );
+		}
+
+		if ( ! empty( $video['duration'] ) ) {
+			$schema['duration'] = sanitize_text_field( $video['duration'] );
+		}
+
+		/**
+		 * Filter an individual video SEO schema entry before output.
+		 *
+		 * Allows add-ons to modify or extend a single VideoObject schema,
+		 * e.g. by adding an associatedProduct for WooCommerce integration.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param array $schema  The VideoObject schema array.
+		 * @param array $video   The raw cached video SEO data.
+		 * @param int   $post_id The current post ID.
+		 */
+		return apply_filters( 'godam_video_seo_schema', $schema, $video, $post_id );
+	}
+
+	/**
+	 * Whether the current request is a front-end page render where render-time
+	 * video SEO should be collected and emitted.
+	 *
+	 * Unlike the cached wp_head output ({@see add_video_seo_schema}), this is
+	 * intentionally NOT limited to singular views: a godam/video block may be
+	 * placed in any block-theme template, including templates that render an
+	 * archive, the blog home, the front page, search results or 404. It only
+	 * excludes admin screens, REST requests (e.g. editor block previews) and
+	 * feeds, none of which output a `wp_footer` document head we can attach to.
+	 *
+	 * @return bool True on a front-end HTML page render, false otherwise.
+	 */
+	private function is_render_time_seo_context() {
+		if ( is_admin() ) {
+			return false;
+		}
+
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return false;
+		}
+
+		if ( is_feed() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Collect video SEO schema from blocks rendered outside the queried post's
+	 * content — block-theme templates, template parts and synced patterns.
+	 *
+	 * The cached wp_head output ({@see add_video_seo_schema}) only covers
+	 * godam/video blocks stored in the queried post's own post_content. Videos
+	 * placed in a template, template part or synced pattern (a `wp_block` post)
+	 * are composed into the page at render time and never appear in that
+	 * content, so they are captured here via the `render_block` filter and
+	 * emitted together in {@see output_render_time_video_seo_schema}.
+	 *
+	 * This is a read-only pass; the block output is always returned unchanged.
+	 *
+	 * @param string $block_content The rendered block HTML (returned unchanged).
+	 * @param array  $parsed_block  The parsed block array.
+	 * @return string The unchanged block HTML.
+	 */
+	public function collect_render_time_video_seo( $block_content, $parsed_block ) {
+		// Cheapest check first: skip every block that is not a godam/video.
+		if ( empty( $parsed_block['blockName'] ) || 'godam/video' !== $parsed_block['blockName'] ) {
+			return $block_content;
+		}
+
+		// Front-end page renders only — but any view, not just singular: the
+		// video may be placed in a template that renders an archive, the blog
+		// home or the front page.
+		if ( ! $this->is_render_time_seo_context() ) {
+			return $block_content;
+		}
+
+		$schemas = $this->extract_video_seo_schema_from_block( $parsed_block );
+
+		foreach ( $schemas as $seo_entry ) {
+			if ( ! is_array( $seo_entry ) || empty( $seo_entry['headline'] ) ) {
+				continue;
+			}
+
+			$content_url = ! empty( $seo_entry['contentUrl'] ) && is_string( $seo_entry['contentUrl'] ) ? $seo_entry['contentUrl'] : '';
+
+			// Deduplicate within the render-collected set (a template part or
+			// synced pattern carrying the same video can render many times).
+			//
+			// De-duplication against the cached wp_head output is deferred to
+			// flush time ({@see output_render_time_video_seo_schema}): in block
+			// themes the template — and therefore render_block — runs *before*
+			// wp_head, so the "already emitted" sets are not yet populated while
+			// this collector runs.
+			$dedupe_key = $content_url ? $content_url : 'headline:' . $seo_entry['headline'];
+			if ( isset( $this->render_collected_schemas[ $dedupe_key ] ) ) {
+				continue;
+			}
+
+			$this->render_collected_schemas[ $dedupe_key ] = $seo_entry;
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Output JSON-LD for videos collected at render time — those living in
+	 * block-theme templates, template parts or synced patterns rather than in
+	 * the queried post's content.
+	 *
+	 * Runs in wp_footer, after every block has rendered and after the cached
+	 * wp_head output has recorded which videos it already emitted, so the two
+	 * paths never duplicate a VideoObject.
+	 *
+	 * @return void
+	 */
+	public function output_render_time_video_seo_schema() {
+		if ( ! $this->is_render_time_seo_context() ) {
+			return;
+		}
+
+		if ( empty( $this->render_collected_schemas ) ) {
+			return;
+		}
+
+		$post_id = get_queried_object_id();
+
+		$output_schemas = array();
+		foreach ( $this->render_collected_schemas as $video ) {
+			// Skip videos already emitted by the cached wp_head output. This
+			// de-duplication runs here (not at collect time) because in block
+			// themes the template — and thus render_block — fires before
+			// wp_head; by wp_footer both paths have finished populating state.
+			$content_url   = ! empty( $video['contentUrl'] ) && is_string( $video['contentUrl'] ) ? $video['contentUrl'] : '';
+			$attachment_id = ! empty( $video['attachment_id'] ) ? (int) $video['attachment_id'] : 0;
+
+			if ( $content_url && isset( $this->emitted_content_urls[ $content_url ] ) ) {
+				continue;
+			}
+			if ( $attachment_id > 0 && isset( $this->emitted_attachment_ids[ $attachment_id ] ) ) {
+				continue;
+			}
+
+			$schema = $this->build_video_object_schema( $video, $post_id );
+			if ( ! empty( $schema ) ) {
+				$output_schemas[] = $schema;
+			}
+		}
+
+		if ( empty( $output_schemas ) ) {
+			return;
+		}
+
+		/**
+		 * This filter is documented in this file, in add_video_seo_schema().
+		 *
+		 * The third argument is an empty array here because render-collected
+		 * schemas have no backing post-meta cache; add-ons that inspect it
+		 * (e.g. the VPG ItemList grouping) simply no-op in that case.
+		 */
+		$output_schemas = apply_filters( 'godam_video_seo_schemas', $output_schemas, $post_id, array() );
+
+		if ( empty( $output_schemas ) ) {
+			return;
+		}
+
+		// Output a single <script> with all render-collected schemas.
 		echo '<script type="application/ld+json">' . wp_json_encode(
 			count( $output_schemas ) === 1 ? $output_schemas[0] : $output_schemas,
 			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT

--- a/inc/classes/class-seo.php
+++ b/inc/classes/class-seo.php
@@ -29,6 +29,8 @@ class Seo {
 	 * Lets the render-time collector skip videos that were already output from
 	 * the queried post's content, avoiding duplicate JSON-LD.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @var array<string,bool>
 	 */
 	private $emitted_content_urls = array();
@@ -36,15 +38,31 @@ class Seo {
 	/**
 	 * Attachment IDs already emitted by the cached wp_head schema output.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @var array<int,bool>
 	 */
 	private $emitted_attachment_ids = array();
+
+	/**
+	 * Headlines already emitted by the cached wp_head schema output for entries
+	 * that carry neither a contentUrl nor an attachment ID (e.g. a seoOverride
+	 * block without a media id). Lets the render-time collector de-duplicate
+	 * those entries too, which cannot be keyed by URL or attachment.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var array<string,bool>
+	 */
+	private $emitted_headlines = array();
 
 	/**
 	 * Video SEO entries collected at render time from block-theme templates,
 	 * template parts and synced patterns (content that is not part of the
 	 * queried post's own post_content). Keyed by contentUrl (or headline) for
 	 * de-duplication.
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @var array<string,array>
 	 */
@@ -468,12 +486,17 @@ class Seo {
 			}
 
 			// Record what we emit here so the render-time collector (wp_footer)
-			// does not output the same video a second time.
+			// does not output the same video a second time. Track by contentUrl
+			// and attachment ID, plus headline as a last resort for entries that
+			// have neither (so those can still be de-duplicated at flush time).
 			if ( $content_url ) {
 				$this->emitted_content_urls[ $content_url ] = true;
 			}
 			if ( ! empty( $video['attachment_id'] ) ) {
 				$this->emitted_attachment_ids[ (int) $video['attachment_id'] ] = true;
+			}
+			if ( ! $content_url && empty( $video['attachment_id'] ) && ! empty( $video['headline'] ) ) {
+				$this->emitted_headlines[ $video['headline'] ] = true;
 			}
 
 			$output_schemas[] = $schema;
@@ -520,8 +543,12 @@ class Seo {
 	 * render-time output ({@see output_render_time_video_seo_schema}) so both
 	 * paths produce identical schema and fire the same per-entry filter.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @param array $video   Raw video SEO data (headline, contentUrl, etc.).
-	 * @param int   $post_id The current post ID (filter context).
+	 * @param int   $post_id The current post ID for filter context. May be 0 on
+	 *                       non-singular render-time views (archives/search/404),
+	 *                       where the queried object has no post ID.
 	 * @return array|null The VideoObject schema array, or null when invalid.
 	 */
 	private function build_video_object_schema( $video, $post_id ) {
@@ -557,7 +584,10 @@ class Seo {
 		 *
 		 * @param array $schema  The VideoObject schema array.
 		 * @param array $video   The raw cached video SEO data.
-		 * @param int   $post_id The current post ID.
+		 * @param int   $post_id The current post ID. May be 0 when emitted from
+		 *                       the render-time path on non-singular views
+		 *                       (archives/search/404); guard with a check before
+		 *                       using it (e.g. get_post_type( $post_id )).
 		 */
 		return apply_filters( 'godam_video_seo_schema', $schema, $video, $post_id );
 	}
@@ -576,6 +606,8 @@ class Seo {
 	 * The `godam_video_seo_render_context` filter lets integrators narrow this
 	 * scope further (e.g. suppress on archives to avoid repeating the same
 	 * schema across listing pages).
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @return bool True on a front-end HTML page render, false otherwise.
 	 */
@@ -613,7 +645,7 @@ class Seo {
 		 * All conditional tags (is_singular(), is_archive(), is_front_page(),
 		 * is_search(), …) are available inside the callback.
 		 *
-		 * @since 2.0.0
+		 * @since n.e.x.t
 		 *
 		 * @param bool $emit Whether to emit render-time video SEO on this view.
 		 *                    Defaults to true for every front-end view.
@@ -633,6 +665,8 @@ class Seo {
 	 * emitted together in {@see output_render_time_video_seo_schema}.
 	 *
 	 * This is a read-only pass; the block output is always returned unchanged.
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @param string $block_content The rendered block HTML (returned unchanged).
 	 * @param array  $parsed_block  The parsed block array.
@@ -658,17 +692,27 @@ class Seo {
 				continue;
 			}
 
-			$content_url = ! empty( $seo_entry['contentUrl'] ) && is_string( $seo_entry['contentUrl'] ) ? $seo_entry['contentUrl'] : '';
+			$content_url   = ! empty( $seo_entry['contentUrl'] ) && is_string( $seo_entry['contentUrl'] ) ? $seo_entry['contentUrl'] : '';
+			$attachment_id = ! empty( $seo_entry['attachment_id'] ) ? (int) $seo_entry['attachment_id'] : 0;
 
 			// Deduplicate within the render-collected set (a template part or
 			// synced pattern carrying the same video can render many times).
+			// Prefer the attachment ID as the key: the same underlying video can
+			// render with slightly different contentUrl strings, and keying by
+			// attachment collapses those reliably. Fall back to contentUrl, then
+			// headline, for entries without an attachment (e.g. seoOverride).
 			//
 			// De-duplication against the cached wp_head output is deferred to
-			// flush time ({@see output_render_time_video_seo_schema}): in block
-			// themes the template — and therefore render_block — runs *before*
-			// wp_head, so the "already emitted" sets are not yet populated while
-			// this collector runs.
-			$dedupe_key = $content_url ? $content_url : 'headline:' . $seo_entry['headline'];
+			// flush time ({@see output_render_time_video_seo_schema}): render_block
+			// can fire before wp_head (e.g. in block themes), so the "already
+			// emitted" sets may still be empty while this collector runs.
+			if ( $attachment_id > 0 ) {
+				$dedupe_key = 'attachment:' . $attachment_id;
+			} elseif ( $content_url ) {
+				$dedupe_key = 'url:' . $content_url;
+			} else {
+				$dedupe_key = 'headline:' . $seo_entry['headline'];
+			}
 			if ( isset( $this->render_collected_schemas[ $dedupe_key ] ) ) {
 				continue;
 			}
@@ -688,6 +732,8 @@ class Seo {
 	 * wp_head output has recorded which videos it already emitted, so the two
 	 * paths never duplicate a VideoObject.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @return void
 	 */
 	public function output_render_time_video_seo_schema() {
@@ -704,16 +750,23 @@ class Seo {
 		$output_schemas = array();
 		foreach ( $this->render_collected_schemas as $video ) {
 			// Skip videos already emitted by the cached wp_head output. This
-			// de-duplication runs here (not at collect time) because in block
-			// themes the template — and thus render_block — fires before
-			// wp_head; by wp_footer both paths have finished populating state.
+			// de-duplication runs here (not at collect time) because render_block
+			// can fire before wp_head (e.g. in block themes), so the "already
+			// emitted" sets may still be empty while the collector runs. By
+			// wp_footer — which always runs after both — both paths have finished
+			// populating state, so this comparison is reliable either way.
 			$content_url   = ! empty( $video['contentUrl'] ) && is_string( $video['contentUrl'] ) ? $video['contentUrl'] : '';
 			$attachment_id = ! empty( $video['attachment_id'] ) ? (int) $video['attachment_id'] : 0;
+			$headline      = ! empty( $video['headline'] ) ? $video['headline'] : '';
 
 			if ( $content_url && isset( $this->emitted_content_urls[ $content_url ] ) ) {
 				continue;
 			}
 			if ( $attachment_id > 0 && isset( $this->emitted_attachment_ids[ $attachment_id ] ) ) {
+				continue;
+			}
+			// Last resort for entries with neither a contentUrl nor an attachment.
+			if ( ! $content_url && 0 === $attachment_id && $headline && isset( $this->emitted_headlines[ $headline ] ) ) {
 				continue;
 			}
 
@@ -729,6 +782,9 @@ class Seo {
 
 		/**
 		 * This filter is documented in this file, in add_video_seo_schema().
+		 *
+		 * Note: on this render-time path `$post_id` may be 0 for non-singular
+		 * views (archives/search/404), unlike the singular-only wp_head path.
 		 *
 		 * The third argument is an empty array here because render-collected
 		 * schemas have no backing post-meta cache; add-ons that inspect it


### PR DESCRIPTION
Fixes: https://github.com/rtCamp/godam/issues/2032

This pull request introduces a new mechanism to collect and output VideoObject schema for videos embedded in block-theme templates, template parts, and synced patterns, ensuring that all videos on a page are properly represented in the page's JSON-LD without duplication. The changes add a render-time collection and output process in addition to the existing cached `wp_head` schema output, with careful de-duplication between the two paths.

**Video SEO schema improvements:**

* Added private properties to `Seo` for tracking which video content URLs and attachment IDs have already had schema emitted, and for collecting render-time video schema entries (`$emitted_content_urls`, `$emitted_attachment_ids`, `$render_collected_schemas`).
* Added a render-time collector using the `render_block` filter and a new `collect_render_time_video_seo` method to capture video blocks rendered outside the queried post's content (e.g., in templates or patterns). [[1]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR71-R75) [[2]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL463-R713)
* Added a new `output_render_time_video_seo_schema` method, hooked to `wp_footer`, to output JSON-LD for videos collected at render time, with de-duplication against videos already emitted in `wp_head`. [[1]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaR71-R75) [[2]](diffhunk://#diff-23ed40a36cd121deb111228e8a2fc7d9b08cdbf3ddd59e9f87a4927a0c92befaL463-R713)
* Refactored schema construction into a new `build_video_object_schema` method, ensuring both cached and render-time paths produce identical schema and fire the same filters.
* Introduced an `is_render_time_seo_context` method to precisely determine when render-time schema collection/output should run (i.e., only on front-end HTML page renders, not in admin, REST, or feeds).

## Screenshots (Self tested using https://validator.schema.org/ tool)
Frontpage template
<img width="1470" height="879" alt="Screenshot 2026-07-22 at 7 51 59 PM" src="https://github.com/user-attachments/assets/0f24397c-3cbe-44ca-97bc-d953e7157cef" />

Normal page with video and sync patterns
<img width="1470" height="879" alt="Screenshot 2026-07-22 at 7 54 32 PM" src="https://github.com/user-attachments/assets/cc071b0d-72fe-457b-ae19-9549684b2c76" />
