### PR TITLE
Fix/video transcript UI ux

### DIFF
--- a/assets/src/blocks/godam-audio/edit.js
+++ b/assets/src/blocks/godam-audio/edit.js
@@ -36,24 +36,13 @@ import { plus, trash, edit as editIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { CustomizeVideoIcon } from '../godam-player/icons';
 import AudioMiniPlayer from './player';
 import AudioTabs from './tabs';
 import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const ALLOWED_THUMBNAIL_TYPES = [ 'image' ];
-
-/**
- * Sliders/adjustments icon for the "Customize Audio" button (matches the design).
- */
-const customizeIcon = (
-	<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-		<line x1="4" y1="9" x2="20" y2="9" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-		<line x1="4" y1="15" x2="20" y2="15" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-		<circle cx="9" cy="9" r="2.4" fill="currentColor" />
-		<circle cx="15" cy="15" r="2.4" fill="currentColor" />
-	</svg>
-);
 
 /**
  * Format a byte count as a human-readable size (e.g. "84 KB").
@@ -348,7 +337,8 @@ function AudioEdit( {
 					href={ editorUrl }
 					target="_blank"
 					rel="noopener noreferrer"
-					icon={ customizeIcon }
+					icon={ CustomizeVideoIcon }
+					iconSize={ 14 }
 					className="godam-audio__btn"
 					data-test-id="godam-audio-button-customize"
 				>

--- a/assets/src/blocks/godam-image/block.json
+++ b/assets/src/blocks/godam-image/block.json
@@ -46,5 +46,6 @@
 	},
 	"style": [ "file:./style-index.css" ],
 	"editorScript": [ "file:./index.js" ],
+	"editorStyle": [ "file:./index.css" ],
 	"render": "file:./render.php"
 }

--- a/assets/src/blocks/godam-image/edit.js
+++ b/assets/src/blocks/godam-image/edit.js
@@ -18,11 +18,12 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect } from '@wordpress/element';
-import { edit as editIcon } from '@wordpress/icons';
+import { plus, trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import { CustomizeVideoIcon } from '../godam-player/icons';
 import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -96,41 +97,66 @@ function ImageEdit( { attributes, setAttributes, isSelected } ) {
 	const blockProps = useBlockProps( { className: 'godam-image' } );
 	const hasImage = !! url;
 
-	// ── Empty state ───────────────────────────────────────────────────────────
-	if ( ! hasImage ) {
-		return (
-			<figure { ...blockProps } data-test-id="godam-image-canvas-placeholder">
-				<div className="godam-image-empty">
-					<h3 className="godam-image-empty__title">{ __( 'Add an image', 'godam' ) }</h3>
-					<p className="godam-image-empty__subtitle">
-						{ __( 'Select an image to overlay GoDAM hotspot and product layers.', 'godam' ) }
-					</p>
-					<MediaUploadCheck>
-						<MediaUpload
-							onSelect={ onSelectImage }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							accept="image/*"
-							render={ ( { open } ) => (
-								<Button
-									variant="primary"
-									onClick={ open }
-									className="godam-image-empty__btn"
-									data-test-id="godam-image-button-upload"
-								>
-									{ __( '+ Select Image', 'godam' ) }
-								</Button>
-							) }
-						/>
-					</MediaUploadCheck>
-				</div>
-			</figure>
-		);
-	}
+	// The inspector "Image Selection" panel mirrors the GoDAM Video block: an
+	// outlined "Add Image" button when empty, or a "Customize Image" button plus
+	// the selected-media row once an image is chosen.
+	const imageSelectionPanelContent = ! hasImage ? (
+		<MediaUploadCheck>
+			<MediaUpload
+				onSelect={ onSelectImage }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				accept="image/*"
+				render={ ( { open } ) => (
+					<Button
+						onClick={ open }
+						icon={ plus }
+						className="godam-image-selection__add-btn"
+						data-test-id="godam-image-button-add-image"
+					>
+						{ __( 'Add Image', 'godam' ) }
+					</Button>
+				) }
+			/>
+		</MediaUploadCheck>
+	) : (
+		<>
+			{ id && (
+				<Button
+					href={ editorUrl }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="godam-image-selection__customize-btn"
+					icon={ CustomizeVideoIcon }
+					iconSize={ 14 }
+					data-test-id="godam-image-button-edit"
+				>
+					{ __( 'Customize Image', 'godam' ) }
+				</Button>
+			) }
+			<div className="godam-image-selection__item">
+				<img
+					src={ url }
+					alt=""
+					className="godam-image-selection__item-thumbnail"
+				/>
+				<span className="godam-image-selection__item-title">
+					{ alt || url }
+				</span>
+				<Button
+					icon={ trash }
+					iconSize={ 16 }
+					label={ __( 'Remove image', 'godam' ) }
+					onClick={ () => onSelectImage( undefined ) }
+					className="godam-image-selection__item-delete"
+					data-test-id="godam-image-button-remove"
+				/>
+			</div>
+		</>
+	);
 
-	// ── Has image ─────────────────────────────────────────────────────────────
 	return (
 		<>
-			{ isSelected && (
+			{ isSelected && hasImage && (
 				<BlockControls group="other">
 					<MediaReplaceFlow
 						mediaId={ id }
@@ -144,37 +170,62 @@ function ImageEdit( { attributes, setAttributes, isSelected } ) {
 			) }
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Image Layers', 'godam' ) } initialOpen={ true } data-test-id="godam-image-panel-layers">
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Show image layers', 'godam' ) }
-						checked={ !! showImageLayers }
-						onChange={ ( value ) => setAttributes( { showImageLayers: value } ) }
-						help={ __( 'Overlays the hotspot / product layers authored in the GoDAM image editor.', 'godam' ) }
-						data-test-id="godam-image-control-show-layers"
-					/>
-					{ id && (
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							href={ editorUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							icon={ editIcon }
-							className="godam-image__btn"
-							data-test-id="godam-image-button-edit"
-						>
-							{ __( 'Edit in GoDAM', 'godam' ) }
-						</Button>
+				<PanelBody title={ __( 'Image Selection', 'godam' ) } data-test-id="godam-image-panel-image-selection">
+					<p className="godam-image-selection__description">
+						{ __( 'Add hotspot and product layers to make your image stand out.', 'godam' ) }
+					</p>
+					{ imageSelectionPanelContent }
+					{ hasImage && (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							className="godam-image-selection__toggle"
+							label={ __( 'Show image layers', 'godam' ) }
+							checked={ !! showImageLayers }
+							onChange={ ( value ) => setAttributes( { showImageLayers: value } ) }
+							help={ __( 'Overlays the hotspot / product layers authored in the GoDAM image editor.', 'godam' ) }
+							data-test-id="godam-image-control-show-layers"
+						/>
 					) }
 				</PanelBody>
 			</InspectorControls>
 
-			<figure { ...blockProps } data-test-id="godam-image-canvas">
-				<div className="godam-image__frame">
-					<img className="godam-image__img" src={ url } alt={ alt || '' } />
+			{ ! hasImage ? (
+				<div { ...blockProps } data-test-id="godam-image-canvas-placeholder">
+					<div className="godam-image-add-placeholder">
+						<div className="godam-image-add-placeholder__preview" />
+						<h2 className="godam-image-add-placeholder__title">
+							{ __( 'Add Image Here', 'godam' ) }
+						</h2>
+						<p className="godam-image-add-placeholder__description">
+							{ __( 'Upload or select an image from your media library to get started.', 'godam' ) }
+						</p>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectImage }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								accept="image/*"
+								render={ ( { open } ) => (
+									<Button
+										onClick={ open }
+										icon={ plus }
+										variant="primary"
+										className="godam-image-add-placeholder__btn"
+										data-test-id="godam-image-button-upload"
+									>
+										{ __( 'Add Image', 'godam' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
+					</div>
 				</div>
-			</figure>
+			) : (
+				<figure { ...blockProps } data-test-id="godam-image-canvas">
+					<div className="godam-image__frame">
+						<img className="godam-image__img" src={ url } alt={ alt || '' } />
+					</div>
+				</figure>
+			) }
 		</>
 	);
 }

--- a/assets/src/blocks/godam-image/editor.scss
+++ b/assets/src/blocks/godam-image/editor.scss
@@ -81,7 +81,7 @@
 		background: transparent;
 
 		&:hover:not(:disabled) {
-			background: color-mix(in srgb, var(--wp-admin-theme-color, #5d31ff) 5%, transparent);
+			background: color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 5%, transparent);
 			border-color: var(--wp-admin-theme-color-darker-10, #2145e6);
 			color: var(--wp-admin-theme-color-darker-10, #2145e6);
 		}

--- a/assets/src/blocks/godam-image/editor.scss
+++ b/assets/src/blocks/godam-image/editor.scss
@@ -1,30 +1,148 @@
 /**
  * GoDAM Image block — editor-only styles (empty state placeholder).
+ *
+ * Mirrors the GoDAM Video block's "Add Video Here" placeholder so the two
+ * blocks share the same authoring UI (see godam-player/editor.scss).
  */
-.godam-image-empty {
+.godam-image-add-placeholder {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	padding: 40px 24px;
 	text-align: center;
-	border: 1px dashed var( --wp-admin-theme-color, #3858e9 );
-	border-radius: 8px;
-	background: rgba( 0, 0, 0, 0.02 );
+	gap: 16px;
+	padding: 24px;
+	background-color: #f2f2ff;
+	border: 2px dashed #5a13d51a;
+	border-radius: 6px;
+
+	&__preview {
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		background-color: #fff;
+		border-radius: 4px;
+		box-shadow: 0 6px 6px 0 #94a3b81f;
+	}
 
 	&__title {
 		margin: 0;
-		font-size: 15px;
+		font-size: 18px;
+		font-weight: 500;
+		color: #111;
+		line-height: 1.33;
 	}
 
-	&__subtitle {
+	&__description {
 		margin: 0;
 		font-size: 13px;
-		color: #6b7280;
+		line-height: 1.38;
+		color: #646970;
+		max-width: 400px;
 	}
 
-	&__btn {
-		margin-top: 8px;
+	&__btn.components-button.is-primary {
+		border-radius: 2px;
+		background-color: var(--wp-admin-theme-color, #3858e9);
+		border-color: var(--wp-admin-theme-color, #3858e9);
+
+		&:hover:not(:disabled) {
+			background-color: var(--wp-admin-theme-color-darker-10, #2145e6);
+			border-color: var(--wp-admin-theme-color-darker-10, #2145e6);
+		}
+	}
+}
+
+/**
+ * Inspector "Image Selection" panel — mirrors the GoDAM Video block's
+ * "Video Selection" panel (see godam-player/editor.scss).
+ */
+.godam-image-selection {
+
+	&__description {
+		font-size: 12px;
+		color: #646970;
+		margin: 0 0 16px;
+		line-height: 1.33;
+	}
+
+	&__add-btn.components-button,
+	&__customize-btn.components-button {
+		width: 100%;
+		justify-content: center;
+		border-radius: 2px;
+		padding: 8px;
+		font-size: 13px;
+		line-height: 1.15;
+		font-weight: 500;
+	}
+
+	&__add-btn.components-button {
+		border: 1px solid var(--wp-admin-theme-color, #3858e9);
+		color: var(--wp-admin-theme-color, #3858e9);
+		background: transparent;
+
+		&:hover:not(:disabled) {
+			background: color-mix(in srgb, var(--wp-admin-theme-color, #5d31ff) 5%, transparent);
+			border-color: var(--wp-admin-theme-color-darker-10, #2145e6);
+			color: var(--wp-admin-theme-color-darker-10, #2145e6);
+		}
+	}
+
+	&__customize-btn.components-button {
+		margin-bottom: 10px;
+		background-color: var(--wp-admin-theme-color, #3858e9);
+		border-color: var(--wp-admin-theme-color, #3858e9);
+		color: #fff;
+
+		&:hover:not(:disabled) {
+			background-color: var(--wp-admin-theme-color-darker-10, #2145e6);
+			border-color: var(--wp-admin-theme-color-darker-10, #2145e6);
+			color: #fff;
+		}
+	}
+
+	&__item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+
+	&__item-thumbnail {
+		width: 40px;
+		height: 40px !important; // To override default height: auto css.
+		object-fit: cover;
+		border-radius: 2px;
+
+		&--placeholder {
+			background: #ddd;
+			display: block;
+		}
+	}
+
+	&__item-title {
+		flex: 1;
+		font-size: 13px;
+		line-height: 1.15;
+		font-weight: 400;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: #061014;
+	}
+
+	&__item-delete.components-button {
+		color: #061014;
+		padding: 0;
+		min-width: unset;
+
+		&:hover {
+			color: #cc1818;
+		}
+	}
+
+	&__toggle {
+		margin-top: 16px;
 	}
 }

--- a/assets/src/blocks/godam-image/index.js
+++ b/assets/src/blocks/godam-image/index.js
@@ -5,6 +5,7 @@ import initBlock from '../../utils/init-block';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import icon from '../../images/godam-image-filled.svg';
 import './style.scss';
 
 const { name } = metadata;
@@ -15,6 +16,7 @@ export { metadata, name };
  * Block registration settings.
  */
 export const settings = {
+	icon: <img src={ icon } alt={ metadata.title } />,
 	edit,
 	save,
 };

--- a/assets/src/blocks/godam-image/index.js
+++ b/assets/src/blocks/godam-image/index.js
@@ -16,7 +16,8 @@ export { metadata, name };
  * Block registration settings.
  */
 export const settings = {
-	icon: <img src={ icon } alt={ metadata.title } />,
+	// Block inserter icons are decorative — keep it out of the a11y tree.
+	icon: <img src={ icon } alt="" aria-hidden="true" />,
 	edit,
 	save,
 };

--- a/assets/src/css/bubble-skin.scss
+++ b/assets/src/css/bubble-skin.scss
@@ -227,6 +227,7 @@
 
 			img {
 				height: 12px;
+				width: auto;
 				max-width: unset;
 			}
 		}

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -2327,8 +2327,10 @@ body.godam-share-modal-open {
 	// edge when closed, so clip the wrapper to keep it from widening the block
 	// or spawning a horizontal scrollbar. The clip would cut the inner
 	// container's drop shadow, so re-apply the same shadow on the wrapper (an
-	// element's own box-shadow is not affected by its overflow).
-	&:has(.godam-transcript-panel) {
+	// element's own box-shadow is not affected by its overflow). The
+	// `godam-has-transcript-panel` class is toggled by TranscriptPanelManager —
+	// a plain class avoids `:has()`, which some browsers do not support.
+	&.godam-has-transcript-panel {
 		overflow: hidden;
 		box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 	}

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1837,6 +1837,18 @@ body.godam-share-modal-open {
 		}
 	}
 
+	// Share-specific: size the icon to the transcript icon's footprint so the
+	// share and transcript buttons read as one consistent set across every skin.
+	// (Skins that intentionally restyle both buttons — e.g. Bubble — override this
+	// on higher specificity.)
+	.vjs-button.godam-share-button img {
+		display: block;
+		width: 24px;
+		height: 24px;
+		max-width: unset;
+		object-fit: contain;
+	}
+
 	// The transcript button sits at the top of the stack; when it is present the
 	// share button drops directly below it. (Bubble skin positions both via the
 	// control-bar column and is unaffected — its rules win on specificity.)

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -1846,12 +1846,6 @@ body.godam-share-modal-open {
 
 	// FULLSCREEN CONTAINER STYLES - Critical for iOS Safari compatibility
 	&.godam-video-fullscreen {
-		// Hide share button in custom fullscreen (consistency with other devices)
-		.vjs-button.godam-share-button,
-		.vjs-button.godam-transcript-button {
-			display: none !important;
-		}
-
 		// Position the player to cover the entire viewport
 		position: fixed;
 		inset: 0;
@@ -1909,12 +1903,10 @@ body.godam-share-modal-open {
 		}
 	}
 
-	// Hide share button in standard fullscreen
-	.video-js.vjs-fullscreen .vjs-button.godam-share-button,
-	.video-js.vjs-fullscreen .vjs-button.godam-transcript-button {
-		display: none !important;
-	}
-
+	// In fullscreen the share/transcript buttons are reparented into the
+	// fullscreen element (`.video-js`) so they render in the fullscreen top
+	// layer. They keep the normal hover-to-reveal behaviour (a wider hit area
+	// than the auto-hiding control bar), so no extra fullscreen rule is needed.
 
 	.video-js {
 
@@ -2310,43 +2302,46 @@ body.godam-share-modal-open {
 // ---------------------------------------------------------------------------
 // Transcript side panel
 // ---------------------------------------------------------------------------
-// The video and the transcript panel share the block's full width. When the
-// panel is open the wrapper becomes a flex row: the video flexes down and the
-// panel takes a column beside it. The wrapper is a size container, so below a
-// container-query threshold the two items wrap onto separate rows and the
-// panel drops beneath the video (responsive without media queries).
+// The panel overlays the right side of the video so the video keeps its full
+// width when the transcript opens (no reflow / resize). It slides in from the
+// right for a smooth transition. The wrapper is a size container, so below a
+// container-query threshold the panel instead drops beneath the video and
+// stacks full width (see the container query at the end of this section).
 .godam-video-wrapper {
 	container-type: inline-size;
 	container-name: godam-video-wrapper;
-}
 
-.godam-video-wrapper.godam-transcript-open {
-	display: flex;
-	flex-wrap: wrap;
-	// Top-align so the panel doesn't stretch the video to its content height;
-	// the panel's height is matched to the video in JS (with internal scroll).
-	align-items: flex-start;
-
-	// Grow from a zero basis so the video fills whatever width the fixed-width
-	// panel leaves — keeps them side by side instead of wrapping.
-	.easydam-video-container {
-		flex: 1 1 0;
-		min-width: 0;
+	// While a transcript panel is present it is parked (slid) off the right
+	// edge when closed, so clip the wrapper to keep it from widening the block
+	// or spawning a horizontal scrollbar. The clip would cut the inner
+	// container's drop shadow, so re-apply the same shadow on the wrapper (an
+	// element's own box-shadow is not affected by its overflow).
+	&:has(.godam-transcript-panel) {
+		overflow: hidden;
+		box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 	}
 }
 
 .godam-transcript-panel {
-	display: none;
+	position: absolute;
+	inset: 0 0 0 auto;
+	z-index: 20;
+	width: clamp(260px, 38%, 340px);
+	display: flex;
 	flex-direction: column;
 	min-height: 0;
 	background-color: #fff;
 	color: #1e1e1e;
 	border: 1px solid #e0e0e0;
-	box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+	box-shadow: -4px 0 12px rgba(0, 0, 0, 0.12);
+
+	// Closed: slid out to the right and non-interactive.
+	transform: translateX(100%);
+	transition: transform 0.3s ease;
+	will-change: transform;
 
 	.godam-transcript-open & {
-		display: flex;
-		flex: 0 0 clamp(260px, 38%, 340px);
+		transform: translateX(0);
 	}
 
 	&__header {
@@ -2385,10 +2380,14 @@ body.godam-share-modal-open {
 		&:hover {
 			background-color: #f0f0f1;
 		}
-	}
 
-	&__close {
-		font-size: 22px;
+		/* stylelint-disable-next-line no-descending-specificity */
+		svg {
+			display: block;
+			width: 20px;
+			height: 20px;
+			fill: currentcolor;
+		}
 	}
 
 	&__body {
@@ -2433,18 +2432,60 @@ body.godam-share-modal-open {
 	}
 }
 
-// Below this width the video + panel stack vertically (panel under the video).
+// Below this width the right-side strip would be too narrow, so the panel
+// covers the full video instead — but it keeps the exact same overlay layout
+// and slide-in-from-the-right behaviour as desktop (base rule), rather than
+// stacking beneath the video. Only the width changes (full cover); `inset: 0
+// 0 0 auto` from the base already spans top-to-bottom.
 @container godam-video-wrapper (max-width: 560px) {
 
-	.godam-transcript-open {
-
-		.easydam-video-container,
-		.godam-transcript-panel {
-			flex-basis: 100%;
-		}
-
-		.godam-transcript-panel {
-			max-height: 320px;
-		}
+	.godam-transcript-panel {
+		width: 100%;
 	}
+}
+
+// In fullscreen the panel is reparented into the fullscreen element
+// (`.video-js.vjs-fullscreen`). Force the slide-in overlay layout there so a
+// narrow block (whose container query would otherwise stack/hide the panel)
+// still shows it as an on-video overlay. Higher specificity than the base and
+// container-query rules so it wins regardless of source order.
+.video-js.vjs-fullscreen .godam-transcript-panel {
+	position: absolute;
+	inset: 0 0 0 auto;
+	width: clamp(280px, 32%, 420px);
+	max-height: none;
+	display: flex;
+	transform: translateX(100%);
+}
+
+.godam-transcript-open .video-js.vjs-fullscreen .godam-transcript-panel {
+	transform: translateX(0);
+}
+
+// In fullscreen the overlay share/transcript buttons are reparented as direct
+// children of the fullscreen element (`.video-js`). That makes them start
+// matching Video.js's own `.video-js .vjs-control { height:100%; width:4em }`,
+// which — with `border-radius:50%` — stretches them into a full-height lens.
+// Restore their intrinsic circular size. The child combinator keeps this from
+// touching the Bubble skin's buttons, which live inside the control bar.
+// (Sizing props only — the earlier `:hover` reveal rule sets opacity/filter, so
+// there is no real cascade conflict despite the specificity-order lint.)
+/* stylelint-disable no-descending-specificity */
+.video-js.vjs-fullscreen > .vjs-button.godam-share-button,
+.video-js.vjs-fullscreen > .vjs-button.godam-transcript-button {
+	width: auto;
+	height: auto;
+}
+/* stylelint-enable no-descending-specificity */
+
+// The normal hover-to-reveal relies on `.easydam-video-container:hover`, which
+// does not propagate reliably across the fullscreen top layer — so tie the
+// buttons' visibility to Video.js's user-active state instead, exactly like the
+// control bar (visible while the user is active or the video is paused, hidden
+// once the controls auto-hide during playback).
+.video-js.vjs-fullscreen:not(.vjs-user-inactive) .vjs-button.godam-share-button,
+.video-js.vjs-fullscreen:not(.vjs-user-inactive) .vjs-button.godam-transcript-button {
+	opacity: 1;
+	visibility: visible;
+	pointer-events: auto;
 }

--- a/assets/src/css/minimal-skin.scss
+++ b/assets/src/css/minimal-skin.scss
@@ -67,19 +67,12 @@
 		order: 2;
 	}
 
-	.vjs-button.godam-share-button{
-		background: #FFFFFF24;
-		border-radius: 4px;
-		width: 40px;
-		height: 36px;		
-		display: flex;
-		align-items: center;
-		justify-content: center;
-
-		img {
-			height: 18px;
-			width: 16px;
-		}
+	// Share button inherits the shared circular button style so it matches the
+	// transcript button (see godam-player.scss). Scale just the arrow down to the
+	// smaller size this skin used before — the 24px icon box (and so the button's
+	// circular footprint) is left intact.
+	.vjs-button.godam-share-button img {
+		transform: scale(0.7);
 	}
 
 	.video-js .vjs-remaining-time {

--- a/assets/src/css/pills-skin.scss
+++ b/assets/src/css/pills-skin.scss
@@ -99,20 +99,12 @@
 		}
 	}
 
-	.vjs-button.godam-share-button{
-		background: #FFFFFF24;
-		border-radius: 4px;
-		width: 40px;
-		height: 36px;		
-		display: flex;
-		align-items: center;
-		justify-content: center;
-
-		img {
-			height: 18px;
-			width: 16px;
-			max-width: unset;
-		}
+	// Share button inherits the shared circular button style so it matches the
+	// transcript button (see godam-player.scss). Scale just the arrow down to the
+	// smaller size this skin used before — the 24px icon box (and so the button's
+	// circular footprint) is left intact.
+	.vjs-button.godam-share-button img {
+		transform: scale(0.7);
 	}
 
 	.video-js .vjs-remaining-time {
@@ -211,14 +203,6 @@
 			}
 		}
 
-
-		.vjs-button.godam-share-button {
-			background-color: var(--rtgodam-control-bar-color, #000000AD);
-			border: 0.26px solid #FFF3;
-			height: 24px;
-			padding: 4px 20px;
-			border-radius: 12px;
-		}
 
 		.video-js .vjs-menu {
 			width: 8em;

--- a/assets/src/images/godam-image-filled.svg
+++ b/assets/src/images/godam-image-filled.svg
@@ -1,0 +1,6 @@
+<svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="34" height="34" rx="6" fill="#5D31FF"/>
+<path d="M24 8H10C8.89543 8 8 8.89543 8 10V24C8 25.1046 8.89543 26 10 26H24C25.1046 26 26 25.1046 26 24V10C26 8.89543 25.1046 8 24 8Z" stroke="#FFFEFC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 16C15.1046 16 16 15.1046 16 14C16 12.8954 15.1046 12 14 12C12.8954 12 12 12.8954 12 14C12 15.1046 12.8954 16 14 16Z" stroke="#FFFEFC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26 20L22.914 16.914C22.5389 16.5391 22.0303 16.3284 21.5 16.3284C20.9697 16.3284 20.4611 16.5391 20.086 16.914L11 26" stroke="#FFFEFC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/src/js/godam-player/managers/shareManager.js
+++ b/assets/src/js/godam-player/managers/shareManager.js
@@ -91,6 +91,12 @@ class ShareManager {
 		this.videoSetupOptions = videoSetupOptions;
 		this.Button = videojs.getComponent( 'Button' );
 
+		this.container = null;
+		this.shareButtonEl = null;
+		this.buttonInControlBar = false;
+
+		this.handleFullscreenChange = this.handleFullscreenChange.bind( this );
+
 		this.init();
 	}
 
@@ -343,10 +349,28 @@ class ShareManager {
 		container.className = MODAL_CONTAINER_CLASS;
 		container.innerHTML = DOMPurify.sanitize( modalHtml, { ADD_ATTR: [ 'target', 'rel' ] } );
 
-		document.body.appendChild( container );
+		// In fullscreen only the player element's subtree renders (the fullscreen
+		// top layer), so a modal on `<body>` would be invisible. Mount it inside
+		// the fullscreen element instead; otherwise use `<body>` as before.
+		this.getModalParent().appendChild( container );
 		document.body.classList.add( BODY_MODAL_OPEN_CLASS );
 
 		this.setupModalEventListeners( container, socialLinks, urls );
+	}
+
+	/**
+	 * Resolve where the share modal should mount: the fullscreen player element
+	 * when in fullscreen, otherwise the document body.
+	 *
+	 * @return {HTMLElement} The element to append the modal to.
+	 */
+	getModalParent() {
+		const fullscreenEl = this.player?.el?.();
+		const isFullscreen = this.player?.isFullscreen?.() || fullscreenEl?.classList?.contains( 'vjs-fullscreen' );
+		if ( isFullscreen && fullscreenEl ) {
+			return fullscreenEl;
+		}
+		return document.body;
 	}
 
 	/**
@@ -652,6 +676,8 @@ class ShareManager {
 			return;
 		}
 
+		this.container = container;
+
 		const ShareButton = videojs.getComponent( 'GodamShareButton' );
 		const shareButtonInstance = new ShareButton( this.player );
 		const buttonElement = shareButtonInstance.createEl();
@@ -660,8 +686,54 @@ class ShareManager {
 
 		if ( this.shouldAddBubbleToControlBar( container ) ) {
 			this.player.controlBar.addChild( 'GodamShareButton', {} );
+			this.buttonInControlBar = true;
 		} else {
 			container.appendChild( buttonElement );
+			this.shareButtonEl = buttonElement;
+			this.buttonInControlBar = false;
+		}
+
+		this.setupFullscreenReparenting();
+	}
+
+	/**
+	 * Keep the overlay share button visible in fullscreen.
+	 *
+	 * Video.js fullscreens the player element (`.video-js`); only its subtree
+	 * renders in the fullscreen top layer. The overlay button lives in
+	 * `.easydam-video-container` (an ancestor of `.video-js`), so it vanishes in
+	 * fullscreen unless moved inside it. Reparent on enter, restore on exit.
+	 * Control-bar buttons (Bubble skin) are already inside `.video-js`, so they
+	 * are left in place.
+	 */
+	setupFullscreenReparenting() {
+		this.player.on( 'fullscreenchange', this.handleFullscreenChange );
+		this.player.on( 'customfullscreenchange', this.handleFullscreenChange );
+		this.player.one( 'dispose', () => {
+			this.player.off( 'fullscreenchange', this.handleFullscreenChange );
+			this.player.off( 'customfullscreenchange', this.handleFullscreenChange );
+		} );
+	}
+
+	/**
+	 * Move the overlay share button into (or out of) the fullscreen element.
+	 */
+	handleFullscreenChange() {
+		if ( ! this.shareButtonEl || this.buttonInControlBar ) {
+			return;
+		}
+
+		const fullscreenEl = this.player.el();
+		// Native fullscreen sets `isFullscreen()`; the iOS custom fullscreen only
+		// toggles the `vjs-fullscreen` class. Check both so either path works.
+		const isFullscreen = this.player.isFullscreen() || fullscreenEl.classList.contains( 'vjs-fullscreen' );
+
+		if ( isFullscreen ) {
+			if ( this.shareButtonEl.parentElement !== fullscreenEl ) {
+				fullscreenEl.appendChild( this.shareButtonEl );
+			}
+		} else if ( this.container && this.shareButtonEl.parentElement !== this.container ) {
+			this.container.appendChild( this.shareButtonEl );
 		}
 	}
 

--- a/assets/src/js/godam-player/managers/shareManager.js
+++ b/assets/src/js/godam-player/managers/shareManager.js
@@ -24,6 +24,7 @@ import Complete from '../../../../../assets/src/images/check.svg';
 
 import videojs from 'video.js';
 import { formatTime, parseTime, validateTimeString } from '../utils/dataHelpers.js';
+import { setupFullscreenReparenting, isPlayerFullscreen } from '../utils/fullscreenReparent.js';
 
 import { KEYBOARD_CONTROLS } from '../utils/constants';
 
@@ -95,7 +96,10 @@ class ShareManager {
 		this.shareButtonEl = null;
 		this.buttonInControlBar = false;
 
-		this.handleFullscreenChange = this.handleFullscreenChange.bind( this );
+		// The share modal is transient; while it is open its reparenting listeners
+		// are tracked here so they can be removed when it closes.
+		this.modalContainer = null;
+		this.modalFullscreenDispose = null;
 
 		this.init();
 	}
@@ -355,6 +359,17 @@ class ShareManager {
 		this.getModalParent().appendChild( container );
 		document.body.classList.add( BODY_MODAL_OPEN_CLASS );
 
+		this.modalContainer = container;
+		// Keep the modal in the right layer if the user enters/exits fullscreen
+		// while it is open: into `.video-js` in fullscreen, back to `<body>` on
+		// exit. Torn down in `setupModalCloseHandlers` when the modal closes.
+		this.modalFullscreenDispose = setupFullscreenReparenting( {
+			player: this.player,
+			getElement: () => this.modalContainer,
+			getRestoreParent: () => document.body,
+			runNow: false,
+		} );
+
 		this.setupModalEventListeners( container, socialLinks, urls );
 	}
 
@@ -366,8 +381,7 @@ class ShareManager {
 	 */
 	getModalParent() {
 		const fullscreenEl = this.player?.el?.();
-		const isFullscreen = this.player?.isFullscreen?.() || fullscreenEl?.classList?.contains( 'vjs-fullscreen' );
-		if ( isFullscreen && fullscreenEl ) {
+		if ( isPlayerFullscreen( this.player ) && fullscreenEl ) {
 			return fullscreenEl;
 		}
 		return document.body;
@@ -419,6 +433,11 @@ class ShareManager {
 			container.classList.add( `${ MODAL_CONTAINER_CLASS }${ CLOSING_CLASS_SUFFIX }` );
 			container.querySelector( `.${ MODAL_POPUP_CLASS }` )
 				.classList.add( `${ MODAL_POPUP_CLASS }${ CLOSING_CLASS_SUFFIX }` );
+
+			// Stop tracking the modal for fullscreen reparenting before it is gone.
+			this.modalFullscreenDispose?.();
+			this.modalFullscreenDispose = null;
+			this.modalContainer = null;
 
 			setTimeout( () => {
 				container.remove();
@@ -707,34 +726,13 @@ class ShareManager {
 	 * are left in place.
 	 */
 	setupFullscreenReparenting() {
-		this.player.on( 'fullscreenchange', this.handleFullscreenChange );
-		this.player.on( 'customfullscreenchange', this.handleFullscreenChange );
-		this.player.one( 'dispose', () => {
-			this.player.off( 'fullscreenchange', this.handleFullscreenChange );
-			this.player.off( 'customfullscreenchange', this.handleFullscreenChange );
+		// Control-bar buttons (Bubble skin) are already inside `.video-js`, so the
+		// getter returns null for them and only the overlay button is moved.
+		setupFullscreenReparenting( {
+			player: this.player,
+			getElement: () => ( this.buttonInControlBar ? null : this.shareButtonEl ),
+			getRestoreParent: () => this.container,
 		} );
-	}
-
-	/**
-	 * Move the overlay share button into (or out of) the fullscreen element.
-	 */
-	handleFullscreenChange() {
-		if ( ! this.shareButtonEl || this.buttonInControlBar ) {
-			return;
-		}
-
-		const fullscreenEl = this.player.el();
-		// Native fullscreen sets `isFullscreen()`; the iOS custom fullscreen only
-		// toggles the `vjs-fullscreen` class. Check both so either path works.
-		const isFullscreen = this.player.isFullscreen() || fullscreenEl.classList.contains( 'vjs-fullscreen' );
-
-		if ( isFullscreen ) {
-			if ( this.shareButtonEl.parentElement !== fullscreenEl ) {
-				fullscreenEl.appendChild( this.shareButtonEl );
-			}
-		} else if ( this.container && this.shareButtonEl.parentElement !== this.container ) {
-			this.container.appendChild( this.shareButtonEl );
-		}
 	}
 
 	/**

--- a/assets/src/js/godam-player/managers/transcriptPanelManager.js
+++ b/assets/src/js/godam-player/managers/transcriptPanelManager.js
@@ -18,6 +18,9 @@ const COPY_ICON_SVG = `<svg class="godam-transcript-panel__copy-icon" viewBox="0
 // WordPress "check" icon, shown briefly after a successful copy.
 const CHECK_ICON_SVG = `<svg class="godam-transcript-panel__copy-icon" viewBox="0 0 24 24" width="20" height="20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z" fill="currentColor"/></svg>`;
 
+// WordPress "close" icon (matches @wordpress/icons `close`).
+const CLOSE_ICON_SVG = `<svg class="godam-transcript-panel__close-icon" viewBox="0 0 24 24" width="20" height="20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z" fill="currentColor"/></svg>`;
+
 // Transcript button icon (a document with text lines).
 const TRANSCRIPT_ICON_SVG = `<svg class="godam-transcript-icon" viewBox="0 0 24 24" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
 		<path d="M5 3.5h14a1.5 1.5 0 0 1 1.5 1.5v14a1.5 1.5 0 0 1-1.5 1.5H5A1.5 1.5 0 0 1 3.5 19V5A1.5 1.5 0 0 1 5 3.5Z" stroke="currentColor" stroke-width="1.6"/>
@@ -64,6 +67,7 @@ export default class TranscriptPanelManager {
 		this.container = null;
 		this.wrapper = null;
 		this.button = null;
+		this.buttonInControlBar = false;
 		this.panel = null;
 		this.bodyEl = null;
 		this.cues = [];
@@ -73,7 +77,7 @@ export default class TranscriptPanelManager {
 		this.isOpen = false;
 
 		this.handleTimeUpdate = this.handleTimeUpdate.bind( this );
-		this.syncPanelHeight = this.syncPanelHeight.bind( this );
+		this.handleFullscreenChange = this.handleFullscreenChange.bind( this );
 
 		this.init();
 	}
@@ -96,8 +100,9 @@ export default class TranscriptPanelManager {
 		if ( ! this.container ) {
 			return;
 		}
-		// The panel is a flex sibling of the video container so the two can
-		// share the block's width; the wrapper is the flex parent we toggle.
+		// The panel overlays the video (absolutely positioned inside the
+		// wrapper) so the video keeps its full width when the transcript opens;
+		// the wrapper is the positioned parent and the element we toggle.
 		this.wrapper = this.container.closest( '.godam-video-wrapper' ) || this.container.parentElement;
 
 		// Resolve the transcript and only render the UI once we know cues exist.
@@ -236,29 +241,9 @@ export default class TranscriptPanelManager {
 		this.registerButtonComponent();
 		this.addToggleButton();
 		this.createPanel();
+		this.setupFullscreenReparenting();
 		this.player.on( 'timeupdate', this.handleTimeUpdate );
-		// Re-match the panel height to the video when the player is resized
-		// (e.g. window resize, fullscreen, responsive breakpoints).
-		this.player.on( 'playerresize', this.syncPanelHeight );
-		window.addEventListener( 'resize', this.syncPanelHeight );
 		this.player.one( 'dispose', () => this.destroy() );
-	}
-
-	/**
-	 * Match the panel's height to the video when they sit side by side, so the
-	 * panel scrolls internally instead of stretching the video. When stacked
-	 * (narrow container) the inline height is cleared and CSS drives the size.
-	 */
-	syncPanelHeight() {
-		if ( ! this.isOpen || ! this.panel || ! this.container ) {
-			return;
-		}
-		const containerRect = this.container.getBoundingClientRect();
-		const panelRect = this.panel.getBoundingClientRect();
-		// Side by side when the panel starts at (roughly) the container's right edge.
-		const sideBySide = panelRect.left >= containerRect.right - 2;
-
-		this.panel.style.height = sideBySide ? `${ Math.round( containerRect.height ) }px` : '';
 	}
 
 	/**
@@ -315,6 +300,7 @@ export default class TranscriptPanelManager {
 		if ( this.shouldAddToControlBar() ) {
 			const child = this.player.controlBar.addChild( 'GodamTranscriptButton', {} );
 			this.button = child.el();
+			this.buttonInControlBar = true;
 			return;
 		}
 
@@ -324,6 +310,7 @@ export default class TranscriptPanelManager {
 		element.addEventListener( 'click', instance.handleClick.bind( instance ) );
 		this.container.appendChild( element );
 		this.button = element;
+		this.buttonInControlBar = false;
 	}
 
 	/**
@@ -372,7 +359,7 @@ export default class TranscriptPanelManager {
 		closeButton.setAttribute( 'aria-label', __( 'Close transcript', 'godam' ) );
 		closeButton.setAttribute( 'data-test-id', 'godam-video-transcript-close' );
 		closeButton.title = __( 'Close transcript', 'godam' );
-		closeButton.innerHTML = '&times;';
+		closeButton.innerHTML = CLOSE_ICON_SVG;
 		closeButton.addEventListener( 'click', () => this.close() );
 
 		actions.appendChild( copyButton );
@@ -409,10 +396,57 @@ export default class TranscriptPanelManager {
 		panel.appendChild( header );
 		panel.appendChild( body );
 
-		// Append beside the video container (flex sibling) so they share width.
+		// Append inside the wrapper as an overlay so it sits above the video
+		// without taking layout space (the video keeps its full width).
 		this.wrapper.appendChild( panel );
 		this.panel = panel;
 		this.bodyEl = body;
+	}
+
+	/**
+	 * Keep the button and panel visible in fullscreen.
+	 *
+	 * Video.js requests fullscreen on the player element (`.video-js`), and only
+	 * that element's subtree renders in the fullscreen top layer. The overlay
+	 * button lives in `.easydam-video-container` and the panel in the wrapper —
+	 * both ancestors of `.video-js` — so they vanish in fullscreen unless moved
+	 * inside it. Reparent on enter and restore on exit (the same approach the
+	 * layer managers use). Listens to the native `fullscreenchange` and the
+	 * iOS custom `customfullscreenchange` events; the `.vjs-fullscreen` class on
+	 * the player element is set for both.
+	 */
+	setupFullscreenReparenting() {
+		this.player.on( 'fullscreenchange', this.handleFullscreenChange );
+		this.player.on( 'customfullscreenchange', this.handleFullscreenChange );
+	}
+
+	/**
+	 * Move the overlay button and panel into (or out of) the fullscreen element.
+	 */
+	handleFullscreenChange() {
+		const fullscreenEl = this.player.el();
+		// Native fullscreen sets `isFullscreen()`; the iOS custom fullscreen only
+		// toggles the `vjs-fullscreen` class. Check both so either path works.
+		const isFullscreen = this.player.isFullscreen() || fullscreenEl.classList.contains( 'vjs-fullscreen' );
+
+		// The panel always starts life in the wrapper; the control-bar button is
+		// already inside `.video-js`, so only the overlay button needs moving.
+		if ( isFullscreen ) {
+			if ( this.panel && this.panel.parentElement !== fullscreenEl ) {
+				fullscreenEl.appendChild( this.panel );
+			}
+			if ( this.button && ! this.buttonInControlBar && this.button.parentElement !== fullscreenEl ) {
+				fullscreenEl.appendChild( this.button );
+			}
+			return;
+		}
+
+		if ( this.panel && this.wrapper && this.panel.parentElement !== this.wrapper ) {
+			this.wrapper.appendChild( this.panel );
+		}
+		if ( this.button && ! this.buttonInControlBar && this.container && this.button.parentElement !== this.container ) {
+			this.container.appendChild( this.button );
+		}
 	}
 
 	/**
@@ -437,8 +471,7 @@ export default class TranscriptPanelManager {
 		this.wrapper.classList.add( OPEN_CLASS );
 		this.button?.setAttribute( 'aria-expanded', 'true' );
 		this.button?.classList.add( `${ BUTTON_CLASS }--active` );
-		// Match the panel height to the video and sync the active-cue highlight.
-		this.syncPanelHeight();
+		// Sync the active-cue highlight to the current playhead.
 		this.handleTimeUpdate();
 	}
 
@@ -537,8 +570,8 @@ export default class TranscriptPanelManager {
 	destroy() {
 		clearTimeout( this.copyResetTimeout );
 		this.player.off( 'timeupdate', this.handleTimeUpdate );
-		this.player.off( 'playerresize', this.syncPanelHeight );
-		window.removeEventListener( 'resize', this.syncPanelHeight );
+		this.player.off( 'fullscreenchange', this.handleFullscreenChange );
+		this.player.off( 'customfullscreenchange', this.handleFullscreenChange );
 		this.wrapper?.classList.remove( OPEN_CLASS );
 		this.container?.classList.remove( 'godam-has-transcript' );
 		this.button?.remove();

--- a/assets/src/js/godam-player/managers/transcriptPanelManager.js
+++ b/assets/src/js/godam-player/managers/transcriptPanelManager.js
@@ -8,6 +8,11 @@ import videojs from 'video.js';
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { setupFullscreenReparenting } from '../utils/fullscreenReparent.js';
+
 // Minimum container width (px) at which the Bubble skin routes the button into
 // the control bar instead of overlaying it — matches ShareManager.
 const MIN_BUBBLE_WIDTH = 480;
@@ -33,6 +38,9 @@ const PANEL_CLASS = 'godam-transcript-panel';
 const CUE_CLASS = 'godam-transcript-cue';
 // Added to the video wrapper so the video + panel share the block width.
 const OPEN_CLASS = 'godam-transcript-open';
+// Added to the wrapper while a panel is present so its overflow/shadow can be
+// clipped without relying on `:has()` (unsupported in some browsers).
+const HAS_PANEL_CLASS = 'godam-has-transcript-panel';
 const ACTIVE_CUE_CLASS = 'godam-transcript-cue--active';
 
 // Copy feedback duration in ms.
@@ -77,7 +85,6 @@ export default class TranscriptPanelManager {
 		this.isOpen = false;
 
 		this.handleTimeUpdate = this.handleTimeUpdate.bind( this );
-		this.handleFullscreenChange = this.handleFullscreenChange.bind( this );
 
 		this.init();
 	}
@@ -399,6 +406,9 @@ export default class TranscriptPanelManager {
 		// Append inside the wrapper as an overlay so it sits above the video
 		// without taking layout space (the video keeps its full width).
 		this.wrapper.appendChild( panel );
+		// Flag the wrapper so its overflow/shadow clip can be scoped with a plain
+		// class selector instead of `:has()` (which some browsers lack).
+		this.wrapper.classList.add( HAS_PANEL_CLASS );
 		this.panel = panel;
 		this.bodyEl = body;
 	}
@@ -416,37 +426,19 @@ export default class TranscriptPanelManager {
 	 * the player element is set for both.
 	 */
 	setupFullscreenReparenting() {
-		this.player.on( 'fullscreenchange', this.handleFullscreenChange );
-		this.player.on( 'customfullscreenchange', this.handleFullscreenChange );
-	}
-
-	/**
-	 * Move the overlay button and panel into (or out of) the fullscreen element.
-	 */
-	handleFullscreenChange() {
-		const fullscreenEl = this.player.el();
-		// Native fullscreen sets `isFullscreen()`; the iOS custom fullscreen only
-		// toggles the `vjs-fullscreen` class. Check both so either path works.
-		const isFullscreen = this.player.isFullscreen() || fullscreenEl.classList.contains( 'vjs-fullscreen' );
-
-		// The panel always starts life in the wrapper; the control-bar button is
-		// already inside `.video-js`, so only the overlay button needs moving.
-		if ( isFullscreen ) {
-			if ( this.panel && this.panel.parentElement !== fullscreenEl ) {
-				fullscreenEl.appendChild( this.panel );
-			}
-			if ( this.button && ! this.buttonInControlBar && this.button.parentElement !== fullscreenEl ) {
-				fullscreenEl.appendChild( this.button );
-			}
-			return;
-		}
-
-		if ( this.panel && this.wrapper && this.panel.parentElement !== this.wrapper ) {
-			this.wrapper.appendChild( this.panel );
-		}
-		if ( this.button && ! this.buttonInControlBar && this.container && this.button.parentElement !== this.container ) {
-			this.container.appendChild( this.button );
-		}
+		// The panel restores into the wrapper; the overlay button into the
+		// container. The control-bar button (Bubble skin) is already inside
+		// `.video-js`, so it is skipped by returning null from its getter.
+		setupFullscreenReparenting( {
+			player: this.player,
+			getElement: () => this.panel,
+			getRestoreParent: () => this.wrapper,
+		} );
+		setupFullscreenReparenting( {
+			player: this.player,
+			getElement: () => ( this.buttonInControlBar ? null : this.button ),
+			getRestoreParent: () => this.container,
+		} );
 	}
 
 	/**
@@ -570,9 +562,10 @@ export default class TranscriptPanelManager {
 	destroy() {
 		clearTimeout( this.copyResetTimeout );
 		this.player.off( 'timeupdate', this.handleTimeUpdate );
-		this.player.off( 'fullscreenchange', this.handleFullscreenChange );
-		this.player.off( 'customfullscreenchange', this.handleFullscreenChange );
+		// Fullscreen listeners are removed by the reparenting helper on player
+		// `dispose`; nothing to detach here.
 		this.wrapper?.classList.remove( OPEN_CLASS );
+		this.wrapper?.classList.remove( HAS_PANEL_CLASS );
 		this.container?.classList.remove( 'godam-has-transcript' );
 		this.button?.remove();
 		this.panel?.remove();

--- a/assets/src/js/godam-player/utils/fullscreenReparent.js
+++ b/assets/src/js/godam-player/utils/fullscreenReparent.js
@@ -1,0 +1,90 @@
+/**
+ * Shared fullscreen reparenting helpers.
+ *
+ * Video.js requests fullscreen on the player element (`.video-js`), and only
+ * that element's subtree renders in the fullscreen top layer. Overlay UI that
+ * lives in an ancestor (the video container, the wrapper, or `document.body`)
+ * therefore vanishes in fullscreen unless it is moved inside `.video-js`.
+ *
+ * The share button, the transcript button + panel, and the share modal all need
+ * the same enter/exit dance, so it lives here once instead of being duplicated
+ * across managers.
+ */
+
+/**
+ * Whether the player is in fullscreen.
+ *
+ * Native fullscreen sets `player.isFullscreen()`; the iOS custom fullscreen only
+ * toggles the `vjs-fullscreen` class on the player element. Check both so either
+ * path is detected.
+ *
+ * @param {Object} player Video.js player instance.
+ * @return {boolean} True when the player is (natively or custom) fullscreen.
+ */
+export function isPlayerFullscreen( player ) {
+	const el = player?.el?.();
+	return !! ( player?.isFullscreen?.() || el?.classList?.contains( 'vjs-fullscreen' ) );
+}
+
+/**
+ * Keep an overlay element visible in fullscreen by reparenting it into the
+ * fullscreen player element on enter and back to its normal parent on exit.
+ *
+ * The element and its restore parent are resolved lazily (via callbacks) on
+ * every fullscreen change, so callers can move elements that are created after
+ * setup or that come and go (e.g. a transient modal).
+ *
+ * @param {Object}   options                          Options.
+ * @param {Object}   options.player                   Video.js player instance.
+ * @param {Function} options.getElement               Returns the element to move (falsy to skip this change).
+ * @param {Function} options.getRestoreParent         Returns the element to restore into when exiting fullscreen.
+ * @param {boolean}  [options.runNow=true]            Reparent once immediately so an already-fullscreen player is handled.
+ * @param {boolean}  [options.disposeWithPlayer=true] Auto-remove listeners on player `dispose`.
+ * @return {Function} A disposer that removes the listeners.
+ */
+export function setupFullscreenReparenting( {
+	player,
+	getElement,
+	getRestoreParent,
+	runNow = true,
+	disposeWithPlayer = true,
+} ) {
+	const handleChange = () => {
+		const el = getElement();
+		if ( ! el ) {
+			return;
+		}
+
+		const fullscreenEl = player.el();
+
+		if ( isPlayerFullscreen( player ) ) {
+			if ( fullscreenEl && el.parentElement !== fullscreenEl ) {
+				fullscreenEl.appendChild( el );
+			}
+			return;
+		}
+
+		const restoreParent = getRestoreParent();
+		if ( restoreParent && el.parentElement !== restoreParent ) {
+			restoreParent.appendChild( el );
+		}
+	};
+
+	player.on( 'fullscreenchange', handleChange );
+	player.on( 'customfullscreenchange', handleChange );
+
+	const dispose = () => {
+		player.off( 'fullscreenchange', handleChange );
+		player.off( 'customfullscreenchange', handleChange );
+	};
+
+	if ( disposeWithPlayer ) {
+		player.one( 'dispose', dispose );
+	}
+
+	if ( runNow ) {
+		handleChange();
+	}
+
+	return dispose;
+}


### PR DESCRIPTION
This pull request makes several significant improvements to the GoDAM Image and Video blocks, focusing on aligning the image block's authoring UI with the video block, updating visual styles, and refining the fullscreen and transcript panel behaviors for a more consistent and user-friendly experience.

**GoDAM Image Block UI/UX Alignment:**

* Refactored the image selection and placeholder UI in `godam-image/edit.js` to closely match the video block, including a new "Add Image" placeholder, a "Customize Image" button (with matching icon), and a media item row with remove functionality. The Inspector panel now has an "Image Selection" section with improved controls and descriptions. [[1]](diffhunk://#diff-ac0fbbc792e47196986f8b9d05f93238c8d2695b78e967d1257978ecb8cd4c34L99-R159) [[2]](diffhunk://#diff-ac0fbbc792e47196986f8b9d05f93238c8d2695b78e967d1257978ecb8cd4c34L147-R228)
* Updated editor styles in `godam-image/editor.scss` to mirror the video block, including new placeholder visuals, button styles, and selection panel layout.
* Added `editorStyle` to `block.json` to ensure editor-only styles are loaded.
* Registered a custom SVG icon for the image block in the block settings and used it in the block registration. [[1]](diffhunk://#diff-4467cd5dea0ffceae8875aedf40e51469b237d459f5201ab41e41a0ed180d5a5R8) [[2]](diffhunk://#diff-4467cd5dea0ffceae8875aedf40e51469b237d459f5201ab41e41a0ed180d5a5R19)

**Icon and Button Consistency:**

* Replaced the local `customizeIcon` SVG in the audio and image blocks with the shared `CustomizeVideoIcon` for visual consistency. Updated button usages accordingly. [[1]](diffhunk://#diff-f6b2e4d63567e93a73ddd90e3545ff9bcc28f9ff25365c16e3faaf3738605cb3R39-L57) [[2]](diffhunk://#diff-f6b2e4d63567e93a73ddd90e3545ff9bcc28f9ff25365c16e3faaf3738605cb3L351-R341) [[3]](diffhunk://#diff-ac0fbbc792e47196986f8b9d05f93238c8d2695b78e967d1257978ecb8cd4c34L21-R26)

**Video Player and Transcript Panel Enhancements:**

* Overhauled the transcript panel in `godam-player.scss` to overlay the video on the right, slide in smoothly, and remain consistent across desktop, mobile, and fullscreen. The panel no longer resizes/reflows the video, and its responsive and fullscreen behaviors are improved. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L2313-R2356) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L2436-R2502)
* Updated share/transcript button handling in fullscreen: buttons are now visible when the user is active, properly sized, and reparented for consistent layout and interaction. Removed old rules that hid them in fullscreen. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L1849-L1854) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L1912-R1921)
* Standardized share button sizing and scaling across skins (`bubble-skin.scss`, `minimal-skin.scss`, `pills-skin.scss`) for visual consistency with the transcript button. [[1]](diffhunk://#diff-f87d3f3ea5c0df5bbe0a9b8b67de20af0100d841881b0b0ac3596a8d3fa27138R230) [[2]](diffhunk://#diff-ccd97c1988b35167275aa30598e2aaaa5ea728eda2aceb84f089f50b033a9502L70-R75) [[3]](diffhunk://#diff-f678c6b3cdf1601812afd91da5d6850d8edc3640dd563c91bfbc5a4a10683300L102-R107)
* Improved share button icon sizing in the default player skin for alignment with transcript controls.

These changes collectively bring the image block up to parity with the video block in terms of authoring experience, unify button/icon styles, and deliver a smoother, more modern transcript and sharing experience in the video player.

## Demo

https://github.com/user-attachments/assets/32170adb-9fc0-494c-a182-a77a91faaac8

https://github.com/user-attachments/assets/9ade30a5-b826-4a6a-aafd-3e8ffa66401c



