### PR TITLE
feat(video-editor): add ref to video canvas wrapper for responsive video width

### DIFF
--- a/pages/video-editor/VideoEditor.js
+++ b/pages/video-editor/VideoEditor.js
@@ -738,7 +738,7 @@ const VideoEditor = ( { attachmentID, onBackToAttachmentPicker } ) => {
 							/>
 						) }
 						{ attachmentConfig && sources.length > 0 && capability.preview === 'videojs' && (
-							<div className="w-full video-canvas-wrapper">
+							<div className="w-full video-canvas-wrapper" ref={ canvasWrapperRef }>
 								<div className="relative">
 									<VideoJSPlayer
 										options={ {


### PR DESCRIPTION
This pull request makes a small update to the `VideoEditor` component to support referencing the video canvas wrapper element. The change adds a `ref` attribute to the video canvas wrapper `div`, allowing the component to access the DOM node directly for future enhancements or manipulations.


https://github.com/user-attachments/assets/ebdc8237-3f5f-4a37-b5c3-70683afd77d5

