### PR TITLE
Feat/elementor document widget

### DIFF
--- a/inc/classes/class-elementor-widgets.php
+++ b/inc/classes/class-elementor-widgets.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use RTGODAM\Inc\Elementor_Controls\Godam_Media;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Audio;
+use RTGODAM\Inc\Elementor_Widgets\Godam_Document;
 use RTGODAM\Inc\Elementor_Widgets\Godam_Gallery;
 use RTGODAM\Inc\Elementor_Widgets\GoDAM_Video;
 use RTGODAM\Inc\Traits\Singleton;
@@ -75,13 +76,15 @@ class Elementor_Widgets {
 		// each class is backed by the SVG via background-image (absolute URLs, so
 		// no build-time url() resolution is needed).
 		$godam_icon_css = sprintf(
-			'.godam-eicon-video,.godam-eicon-gallery,.godam-eicon-audio{display:inline-block;width:1em;height:1em;vertical-align:middle;background-size:contain;background-repeat:no-repeat;background-position:center;}' .
+			'.godam-eicon-video,.godam-eicon-gallery,.godam-eicon-audio,.godam-eicon-document{display:inline-block;width:1em;height:1em;vertical-align:middle;background-size:contain;background-repeat:no-repeat;background-position:center;}' .
 			'.godam-eicon-video{background-image:url(%1$s);}' .
 			'.godam-eicon-gallery{background-image:url(%2$s);}' .
-			'.godam-eicon-audio{background-image:url(%3$s);}',
+			'.godam-eicon-audio{background-image:url(%3$s);}' .
+			'.godam-eicon-document{background-image:url(%4$s);}',
 			esc_url( RTGODAM_URL . 'assets/images/godam-video-filled.svg' ),
 			esc_url( RTGODAM_URL . 'assets/images/godam-gallery-filled.svg' ),
-			esc_url( RTGODAM_URL . 'assets/images/godam-audio-filled.svg' )
+			esc_url( RTGODAM_URL . 'assets/images/godam-audio-filled.svg' ),
+			esc_url( RTGODAM_URL . 'assets/images/godam-pdf.svg' )
 		);
 		wp_add_inline_style( 'godam-elementor-editor-style', $godam_icon_css );
 	}
@@ -151,6 +154,7 @@ class Elementor_Widgets {
 		\Elementor\Plugin::$instance->widgets_manager->register( new GoDAM_Video() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Gallery() );
 		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Audio() );
+		\Elementor\Plugin::$instance->widgets_manager->register( new Godam_Document() );
 	}
 
 	/**

--- a/inc/classes/elementor-widgets/class-godam-document.php
+++ b/inc/classes/elementor-widgets/class-godam-document.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Register Custom Widget - GoDAM Document
+ *
+ * Mirrors the godam/pdf ("Document") Gutenberg block and the WPBakery Document
+ * element. Widget controls map to the [godam_document] shortcode, which itself
+ * renders through assets/build/blocks/godam-pdf/render.php — so block,
+ * shortcode, WPBakery element, and widget share one template and JS contract.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Elementor_Widgets;
+
+use Elementor\Controls_Manager;
+
+/**
+ * GoDAM Document Widget.
+ */
+class Godam_Document extends Base {
+
+	/**
+	 * Default config for GoDAM Document Widget.
+	 *
+	 * @return array
+	 */
+	public function set_default_config() {
+		return array(
+			'name'            => 'godam-document',
+			'title'           => _x( 'Document', 'Widget Title', 'godam' ),
+			'icon'            => 'godam-eicon-document',
+			'categories'      => array( 'godam' ),
+			'keywords'        => array( 'godam', 'document', 'pdf', 'file' ),
+			// The [godam_document] shortcode also enqueues these at render time;
+			// declaring them lets Elementor account for the widget's assets.
+			'depended_script' => array( 'godam-pdf-view-script' ),
+			'depended_styles' => array( 'godam-pdf-style' ),
+		);
+	}
+
+	/**
+	 * Register Widget Controls.
+	 *
+	 * @access protected
+	 */
+	protected function register_controls() {
+		$this->start_controls_section(
+			'section_document_settings',
+			array(
+				'label' => esc_html__( 'Document Settings', 'godam' ),
+			)
+		);
+
+		$this->add_control(
+			'document-file',
+			array(
+				'label'       => esc_html__( 'Select Document', 'godam' ),
+				'type'        => 'godam-media',
+				// `media_type` (singular) is what godam-media.js reads to set the
+				// WP Media Library `library.type` filter — restricting selection to
+				// PDF files only. The control's file-picker branch renders for any
+				// non-image/video type, so PDFs need no control changes.
+				'media_type'  => 'application/pdf',
+				'label_block' => true,
+				'description' => esc_html__( 'Select a PDF document from the media library.', 'godam' ),
+			)
+		);
+
+		$this->add_control(
+			'doc_title',
+			array(
+				'label'       => esc_html__( 'Doc Title', 'godam' ),
+				'type'        => Controls_Manager::TEXT,
+				'label_block' => true,
+				'placeholder' => esc_html__( 'Add document title', 'godam' ),
+				'description' => esc_html__( 'Leave empty to use the attachment title.', 'godam' ),
+				'condition'   => array(
+					'document-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'       => esc_html__( 'Description', 'godam' ),
+				'type'        => Controls_Manager::TEXTAREA,
+				'label_block' => true,
+				'description' => esc_html__( 'Shown in card view.', 'godam' ),
+				'condition'   => array(
+					'document-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'preview_mode',
+			array(
+				'label'       => esc_html__( 'View', 'godam' ),
+				'type'        => Controls_Manager::SELECT,
+				'default'     => 'default',
+				'options'     => array(
+					'default' => esc_html__( 'Default View', 'godam' ),
+					'card'    => esc_html__( 'Card View', 'godam' ),
+				),
+				'description' => esc_html__( 'Embedded PDF viewer, or a card with a cover image.', 'godam' ),
+				'condition'   => array(
+					'document-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'height',
+			array(
+				'label'      => esc_html__( 'Height (px)', 'godam' ),
+				'type'       => Controls_Manager::SLIDER,
+				'size_units' => array( 'px' ),
+				'range'      => array(
+					'px' => array(
+						'min'  => 200,
+						'max'  => 1200,
+						'step' => 10,
+					),
+				),
+				'default'    => array(
+					'unit' => 'px',
+					'size' => 600,
+				),
+				'condition'  => array(
+					'document-file[url]!' => '',
+					'preview_mode'        => 'default',
+				),
+			)
+		);
+
+		$this->add_control(
+			'show_cover',
+			array(
+				'label'     => esc_html__( 'Show Cover', 'godam' ),
+				'type'      => Controls_Manager::SWITCHER,
+				'default'   => '',
+				'condition' => array(
+					'document-file[url]!' => '',
+					'preview_mode'        => 'card',
+				),
+			)
+		);
+
+		$this->add_control(
+			'custom_cover',
+			array(
+				'label'       => esc_html__( 'Cover Image', 'godam' ),
+				'type'        => 'godam-media',
+				'media_type'  => 'image',
+				'label_block' => true,
+				'description' => esc_html__( 'Leave empty to use the auto-generated cover. Recommended aspect ratio: 16:9.', 'godam' ),
+				'condition'   => array(
+					'document-file[url]!' => '',
+					'preview_mode'        => 'card',
+					'show_cover'          => 'yes',
+				),
+			)
+		);
+
+		$this->add_control(
+			'caption',
+			array(
+				'label'     => esc_html__( 'Caption', 'godam' ),
+				'type'      => Controls_Manager::TEXTAREA,
+				'condition' => array(
+					'document-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Render GoDAM Document widget output on the frontend.
+	 *
+	 * @access protected
+	 */
+	protected function render() {
+		$document_file = $this->get_settings_for_display( 'document-file' );
+
+		if ( empty( $document_file['url'] ) ) {
+			return;
+		}
+
+		$doc_title    = $this->get_settings_for_display( 'doc_title' ) ?? '';
+		$description  = $this->get_settings_for_display( 'description' ) ?? '';
+		$preview_mode = $this->get_settings_for_display( 'preview_mode' ) ?? 'default';
+		$height       = $this->get_settings_for_display( 'height' );
+		$show_cover   = 'yes' === $this->get_settings_for_display( 'show_cover' );
+		$custom_cover = $this->get_settings_for_display( 'custom_cover' );
+		$caption      = $this->get_settings_for_display( 'caption' ) ?? '';
+
+		$shortcode_atts = array(
+			'id'           => isset( $document_file['id'] ) ? $document_file['id'] : '',
+			'src'          => $document_file['url'],
+			'doc_title'    => $doc_title,
+			'description'  => $description,
+			'preview_mode' => $preview_mode,
+			'height'       => ! empty( $height['size'] ) ? intval( $height['size'] ) : 600,
+			'show_cover'   => $show_cover ? 'true' : 'false',
+			'custom_cover' => isset( $custom_cover['url'] ) ? $custom_cover['url'] : '',
+			'caption'      => $caption,
+		);
+
+		$shortcode_atts_string = '';
+		foreach ( $shortcode_atts as $key => $value ) {
+			$shortcode_atts_string .= sprintf( ' %s="%s"', $key, esc_attr( $value ) );
+		}
+
+		echo do_shortcode( '[godam_document' . $shortcode_atts_string . ']' );
+	}
+}

--- a/inc/classes/elementor-widgets/class-godam-document.php
+++ b/inc/classes/elementor-widgets/class-godam-document.php
@@ -209,11 +209,13 @@ class Godam_Document extends Base {
 			'caption'      => $caption,
 		);
 
-		$shortcode_atts_string = '';
-		foreach ( $shortcode_atts as $key => $value ) {
-			$shortcode_atts_string .= sprintf( ' %s="%s"', $key, esc_attr( $value ) );
-		}
-
-		echo do_shortcode( '[godam_document' . $shortcode_atts_string . ']' );
+		// Call the shortcode renderer directly with the raw attributes instead of
+		// building a "[godam_document …]" string. Round-tripping the free-text
+		// fields (doc_title/description/caption) through a shortcode string breaks
+		// on a "]" (it truncates the tag, dropping every later attribute and
+		// leaking the remainder as raw text), lets a "[…]" inject an unintended
+		// shortcode, and double-encodes entities via esc_attr(). render() enqueues
+		// its own script/style and returns escaped HTML.
+		echo \RTGODAM\Inc\Shortcodes\GoDAM_Document::get_instance()->render( $shortcode_atts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render() returns escaped HTML.
 	}
 }


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-plugin-wp/issues/21

This pull request introduces a new Elementor widget for embedding PDF documents, aligning it with existing Gutenberg and WPBakery document blocks. It also updates the icon styling and widget registration to support the new document widget.

**New Widget: GoDAM Document**

* Added a new `Godam_Document` Elementor widget in `class-godam-document.php`, mirroring the Gutenberg and WPBakery document blocks. The widget supports PDF selection, title, description, view mode, cover image, and caption options, and renders using the shared `[godam_document]` shortcode logic.

**Widget Registration and Integration**

* Registered the new `Godam_Document` widget in the Elementor widgets manager in `class-elementor-widgets.php`.
* Imported the `Godam_Document` class in `class-elementor-widgets.php`.

**UI/Icon Updates**

* Updated the inline CSS in `enqueue_scripts()` to add styling and an SVG icon for the new document widget, ensuring consistent icon display with other media widgets.

## Demo

https://github.com/user-attachments/assets/b70f4b4d-5c54-4f19-842e-73d06a62bd34

