### PR TITLE
Feat: Upgate Audio Block in elementor

### DIFF
--- a/assets/src/js/elementor/editor.js
+++ b/assets/src/js/elementor/editor.js
@@ -399,23 +399,62 @@ function refreshPanelControls( names ) {
  * @param {Object} values Map of setting keys to values.
  */
 function applyAudioSettings( values ) {
-	if ( activeAudioContainer && window.$e?.run ) {
-		window.$e.run( 'document/elements/settings', {
-			container: activeAudioContainer,
-			settings: values,
-		} );
-	} else if ( activeAudioSettings ) {
-		Object.keys( values ).forEach( ( key ) => activeAudioSettings.set( key, values[ key ] ) );
+	// The container ref is captured at hydrate; if Elementor rebuilt the element
+	// it can go stale and $e.run() may throw. Guard it (this runs from a fetch
+	// .then()/.catch(), so an unguarded throw would surface as an unhandled
+	// rejection) and fall back to a direct model update.
+	try {
+		if ( activeAudioContainer && window.$e?.run ) {
+			window.$e.run( 'document/elements/settings', {
+				container: activeAudioContainer,
+				settings: values,
+			} );
+		} else if ( activeAudioSettings ) {
+			Object.keys( values ).forEach( ( key ) => activeAudioSettings.set( key, values[ key ] ) );
+		}
+	} catch ( e ) {
+		try {
+			if ( activeAudioSettings ) {
+				Object.keys( values ).forEach( ( key ) => activeAudioSettings.set( key, values[ key ] ) );
+			}
+		} catch ( e2 ) {}
 	}
 
 	refreshPanelControls( Object.keys( values ) );
 }
 
 /**
+ * Apply only the fields the user has NOT edited since `snapshot` was captured,
+ * so a late REST populate never clobbers an in-progress Title / Description edit
+ * (the user may select an audio and immediately start typing an override).
+ *
+ * @param {Object} values   Proposed setting values.
+ * @param {Object} snapshot Field values captured when the populate started.
+ */
+function applyAudioSettingsIfUntouched( values, snapshot ) {
+	const settings = activeAudioSettings;
+	if ( ! settings ) {
+		return;
+	}
+	const toApply = {};
+	Object.keys( values ).forEach( ( key ) => {
+		if ( settings.get( key ) === snapshot[ key ] ) {
+			toApply[ key ] = values[ key ];
+		}
+	} );
+	if ( Object.keys( toApply ).length ) {
+		applyAudioSettings( toApply );
+	}
+}
+
+/**
  * Fill the Audio Title + Description controls from the selected attachment.
  * Title is already carried on the godam-media control value; the description is
  * fetched from the REST API. Mirrors the block: a new selection overwrites both,
- * and clearing the audio empties them.
+ * clearing the audio empties them — but an edit the user makes after selecting
+ * is preserved (see applyAudioSettingsIfUntouched). Only runs on an audio-file
+ * change, never on panel open, so existing widgets keep their saved values and
+ * render.php's "leave empty → attachment title" fallback stays intact.
  */
 function populateAudioMeta() {
 	const settings = activeAudioSettings;
@@ -426,9 +465,16 @@ function populateAudioMeta() {
 	const audioFile = settings.get( 'audio-file' ) || {};
 	const id = audioFile.id;
 
+	// Snapshot current field values so a late apply only writes fields the user
+	// hasn't touched since this populate started.
+	const snapshot = {
+		audio_title: settings.get( 'audio_title' ),
+		description: settings.get( 'description' ),
+	};
+
 	// Audio removed — clear the auto-filled fields (matches the block).
 	if ( ! id ) {
-		applyAudioSettings( { audio_title: '', description: '' } );
+		applyAudioSettingsIfUntouched( { audio_title: '', description: '' }, snapshot );
 		return;
 	}
 
@@ -442,17 +488,17 @@ function populateAudioMeta() {
 			}
 			const title = media?.title?.raw ?? media?.title?.rendered ?? controlTitle;
 			const description = media?.description?.raw ?? stripHtml( media?.description?.rendered );
-			applyAudioSettings( {
+			applyAudioSettingsIfUntouched( {
 				audio_title: title || controlTitle,
 				description: ( description || '' ).trim(),
-			} );
+			}, snapshot );
 		} )
 		.catch( () => {
 			if ( token !== audioFetchToken ) {
 				return;
 			}
 			// Fall back to the title already on the control value.
-			applyAudioSettings( { audio_title: controlTitle } );
+			applyAudioSettingsIfUntouched( { audio_title: controlTitle }, snapshot );
 		} );
 }
 

--- a/assets/src/js/elementor/editor.js
+++ b/assets/src/js/elementor/editor.js
@@ -53,6 +53,15 @@ window.addEventListener( 'load', function() {
 			setTimeout( makeFieldsReadonly, 200 );
 		}
 	} );
+
+	// GoDAM Audio: auto-fill the title/description from the selected attachment,
+	// mirroring the Gutenberg block (which populates them on selection).
+	window?.elementor.hooks.addAction(
+		'panel/open_editor/widget/godam-audio',
+		function( panel, model, view ) {
+			hydrateAudioWidget( model, view );
+		},
+	);
 } );
 
 /**
@@ -328,4 +337,159 @@ function escapeAttr( value ) {
 		.replace( /"/g, '&quot;' )
 		.replace( /</g, '&lt;' )
 		.replace( />/g, '&gt;' );
+}
+
+/* ── GoDAM Audio: auto-populate title / description ────────────────────────── */
+
+/**
+ * Settings model + container of the currently-edited godam-audio widget.
+ */
+let activeAudioSettings = null;
+let activeAudioContainer = null;
+
+/**
+ * Monotonic token so a stale description fetch (user swapped the audio before
+ * the previous request resolved) is discarded.
+ */
+let audioFetchToken = 0;
+
+/**
+ * Strip tags from a rendered HTML string and collapse whitespace. Used for the
+ * attachment description, whose REST `rendered` form is wrapped in markup.
+ *
+ * @param {string} html Rendered HTML.
+ * @return {string} Plain text.
+ */
+function stripHtml( html ) {
+	const tmp = document.createElement( 'div' );
+	tmp.innerHTML = String( html || '' );
+	return ( tmp.textContent || tmp.innerText || '' ).replace( /\s+/g, ' ' ).trim();
+}
+
+/**
+ * Re-render the given controls in the currently open panel so their inputs
+ * reflect the model. Elementor text/textarea controls read the model only on
+ * render and deliberately don't sync external model changes back into the input
+ * (to avoid cursor jumps while typing), so a programmatic value change leaves
+ * the visible field stale until we force a re-render. No-op when the panel
+ * isn't showing a widget with these controls.
+ *
+ * @param {string[]} names Control names to refresh.
+ */
+function refreshPanelControls( names ) {
+	try {
+		const page = window.elementor?.getPanelView?.()?.getCurrentPageView?.();
+		if ( ! page || ! page.children || ! page.children.each ) {
+			return;
+		}
+		page.children.each( ( view ) => {
+			const name = view?.model?.get?.( 'name' );
+			if ( name && names.indexOf( name ) !== -1 && 'function' === typeof view.render ) {
+				view.render();
+			}
+		} );
+	} catch ( e ) {}
+}
+
+/**
+ * Push settings onto the active audio widget so the canvas preview re-renders
+ * (a bare Backbone .set() updates the model but not the preview node), then
+ * refresh the matching panel inputs so the field values are visible immediately.
+ *
+ * @param {Object} values Map of setting keys to values.
+ */
+function applyAudioSettings( values ) {
+	if ( activeAudioContainer && window.$e?.run ) {
+		window.$e.run( 'document/elements/settings', {
+			container: activeAudioContainer,
+			settings: values,
+		} );
+	} else if ( activeAudioSettings ) {
+		Object.keys( values ).forEach( ( key ) => activeAudioSettings.set( key, values[ key ] ) );
+	}
+
+	refreshPanelControls( Object.keys( values ) );
+}
+
+/**
+ * Fill the Audio Title + Description controls from the selected attachment.
+ * Title is already carried on the godam-media control value; the description is
+ * fetched from the REST API. Mirrors the block: a new selection overwrites both,
+ * and clearing the audio empties them.
+ */
+function populateAudioMeta() {
+	const settings = activeAudioSettings;
+	if ( ! settings ) {
+		return;
+	}
+
+	const audioFile = settings.get( 'audio-file' ) || {};
+	const id = audioFile.id;
+
+	// Audio removed — clear the auto-filled fields (matches the block).
+	if ( ! id ) {
+		applyAudioSettings( { audio_title: '', description: '' } );
+		return;
+	}
+
+	const controlTitle = 'string' === typeof audioFile.title ? audioFile.title : '';
+	const token = ++audioFetchToken;
+
+	apiFetch( { path: '/wp/v2/media/' + encodeURIComponent( id ) + '?context=edit' } )
+		.then( ( media ) => {
+			if ( token !== audioFetchToken ) {
+				return; // A newer selection is in flight.
+			}
+			const title = media?.title?.raw ?? media?.title?.rendered ?? controlTitle;
+			const description = media?.description?.raw ?? stripHtml( media?.description?.rendered );
+			applyAudioSettings( {
+				audio_title: title || controlTitle,
+				description: ( description || '' ).trim(),
+			} );
+		} )
+		.catch( () => {
+			if ( token !== audioFetchToken ) {
+				return;
+			}
+			// Fall back to the title already on the control value.
+			applyAudioSettings( { audio_title: controlTitle } );
+		} );
+}
+
+/**
+ * Change handler for the audio widget. The godam-media control emits sub-key
+ * changes (`change:audio-file.id` / `.url` / `.title`), so inspect model.changed
+ * and react to any `audio-file*` key.
+ *
+ * @param {Object} changedModel Backbone model that changed.
+ */
+function onAudioSettingsChange( changedModel ) {
+	const changed = changedModel?.changed || {};
+	const keys = Object.keys( changed );
+	if ( keys.some( ( key ) => key === 'audio-file' || key.indexOf( 'audio-file' ) === 0 ) ) {
+		populateAudioMeta();
+	}
+}
+
+/**
+ * Track the currently-edited godam-audio widget and wire the change listener.
+ *
+ * @param {Object} model Backbone model of the widget element.
+ * @param {Object} view  Editor view (used to resolve the $e.run container).
+ */
+function hydrateAudioWidget( model, view ) {
+	const settings = model?.get?.( 'settings' );
+	if ( ! settings ) {
+		return;
+	}
+
+	if ( activeAudioSettings && activeAudioSettings !== settings ) {
+		activeAudioSettings.off( 'change', onAudioSettingsChange );
+	}
+
+	activeAudioSettings = settings;
+	activeAudioContainer = view?.getContainer?.() || view?.container || null;
+
+	settings.off( 'change', onAudioSettingsChange );
+	settings.on( 'change', onAudioSettingsChange );
 }

--- a/inc/classes/elementor-widgets/class-godam-audio.php
+++ b/inc/classes/elementor-widgets/class-godam-audio.php
@@ -134,8 +134,10 @@ class Godam_Audio extends Base {
 				'label'     => __( 'Preload', 'godam' ),
 				'type'      => Controls_Manager::SELECT,
 				'default'   => 'metadata',
+				// No "Browser default" (empty) option: the shared render.php coerces
+				// an empty preload to "metadata", so an empty choice could never take
+				// effect. Offer only values that actually render.
 				'options'   => array(
-					''         => esc_html__( 'Browser default', 'godam' ),
 					'auto'     => esc_html__( 'Auto', 'godam' ),
 					'metadata' => esc_html__( 'Metadata', 'godam' ),
 					'none'     => esc_html_x( 'None', 'Preload value', 'godam' ),

--- a/inc/classes/elementor-widgets/class-godam-audio.php
+++ b/inc/classes/elementor-widgets/class-godam-audio.php
@@ -25,13 +25,23 @@ class Godam_Audio extends Base {
 			'title'           => _x( 'GoDAM Audio', 'Widget Title', 'godam' ),
 			'icon'            => 'godam-eicon-audio',
 			'categories'      => array( 'godam' ),
-			'keywords'        => array( 'godam', 'audio' ),
-			'depended_styles' => array( 'elementor-godam-audio-style' ),
+			'keywords'        => array( 'godam', 'audio', 'podcast', 'sound' ),
+			// The redesigned player + Chapters/Transcript panel is driven by the
+			// block's own view script and stylesheet (registered by
+			// register_block_type()), so the widget reuses them instead of the old
+			// bare-<audio> stylesheet — this keeps it visually identical to the
+			// Gutenberg block and the WPBakery element.
+			'depended_script' => array( 'godam-audio-view-script' ),
+			'depended_styles' => array( 'godam-audio-style' ),
 		);
 	}
 
 	/**
 	 * Register Widget Controls.
+	 *
+	 * Mirrors the redesigned godam/audio block inspector (and the WPBakery
+	 * element): media selection, optional title/description/cover overrides, the
+	 * playback switches, and the Chapters/Transcript panel toggles.
 	 *
 	 * @access protected
 	 */
@@ -39,7 +49,7 @@ class Godam_Audio extends Base {
 		$this->start_controls_section(
 			'section_audio_settings',
 			array(
-				'label' => __( 'Widget Settings', 'godam' ),
+				'label' => __( 'Player Settings', 'godam' ),
 			)
 		);
 
@@ -55,12 +65,52 @@ class Godam_Audio extends Base {
 		);
 
 		$this->add_control(
+			'audio_title',
+			array(
+				'label'       => __( 'Audio Title', 'godam' ),
+				'type'        => Controls_Manager::TEXT,
+				'label_block' => true,
+				'description' => __( 'Title shown in the player. Leave empty to use the attachment title.', 'godam' ),
+				'condition'   => array(
+					'audio-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'       => __( 'Description', 'godam' ),
+				'type'        => Controls_Manager::TEXTAREA,
+				'description' => __( 'Short description shown beneath the title.', 'godam' ),
+				'condition'   => array(
+					'audio-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'thumbnail',
+			array(
+				'label'       => __( 'Thumbnail', 'godam' ),
+				'type'        => 'godam-media',
+				'media_type'  => 'image',
+				'label_block' => true,
+				'description' => __( 'Cover image for the player. Leave empty to use the GoDAM-generated cover.', 'godam' ),
+				'condition'   => array(
+					'audio-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
 			'autoplay',
 			array(
-				'label'     => __( 'Autoplay', 'godam' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'default'   => 'no',
-				'condition' => array(
+				'label'       => __( 'Autoplay', 'godam' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'default'     => 'no',
+				'description' => __( 'Autoplay may cause usability issues for some users.', 'godam' ),
+				'condition'   => array(
 					'audio-file[url]!' => '',
 				),
 			)
@@ -70,18 +120,6 @@ class Godam_Audio extends Base {
 			'loop',
 			array(
 				'label'     => __( 'Loop', 'godam' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'default'   => 'no',
-				'condition' => array(
-					'audio-file[url]!' => '',
-				),
-			)
-		);
-
-		$this->add_control(
-			'caption',
-			array(
-				'label'     => __( 'Show Caption', 'godam' ),
 				'type'      => Controls_Manager::SWITCHER,
 				'default'   => 'no',
 				'condition' => array(
@@ -108,90 +146,131 @@ class Godam_Audio extends Base {
 			)
 		);
 
+		$this->add_control(
+			'show_transcript',
+			array(
+				'label'       => __( 'Show Transcript', 'godam' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'default'     => 'yes',
+				'description' => __( 'Show the transcript panel (when a transcript is available).', 'godam' ),
+				'condition'   => array(
+					'audio-file[url]!' => '',
+				),
+			)
+		);
+
+		$this->add_control(
+			'show_chapters',
+			array(
+				'label'       => __( 'Show Chapters', 'godam' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'default'     => 'yes',
+				'description' => __( 'Show the chapters panel (when chapters are available).', 'godam' ),
+				'condition'   => array(
+					'audio-file[url]!' => '',
+				),
+			)
+		);
+
 		$this->end_controls_section();
 	}
 
 	/**
 	 * Render GoDAM Audio widget output on the frontend.
 	 *
+	 * Reuses the audio block's render.php (the single source of truth shared by
+	 * the block, the [godam_audio] shortcode and the WPBakery element) so the
+	 * widget outputs the same custom player and Chapters/Transcript panel. The
+	 * widget settings are mapped into the block's camelCase attribute shape that
+	 * render.php consumes; title/cover/transcript/chapters fall back to the
+	 * attachment's own data when left empty.
+	 *
 	 * @access protected
 	 */
 	protected function render() {
-		$attachment    = $this->get_settings_for_display( 'audio-file' );
-		$attachment_id = $attachment['id'];
-		$show_caption  = 'yes' === $this->get_settings_for_display( 'caption' );
-		$caption       = wp_get_attachment_caption( $attachment_id ) ?? '';
-		$autoplay      = 'yes' === $this->get_settings_for_display( 'autoplay' ) ? 'autoplay' : '';
-		$loop          = 'yes' === $this->get_settings_for_display( 'loop' ) ? 'loop' : '';
-		$preload       = $this->get_settings_for_display( 'preload' );
+		$audio_file = $this->get_settings_for_display( 'audio-file' );
 
-		if ( ! $attachment_id ) {
+		// A GoDAM Audio needs a source; nothing to render without one.
+		if ( empty( $audio_file['url'] ) ) {
+			$this->render_empty_state();
 			return;
 		}
 
-		$sources = array();
+		$thumbnail = $this->get_settings_for_display( 'thumbnail' );
 
-		if ( is_numeric( $attachment_id ) ) {
-			$attachment_id = intval( $attachment_id );
+		// Map widget settings to the block attribute shape render.php reads.
+		$attributes = array(
+			'id'             => isset( $audio_file['id'] ) ? $audio_file['id'] : '',
+			'src'            => $audio_file['url'],
+			'autoplay'       => 'yes' === $this->get_settings_for_display( 'autoplay' ),
+			'loop'           => 'yes' === $this->get_settings_for_display( 'loop' ),
+			'preload'        => $this->get_settings_for_display( 'preload' ) ?? 'metadata',
+			'audioTitle'     => $this->get_settings_for_display( 'audio_title' ) ?? '',
+			'description'    => $this->get_settings_for_display( 'description' ) ?? '',
+			'thumbnail'      => isset( $thumbnail['url'] ) ? $thumbnail['url'] : '',
+			'showTranscript' => 'yes' === $this->get_settings_for_display( 'show_transcript' ),
+			'showChapters'   => 'yes' === $this->get_settings_for_display( 'show_chapters' ),
+		);
 
-			$primary_url  = get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true );
-			$fallback_url = wp_get_attachment_url( $attachment_id );
+		// Enqueue the block's front-end script + styles so the widget gets the
+		// same custom player and Chapters/Transcript panel as the block. These
+		// handles are registered by register_block_type() (see class-blocks.php);
+		// WordPress auto-enqueues them for the block, but not when the shared
+		// render.php is included directly here.
+		wp_enqueue_script( 'godam-audio-view-script' );
+		wp_enqueue_style( 'godam-audio-style' );
 
-			if ( ! empty( $primary_url ) ) {
-				$sources[] = array(
-					'src'  => $primary_url,
-					'type' => 'audio/mpeg',
-				);
-			}
+		// Tells the shared render.php it runs outside block context, so it skips
+		// get_block_wrapper_attributes() (which warns without a block) and still
+		// emits the stable `godam-audio` hook class that view.js targets.
+		$godam_is_shortcode = true;
 
-			if ( ! empty( $fallback_url ) ) {
-				$sources[] = array(
-					'src'  => $fallback_url,
-					'type' => 'audio/mpeg',
-				);
-			}
-		} else {
-			// Handle non-numeric (external or remote) attachments.
-			if ( ! empty( $attachment['url'] ) ) {
-				$sources[] = array(
-					'src'  => $attachment['url'],
-					'type' => 'audio/mpeg',
-				);
-			}
+		require RTGODAM_PATH . 'assets/build/blocks/godam-audio/render.php';
+	}
 
-			if ( ! empty( $attachment['sources'] ) && is_array( $attachment['sources'] ) ) {
-				foreach ( $attachment['sources'] as $source ) {
-					if ( ! empty( $source['src'] ) ) {
-						$sources[] = array(
-							'src'  => $source['src'],
-							'type' => $source['type'] ?? 'audio/mpeg',
-						);
-					}
-				}
-			}
-		}
-
-		if ( empty( $sources ) ) {
+	/**
+	 * Editor-only empty-state placeholder.
+	 *
+	 * Mirrors the Gutenberg block's empty state (a titled prompt) so an
+	 * audio-less widget reads clearly in the editor instead of showing a bare,
+	 * confusing box. The widget preview renders inside Elementor's preview iframe
+	 * where the plugin's editor stylesheet isn't loaded, so the styling is kept
+	 * self-contained inline. Nothing is output on the front end — an unset widget
+	 * renders nothing there.
+	 *
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_empty_state() {
+		if ( ! class_exists( '\Elementor\Plugin' ) ) {
 			return;
 		}
+
+		$plugin        = \Elementor\Plugin::$instance;
+		$is_editing    = isset( $plugin->editor ) && $plugin->editor->is_edit_mode();
+		$is_previewing = isset( $plugin->preview ) && $plugin->preview->is_preview_mode();
+		if ( ! $is_editing && ! $is_previewing ) {
+			return;
+		}
+
+		$icon_url = RTGODAM_URL . 'assets/images/godam-audio-filled.svg';
 		?>
-
-		<figure class="elementor-godam-audio" data-test-id="godam-audio-render">
-			<audio controls <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $loop ); ?> preload="<?php echo esc_attr( $preload ); ?>">
-				<?php foreach ( $sources as $source ) : ?>
-					<source src="<?php echo esc_url( $source['src'] ); ?>" type="<?php echo esc_attr( $source['type'] ); ?>" />
-				<?php endforeach; ?>
-
-				<?php esc_html_e( 'Your browser does not support the audio element.', 'godam' ); ?>
-			</audio>
-
-			<?php if ( $show_caption && ! empty( $caption ) ) : ?>
-				<figcaption class="wp-element-caption">
-					<?php echo wp_kses_post( $caption ); ?>
-				</figcaption>
-			<?php endif; ?>
-		</figure>
-
+		<div
+			class="godam-audio-elementor-empty"
+			data-test-id="godam-audio-elementor-empty"
+			style="display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:6px;padding:40px 24px;border:1px dashed #c3c4c7;border-radius:8px;background:#f6f7f7;color:#1e1e1e;"
+		>
+			<span
+				aria-hidden="true"
+				style="width:40px;height:40px;margin-bottom:4px;opacity:.55;background:url('<?php echo esc_url( $icon_url ); ?>') center/contain no-repeat;"
+			></span>
+			<h3 style="margin:0;font-size:15px;font-weight:600;line-height:1.3;">
+				<?php esc_html_e( 'Add an audio file', 'godam' ); ?>
+			</h3>
+			<p style="margin:0;max-width:320px;font-size:13px;color:#646970;line-height:1.5;">
+				<?php esc_html_e( 'Select an audio file in the Player Settings panel to embed a player on your page or post.', 'godam' ); ?>
+			</p>
+		</div>
 		<?php
 	}
 }


### PR DESCRIPTION
# PR Desc

Issue - rtCamp/godam-plugin-wp#21

The widget was already registered in Elementor, but it output a plain `<audio controls>` with a figcaption — none of the redesigned player (custom UI, cover, title/description, Chapters/Transcript panel). I aligned it with the `godam/audio` block the same way the video widget and WPBakery element were aligned:

- **Controls** now mirror the block inspector: audio file, optional Title / Description / Thumbnail overrides, Autoplay, Loop, Preload, and **Show Transcript** / **Show Chapters** toggles. (Dropped the old "Show Caption" switch — the redesigned block has no caption; it uses title/description.)
- **Render** reuses the block's `render.php` — the single source of truth shared by the block, the `[godam_audio]` shortcode, and the WPBakery element. Widget settings map into the block's camelCase attribute shape (`audioTitle`, `showTranscript`, etc.); title/cover/transcript/chapters fall back to the attachment's own data when left empty. It enqueues `godam-audio-view-script` + `godam-audio-style` (the block's handles) and sets `$godam_is_shortcode` so `render.php` skips `get_block_wrapper_attributes()` outside block context.
- The block's view script/style are also declared as `depended_script`/`depended_styles` so the editor preview picks them up.

To test: in Elementor, drop the **GoDAM Audio** widget, pick an audio attachment (ideally one with a transcript + chapters). You should see the redesigned player with cover/title/description and the Chapters/Transcript tabs, matching the Gutenberg block — plus the toggles hiding each panel, and title/cover falling back to the attachment when the override fields are blank.

## Demo


https://github.com/user-attachments/assets/c059b405-cbc6-4ed6-b76f-b3e789c8e5d2

