### PR TITLE
Feat: Update Video gallery Block in elementor

### DIFF
--- a/inc/classes/elementor-widgets/class-godam-gallery.php
+++ b/inc/classes/elementor-widgets/class-godam-gallery.php
@@ -361,10 +361,13 @@ class Godam_Gallery extends Base {
 		$this->add_control(
 			'show_play_button',
 			array(
-				'label'       => esc_html__( 'Show Play Button', 'godam' ),
-				'type'        => Controls_Manager::SWITCHER,
-				'default'     => 'yes',
-				'description' => esc_html__( 'Show the play button overlay on each tile.', 'godam' ),
+				'label'        => esc_html__( 'Show Play Button', 'godam' ),
+				'type'         => Controls_Manager::SWITCHER,
+				'default'      => 'yes',
+				// Be explicit about the stored value rather than relying on the
+				// implicit Elementor default, so render() reads a stable 'yes'/''.
+				'return_value' => 'yes',
+				'description'  => esc_html__( 'Show the play button overlay on each tile.', 'godam' ),
 			)
 		);
 
@@ -461,7 +464,9 @@ class Godam_Gallery extends Base {
 
 			// No videos picked yet: show the editor placeholder (mirrors the
 			// block's empty state) instead of an empty widget box. On the front
-			// end an empty handpicked gallery simply renders nothing.
+			// end this returns before the shortcode runs, so no gallery markup is
+			// emitted (the shortcode would otherwise output an empty
+			// `.godam-gallery-v2__item-list` wrapper).
 			if ( empty( $ids ) ) {
 				$this->render_empty_state();
 				return;
@@ -511,8 +516,10 @@ class Godam_Gallery extends Base {
 	 * Mirrors the Gutenberg block's empty state (faux tiles + prompt) so the
 	 * widget reads clearly in the editor instead of showing a bare, confusing
 	 * box. The widget preview renders inside Elementor's preview iframe where the
-	 * plugin's editor stylesheet isn't loaded, so the styling is kept
-	 * self-contained inline. Nothing renders on the front end.
+	 * plugin's editor stylesheet isn't loaded, so the styling ships as a small
+	 * self-contained <style> block (printed once per request, scoped to the
+	 * placeholder's classes) rather than long inline style attributes. Nothing
+	 * renders on the front end.
 	 *
 	 * @access protected
 	 * @return void
@@ -528,22 +535,34 @@ class Godam_Gallery extends Base {
 		if ( ! $is_editing && ! $is_previewing ) {
 			return;
 		}
+
+		// Print the scoped stylesheet only once per request even if several empty
+		// galleries render on the same page.
+		static $style_printed = false;
+		if ( ! $style_printed ) {
+			$style_printed = true;
+			?>
+			<style>
+				.godam-gallery-elementor-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:8px;padding:40px 24px;border:1px dashed #c3c4c7;border-radius:8px;background:#f6f7f7;color:#1e1e1e;}
+				.godam-gallery-elementor-empty__tiles{display:flex;gap:8px;margin-bottom:8px;}
+				.godam-gallery-elementor-empty__tile{width:48px;height:32px;border-radius:4px;background:#e0e0e0;}
+				.godam-gallery-elementor-empty__title{margin:0;font-size:15px;font-weight:600;line-height:1.3;}
+				.godam-gallery-elementor-empty__desc{margin:0;max-width:340px;font-size:13px;color:#646970;line-height:1.5;}
+			</style>
+			<?php
+		}
 		?>
-		<div
-			class="godam-gallery-elementor-empty"
-			data-test-id="godam-gallery-elementor-empty"
-			style="display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:8px;padding:40px 24px;border:1px dashed #c3c4c7;border-radius:8px;background:#f6f7f7;color:#1e1e1e;"
-		>
-			<div aria-hidden="true" style="display:flex;gap:8px;margin-bottom:8px;">
+		<div class="godam-gallery-elementor-empty" data-test-id="godam-gallery-elementor-empty">
+			<div class="godam-gallery-elementor-empty__tiles" aria-hidden="true">
 				<?php for ( $i = 0; $i < 4; $i++ ) : ?>
-					<span style="width:48px;height:32px;border-radius:4px;background:#e0e0e0;"></span>
+					<span class="godam-gallery-elementor-empty__tile"></span>
 				<?php endfor; ?>
 			</div>
-			<h3 style="margin:0;font-size:15px;font-weight:600;line-height:1.3;">
+			<h3 class="godam-gallery-elementor-empty__title">
 				<?php esc_html_e( 'Create your media gallery', 'godam' ); ?>
 			</h3>
-			<p style="margin:0;max-width:340px;font-size:13px;color:#646970;line-height:1.5;">
-				<?php esc_html_e( 'Add videos under “Videos” in the Gallery Settings panel to build your gallery.', 'godam' ); ?>
+			<p class="godam-gallery-elementor-empty__desc">
+				<?php esc_html_e( 'Add videos under "Videos" in the Gallery Settings panel to build your gallery.', 'godam' ); ?>
 			</p>
 		</div>
 		<?php

--- a/inc/classes/elementor-widgets/class-godam-gallery.php
+++ b/inc/classes/elementor-widgets/class-godam-gallery.php
@@ -299,6 +299,7 @@ class Godam_Gallery extends Base {
 				'default' => 'grid',
 				'options' => array(
 					'grid'     => esc_html__( 'Grid', 'godam' ),
+					'list'     => esc_html__( 'List', 'godam' ),
 					'carousel' => esc_html__( 'Carousel', 'godam' ),
 				),
 			)
@@ -340,6 +341,30 @@ class Godam_Gallery extends Base {
 				'label'   => esc_html__( 'Show Video Titles and Dates', 'godam' ),
 				'type'    => Controls_Manager::SWITCHER,
 				'default' => 'yes',
+			)
+		);
+
+		$this->add_control(
+			'interaction',
+			array(
+				'label'       => esc_html__( 'Interaction', 'godam' ),
+				'type'        => Controls_Manager::SELECT,
+				'default'     => 'hover',
+				'options'     => array(
+					'hover'    => esc_html__( 'Play on hover', 'godam' ),
+					'autoplay' => esc_html__( 'Autoplay all videos', 'godam' ),
+				),
+				'description' => esc_html__( 'Play on hover: videos play when hovered. Autoplay: visible videos autoplay one at a time.', 'godam' ),
+			)
+		);
+
+		$this->add_control(
+			'show_play_button',
+			array(
+				'label'       => esc_html__( 'Show Play Button', 'godam' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'default'     => 'yes',
+				'description' => esc_html__( 'Show the play button overlay on each tile.', 'godam' ),
 			)
 		);
 
@@ -401,7 +426,11 @@ class Godam_Gallery extends Base {
 		$view_ratio       = $this->get_settings_for_display( 'view_ratio' );
 		$show_title       = 'yes' === $this->get_settings_for_display( 'show_title' );
 		$performance_mode = $this->get_settings_for_display( 'performance_mode' );
-		$engagements      = rtgodam_is_engagement_feature_enabled()
+		$show_play_button = 'yes' === $this->get_settings_for_display( 'show_play_button' );
+		// 'autoplay' or 'hover'; the shortcode maps this to the block's
+		// mutually-exclusive autoplay / playOnHover booleans.
+		$interaction = 'autoplay' === $this->get_settings_for_display( 'interaction' ) ? 'autoplay' : 'hover';
+		$engagements = rtgodam_is_engagement_feature_enabled()
 			&& 'yes' === $this->get_settings_for_display( 'engagements' );
 
 		// Attributes shared by both modes.
@@ -411,6 +440,8 @@ class Godam_Gallery extends Base {
 			'item_width'       => $item_width,
 			'view_ratio'       => $view_ratio,
 			'show_title'       => $show_title ? 'true' : 'false',
+			'interaction'      => $interaction,
+			'show_play_button' => $show_play_button ? 'true' : 'false',
 			'performance_mode' => $performance_mode,
 			'engagements'      => $engagements ? 'true' : 'false',
 		);
@@ -426,6 +457,14 @@ class Godam_Gallery extends Base {
 						$ids[] = $row_id;
 					}
 				}
+			}
+
+			// No videos picked yet: show the editor placeholder (mirrors the
+			// block's empty state) instead of an empty widget box. On the front
+			// end an empty handpicked gallery simply renders nothing.
+			if ( empty( $ids ) ) {
+				$this->render_empty_state();
+				return;
 			}
 
 			$shortcode_atts['ids'] = implode( ',', $ids );
@@ -464,5 +503,49 @@ class Godam_Gallery extends Base {
 		}
 
 		echo do_shortcode( '[godam_video_gallery' . $shortcode_atts_string . ']' );
+	}
+
+	/**
+	 * Editor-only empty-state placeholder for handpicked mode with no videos.
+	 *
+	 * Mirrors the Gutenberg block's empty state (faux tiles + prompt) so the
+	 * widget reads clearly in the editor instead of showing a bare, confusing
+	 * box. The widget preview renders inside Elementor's preview iframe where the
+	 * plugin's editor stylesheet isn't loaded, so the styling is kept
+	 * self-contained inline. Nothing renders on the front end.
+	 *
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_empty_state() {
+		if ( ! class_exists( '\Elementor\Plugin' ) ) {
+			return;
+		}
+
+		$plugin        = \Elementor\Plugin::$instance;
+		$is_editing    = isset( $plugin->editor ) && $plugin->editor->is_edit_mode();
+		$is_previewing = isset( $plugin->preview ) && $plugin->preview->is_preview_mode();
+		if ( ! $is_editing && ! $is_previewing ) {
+			return;
+		}
+		?>
+		<div
+			class="godam-gallery-elementor-empty"
+			data-test-id="godam-gallery-elementor-empty"
+			style="display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:8px;padding:40px 24px;border:1px dashed #c3c4c7;border-radius:8px;background:#f6f7f7;color:#1e1e1e;"
+		>
+			<div aria-hidden="true" style="display:flex;gap:8px;margin-bottom:8px;">
+				<?php for ( $i = 0; $i < 4; $i++ ) : ?>
+					<span style="width:48px;height:32px;border-radius:4px;background:#e0e0e0;"></span>
+				<?php endfor; ?>
+			</div>
+			<h3 style="margin:0;font-size:15px;font-weight:600;line-height:1.3;">
+				<?php esc_html_e( 'Create your media gallery', 'godam' ); ?>
+			</h3>
+			<p style="margin:0;max-width:340px;font-size:13px;color:#646970;line-height:1.5;">
+				<?php esc_html_e( 'Add videos under “Videos” in the Gallery Settings panel to build your gallery.', 'godam' ); ?>
+			</p>
+		</div>
+		<?php
 	}
 }


### PR DESCRIPTION
## PR Description

Issue - rtCamp/godam-plugin-wp#21

The Elementor Video Gallery widget already mirrored most of the godam/gallery-v2 block (mode, handpicked/query filters, layout, item width, view ratio, titles, performance, engagements, load-more). The only gaps versus the redesign were the two playback controls the WPBakery element and shortcode already support — now added:

Interaction (select): Play on hover (default) or Autoplay all videos — the shortcode maps this to the block's mutually-exclusive autoplay / playOnHover.
Show Play Button (toggle, default on) → show_play_button → showPlayButton.

Both are passed into the [godam_video_gallery] shortcode alongside the existing shared atts, so the widget, block, shortcode, and WPBakery element now render identically. Defaults match the block (hover = playOnHover true/autoplay false; play button on).

- List layout — added "List" to the Layout dropdown (block/WPBakery/shortcode already support grid, list, carousel; the widget was missing list). It flows straight through the [godam_video_gallery] shortcode.

- Handpicked empty state — when handpicked mode has no videos, the widget now renders a Gutenberg-style placeholder (faux tiles + "Create your media gallery" + a prompt to add videos in the Gallery Settings panel) instead of the confusing thin bar. It's editor/preview-only with self-contained inline styles (the preview iframe doesn't load the plugin's editor stylesheet); the front end still renders nothing for an empty handpicked gallery.

Test: drop the GoDAM Video Gallery widget → in Display Settings you'll see Interaction and Show Play Button. Set Interaction to Autoplay → tiles autoplay one at a time; Play on hover → play on hover. Toggle Show Play Button off → the overlay disappears. Confirm parity with the Gutenberg block and WPBakery element.

Test: set Mode = Handpicked with no videos → friendly placeholder appears; add a video → gallery renders. In Display Settings, Layout now offers Grid / List / Carousel, and List matches the Gutenberg/WPBakery list layout.

## Demo


https://github.com/user-attachments/assets/48a54222-fd7e-40e9-8658-1c8f82bc97f8

