### PR TITLE
Feat: Add Image Block in WP Bakery

### DIFF
--- a/assets/src/blocks/godam-image/render.php
+++ b/assets/src/blocks/godam-image/render.php
@@ -119,7 +119,15 @@ $godam_frame_style = $godam_width
 	: 'position:relative;display:inline-block;max-width:100%;line-height:0;';
 
 // Block-support wrapper attributes (align / spacing / anchor + our hook class).
-$godam_wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'godam-image' ) );
+// The [godam_image] shortcode (WPBakery element) sets $godam_is_shortcode and
+// runs outside a block, where get_block_wrapper_attributes() would warn, so it
+// gets the stable hook class plus any WPBakery Design Options CSS class.
+if ( empty( $godam_is_shortcode ) ) {
+	$godam_wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'godam-image' ) );
+} else {
+	$godam_shortcode_class    = trim( 'godam-image ' . ( isset( $godam_css_class ) ? $godam_css_class : '' ) );
+	$godam_wrapper_attributes = 'class="' . esc_attr( $godam_shortcode_class ) . '"';
+}
 ?>
 <figure data-test-id="godam-image-render" <?php echo wp_kses_data( $godam_wrapper_attributes ); ?>>
 	<div

--- a/assets/src/js/godam-image-layers/frontend.js
+++ b/assets/src/js/godam-image-layers/frontend.js
@@ -218,8 +218,66 @@ function initFrame( frame ) {
 	}
 }
 
-document.addEventListener( 'DOMContentLoaded', () => {
+const initAllFrames = () => {
 	document
 		.querySelectorAll( '.godam-image__frame[data-godam-image-layers]' )
 		.forEach( initFrame );
-} );
+};
+
+// Run on DOMContentLoaded, or immediately if the DOM is already parsed — the
+// script may execute after that event (e.g. injected by a page builder).
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', initAllFrames );
+} else {
+	initAllFrames();
+}
+
+/**
+ * Detect a WPBakery editor preview. Its inline editor renders the block markup
+ * (hotspot / product-hotspot layers) into an iframe AFTER this script has run,
+ * so a one-shot init never sees it — the layers stay invisible even though the
+ * published page renders them fine. The Gutenberg canvas draws them via React,
+ * which is why they show there.
+ *
+ * @return {boolean} True when running inside a WPBakery editor preview.
+ */
+const isBuilderPreview = () => {
+	try {
+		const fe = window.frameElement;
+		if ( fe && /vc[-_]inline-frame|vc_editor/i.test( ( fe.id || '' ) + ' ' + ( fe.className || '' ) ) ) {
+			return true;
+		}
+	} catch ( e ) {}
+	try {
+		return !! document.body?.classList.contains( 'vc_editor' );
+	} catch ( e ) {
+		return false;
+	}
+};
+
+// Editor preview only: re-run init on a few deferred passes plus an observer for
+// ongoing edits. initFrame() is idempotent (guarded by data-godam-layers-rendered),
+// so re-running is safe. Nothing extra is scheduled on the published front end.
+if ( isBuilderPreview() ) {
+	[ 300, 1200, 3000 ].forEach( ( delay ) => setTimeout( initAllFrames, delay ) );
+
+	if ( 'MutationObserver' in window ) {
+		let scheduled = false;
+		const observer = new MutationObserver( () => {
+			if ( scheduled ) {
+				return;
+			}
+			scheduled = true;
+			window.requestAnimationFrame( () => {
+				scheduled = false;
+				initAllFrames();
+			} );
+		} );
+		const startObserving = () => observer.observe( document.body, { childList: true, subtree: true } );
+		if ( document.body ) {
+			startObserving();
+		} else {
+			document.addEventListener( 'DOMContentLoaded', startObserving );
+		}
+	}
+}

--- a/assets/src/js/wpbakery/wpbakery-image-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-image-selector-param.js
@@ -1,6 +1,10 @@
 ( function( $ ) {
 	'use strict';
 
+	// Use WordPress i18n when available so the WPBakery param UI is translatable
+	// like the PHP-rendered labels; fall back to identity if wp.i18n is absent.
+	const { __ } = ( window.wp && window.wp.i18n ) ? window.wp.i18n : { __: ( s ) => s };
+
 	// Initialize image selector on document ready and when WPBakery reloads the params.
 	$( document ).ready( initImageSelector );
 	$( document ).on( 'vc.reload', initImageSelector );
@@ -14,16 +18,16 @@
 			const paramName = $button.data( 'param' );
 			const $container = $button.closest( '.image_selector_block' );
 			const $input = $container.find( '.image_selector_field' );
-			// Sibling hidden params filled from the attachment; the GoDAM Image
-			// block's render.php falls back to the attachment for anything empty.
+			// Sibling hidden `url` param filled from the attachment; the GoDAM Image
+			// block's render.php falls back to the attachment (URL / alt / size) for
+			// anything empty, so alt is not exposed as a param.
 			const $urlInput = $attributeContainer.find( '[name="url"]' );
-			const $altInput = $attributeContainer.find( '[name="alt"]' );
 
 			// Create WordPress media frame, restricted to images.
 			const frame = wp.media( {
-				title: 'Select or Upload Image',
+				title: __( 'Select or Upload Image', 'godam' ),
 				button: {
-					text: 'Select Image',
+					text: __( 'Select image', 'godam' ),
 				},
 				library: {
 					type: 'image',
@@ -35,17 +39,14 @@
 			frame.on( 'select', function() {
 				const attachment = frame.state().get( 'selection' ).first().toJSON();
 
-				// Store the attachment ID (layers are keyed off it) + url/alt.
+				// Store the attachment ID (layers are keyed off it) + source URL.
 				$input.val( attachment.id ).trigger( 'change' );
 				if ( $urlInput.length ) {
 					$urlInput.val( attachment.url || '' ).trigger( 'change' );
 				}
-				if ( $altInput.length ) {
-					$altInput.val( typeof attachment.alt === 'string' ? attachment.alt : '' ).trigger( 'change' );
-				}
 
 				// Update button text.
-				$button.text( 'Replace' );
+				$button.text( __( 'Replace', 'godam' ) );
 
 				// Add or update preview.
 				let $preview = $container.find( '.image-selector-preview' );
@@ -63,7 +64,7 @@
 				if ( $removeButton.length === 0 ) {
 					$removeButton = $( '<button type="button" class="button image-selector-remove" data-test-id="godam-wpb-button-remove-image-block" style="margin-left: 5px;"></button>' )
 						.attr( 'data-param', paramName )
-						.text( 'Remove' );
+						.text( __( 'Remove', 'godam' ) );
 					$buttonsWrapper.append( $removeButton );
 				}
 
@@ -89,15 +90,11 @@
 			const $input = $container.find( '.image_selector_field' );
 			const $selectButton = $container.find( '.image-selector-button' );
 			const $urlInput = $attributeContainer.find( '[name="url"]' );
-			const $altInput = $attributeContainer.find( '[name="alt"]' );
 
 			// Clear the values.
 			$input.val( '' ).trigger( 'change' );
 			if ( $urlInput.length ) {
 				$urlInput.val( '' ).trigger( 'change' );
-			}
-			if ( $altInput.length ) {
-				$altInput.val( '' ).trigger( 'change' );
 			}
 
 			// Remove preview.
@@ -107,7 +104,7 @@
 			$button.remove();
 
 			// Update button text.
-			$selectButton.text( 'Select image' );
+			$selectButton.text( __( 'Select image', 'godam' ) );
 		} );
 	}
 }( window.jQuery ) );

--- a/assets/src/js/wpbakery/wpbakery-image-selector-param.js
+++ b/assets/src/js/wpbakery/wpbakery-image-selector-param.js
@@ -1,0 +1,113 @@
+( function( $ ) {
+	'use strict';
+
+	// Initialize image selector on document ready and when WPBakery reloads the params.
+	$( document ).ready( initImageSelector );
+	$( document ).on( 'vc.reload', initImageSelector );
+
+	function initImageSelector() {
+		$( '.image-selector-button' ).off( 'click' ).on( 'click', function( e ) {
+			e.preventDefault();
+
+			const $button = $( this );
+			const $attributeContainer = $button.closest( '.wpb_el_type_image_selector' ).parent();
+			const paramName = $button.data( 'param' );
+			const $container = $button.closest( '.image_selector_block' );
+			const $input = $container.find( '.image_selector_field' );
+			// Sibling hidden params filled from the attachment; the GoDAM Image
+			// block's render.php falls back to the attachment for anything empty.
+			const $urlInput = $attributeContainer.find( '[name="url"]' );
+			const $altInput = $attributeContainer.find( '[name="alt"]' );
+
+			// Create WordPress media frame, restricted to images.
+			const frame = wp.media( {
+				title: 'Select or Upload Image',
+				button: {
+					text: 'Select Image',
+				},
+				library: {
+					type: 'image',
+				},
+				multiple: false,
+			} );
+
+			// When an image is selected.
+			frame.on( 'select', function() {
+				const attachment = frame.state().get( 'selection' ).first().toJSON();
+
+				// Store the attachment ID (layers are keyed off it) + url/alt.
+				$input.val( attachment.id ).trigger( 'change' );
+				if ( $urlInput.length ) {
+					$urlInput.val( attachment.url || '' ).trigger( 'change' );
+				}
+				if ( $altInput.length ) {
+					$altInput.val( typeof attachment.alt === 'string' ? attachment.alt : '' ).trigger( 'change' );
+				}
+
+				// Update button text.
+				$button.text( 'Replace' );
+
+				// Add or update preview.
+				let $preview = $container.find( '.image-selector-preview' );
+				if ( $preview.length === 0 ) {
+					$preview = $( '<div class="image-selector-preview" data-test-id="godam-wpb-preview-image-block" style="margin-top: 10px;"></div>' );
+					$container.append( $preview );
+				}
+				$preview.empty().append(
+					$( '<img alt="" style="max-width: 300px; height: auto;" />' ).attr( 'src', attachment.url || '' ),
+				);
+
+				// Add or update remove button in the buttons wrapper.
+				const $buttonsWrapper = $container.find( '.image_selector-buttons-wrapper' );
+				let $removeButton = $buttonsWrapper.find( '.image-selector-remove' );
+				if ( $removeButton.length === 0 ) {
+					$removeButton = $( '<button type="button" class="button image-selector-remove" data-test-id="godam-wpb-button-remove-image-block" style="margin-left: 5px;"></button>' )
+						.attr( 'data-param', paramName )
+						.text( 'Remove' );
+					$buttonsWrapper.append( $removeButton );
+				}
+
+				// Re-attach remove handler.
+				initRemoveHandler();
+			} );
+
+			// Open the media frame.
+			frame.open();
+		} );
+
+		// Initialize remove handler.
+		initRemoveHandler();
+	}
+
+	function initRemoveHandler() {
+		$( '.image-selector-remove' ).off( 'click' ).on( 'click', function( e ) {
+			e.preventDefault();
+
+			const $button = $( this );
+			const $attributeContainer = $button.closest( '.wpb_el_type_image_selector' ).parent();
+			const $container = $button.closest( '.image_selector_block' );
+			const $input = $container.find( '.image_selector_field' );
+			const $selectButton = $container.find( '.image-selector-button' );
+			const $urlInput = $attributeContainer.find( '[name="url"]' );
+			const $altInput = $attributeContainer.find( '[name="alt"]' );
+
+			// Clear the values.
+			$input.val( '' ).trigger( 'change' );
+			if ( $urlInput.length ) {
+				$urlInput.val( '' ).trigger( 'change' );
+			}
+			if ( $altInput.length ) {
+				$altInput.val( '' ).trigger( 'change' );
+			}
+
+			// Remove preview.
+			$container.find( '.image-selector-preview' ).remove();
+
+			// Remove the remove button itself.
+			$button.remove();
+
+			// Update button text.
+			$selectButton.text( 'Select image' );
+		} );
+	}
+}( window.jQuery ) );

--- a/inc/classes/class-plugin.php
+++ b/inc/classes/class-plugin.php
@@ -60,6 +60,7 @@ use RTGODAM\Inc\Shortcodes\GoDAM_Player;
 use RTGODAM\Inc\Shortcodes\GoDAM_Video_Gallery;
 use RTGODAM\Inc\Shortcodes\GoDAM_Audio;
 use RTGODAM\Inc\Shortcodes\GoDAM_Document;
+use RTGODAM\Inc\Shortcodes\GoDAM_Image;
 
 use RTGODAM\Inc\Migrations\Runner as Migrations_Runner;
 use RTGODAM\Inc\Cron_Jobs\Retranscode_Failed_Media;
@@ -80,6 +81,7 @@ use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Video;
 use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Video_Gallery;
 use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Audio;
 use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Document;
+use RTGODAM\Inc\WPBakery_Elements\WPB_GoDAM_Image;
 
 /**
  * Class Plugin.
@@ -118,6 +120,7 @@ class Plugin {
 		GoDAM_Video_Gallery::get_instance();
 		GoDAM_Audio::get_instance();
 		GoDAM_Document::get_instance();
+		GoDAM_Image::get_instance();
 		Video_Engagement::get_instance();
 
 		Video_Editor_Form_Layer_Handler::get_instance()->init();
@@ -253,6 +256,7 @@ class Plugin {
 		WPB_GoDAM_Video_Gallery::get_instance();
 		WPB_GoDAM_Audio::get_instance();
 		WPB_GoDAM_Document::get_instance();
+		WPB_GoDAM_Image::get_instance();
 	}
 
 	/**

--- a/inc/classes/shortcodes/class-godam-image.php
+++ b/inc/classes/shortcodes/class-godam-image.php
@@ -25,6 +25,64 @@ class GoDAM_Image {
 	 */
 	final protected function __construct() {
 		add_shortcode( 'godam_image', array( $this, 'render' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'preload_wpbakery_editor_assets' ) );
+	}
+
+	/**
+	 * Register the shared image-layers front-end script (idempotent).
+	 *
+	 * Mirrors the lazy registration in the block's render.php so the script can
+	 * also be enqueued up front (e.g. in the WPBakery inline editor) with the
+	 * same Woo dependencies applied via the filter.
+	 *
+	 * @return void
+	 */
+	private function register_image_layers_script() {
+		if ( wp_script_is( 'godam-image-layers-frontend', 'registered' ) ) {
+			return;
+		}
+
+		$asset_path = RTGODAM_PATH . 'assets/build/js/godam-image-layers-frontend.min.asset.php';
+		$asset      = file_exists( $asset_path )
+			? include $asset_path
+			: array(
+				'dependencies' => array(),
+				'version'      => RTGODAM_VERSION,
+			);
+
+		$deps = apply_filters( 'godam_image_layers_frontend_dependencies', $asset['dependencies'] );
+
+		wp_register_script(
+			'godam-image-layers-frontend',
+			RTGODAM_URL . 'assets/build/js/godam-image-layers-frontend.min.js',
+			$deps,
+			$asset['version'],
+			true
+		);
+	}
+
+	/**
+	 * Preload the image-layers assets in the WPBakery inline editor.
+	 *
+	 * WPBakery adds/updates an element via AJAX and does NOT inject newly
+	 * enqueued scripts into the running editor page. So when a GoDAM Image is
+	 * added for the first time and saved, the layers script wouldn't be present
+	 * yet — the hotspot / product layers only appeared after a full reload. Load
+	 * the script (and hotspot styles) up front in the inline editor so the
+	 * editor-scoped re-init in frontend.js can draw a just-added image's layers
+	 * immediately, without a refresh. Editor-only; nothing changes on the front end.
+	 *
+	 * @return void
+	 */
+	public function preload_wpbakery_editor_assets() {
+		if ( ! function_exists( 'vc_is_inline' ) || ! vc_is_inline() ) {
+			return;
+		}
+
+		$this->register_image_layers_script();
+		wp_enqueue_script( 'godam-image-layers-frontend' );
+		wp_enqueue_style( 'godam-image-style' );
+		wp_enqueue_style( 'godam-player-style' );
 	}
 
 	/**
@@ -52,8 +110,10 @@ class GoDAM_Image {
 		}
 
 		// Map the flat shortcode atts to the block attribute shape render.php reads.
+		// Normalize the attachment ID to an int (shortcode atts arrive as strings)
+		// so it matches how core attachment APIs and the block attribute expect it.
 		$attributes = array(
-			'id'              => $atts['id'],
+			'id'              => absint( $atts['id'] ),
 			'url'             => $atts['url'],
 			'alt'             => $atts['alt'],
 			'showImageLayers' => filter_var( $atts['show_image_layers'], FILTER_VALIDATE_BOOLEAN ),

--- a/inc/classes/shortcodes/class-godam-image.php
+++ b/inc/classes/shortcodes/class-godam-image.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * GoDAM Image Shortcode Class.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Shortcodes;
+
+defined( 'ABSPATH' ) || exit;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+/**
+ * Class GoDAM_Image.
+ *
+ * Handles the [godam_image] shortcode, which powers the WPBakery "GoDAM Image"
+ * element by reusing the Image block's render template.
+ */
+class GoDAM_Image {
+	use Singleton;
+
+	/**
+	 * Constructor.
+	 */
+	final protected function __construct() {
+		add_shortcode( 'godam_image', array( $this, 'render' ) );
+	}
+
+	/**
+	 * Render the GoDAM image shortcode.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string HTML output of the image (with hotspot/product layers).
+	 */
+	public function render( $atts ) {
+		$atts = shortcode_atts(
+			array(
+				'id'                => '',
+				'url'               => '',
+				'alt'               => '',
+				'show_image_layers' => true,
+				'css'               => '',
+			),
+			$atts,
+			'godam_image'
+		);
+
+		// A GoDAM Image needs either an attachment ID or a source URL.
+		if ( empty( $atts['id'] ) && empty( $atts['url'] ) ) {
+			return '';
+		}
+
+		// Map the flat shortcode atts to the block attribute shape render.php reads.
+		$attributes = array(
+			'id'              => $atts['id'],
+			'url'             => $atts['url'],
+			'alt'             => $atts['alt'],
+			'showImageLayers' => filter_var( $atts['show_image_layers'], FILTER_VALIDATE_BOOLEAN ),
+		);
+
+		// Get WPBakery Design Options CSS class if available.
+		$godam_css_class = '';
+		if ( ! empty( $atts['css'] ) && function_exists( 'vc_shortcode_custom_css_class' ) ) {
+			$godam_css_class = vc_shortcode_custom_css_class( $atts['css'], ' ' );
+		}
+
+		// The block's hotspot stylesheet is attached via wp_enqueue_block_style()
+		// (see class-blocks.php), which only fires in block context. Enqueue the
+		// image block style + the shared hotspot styles for the shortcode path.
+		wp_enqueue_style( 'godam-image-style' );
+		wp_enqueue_style( 'godam-player-style' );
+
+		// Tells the shared render.php it runs outside block context.
+		$godam_is_shortcode = true;
+
+		ob_start();
+		require RTGODAM_PATH . 'assets/build/blocks/godam-image/render.php';
+		return ob_get_clean();
+	}
+}

--- a/inc/classes/shortcodes/class-godam-image.php
+++ b/inc/classes/shortcodes/class-godam-image.php
@@ -44,6 +44,7 @@ class GoDAM_Image {
 
 		$asset_path = RTGODAM_PATH . 'assets/build/js/godam-image-layers-frontend.min.asset.php';
 		$asset      = file_exists( $asset_path )
+			// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is a plugin constant + hardcoded build filename.
 			? include $asset_path
 			: array(
 				'dependencies' => array(),

--- a/inc/classes/wpbakery-elements/class-wpb-godam-image.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-image.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * WPBakery GoDAM Image Element
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\WPBakery_Elements;
+
+use RTGODAM\Inc\Traits\Singleton;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WPB_GoDAM_Image
+ *
+ * @since 2.0.0
+ *
+ * @package GoDAM
+ */
+class WPB_GoDAM_Image {
+	use Singleton;
+
+	/**
+	 * WPB_GoDAM_Image constructor.
+	 *
+	 * @since 2.0.0
+	 */
+	protected function __construct() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$is_wpbakery_active = is_plugin_active( 'js_composer/js_composer.php' );
+
+		if ( $is_wpbakery_active ) {
+			$this->setup_hooks();
+		}
+	}
+
+	/**
+	 * Setup hooks.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+		add_action( 'vc_before_init', array( $this, 'godam_image' ) );
+	}
+
+	/**
+	 * Map image element to WPBakery.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return void
+	 */
+	public function godam_image() {
+		if ( ! function_exists( 'vc_map' ) ) {
+			return;
+		}
+
+		vc_map(
+			array(
+				'name'        => esc_html__( 'GoDAM Image', 'godam' ),
+				'base'        => 'godam_image',
+				'category'    => esc_html__( 'GoDAM', 'godam' ),
+				'description' => esc_html__( 'Image with interactive GoDAM hotspot & product layers', 'godam' ),
+				'icon'        => RTGODAM_URL . 'assets/src/images/godam-image-filled.svg',
+				'params'      => array(
+					// Image Selection (stores the attachment ID).
+					array(
+						'type'        => 'image_selector',
+						'heading'     => esc_html__( 'Select Image', 'godam' ),
+						'param_name'  => 'id',
+						'value'       => '',
+						'description' => esc_html__( 'Select an image from the WordPress Media Library.', 'godam' ),
+						'admin_label' => true,
+						'save_always' => true,
+					),
+
+					// Source URL (auto-filled by the image selector).
+					array(
+						'type'        => 'textfield_hidden',
+						'heading'     => esc_html__( 'Source URL', 'godam' ),
+						'param_name'  => 'url',
+						'value'       => '',
+						'admin_label' => true,
+						'description' => esc_html__( 'The source URL for the image.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Alt text (auto-filled by the image selector).
+					array(
+						'type'        => 'textfield_hidden',
+						'heading'     => esc_html__( 'Alt Text', 'godam' ),
+						'param_name'  => 'alt',
+						'value'       => '',
+						'description' => esc_html__( 'Alternative text for the image.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// Show Image Layers toggle.
+					array(
+						'type'        => 'checkbox',
+						'heading'     => esc_html__( 'Show Image Layers', 'godam' ),
+						'param_name'  => 'show_image_layers',
+						'value'       => array( esc_html__( 'Yes', 'godam' ) => 'true' ),
+						'std'         => 'true',
+						'description' => esc_html__( 'Display the authored hotspot & product layers over the image.', 'godam' ),
+						'save_always' => true,
+						'dependency'  => array(
+							'element'   => 'id',
+							'not_empty' => true,
+						),
+					),
+
+					// WPBakery Design Options tab.
+					array(
+						'type'       => 'css_editor',
+						'heading'    => esc_html__( 'Design Options', 'godam' ),
+						'param_name' => 'css',
+						'group'      => esc_html__( 'Design Options', 'godam' ),
+					),
+				),
+			)
+		);
+	}
+}

--- a/inc/classes/wpbakery-elements/class-wpb-godam-image.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-image.php
@@ -95,20 +95,6 @@ class WPB_GoDAM_Image {
 						),
 					),
 
-					// Alt text (auto-filled by the image selector).
-					array(
-						'type'        => 'textfield_hidden',
-						'heading'     => esc_html__( 'Alt Text', 'godam' ),
-						'param_name'  => 'alt',
-						'value'       => '',
-						'description' => esc_html__( 'Alternative text for the image.', 'godam' ),
-						'save_always' => true,
-						'dependency'  => array(
-							'element'   => 'id',
-							'not_empty' => true,
-						),
-					),
-
 					// Show Image Layers toggle.
 					array(
 						'type'        => 'checkbox',

--- a/inc/classes/wpbakery-elements/class-wpb-godam-params.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-params.php
@@ -66,6 +66,12 @@ class WPB_GoDAM_Params {
 		);
 
 		vc_add_shortcode_param(
+			'image_selector',
+			array( $this, 'image_selector_settings_field' ),
+			RTGODAM_URL . 'assets/build/js/wpbakery-image-selector-param.min.js'
+		);
+
+		vc_add_shortcode_param(
 			'document_selector',
 			array( $this, 'document_selector_settings_field' ),
 			RTGODAM_URL . 'assets/build/js/wpbakery-document-selector-param.min.js'
@@ -260,6 +266,47 @@ class WPB_GoDAM_Params {
 			. '<div class="document_cover_selector-buttons-wrapper" style="display:flex;align-items:center;">'
 			. '<button type="button" class="button document-cover-select" data-test-id="godam-wpb-button-select-cover">' . esc_html__( 'Select image', 'godam' ) . '</button>'
 			. '</div>'
+			. '</div>';
+	}
+
+	/**
+	 * Image selector settings field.
+	 *
+	 * Stores the image attachment ID (the GoDAM Image block keys its hotspot /
+	 * product layers off the attachment ID). The selector JS also fills the
+	 * sibling hidden `url` and `alt` params from the chosen attachment.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array  $settings Field settings.
+	 * @param string $value    Field value (attachment ID).
+	 * @return string
+	 */
+	public function image_selector_settings_field( $settings, $value ) {
+		$button_text   = ! empty( $value ) ? esc_html__( 'Replace', 'godam' ) : esc_html__( 'Select image', 'godam' );
+		$preview_html  = '';
+		$remove_button = '';
+
+		// If an image is selected, show preview and remove button.
+		if ( ! empty( $value ) && is_numeric( $value ) ) {
+			$attachment = wp_get_attachment_image_url( $value, 'medium' );
+			if ( $attachment ) {
+				$preview_html  = '<div class="image-selector-preview" data-test-id="godam-wpb-preview-image-block" style="margin-top: 10px;">
+					<img src="' . esc_url( $attachment ) . '" alt="" style="max-width: 300px; height: auto;" />
+				</div>';
+				$remove_button = '<button type="button" class="button image-selector-remove" data-test-id="godam-wpb-button-remove-image-block" data-param="' . esc_attr( $settings['param_name'] ) . '" style="margin-left: 5px;">' . esc_html__( 'Remove', 'godam' ) . '</button>';
+			}
+		}
+
+		return '<div class="image_selector_block">'
+			. '<input name="' . esc_attr( $settings['param_name'] ) . '" data-test-id="godam-wpb-input-image-block" class="wpb_vc_param_value wpb-textinput image_selector_field ' .
+			esc_attr( $settings['param_name'] ) . ' ' .
+			esc_attr( $settings['type'] ) . '_field" type="hidden" value="' . esc_attr( $value ) . '" />'
+			. '<div class="image_selector-buttons-wrapper" style="display: flex; align-items: center;">'
+			. '<button type="button" class="button image-selector-button" data-test-id="godam-wpb-button-select-image-block" data-param="' . esc_attr( $settings['param_name'] ) . '">' . $button_text . '</button>'
+			. $remove_button
+			. '</div>'
+			. $preview_html
 			. '</div>';
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -286,6 +286,13 @@ const wpBakeryImageSrcSelectorParam = {
 	},
 };
 
+const wpBakeryImageSelectorParam = {
+	...sharedConfig,
+	entry: {
+		'wpbakery-image-selector-param': path.resolve( process.cwd(), 'assets', 'src', 'js', 'wpbakery', 'wpbakery-image-selector-param.js' ),
+	},
+};
+
 const wpBakeryDocumentSelectorParam = {
 	...sharedConfig,
 	entry: {
@@ -426,6 +433,7 @@ module.exports = [
 	wpBakeryVideoSelectorParam,
 	wpBakeryAudioSelectorParam,
 	wpBakeryImageSrcSelectorParam,
+	wpBakeryImageSelectorParam,
 	wpBakeryDocumentSelectorParam,
 	wpBakeryDocumentCoverSelectorParam,
 	ninjaFormsSubmissionsList,


### PR DESCRIPTION
# Register the GoDAM Image block in WPBakery

Issue - https://github.com/rtCamp/godam-plugin-wp/issues/19

## Summary

The `godam/image` **GoDAM Image** block (hotspot / WooCommerce product layers over an image) was available in Gutenberg but not in the WPBakery (Visual Composer) page builder. This PR registers a **GoDAM Image** element under the GoDAM category in WPBakery — wired the same way as the existing Video, Video Gallery, Audio, and Document elements — and makes the hotspot / product layers render in the WPBakery inline-editor preview.

Branch: `feat/image-block-wp-bakery` → `develop`

## Background

WPBakery elements render through shortcodes (`base` → shortcode name), and each existing GoDAM element reuses the corresponding block's `render.php` as the single source of truth. The Image block had no WPBakery element and no shortcode, so it couldn't be added from the builder.

The GoDAM Image block keys its authored hotspot / product-hotspot layers off the **attachment ID** (they live in the attachment's `rtgodam_meta`), so the WPBakery element captures the image by ID (not just a URL).

## What changed

### New files
- `inc/classes/wpbakery-elements/class-wpb-godam-image.php` — maps the `godam_image` element via `vc_map()` under the **GoDAM** category (WPBakery-active guard, `vc_before_init` hook, `Singleton`), mirroring the other GoDAM elements.
- `inc/classes/shortcodes/class-godam-image.php` — registers the `[godam_image]` shortcode, which reuses the Image block's `render.php` (same approach as `[godam_audio]`/`[godam_document]`) and maps the flat shortcode attributes to the block's attribute shape. It also enqueues the image + hotspot styles the block normally attaches via `wp_enqueue_block_style()` (which only fires in block context).
- `assets/src/js/wpbakery/wpbakery-image-selector-param.js` — the custom `image_selector` param UI: opens the media library (images only), stores the **attachment ID**, and auto-fills the hidden `url` / `alt` params from the chosen attachment (the render falls back to the attachment for anything empty).

### Modified files
- `inc/classes/wpbakery-elements/class-wpb-godam-params.php` — registers the new `image_selector` custom param type and its server-rendered field (ID-based, distinct from the existing URL-based `image_src_selector`).
- `assets/src/blocks/godam-image/render.php` — supports being called outside block context: when the shortcode sets `$godam_is_shortcode` it skips `get_block_wrapper_attributes()` (which warns without an active block) and applies the stable `godam-image` hook class + any WPBakery **Design Options** CSS class instead.
- `inc/classes/class-plugin.php` — registers `GoDAM_Image` (shortcode) and `WPB_GoDAM_Image` (element) alongside the existing ones.
- `webpack.config.js` — adds the build entry for the new `image_selector` param script.
- `assets/src/js/godam-image-layers/frontend.js` — makes the layers render in the **WPBakery editor preview** (see below).

## Element params (`base: godam_image`)

| WPBakery param | Block attribute | Notes |
|---|---|---|
| `id` | `id` | Image picker (media library, images only) |
| `url` | `url` | Hidden, auto-filled by the picker |
| `alt` | `alt` | Hidden, auto-filled by the picker |
| `show_image_layers` | `showImageLayers` | Toggle (default on) — overlays the authored hotspot / product layers |
| `css` | — | WPBakery Design Options tab |

## Layers in the WPBakery editor preview

**Problem:** The block's hotspot / product layers are drawn by the front-end script `godam-image-layers/frontend.js`, which initialized only on `DOMContentLoaded`. WPBakery's inline editor renders the shortcode markup into its preview iframe **after** that event, so the script never saw the injected image and the layers were invisible in the WPBakery editor (they render fine on the published page).

**Fix (in `frontend.js`):**
- Run init immediately when the DOM is already parsed (`readyState` fallback), not only on `DOMContentLoaded`.
- In a WPBakery editor preview only (detected via the `#vc_inline-frame` iframe / `vc_editor` body class), re-run init on a few deferred passes plus a `MutationObserver` for ongoing edits. `initFrame()` is idempotent (guarded by `data-godam-layers-rendered`), so re-running is safe and never double-draws. Nothing extra is scheduled on the published front end.

This is the same editor-init pattern used for the Video player preview.

## Key implementation notes

- **ID-based selection.** Layers resolve from the attachment's `rtgodam_meta`, so the element stores the attachment ID (via `image_selector`) rather than only a URL; `url`/`alt` are auto-filled for convenience and the render falls back to the attachment when they're empty.
- **Single source of truth.** No markup is duplicated — the shortcode reuses the block's `render.php`, so block and WPBakery output stay in sync.
- **Shortcode attribute casing.** As with the other elements, param names are lowercase/snake_case (`show_image_layers`) because WordPress lowercases shortcode attribute names; the shortcode maps them to the block's camelCase attributes.

## How to test

1. Ensure WPBakery (`js_composer`) is active. Run `npm run build:js` and `npm run build:blocks` (build artifacts under `assets/build/` are gitignored).
2. Edit a page with WPBakery → add the **GoDAM → GoDAM Image** element.
3. Pick an image (ideally one with authored hotspot / product layers) → confirm the selected-image preview and the **Show Image Layers** toggle.
4. In the WPBakery inline-editor preview, confirm the image renders and — for an image with layers and the toggle on — the hotspot / product layers are drawn.
5. Publish and confirm the front end renders the image + layers (parity with the Gutenberg-inserted block).
6. Verify the **Design Options** tab styling applies on the front end.

## Notes for reviewers

- `assets/build/**` are build artifacts (gitignored) — rebuild with `npm run build:js` / `npm run build:blocks`.
- Drawing the layers inside the **Gutenberg** block-editor canvas (and the companion `godam-for-woo` editor enqueue for product hotspots) is a separate follow-up and not part of this PR.

## Demo

https://github.com/user-attachments/assets/56df847e-636e-4483-90fa-cdddf422c2e9


