### PR TITLE
Feat: Add layers in Image Block in Gutenberg

### DIFF
--- a/assets/src/blocks/godam-image/edit.js
+++ b/assets/src/blocks/godam-image/edit.js
@@ -134,18 +134,16 @@ function ImageEdit( { attributes, setAttributes, isSelected } ) {
 	// image or layers change. The canvas is an iframe; the ref points at the real
 	// node inside it, and initImageFrame() draws directly onto that node — the
 	// same renderer the front end uses (Woo hotspots included, when the woo add-on
-	// registers its manager). We reset the render guard + overlay so edits redraw.
+	// registers its manager). initImageFrame is self-cleaning and returns a
+	// teardown that removes its resize listener / ResizeObserver / pending load
+	// handler and clears the overlay; returning it lets React tear down before
+	// each redraw and on unmount (e.g. toggling layers off), so nothing leaks.
 	useEffect( () => {
 		const frame = frameRef.current;
 		if ( ! frame || ! showLayers ) {
-			return;
+			return undefined;
 		}
-		frame.dataset.godamLayersRendered = '';
-		const overlay = frame.querySelector( '.godam-image-layer' );
-		if ( overlay ) {
-			overlay.innerHTML = '';
-		}
-		initImageFrame( frame );
+		return initImageFrame( frame );
 	}, [ showLayers, layersJson, url, instanceId ] );
 
 	// The inspector "Image Selection" panel mirrors the GoDAM Video block: an

--- a/assets/src/blocks/godam-image/edit.js
+++ b/assets/src/blocks/godam-image/edit.js
@@ -15,15 +15,17 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { plus, trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { CustomizeVideoIcon } from '../godam-player/icons';
+import { initImageFrame } from '../../js/godam-image-layers/render-image-frame.js';
 import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -96,6 +98,55 @@ function ImageEdit( { attributes, setAttributes, isSelected } ) {
 
 	const blockProps = useBlockProps( { className: 'godam-image' } );
 	const hasImage = !! url;
+
+	// Fetch the attachment's authored layers so the editor canvas can preview the
+	// same hotspot / product-hotspot overlays the front end renders. rtgodam_meta
+	// is exposed as a REST field on attachments (see Meta_Rest_Fields).
+	const rtgodamMeta = useSelect(
+		( select ) => ( id ? select( coreStore ).getEntityRecord( 'postType', 'attachment', id )?.rtgodam_meta : null ),
+		[ id ],
+	);
+
+	// Keep only drawable layers (mirror render.php): hotspot layers with hotspots
+	// and Woo layers with product hotspots.
+	const layers = useMemo( () => {
+		const all = ( rtgodamMeta && Array.isArray( rtgodamMeta.layers ) ) ? rtgodamMeta.layers : [];
+		return all.filter( ( layer ) => {
+			if ( ! layer || ! layer.type ) {
+				return false;
+			}
+			if ( 'hotspot' === layer.type ) {
+				return Array.isArray( layer.hotspots ) && layer.hotspots.length > 0;
+			}
+			if ( 'woo' === layer.type ) {
+				return Array.isArray( layer.productHotspots ) && layer.productHotspots.length > 0;
+			}
+			return false;
+		} );
+	}, [ rtgodamMeta ] );
+
+	const showLayers = !! showImageLayers && layers.length > 0;
+	const layersJson = useMemo( () => JSON.stringify( layers ), [ layers ] );
+	const instanceId = useMemo( () => `img_editor_${ Math.random().toString( 36 ).slice( 2, 10 ) }`, [] );
+	const frameRef = useRef( null );
+
+	// Draw (and redraw) the layers onto the editor-canvas frame whenever the
+	// image or layers change. The canvas is an iframe; the ref points at the real
+	// node inside it, and initImageFrame() draws directly onto that node — the
+	// same renderer the front end uses (Woo hotspots included, when the woo add-on
+	// registers its manager). We reset the render guard + overlay so edits redraw.
+	useEffect( () => {
+		const frame = frameRef.current;
+		if ( ! frame || ! showLayers ) {
+			return;
+		}
+		frame.dataset.godamLayersRendered = '';
+		const overlay = frame.querySelector( '.godam-image-layer' );
+		if ( overlay ) {
+			overlay.innerHTML = '';
+		}
+		initImageFrame( frame );
+	}, [ showLayers, layersJson, url, instanceId ] );
 
 	// The inspector "Image Selection" panel mirrors the GoDAM Video block: an
 	// outlined "Add Image" button when empty, or a "Customize Image" button plus
@@ -221,9 +272,28 @@ function ImageEdit( { attributes, setAttributes, isSelected } ) {
 				</div>
 			) : (
 				<figure { ...blockProps } data-test-id="godam-image-canvas">
-					<div className="godam-image__frame">
-						<img className="godam-image__img" src={ url } alt={ alt || '' } />
-					</div>
+					{ showLayers ? (
+						<div
+							className="godam-image__frame"
+							ref={ frameRef }
+							data-id={ id }
+							data-instance-id={ instanceId }
+							data-godam-image-layers={ layersJson }
+							style={ { position: 'relative', display: 'inline-block', maxWidth: '100%', lineHeight: 0 } }
+						>
+							<img
+								className="godam-image__img"
+								src={ url }
+								alt={ alt || '' }
+								style={ { display: 'block', width: '100%', height: 'auto' } }
+							/>
+							<div className="easydam-layer hotspot-layer godam-image-layer"></div>
+						</div>
+					) : (
+						<div className="godam-image__frame">
+							<img className="godam-image__img" src={ url } alt={ alt || '' } />
+						</div>
+					) }
 				</figure>
 			) }
 		</>

--- a/assets/src/js/godam-image-layers/frontend.js
+++ b/assets/src/js/godam-image-layers/frontend.js
@@ -1,225 +1,77 @@
 /**
- * GoDAM Image Layers — front-end renderer.
+ * GoDAM Image Layers — front-end bootstrap.
  *
  * Renders hotspot and WooCommerce product-hotspot layers on a `godam/image`
- * block. Images have no timeline, so every layer is always visible and ALL
- * layers render into ONE shared overlay element (a single stacking context,
- * so hotspots/tooltips from different layers never clip or cover each other).
- *
- * It reuses the existing player-side managers unchanged except for a single
- * seam: `manager.computeContentRect` is overridden with an image-box
- * implementation (the managers' own version reads a `<video>`, which does not
- * exist here). A tiny "media host" adapter satisfies every other manager call
- * site; timeline/playback methods are no-ops.
+ * block. The actual drawing lives in the shared `render-image-frame` module so
+ * the block editor preview (edit.js) can reuse it; this file only finds the
+ * server-rendered frames and initializes them.
  */
 
 /**
  * Internal dependencies
  */
-// Side-effect import: creates window.godamLayerRegistry and drains the queue the
-// Woo front-end script pushed to (image-only pages never boot the video player).
-import './../godam-player/utils/layer-registry-init.js';
-import HotspotLayerManager from './../godam-player/managers/layers/hotspotLayerManager.js';
-import { loadFontAwesome, hasHotspotsWithIcons } from './../godam-player/utils/pluginLoader.js';
-import { resolveHotspotStyle } from './../godam-player/utils/hotspotStyle.js';
+import { initImageFrame } from './render-image-frame.js';
 
-/**
- * Build a minimal "media host" adapter for the layer managers.
- *
- * @param {HTMLElement}      frame The positioned `.godam-image__frame` wrapper.
- * @param {HTMLImageElement} img   The image element.
- * @return {Object} An object satisfying the manager player interface.
- */
-function makeImageAdapter( frame, img ) {
-	return {
-		// Managers read the container element and its `data-id` (analytics key).
-		el: () => frame,
-		// The one real override: content rect = the rendered <img> box relative
-		// to the positioned frame. Kept in sync with the image on resize.
-		computeContentRect: () => {
-			const frameRect = frame.getBoundingClientRect();
-			const imgRect = img.getBoundingClientRect();
-			return {
-				left: Math.round( imgRect.left - frameRect.left ),
-				top: Math.round( imgRect.top - frameRect.top ),
-				width: Math.round( img.clientWidth || imgRect.width ),
-				height: Math.round( img.clientHeight || imgRect.height ),
-			};
-		},
-		tech: () => null,
-		videoWidth: () => img.naturalWidth,
-		videoHeight: () => img.naturalHeight,
-		// No timeline / playback on an image — these keep pauseOnHover, analytics
-		// enrichment and fullscreen handling as safe no-ops.
-		currentTime: () => 0,
-		isFullscreen: () => false,
-		paused: () => true,
-		pause: () => {},
-		play: () => {},
-		one: () => {},
-		on: () => {},
-	};
-}
-
-/**
- * Render all layers of one `godam/image` block into its shared overlay.
- *
- * @param {HTMLElement} frame The `.godam-image__frame` element.
- */
-function initFrame( frame ) {
-	if ( frame.dataset.godamLayersRendered === 'true' ) {
-		return;
-	}
-
-	let layers = [];
-	try {
-		layers = JSON.parse( frame.dataset.godamImageLayers || '[]' );
-	} catch ( e ) {
-		layers = [];
-	}
-	if ( ! Array.isArray( layers ) || layers.length === 0 ) {
-		return;
-	}
-
-	const img = frame.querySelector( 'img' );
-	const sharedEl = frame.querySelector( '.easydam-layer.godam-image-layer' );
-	if ( ! img || ! sharedEl ) {
-		return;
-	}
-
-	const instanceId = frame.dataset.instanceId || '';
-	const hotspotLayers = layers.filter( ( layer ) => layer?.type === 'hotspot' );
-	const wooLayers = layers.filter( ( layer ) => layer?.type === 'woo' );
-	const adapter = makeImageAdapter( frame, img );
-
-	const render = () => {
-		if ( frame.dataset.godamLayersRendered === 'true' ) {
-			return;
-		}
-		frame.dataset.godamLayersRendered = 'true';
-
-		let hotspotManager = null;
-		let wooManager = null;
-
-		// Two `display:contents` group wrappers inside the SINGLE overlay. They
-		// carry no box and form no stacking context, so all markers share the one
-		// overlay's stacking context (the z-index fix), while giving each manager a
-		// private scope for its index-based `.hotspot` reposition queries — hotspot
-		// and Woo markers both use the `.hotspot` class, so they must not share a
-		// query root.
-		const hotspotGroup = document.createElement( 'div' );
-		hotspotGroup.className = 'godam-image-hotspot-group';
-		hotspotGroup.style.display = 'contents';
-		const wooGroup = document.createElement( 'div' );
-		wooGroup.className = 'godam-image-woo-group';
-		wooGroup.style.display = 'contents';
-		sharedEl.appendChild( hotspotGroup );
-		sharedEl.appendChild( wooGroup );
-
-		// Merge every hotspot layer into ONE manager layer object so the manager's
-		// index-based reposition stays consistent. Per-layer style is flattened
-		// onto each hotspot (legacy per-hotspot fields) so distinct layer colours /
-		// icons survive the merge.
-		if ( hotspotLayers.length ) {
-			const mergedHotspots = [];
-			hotspotLayers.forEach( ( layer ) => {
-				( layer.hotspots || [] ).forEach( ( hotspot ) => {
-					const style = resolveHotspotStyle( layer, hotspot );
-					mergedHotspots.push( {
-						...hotspot,
-						icon: style.icon || '',
-						customIconUrl: style.customIconUrl || null,
-						backgroundColor: style.color,
-					} );
-				} );
-			} );
-			const mergedLayer = {
-				id: 'godam-image-hotspots',
-				type: 'hotspot',
-				pauseOnHover: false,
-				hotspots: mergedHotspots,
-			};
-			hotspotManager = new HotspotLayerManager( adapter, {}, instanceId );
-			hotspotManager.computeContentRect = () => adapter.computeContentRect();
-			hotspotManager.setupHotspotLayer( mergedLayer, hotspotGroup );
-			const layerObj = hotspotManager.hotspotLayers[ hotspotManager.hotspotLayers.length - 1 ];
-			// No analytics on images (see godam-image/render.php): the block does
-			// not load the analytics buffer, so the managers' interaction emits are
-			// guarded no-ops — there is no `viewed` beacon to fire here.
-			hotspotManager.createHotspots( layerObj );
-		}
-
-		// Woo layers — resolved from the shared registry (present only when the
-		// godam-for-woo add-on is active). Each layer is set up INDIVIDUALLY on
-		// its own container rather than merged into one: the Woo manager resolves
-		// every marker's style (pulse / icon / custom icon + colours), behaviour
-		// (clickBehaviour, tooltipDisplay, pauseOnHover) and analytics id from that
-		// layer's own config, and its resize reposition queries `.hotspot` by index
-		// WITHIN each layer's element against that layer's productHotspots. Merging
-		// (the old behaviour) forced every product to inherit the first layer's
-		// style/id, so a second layer's custom icon rendered as the first layer's
-		// pulse. A single shared manager instance keeps the product cache/prefetch
-		// shared across layers.
-		if ( wooLayers.length ) {
-			const WooManager = window.godamLayerRegistry?.getLayerManager?.( 'woo' );
-			if ( WooManager ) {
-				wooManager = new WooManager( adapter, {}, instanceId );
-				wooManager.computeContentRect = () => adapter.computeContentRect();
-				wooLayers.forEach( ( layer ) => {
-					// A per-layer `display:contents` wrapper: it carries no box and
-					// forms no stacking context, so all markers still share the ONE
-					// overlay's stacking context (the z-index fix) and absolute
-					// markers resolve against the positioned `.godam-image__frame`,
-					// while giving each layer a private scope for the manager's
-					// index-based `.hotspot` reposition queries.
-					const layerEl = document.createElement( 'div' );
-					layerEl.className = 'godam-image-woo-layer';
-					layerEl.style.display = 'contents';
-					wooGroup.appendChild( layerEl );
-					wooManager.setupLayer( layer, layerEl );
-					const layerObj = wooManager.wooLayers[ wooManager.wooLayers.length - 1 ];
-					wooManager.createProductHotspots( layerObj );
-				} );
-			}
-		}
-
-		// Reposition markers when the rendered image box changes.
-		const reposition = () => {
-			if ( hotspotManager && typeof hotspotManager.updateHotspotPositions === 'function' ) {
-				hotspotManager.updateHotspotPositions();
-			}
-			if ( wooManager && typeof wooManager.updateProductHotspotPositions === 'function' ) {
-				wooManager.updateProductHotspotPositions();
-			}
-		};
-		window.addEventListener( 'resize', reposition );
-		if ( 'ResizeObserver' in window ) {
-			const observer = new ResizeObserver( reposition );
-			observer.observe( img );
-		}
-	};
-
-	const start = () => {
-		// Load FontAwesome first when any hotspot uses an icon style, else the
-		// icon glyphs render as empty boxes.
-		if ( hasHotspotsWithIcons( layers ) ) {
-			loadFontAwesome().then( render ).catch( render );
-		} else {
-			render();
-		}
-	};
-
-	// Positioning needs the image's laid-out box; wait for load when necessary
-	// (core images are lazy-loaded / async-decoded).
-	if ( img.complete && img.naturalWidth ) {
-		start();
-	} else {
-		img.addEventListener( 'load', start, { once: true } );
-	}
-}
-
-document.addEventListener( 'DOMContentLoaded', () => {
+const initAllFrames = () => {
 	document
 		.querySelectorAll( '.godam-image__frame[data-godam-image-layers]' )
-		.forEach( initFrame );
-} );
+		.forEach( initImageFrame );
+};
+
+// Run on DOMContentLoaded, or immediately if the DOM is already parsed — the
+// script may execute after that event (e.g. injected by a page builder).
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', initAllFrames );
+} else {
+	initAllFrames();
+}
+
+/**
+ * Detect a WPBakery editor preview. Its inline editor renders the block markup
+ * (hotspot / product-hotspot layers) into an iframe AFTER this script has run,
+ * so a one-shot init never sees it — the layers stay invisible even though the
+ * published page renders them fine. The Gutenberg canvas draws them via edit.js.
+ *
+ * @return {boolean} True when running inside a WPBakery editor preview.
+ */
+const isBuilderPreview = () => {
+	try {
+		const fe = window.frameElement;
+		if ( fe && /vc[-_]inline-frame|vc_editor/i.test( ( fe.id || '' ) + ' ' + ( fe.className || '' ) ) ) {
+			return true;
+		}
+	} catch ( e ) {}
+	try {
+		return !! document.body?.classList.contains( 'vc_editor' );
+	} catch ( e ) {
+		return false;
+	}
+};
+
+// Editor preview only: re-run init on a few deferred passes plus an observer for
+// ongoing edits. initImageFrame() is idempotent (guarded by
+// data-godam-layers-rendered), so re-running is safe. Nothing extra is scheduled
+// on the published front end.
+if ( isBuilderPreview() ) {
+	[ 300, 1200, 3000 ].forEach( ( delay ) => setTimeout( initAllFrames, delay ) );
+
+	if ( 'MutationObserver' in window ) {
+		let scheduled = false;
+		const observer = new MutationObserver( () => {
+			if ( scheduled ) {
+				return;
+			}
+			scheduled = true;
+			window.requestAnimationFrame( () => {
+				scheduled = false;
+				initAllFrames();
+			} );
+		} );
+		const startObserving = () => observer.observe( document.body, { childList: true, subtree: true } );
+		if ( document.body ) {
+			startObserving();
+		} else {
+			document.addEventListener( 'DOMContentLoaded', startObserving );
+		}
+	}
+}

--- a/assets/src/js/godam-image-layers/render-image-frame.js
+++ b/assets/src/js/godam-image-layers/render-image-frame.js
@@ -12,6 +12,11 @@
  * implementation (the managers' own version reads a `<video>`, which does not
  * exist here). A tiny "media host" adapter satisfies every other manager call
  * site; timeline/playback methods are no-ops.
+ *
+ * Note: importing this module is NOT side-effect-free — it initializes
+ * `window.godamLayerRegistry` (see the layer-registry-init import below). It
+ * does not auto-run any rendering, though: nothing draws until a caller invokes
+ * `initImageFrame()`.
  */
 
 /**
@@ -21,7 +26,7 @@
 // Woo front-end script pushed to (image-only pages never boot the video player).
 import './../godam-player/utils/layer-registry-init.js';
 import HotspotLayerManager from './../godam-player/managers/layers/hotspotLayerManager.js';
-import { loadFontAwesome, hasHotspotsWithIcons } from './../godam-player/utils/pluginLoader.js';
+import { loadFontAwesome, hasHotspotsWithIcons, renderFontAwesomeIcons } from './../godam-player/utils/pluginLoader.js';
 import { resolveHotspotStyle } from './../godam-player/utils/hotspotStyle.js';
 
 /**
@@ -65,11 +70,28 @@ function makeImageAdapter( frame, img ) {
 /**
  * Render all layers of one `godam/image` block into its shared overlay.
  *
+ * Idempotent and self-cleaning. A frame is initialized only once — tracked by a
+ * per-frame teardown handle rather than a boolean, so the awaiting-image-load
+ * window is covered too — and the returned teardown removes every listener,
+ * ResizeObserver and any pending `load` handler, then clears the overlay and the
+ * render guard so the frame can be re-initialized. Callers that redraw on change
+ * (the block editor) should run the returned teardown before the next call
+ * (React does this automatically when it is returned from an effect); the front
+ * end can ignore the return value.
+ *
  * @param {HTMLElement} frame The `.godam-image__frame` element.
+ * @return {Function} Teardown for this frame (a no-op when nothing was set up).
  */
 export function initImageFrame( frame ) {
-	if ( ! frame || frame.dataset.godamLayersRendered === 'true' ) {
-		return;
+	const noop = () => {};
+
+	if ( ! frame ) {
+		return noop;
+	}
+	// Already initialized (rendered, or awaiting the image's load): hand back the
+	// existing teardown instead of stacking a second set of listeners/observers.
+	if ( typeof frame._godamLayersTeardown === 'function' ) {
+		return frame._godamLayersTeardown;
 	}
 
 	let layers = [];
@@ -79,13 +101,13 @@ export function initImageFrame( frame ) {
 		layers = [];
 	}
 	if ( ! Array.isArray( layers ) || layers.length === 0 ) {
-		return;
+		return noop;
 	}
 
 	const img = frame.querySelector( 'img' );
 	const sharedEl = frame.querySelector( '.easydam-layer.godam-image-layer' );
 	if ( ! img || ! sharedEl ) {
-		return;
+		return noop;
 	}
 
 	const instanceId = frame.dataset.instanceId || '';
@@ -93,110 +115,164 @@ export function initImageFrame( frame ) {
 	const wooLayers = layers.filter( ( layer ) => layer?.type === 'woo' );
 	const adapter = makeImageAdapter( frame, img );
 
-	const render = () => {
-		if ( frame.dataset.godamLayersRendered === 'true' ) {
+	// Everything that must be undone on teardown — resize listener, ResizeObserver
+	// and (until it fires) the deferred image `load` handler. Populated as setup
+	// progresses so a teardown at any point only unwinds what was actually set up.
+	const cleanups = [];
+	let torn = false;
+
+	const teardown = () => {
+		if ( torn ) {
 			return;
 		}
-		frame.dataset.godamLayersRendered = 'true';
+		torn = true;
+		cleanups.forEach( ( fn ) => {
+			try {
+				fn();
+			} catch ( e ) {}
+		} );
+		cleanups.length = 0;
+		// Clear the drawn markers and reset the guards so the frame can redraw.
+		sharedEl.innerHTML = '';
+		delete frame.dataset.godamLayersRendered;
+		delete frame._godamLayersTeardown;
+	};
+
+	// Claim the frame up front (covers the awaiting-load window) so a concurrent
+	// call is a no-op; teardown releases it to allow a subsequent redraw.
+	frame._godamLayersTeardown = teardown;
+
+	const render = () => {
+		// A late `load` firing after teardown, or a stray double call, is a no-op.
+		if ( torn || frame.dataset.godamLayersRendered === 'true' ) {
+			return;
+		}
 
 		let hotspotManager = null;
 		let wooManager = null;
 
-		// Two `display:contents` group wrappers inside the SINGLE overlay. They
-		// carry no box and form no stacking context, so all markers share the one
-		// overlay's stacking context (the z-index fix), while giving each manager a
-		// private scope for its index-based `.hotspot` reposition queries — hotspot
-		// and Woo markers both use the `.hotspot` class, so they must not share a
-		// query root.
-		const hotspotGroup = document.createElement( 'div' );
-		hotspotGroup.className = 'godam-image-hotspot-group';
-		hotspotGroup.style.display = 'contents';
-		const wooGroup = document.createElement( 'div' );
-		wooGroup.className = 'godam-image-woo-group';
-		wooGroup.style.display = 'contents';
-		sharedEl.appendChild( hotspotGroup );
-		sharedEl.appendChild( wooGroup );
+		try {
+			// Two `display:contents` group wrappers inside the SINGLE overlay. They
+			// carry no box and form no stacking context, so all markers share the one
+			// overlay's stacking context (the z-index fix), while giving each manager a
+			// private scope for its index-based `.hotspot` reposition queries — hotspot
+			// and Woo markers both use the `.hotspot` class, so they must not share a
+			// query root.
+			const hotspotGroup = document.createElement( 'div' );
+			hotspotGroup.className = 'godam-image-hotspot-group';
+			hotspotGroup.style.display = 'contents';
+			const wooGroup = document.createElement( 'div' );
+			wooGroup.className = 'godam-image-woo-group';
+			wooGroup.style.display = 'contents';
+			sharedEl.appendChild( hotspotGroup );
+			sharedEl.appendChild( wooGroup );
 
-		// Merge every hotspot layer into ONE manager layer object so the manager's
-		// index-based reposition stays consistent. Per-layer style is flattened
-		// onto each hotspot (legacy per-hotspot fields) so distinct layer colours /
-		// icons survive the merge.
-		if ( hotspotLayers.length ) {
-			const mergedHotspots = [];
-			hotspotLayers.forEach( ( layer ) => {
-				( layer.hotspots || [] ).forEach( ( hotspot ) => {
-					const style = resolveHotspotStyle( layer, hotspot );
-					mergedHotspots.push( {
-						...hotspot,
-						icon: style.icon || '',
-						customIconUrl: style.customIconUrl || null,
-						backgroundColor: style.color,
+			// Merge every hotspot layer into ONE manager layer object so the manager's
+			// index-based reposition stays consistent. Per-layer style is flattened
+			// onto each hotspot (legacy per-hotspot fields) so distinct layer colours /
+			// icons survive the merge.
+			if ( hotspotLayers.length ) {
+				const mergedHotspots = [];
+				hotspotLayers.forEach( ( layer ) => {
+					( layer.hotspots || [] ).forEach( ( hotspot ) => {
+						const style = resolveHotspotStyle( layer, hotspot );
+						mergedHotspots.push( {
+							...hotspot,
+							icon: style.icon || '',
+							customIconUrl: style.customIconUrl || null,
+							backgroundColor: style.color,
+						} );
 					} );
 				} );
-			} );
-			const mergedLayer = {
-				id: 'godam-image-hotspots',
-				type: 'hotspot',
-				pauseOnHover: false,
-				hotspots: mergedHotspots,
+				const mergedLayer = {
+					id: 'godam-image-hotspots',
+					type: 'hotspot',
+					pauseOnHover: false,
+					hotspots: mergedHotspots,
+				};
+				hotspotManager = new HotspotLayerManager( adapter, {}, instanceId );
+				hotspotManager.computeContentRect = () => adapter.computeContentRect();
+				hotspotManager.setupHotspotLayer( mergedLayer, hotspotGroup );
+				const layerObj = hotspotManager.hotspotLayers[ hotspotManager.hotspotLayers.length - 1 ];
+				// No analytics on images (see godam-image/render.php): the block does
+				// not load the analytics buffer, so the managers' interaction emits are
+				// guarded no-ops — there is no `viewed` beacon to fire here.
+				hotspotManager.createHotspots( layerObj );
+			}
+
+			// Woo layers — resolved from the shared registry (present only when the
+			// godam-for-woo add-on is active). Each layer is set up INDIVIDUALLY on
+			// its own container rather than merged into one: the Woo manager resolves
+			// every marker's style (pulse / icon / custom icon + colours), behaviour
+			// (clickBehaviour, tooltipDisplay, pauseOnHover) and analytics id from that
+			// layer's own config, and its resize reposition queries `.hotspot` by index
+			// WITHIN each layer's element against that layer's productHotspots. Merging
+			// (the old behaviour) forced every product to inherit the first layer's
+			// style/id, so a second layer's custom icon rendered as the first layer's
+			// pulse. A single shared manager instance keeps the product cache/prefetch
+			// shared across layers.
+			if ( wooLayers.length ) {
+				const WooManager = window.godamLayerRegistry?.getLayerManager?.( 'woo' );
+				if ( WooManager ) {
+					wooManager = new WooManager( adapter, {}, instanceId );
+					wooManager.computeContentRect = () => adapter.computeContentRect();
+					wooLayers.forEach( ( layer ) => {
+						// A per-layer `display:contents` wrapper: it carries no box and
+						// forms no stacking context, so all markers still share the ONE
+						// overlay's stacking context (the z-index fix) and absolute
+						// markers resolve against the positioned `.godam-image__frame`,
+						// while giving each layer a private scope for the manager's
+						// index-based `.hotspot` reposition queries.
+						const layerEl = document.createElement( 'div' );
+						layerEl.className = 'godam-image-woo-layer';
+						layerEl.style.display = 'contents';
+						wooGroup.appendChild( layerEl );
+						wooManager.setupLayer( layer, layerEl );
+						const layerObj = wooManager.wooLayers[ wooManager.wooLayers.length - 1 ];
+						wooManager.createProductHotspots( layerObj );
+					} );
+				}
+			}
+
+			// Reposition markers when the rendered image box changes. The listener
+			// and observer are registered for teardown so redraws / unmounts in the
+			// editor don't accumulate them (and don't pin a detached <img>).
+			const reposition = () => {
+				if ( hotspotManager && typeof hotspotManager.updateHotspotPositions === 'function' ) {
+					hotspotManager.updateHotspotPositions();
+				}
+				if ( wooManager && typeof wooManager.updateProductHotspotPositions === 'function' ) {
+					wooManager.updateProductHotspotPositions();
+				}
 			};
-			hotspotManager = new HotspotLayerManager( adapter, {}, instanceId );
-			hotspotManager.computeContentRect = () => adapter.computeContentRect();
-			hotspotManager.setupHotspotLayer( mergedLayer, hotspotGroup );
-			const layerObj = hotspotManager.hotspotLayers[ hotspotManager.hotspotLayers.length - 1 ];
-			// No analytics on images (see godam-image/render.php): the block does
-			// not load the analytics buffer, so the managers' interaction emits are
-			// guarded no-ops — there is no `viewed` beacon to fire here.
-			hotspotManager.createHotspots( layerObj );
-		}
+			window.addEventListener( 'resize', reposition );
+			cleanups.push( () => window.removeEventListener( 'resize', reposition ) );
+			if ( 'ResizeObserver' in window ) {
+				const observer = new ResizeObserver( reposition );
+				observer.observe( img );
+				cleanups.push( () => observer.disconnect() );
+			}
 
-		// Woo layers — resolved from the shared registry (present only when the
-		// godam-for-woo add-on is active). Each layer is set up INDIVIDUALLY on
-		// its own container rather than merged into one: the Woo manager resolves
-		// every marker's style (pulse / icon / custom icon + colours), behaviour
-		// (clickBehaviour, tooltipDisplay, pauseOnHover) and analytics id from that
-		// layer's own config, and its resize reposition queries `.hotspot` by index
-		// WITHIN each layer's element against that layer's productHotspots. Merging
-		// (the old behaviour) forced every product to inherit the first layer's
-		// style/id, so a second layer's custom icon rendered as the first layer's
-		// pulse. A single shared manager instance keeps the product cache/prefetch
-		// shared across layers.
-		if ( wooLayers.length ) {
-			const WooManager = window.godamLayerRegistry?.getLayerManager?.( 'woo' );
-			if ( WooManager ) {
-				wooManager = new WooManager( adapter, {}, instanceId );
-				wooManager.computeContentRect = () => adapter.computeContentRect();
-				wooLayers.forEach( ( layer ) => {
-					// A per-layer `display:contents` wrapper: it carries no box and
-					// forms no stacking context, so all markers still share the ONE
-					// overlay's stacking context (the z-index fix) and absolute
-					// markers resolve against the positioned `.godam-image__frame`,
-					// while giving each layer a private scope for the manager's
-					// index-based `.hotspot` reposition queries.
-					const layerEl = document.createElement( 'div' );
-					layerEl.className = 'godam-image-woo-layer';
-					layerEl.style.display = 'contents';
-					wooGroup.appendChild( layerEl );
-					wooManager.setupLayer( layer, layerEl );
-					const layerObj = wooManager.wooLayers[ wooManager.wooLayers.length - 1 ];
-					wooManager.createProductHotspots( layerObj );
-				} );
+			// Transform any FontAwesome icon hotspots into inline SVG within THIS
+			// frame's document. In the block-editor iframe the global FA observer
+			// never sees these nodes, so icon hotspots would otherwise render as
+			// empty boxes; on the front end this is a harmless idempotent pass.
+			if ( hasHotspotsWithIcons( layers ) ) {
+				renderFontAwesomeIcons( frame );
 			}
-		}
 
-		// Reposition markers when the rendered image box changes.
-		const reposition = () => {
-			if ( hotspotManager && typeof hotspotManager.updateHotspotPositions === 'function' ) {
-				hotspotManager.updateHotspotPositions();
+			// Mark rendered only after a fully successful pass. If any manager setup
+			// above throws, the guard stays unset so a later call (editor redraw or
+			// deferred front-end pass) can retry instead of being stuck.
+			frame.dataset.godamLayersRendered = 'true';
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			if ( window.console && typeof window.console.error === 'function' ) {
+				window.console.error( 'GoDAM image layers: render failed', e );
 			}
-			if ( wooManager && typeof wooManager.updateProductHotspotPositions === 'function' ) {
-				wooManager.updateProductHotspotPositions();
-			}
-		};
-		window.addEventListener( 'resize', reposition );
-		if ( 'ResizeObserver' in window ) {
-			const observer = new ResizeObserver( reposition );
-			observer.observe( img );
+			// Undo any partial setup and release the frame so it can be retried,
+			// rather than leaving it permanently flagged as rendered.
+			teardown();
 		}
 	};
 
@@ -215,6 +291,12 @@ export function initImageFrame( frame ) {
 	if ( img.complete && img.naturalWidth ) {
 		start();
 	} else {
-		img.addEventListener( 'load', start, { once: true } );
+		const onLoad = () => start();
+		img.addEventListener( 'load', onLoad, { once: true } );
+		// Cancel the pending load handler on teardown so a rapid image swap while
+		// the previous image is still loading can't fire a stale, late render.
+		cleanups.push( () => img.removeEventListener( 'load', onLoad ) );
 	}
+
+	return teardown;
 }

--- a/assets/src/js/godam-image-layers/render-image-frame.js
+++ b/assets/src/js/godam-image-layers/render-image-frame.js
@@ -1,0 +1,220 @@
+/**
+ * GoDAM Image Layers — shared frame renderer.
+ *
+ * Draws hotspot and WooCommerce product-hotspot layers onto a single
+ * `.godam-image__frame` element. Extracted so it can be reused by both the
+ * front-end bootstrap (frontend.js) and the block editor preview (the
+ * `godam/image` block's edit.js), which renders the same markup into the
+ * editor canvas and calls this against a ref.
+ *
+ * It reuses the existing player-side managers unchanged except for a single
+ * seam: `manager.computeContentRect` is overridden with an image-box
+ * implementation (the managers' own version reads a `<video>`, which does not
+ * exist here). A tiny "media host" adapter satisfies every other manager call
+ * site; timeline/playback methods are no-ops.
+ */
+
+/**
+ * Internal dependencies
+ */
+// Side-effect import: creates window.godamLayerRegistry and drains the queue the
+// Woo front-end script pushed to (image-only pages never boot the video player).
+import './../godam-player/utils/layer-registry-init.js';
+import HotspotLayerManager from './../godam-player/managers/layers/hotspotLayerManager.js';
+import { loadFontAwesome, hasHotspotsWithIcons } from './../godam-player/utils/pluginLoader.js';
+import { resolveHotspotStyle } from './../godam-player/utils/hotspotStyle.js';
+
+/**
+ * Build a minimal "media host" adapter for the layer managers.
+ *
+ * @param {HTMLElement}      frame The positioned `.godam-image__frame` wrapper.
+ * @param {HTMLImageElement} img   The image element.
+ * @return {Object} An object satisfying the manager player interface.
+ */
+function makeImageAdapter( frame, img ) {
+	return {
+		// Managers read the container element and its `data-id` (analytics key).
+		el: () => frame,
+		// The one real override: content rect = the rendered <img> box relative
+		// to the positioned frame. Kept in sync with the image on resize.
+		computeContentRect: () => {
+			const frameRect = frame.getBoundingClientRect();
+			const imgRect = img.getBoundingClientRect();
+			return {
+				left: Math.round( imgRect.left - frameRect.left ),
+				top: Math.round( imgRect.top - frameRect.top ),
+				width: Math.round( img.clientWidth || imgRect.width ),
+				height: Math.round( img.clientHeight || imgRect.height ),
+			};
+		},
+		tech: () => null,
+		videoWidth: () => img.naturalWidth,
+		videoHeight: () => img.naturalHeight,
+		// No timeline / playback on an image — these keep pauseOnHover, analytics
+		// enrichment and fullscreen handling as safe no-ops.
+		currentTime: () => 0,
+		isFullscreen: () => false,
+		paused: () => true,
+		pause: () => {},
+		play: () => {},
+		one: () => {},
+		on: () => {},
+	};
+}
+
+/**
+ * Render all layers of one `godam/image` block into its shared overlay.
+ *
+ * @param {HTMLElement} frame The `.godam-image__frame` element.
+ */
+export function initImageFrame( frame ) {
+	if ( ! frame || frame.dataset.godamLayersRendered === 'true' ) {
+		return;
+	}
+
+	let layers = [];
+	try {
+		layers = JSON.parse( frame.dataset.godamImageLayers || '[]' );
+	} catch ( e ) {
+		layers = [];
+	}
+	if ( ! Array.isArray( layers ) || layers.length === 0 ) {
+		return;
+	}
+
+	const img = frame.querySelector( 'img' );
+	const sharedEl = frame.querySelector( '.easydam-layer.godam-image-layer' );
+	if ( ! img || ! sharedEl ) {
+		return;
+	}
+
+	const instanceId = frame.dataset.instanceId || '';
+	const hotspotLayers = layers.filter( ( layer ) => layer?.type === 'hotspot' );
+	const wooLayers = layers.filter( ( layer ) => layer?.type === 'woo' );
+	const adapter = makeImageAdapter( frame, img );
+
+	const render = () => {
+		if ( frame.dataset.godamLayersRendered === 'true' ) {
+			return;
+		}
+		frame.dataset.godamLayersRendered = 'true';
+
+		let hotspotManager = null;
+		let wooManager = null;
+
+		// Two `display:contents` group wrappers inside the SINGLE overlay. They
+		// carry no box and form no stacking context, so all markers share the one
+		// overlay's stacking context (the z-index fix), while giving each manager a
+		// private scope for its index-based `.hotspot` reposition queries — hotspot
+		// and Woo markers both use the `.hotspot` class, so they must not share a
+		// query root.
+		const hotspotGroup = document.createElement( 'div' );
+		hotspotGroup.className = 'godam-image-hotspot-group';
+		hotspotGroup.style.display = 'contents';
+		const wooGroup = document.createElement( 'div' );
+		wooGroup.className = 'godam-image-woo-group';
+		wooGroup.style.display = 'contents';
+		sharedEl.appendChild( hotspotGroup );
+		sharedEl.appendChild( wooGroup );
+
+		// Merge every hotspot layer into ONE manager layer object so the manager's
+		// index-based reposition stays consistent. Per-layer style is flattened
+		// onto each hotspot (legacy per-hotspot fields) so distinct layer colours /
+		// icons survive the merge.
+		if ( hotspotLayers.length ) {
+			const mergedHotspots = [];
+			hotspotLayers.forEach( ( layer ) => {
+				( layer.hotspots || [] ).forEach( ( hotspot ) => {
+					const style = resolveHotspotStyle( layer, hotspot );
+					mergedHotspots.push( {
+						...hotspot,
+						icon: style.icon || '',
+						customIconUrl: style.customIconUrl || null,
+						backgroundColor: style.color,
+					} );
+				} );
+			} );
+			const mergedLayer = {
+				id: 'godam-image-hotspots',
+				type: 'hotspot',
+				pauseOnHover: false,
+				hotspots: mergedHotspots,
+			};
+			hotspotManager = new HotspotLayerManager( adapter, {}, instanceId );
+			hotspotManager.computeContentRect = () => adapter.computeContentRect();
+			hotspotManager.setupHotspotLayer( mergedLayer, hotspotGroup );
+			const layerObj = hotspotManager.hotspotLayers[ hotspotManager.hotspotLayers.length - 1 ];
+			// No analytics on images (see godam-image/render.php): the block does
+			// not load the analytics buffer, so the managers' interaction emits are
+			// guarded no-ops — there is no `viewed` beacon to fire here.
+			hotspotManager.createHotspots( layerObj );
+		}
+
+		// Woo layers — resolved from the shared registry (present only when the
+		// godam-for-woo add-on is active). Each layer is set up INDIVIDUALLY on
+		// its own container rather than merged into one: the Woo manager resolves
+		// every marker's style (pulse / icon / custom icon + colours), behaviour
+		// (clickBehaviour, tooltipDisplay, pauseOnHover) and analytics id from that
+		// layer's own config, and its resize reposition queries `.hotspot` by index
+		// WITHIN each layer's element against that layer's productHotspots. Merging
+		// (the old behaviour) forced every product to inherit the first layer's
+		// style/id, so a second layer's custom icon rendered as the first layer's
+		// pulse. A single shared manager instance keeps the product cache/prefetch
+		// shared across layers.
+		if ( wooLayers.length ) {
+			const WooManager = window.godamLayerRegistry?.getLayerManager?.( 'woo' );
+			if ( WooManager ) {
+				wooManager = new WooManager( adapter, {}, instanceId );
+				wooManager.computeContentRect = () => adapter.computeContentRect();
+				wooLayers.forEach( ( layer ) => {
+					// A per-layer `display:contents` wrapper: it carries no box and
+					// forms no stacking context, so all markers still share the ONE
+					// overlay's stacking context (the z-index fix) and absolute
+					// markers resolve against the positioned `.godam-image__frame`,
+					// while giving each layer a private scope for the manager's
+					// index-based `.hotspot` reposition queries.
+					const layerEl = document.createElement( 'div' );
+					layerEl.className = 'godam-image-woo-layer';
+					layerEl.style.display = 'contents';
+					wooGroup.appendChild( layerEl );
+					wooManager.setupLayer( layer, layerEl );
+					const layerObj = wooManager.wooLayers[ wooManager.wooLayers.length - 1 ];
+					wooManager.createProductHotspots( layerObj );
+				} );
+			}
+		}
+
+		// Reposition markers when the rendered image box changes.
+		const reposition = () => {
+			if ( hotspotManager && typeof hotspotManager.updateHotspotPositions === 'function' ) {
+				hotspotManager.updateHotspotPositions();
+			}
+			if ( wooManager && typeof wooManager.updateProductHotspotPositions === 'function' ) {
+				wooManager.updateProductHotspotPositions();
+			}
+		};
+		window.addEventListener( 'resize', reposition );
+		if ( 'ResizeObserver' in window ) {
+			const observer = new ResizeObserver( reposition );
+			observer.observe( img );
+		}
+	};
+
+	const start = () => {
+		// Load FontAwesome first when any hotspot uses an icon style, else the
+		// icon glyphs render as empty boxes.
+		if ( hasHotspotsWithIcons( layers ) ) {
+			loadFontAwesome().then( render ).catch( render );
+		} else {
+			render();
+		}
+	};
+
+	// Positioning needs the image's laid-out box; wait for load when necessary
+	// (core images are lazy-loaded / async-decoded).
+	if ( img.complete && img.naturalWidth ) {
+		start();
+	} else {
+		img.addEventListener( 'load', start, { once: true } );
+	}
+}

--- a/assets/src/js/godam-player/utils/pluginLoader.js
+++ b/assets/src/js/godam-player/utils/pluginLoader.js
@@ -27,6 +27,11 @@ let flvPluginPromise = null;
 let quillPromise = null;
 let fontAwesomePromise = null;
 
+// Cached reference to FontAwesome's `dom` API so icons can be transformed
+// explicitly inside a specific document (e.g. the block-editor canvas iframe),
+// where the global `dom.watch()` observer + injected CSS never reach.
+let fontAwesomeDom = null;
+
 // Ad blockers commonly block the `videojs-contrib-ads` chunk (its filename
 // contains "ads"), which rejects the dynamic import with a ChunkLoadError on
 // every player init. Ads are optional and playback is unaffected, so warn once
@@ -187,6 +192,7 @@ export async function loadFontAwesome() {
 
 		library.add( fas );
 		dom.watch();
+		fontAwesomeDom = dom;
 
 		loadedPlugins.fontAwesome = true;
 	} )()
@@ -201,6 +207,42 @@ export async function loadFontAwesome() {
 		} );
 
 	return fontAwesomePromise;
+}
+
+/**
+ * Transform FontAwesome `<i>` icons into inline `<svg>` inside a given node,
+ * and ensure the base SVG CSS exists in that node's document.
+ *
+ * FontAwesome's SVG core auto-transforms icons via a `dom.watch()` observer and
+ * injects its CSS, but both are bound to the document the bundle runs in. In the
+ * block-editor canvas the icons live inside an iframe, so the observer never
+ * sees them and the sizing CSS (`.svg-inline--fa`) is missing there — the icon
+ * renders as an unstyled empty box. Call this after creating the icon markup to
+ * convert + style them in the right document. Safe to call on the front end too
+ * (idempotent: once an `<i>` becomes `<svg>` there is nothing left to convert).
+ *
+ * @param {HTMLElement} node The subtree whose FontAwesome icons should render.
+ * @return {void}
+ */
+export function renderFontAwesomeIcons( node ) {
+	if ( ! fontAwesomeDom || ! node ) {
+		return;
+	}
+	try {
+		const doc = node.ownerDocument;
+		if (
+			doc &&
+			doc.head &&
+			! doc.getElementById( 'godam-fa-svg-css' ) &&
+			typeof fontAwesomeDom.css === 'function'
+		) {
+			const style = doc.createElement( 'style' );
+			style.id = 'godam-fa-svg-css';
+			style.textContent = fontAwesomeDom.css();
+			doc.head.appendChild( style );
+		}
+		fontAwesomeDom.i2svg( { node } );
+	} catch ( e ) {}
 }
 
 /**


### PR DESCRIPTION
# Render GoDAM Image layers in the Gutenberg block editor

## Summary

The `godam/image` block's hotspot / WooCommerce product-hotspot layers were only drawn on the **published page** — the Gutenberg editor canvas previewed just the image (by the block's original design). This PR makes those layers render **inside the block editor canvas**, so authors see the actual hotspot / product overlays while editing, matching the published output.

It does this by extracting the front-end layer renderer into a shared module and reusing it from the block's `edit.js`, so the editor and front end draw layers with the exact same code.

Branch: `chore/add-layers-in-gutenberg` → `develop`

> **Companion:** WooCommerce **product** hotspots additionally need the `godam-for-woo` add-on to load its layer manager + product-hotspot CSS in the editor. That is a separate PR in the `godam-for-woo` repo (`enqueue_block_editor_assets` + a block-tied `wp_enqueue_block_style`). This PR renders core hotspot layers on its own; product hotspots light up once the companion is merged.

## What changed

### New file
- `assets/src/js/godam-image-layers/render-image-frame.js` — the frame renderer (`initImageFrame` + the media-host adapter + hotspot/Woo manager wiring) extracted from `frontend.js` into a shared, side-effect-free module (no auto-run on import). Unchanged rendering logic; it just no longer owns the bootstrap.

### Modified files
- `assets/src/js/godam-image-layers/frontend.js` — now a thin bootstrap: imports `initImageFrame`, finds the server-rendered `.godam-image__frame[data-godam-image-layers]` frames and initializes them. Runs on `DOMContentLoaded` **or immediately if the DOM is already parsed**, and (in a page-builder preview only) re-runs on a few deferred passes + a `MutationObserver` so late-injected markup still hydrates.
- `assets/src/blocks/godam-image/edit.js` — the editor now:
  - fetches the selected attachment's authored layers from `rtgodam_meta` (exposed as a REST field on attachments) and keeps only drawable ones (hotspot layers with hotspots, Woo layers with product hotspots) — mirroring `render.php`;
  - when **Show image layers** is on and layers exist, renders the `.godam-image__frame` with `data-id` / `data-instance-id` / `data-godam-image-layers` + the overlay div via a React ref (the same markup `render.php` outputs);
  - draws them with `initImageFrame( frameRef )` in a `useEffect`, resetting the render guard + overlay so it redraws when the image, layers, or toggle change.

## How it works

The block editor canvas is an iframe; `edit.js`'s React output renders into it. The `useEffect` runs in the editor realm but draws onto the ref'd node inside the iframe (same-origin), using the shared renderer. Because it's the same renderer the front end uses, hotspot layers — and Woo product hotspots, when the Woo layer manager is registered (companion PR) — are drawn identically. Product data is fetched via `api-fetch`, which is available in the editor.

`initImageFrame()` is idempotent (guarded by `data-godam-layers-rendered`); the effect clears the overlay and resets the guard before each redraw so edits (new image, toggled layers) repaint cleanly.

## How to test

1. `npm run build:blocks` and `npm run build:js` (build artifacts under `assets/build/` are gitignored).
2. Gutenberg → add a **GoDAM Image** block → pick an image that has authored hotspot layers (from the GoDAM image editor) → ensure **Show image layers** is on → the hotspots should now render on the image in the editor canvas.
3. Toggle **Show image layers** off → overlays disappear. Replace the image → overlays update to the new attachment's layers.
4. Confirm the published page still renders layers (unchanged path).
5. With the `godam-for-woo` companion active, confirm **product** hotspots render in the editor too.

## Notes for reviewers

- Editor-only caveats: FontAwesome icon-style hotspots may appear unstyled in the canvas (FA injects into the parent `<head>`, not the iframe) — pulse/regular hotspots and product hotspots are unaffected; the front end is unaffected. Repeated redraws in the editor add a `resize` listener each time (small, editor-only).
- WooCommerce **product** hotspots require the `godam-for-woo` companion PR (editor enqueue of `godam-for-woo-layer-frontend` + block-tied product-hotspot CSS). Without it, core hotspot layers still render.
- **Sequencing:** this PR and `feat/image-block-wp-bakery` both modify `godam-image-layers/frontend.js`. Merge order matters — expect a small conflict in `frontend.js` (both add the editor re-init; this PR also relocates the renderer into `render-image-frame.js`). Recommend merging one, then rebasing the other.
- `assets/build/**` are gitignored build artifacts — rebuild rather than reviewing them. Run a full `npm run build` so split chunks regenerate with consistent names.

## Related PR (GoDAM for Woo)

rtcamp/godam-for-woo#183


## Reference

[Discussion with @KMchaudhary on Slack](https://rtcamp.slack.com/archives/D07CELU7Z6J/p1784807069874849)

## Demo Screenshots
<img width="1470" height="830" alt="Screenshot 2026-07-24 at 11 50 01 AM" src="https://github.com/user-attachments/assets/c57701c2-a002-42f9-a698-2adb8bd85ef5" />
<img width="1470" height="833" alt="Screenshot 2026-07-24 at 11 50 13 AM" src="https://github.com/user-attachments/assets/42be84dc-2518-48ec-8b73-0a6ef0263604" />
