### PR TITLE
Feat: update video block in elementor

### DIFF
--- a/assets/src/css/godam-elementor-preview.scss
+++ b/assets/src/css/godam-elementor-preview.scss
@@ -1,0 +1,142 @@
+/**
+ * GoDAM — Elementor editor preview affordances.
+ *
+ * Enqueued INTO the Elementor preview iframe via
+ * RTGODAM\Inc\Elementor_Widgets::enqueue_preview_styles() (hooked to
+ * `elementor/preview/enqueue_styles` in inc/classes/class-elementor-widgets.php).
+ *
+ * These rules style editor-only markup the GoDAM widgets output in the preview
+ * canvas — the empty-state placeholders (image / gallery / audio / video) and
+ * the video share/transcript overlay. None of it renders on the published front
+ * end. The plugin's editor-panel stylesheet (godam-elementor-editor.css) loads
+ * in the editor's main window, not this iframe, which is why these live here.
+ *
+ * Dynamic icon URLs depend on RTGODAM_URL, so they can't be hard-coded here;
+ * each widget passes its SVG via the `--godam-preview-icon` custom property on
+ * the relevant element.
+ */
+
+/* ── Empty-state placeholders ─────────────────────────────────────────────── */
+
+.godam-image-elementor-empty,
+.godam-video-elementor-empty,
+.godam-audio-elementor-empty,
+.godam-gallery-elementor-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	gap: 6px;
+	padding: 40px 24px;
+	border: 1px dashed #c3c4c7;
+	border-radius: 8px;
+	background: #f6f7f7;
+	color: #1e1e1e;
+}
+
+.godam-gallery-elementor-empty {
+	gap: 8px;
+}
+
+.godam-image-elementor-empty__title,
+.godam-video-elementor-empty__title,
+.godam-audio-elementor-empty__title,
+.godam-gallery-elementor-empty__title {
+	margin: 0;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.godam-image-elementor-empty__desc,
+.godam-video-elementor-empty__desc,
+.godam-audio-elementor-empty__desc,
+.godam-gallery-elementor-empty__desc {
+	margin: 0;
+	max-width: 340px;
+	font-size: 13px;
+	color: #646970;
+	line-height: 1.5;
+}
+
+/* Image / Video: a framed dummy-media box with a faint centered glyph. */
+.godam-image-elementor-empty__preview,
+.godam-video-elementor-empty__preview {
+	max-width: 60%;
+	margin-bottom: 12px;
+	border-radius: 6px;
+	background-color: #e6e7e9;
+	background-image: var( --godam-preview-icon );
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 44px auto;
+	box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, .06 );
+}
+
+.godam-image-elementor-empty__preview {
+	width: 180px;
+	aspect-ratio: 16 / 10;
+}
+
+.godam-video-elementor-empty__preview {
+	width: 220px;
+	aspect-ratio: 16 / 9;
+}
+
+/* Audio: a small glyph (no framed box). */
+.godam-audio-elementor-empty__icon {
+	width: 40px;
+	height: 40px;
+	margin-bottom: 4px;
+	opacity: .55;
+	background: var( --godam-preview-icon ) center / contain no-repeat;
+}
+
+/* Gallery: faux tiles above the prompt. */
+.godam-gallery-elementor-empty__tiles {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.godam-gallery-elementor-empty__tile {
+	width: 48px;
+	height: 32px;
+	border-radius: 4px;
+	background: #e0e0e0;
+}
+
+/* ── Video share / transcript overlay (editor preview only) ───────────────── */
+
+.godam-elementor-video-overlay {
+	position: relative;
+	display: block;
+}
+
+.godam-elementor-video-overlay__btn {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	z-index: 5;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	background: rgba( 0, 0, 0, .55 );
+	color: #fff;
+	pointer-events: none;
+}
+
+.godam-elementor-video-overlay__btn--below {
+	top: 60px;
+}
+
+/* The static indicators stand in for the live player's own control-bar
+ * buttons, so hide those within the preview wrapper to avoid duplicates. */
+.godam-elementor-video-overlay .godam-share-button,
+.godam-elementor-video-overlay .godam-transcript-button {
+	display: none !important;
+}

--- a/assets/src/js/elementor/editor.js
+++ b/assets/src/js/elementor/editor.js
@@ -43,7 +43,7 @@ window.addEventListener( 'load', function() {
 		'panel/open_editor/widget/godam-video',
 		function( panel, model, view ) {
 			setTimeout( makeFieldsReadonly, 100 );
-			hydrateWidget( model, view );
+			hydrateWidget( model, view, panel );
 		},
 	);
 
@@ -94,6 +94,16 @@ let activeFetchToken = 0;
 let renderedAttachmentId = null;
 
 /**
+ * Cached tiles markup for `renderedAttachmentId`. Elementor rebuilds the panel
+ * control DOM on every re-render (e.g. the GoDAM Video widget's SEO auto-sync
+ * calls panel.currentPageView.render() right after a video is picked), which
+ * wipes the freshly-populated grid. Caching lets us restore the tiles on the
+ * next render without another REST round-trip. `null` = not fetched yet;
+ * `''` = fetched, no thumbnails available.
+ */
+let renderedTilesHtml = null;
+
+/**
  * Re-render the thumbnail grid for the currently active widget settings.
  */
 function renderThumbnailPicker() {
@@ -109,28 +119,44 @@ function renderThumbnailPicker() {
 	}
 
 	const grid = container.querySelector( '[data-godam-thumbnail-grid]' );
-	const emptyState = container.querySelector( '[data-godam-thumbnail-empty]' );
 	if ( ! grid ) {
 		return;
 	}
+
+	const emptyState = container.querySelector( '[data-godam-thumbnail-empty]' );
 
 	const videoFile = settings.get( 'video-file' );
 	const attachmentId = videoFile?.id;
 	if ( ! attachmentId ) {
 		grid.innerHTML = '';
 		renderedAttachmentId = null;
+		renderedTilesHtml = null;
 		if ( emptyState ) {
 			emptyState.hidden = true;
 		}
 		return;
 	}
 
-	// Same video as last render — skip the REST round-trip and just repaint
-	// the selection ring on the existing tiles. Triggered when the user
-	// clicks a tile (poster changed, video did not).
+	// Same video as last render — no REST round-trip needed.
 	if ( renderedAttachmentId === attachmentId ) {
-		updateSelectionRing( settings, grid );
-		return;
+		// Tiles are still in the DOM: just repaint the selection ring (e.g. the
+		// user clicked a tile, changing only the poster).
+		if ( grid.children.length > 0 ) {
+			updateSelectionRing( settings, grid );
+			return;
+		}
+		// The grid was wiped by a panel re-render (Elementor rebuilds the RAW_HTML
+		// control DOM — notably the SEO auto-sync re-renders the panel right after
+		// a video is picked). Restore the cached tiles instead of refetching.
+		if ( null !== renderedTilesHtml ) {
+			grid.innerHTML = renderedTilesHtml;
+			if ( emptyState ) {
+				emptyState.hidden = grid.children.length > 0;
+			}
+			updateSelectionRing( settings, grid );
+			return;
+		}
+		// Otherwise a fetch is still in flight — fall through and (re)issue it.
 	}
 
 	const token = ++activeFetchToken;
@@ -159,6 +185,7 @@ function renderThumbnailPicker() {
 
 			if ( ! tiles.length ) {
 				grid.innerHTML = '';
+				renderedTilesHtml = ''; // Fetched: no thumbnails for this video.
 				if ( emptyState ) {
 					emptyState.hidden = false;
 				}
@@ -177,6 +204,9 @@ function renderThumbnailPicker() {
 					);
 				} )
 				.join( '' );
+
+			// Cache so a subsequent panel re-render can restore without refetching.
+			renderedTilesHtml = grid.innerHTML;
 		} )
 		.catch( () => {
 			if ( token !== activeFetchToken ) {
@@ -242,23 +272,55 @@ function updateSelectionRing( settings, grid ) {
 }
 
 /**
+ * Render the thumbnail picker once its container is present in the panel DOM.
+ *
+ * The picker is a conditional RAW_HTML control Elementor injects asynchronously
+ * — and only once a video with an id is selected. So on first add (select a
+ * video, which reveals the control) or a passive panel open, the container may
+ * not exist yet at the moment we want to render, and renderThumbnailPicker()
+ * would bail with nothing to re-trigger it (the grid then only fills after a
+ * reload). Poll (bounded, ~2s) until the container appears, then render once;
+ * bail if the panel has since switched to a different widget.
+ */
+function scheduleThumbnailPickerRender() {
+	const settings = activeWidgetSettings;
+	let attempts = 0;
+	const attempt = () => {
+		if ( activeWidgetSettings !== settings ) {
+			return;
+		}
+		if ( document.querySelector( '[data-godam-thumbnail-picker]' ) ) {
+			renderThumbnailPicker();
+			return;
+		}
+		if ( attempts < 20 ) {
+			attempts++;
+			setTimeout( attempt, 100 );
+		}
+	};
+	attempt();
+}
+
+/**
  * Wildcard `change` handler used to refresh the thumbnail grid when the
  * underlying video changes. Elementor's BaseMultiple controls (godam-media
  * included) update sub-keys via paths and emit `change:video-file.id` /
  * `change:video-file.url` — NOT `change:video-file`. Listening to the
  * generic 'change' event and inspecting `model.changed` is the only way to
  * catch both shapes reliably across Elementor versions.
- * @param changedModel
+ * @param {any} changedModel
  */
 function onSettingsChange( changedModel ) {
 	const changed = changedModel?.changed || {};
 	const keys = Object.keys( changed );
 	if ( keys.some( ( key ) => key === 'video-file' || key.indexOf( 'video-file' ) === 0 ) ) {
-		renderThumbnailPicker();
+		// Selecting a video reveals the (conditional) picker control, which
+		// Elementor mounts asynchronously — wait for it before rendering.
+		scheduleThumbnailPickerRender();
 	} else if ( keys.indexOf( 'poster' ) !== -1 ) {
 		// Selection ring follows the poster, even when the user uploads via
 		// the godam-media tile above the grid.
-		renderThumbnailPicker();
+		scheduleThumbnailPickerRender();
 	} else if ( keys.indexOf( 'autoplay' ) !== -1 ) {
 		applyAutoplayLock( !! changed.autoplay && 'yes' === changed.autoplay );
 	}
@@ -287,12 +349,11 @@ function applyAutoplayLock( locked ) {
  * Also wires the autoplay → disabled state for the muted / hover_select
  * controls (these stay visible but go non-interactive when autoplay is on).
  *
- * @param {Object} model Backbone model of the widget element (the `model`
- *                       arg from the `panel/open_editor/widget/X` hook).
- * @param {Object} view  Editor view for the widget — used to resolve the
- *                       Elementor container for $e.run() preview updates.
+ * @param {Object} model Backbone model of the widget element (the `model` arg from the `panel/open_editor/widget/X` hook).
+ * @param {Object} view  Editor view for the widget — used to resolve the Elementor container for $e.run() preview updates.
+ * @param {Object} panel Elementor panel object (the `panel` arg from the hook), used to re-populate the picker after panel re-renders.
  */
-function hydrateWidget( model, view ) {
+function hydrateWidget( model, view, panel ) {
 	const settings = model?.get?.( 'settings' );
 	if ( ! settings ) {
 		return;
@@ -308,40 +369,29 @@ function hydrateWidget( model, view ) {
 	activeWidgetSettings = settings;
 	activeWidgetContainer = view?.getContainer?.() || view?.container || null;
 
-	// Each panel open replaces the picker's DOM. Invalidate the
-	// "same attachment, skip refetch" cache so the first render after
-	// hydration always rebuilds the grid (otherwise the cached id would
-	// match and we'd be left with an empty grid container).
+	// Each panel open replaces the picker's DOM. Invalidate the caches so the
+	// first render after hydration always rebuilds the grid (otherwise the
+	// cached id would match and we'd be left with an empty grid container).
 	renderedAttachmentId = null;
+	renderedTilesHtml = null;
 
 	settings.off( 'change', onSettingsChange );
 	settings.on( 'change', onSettingsChange );
 
+	// Elementor rebuilds the panel control DOM on every re-render (e.g. the SEO
+	// auto-sync calls panel.currentPageView.render() right after a video is
+	// picked), which wipes the freshly-populated picker grid. Re-populate on each
+	// render — renderThumbnailPicker() restores cached tiles without refetching.
+	if ( panel && panel.currentPageView && panel.currentPageView.on ) {
+		panel.currentPageView.off( 'render', scheduleThumbnailPickerRender );
+		panel.currentPageView.on( 'render', scheduleThumbnailPickerRender );
+	}
+
 	// Autoplay-lock doesn't depend on the picker DOM, so apply it on a short delay.
 	setTimeout( () => applyAutoplayLock( 'yes' === settings.get( 'autoplay' ) ), 100 );
 
-	// Elementor injects the RAW_HTML thumbnail-picker control into the panel DOM
-	// asynchronously (and only when a video with an id is selected). A single
-	// fixed delay can fire before the container exists — then renderThumbnailPicker()
-	// bails and, with no settings change to re-trigger it, the grid never fills
-	// and the "none available" message never shows (an empty gap under the label).
-	// Poll (bounded) until the container appears, then render once.
-	let pickerAttempts = 0;
-	const renderPickerWhenReady = () => {
-		// Bail if the panel has since moved to a different widget.
-		if ( activeWidgetSettings !== settings ) {
-			return;
-		}
-		if ( document.querySelector( '[data-godam-thumbnail-picker]' ) ) {
-			renderThumbnailPicker();
-			return;
-		}
-		if ( pickerAttempts < 20 ) {
-			pickerAttempts++;
-			setTimeout( renderPickerWhenReady, 100 );
-		}
-	};
-	setTimeout( renderPickerWhenReady, 100 );
+	// Render the picker once Elementor has mounted its (conditional) control.
+	scheduleThumbnailPickerRender();
 }
 
 /**

--- a/assets/src/js/elementor/editor.js
+++ b/assets/src/js/elementor/editor.js
@@ -317,12 +317,31 @@ function hydrateWidget( model, view ) {
 	settings.off( 'change', onSettingsChange );
 	settings.on( 'change', onSettingsChange );
 
-	// Initial render + autoplay-lock application once Elementor finishes
-	// injecting the control DOM for this panel open.
-	setTimeout( () => {
-		renderThumbnailPicker();
-		applyAutoplayLock( 'yes' === settings.get( 'autoplay' ) );
-	}, 100 );
+	// Autoplay-lock doesn't depend on the picker DOM, so apply it on a short delay.
+	setTimeout( () => applyAutoplayLock( 'yes' === settings.get( 'autoplay' ) ), 100 );
+
+	// Elementor injects the RAW_HTML thumbnail-picker control into the panel DOM
+	// asynchronously (and only when a video with an id is selected). A single
+	// fixed delay can fire before the container exists — then renderThumbnailPicker()
+	// bails and, with no settings change to re-trigger it, the grid never fills
+	// and the "none available" message never shows (an empty gap under the label).
+	// Poll (bounded) until the container appears, then render once.
+	let pickerAttempts = 0;
+	const renderPickerWhenReady = () => {
+		// Bail if the panel has since moved to a different widget.
+		if ( activeWidgetSettings !== settings ) {
+			return;
+		}
+		if ( document.querySelector( '[data-godam-thumbnail-picker]' ) ) {
+			renderThumbnailPicker();
+			return;
+		}
+		if ( pickerAttempts < 20 ) {
+			pickerAttempts++;
+			setTimeout( renderPickerWhenReady, 100 );
+		}
+	};
+	setTimeout( renderPickerWhenReady, 100 );
 }
 
 /**

--- a/inc/classes/class-elementor-widgets.php
+++ b/inc/classes/class-elementor-widgets.php
@@ -47,6 +47,32 @@ class Elementor_Widgets {
 		add_action( 'elementor/editor/before_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'preload_image_layers_in_editor' ) );
+		add_action( 'elementor/preview/enqueue_styles', array( $this, 'enqueue_preview_styles' ) );
+	}
+
+	/**
+	 * Enqueue the editor-preview stylesheet INTO the Elementor preview iframe.
+	 *
+	 * The GoDAM widgets render editor-only affordances in the preview canvas —
+	 * empty-state placeholders and the video share/transcript overlay. Their
+	 * styling can't come from the editor-panel stylesheet (that loads in the
+	 * editor's main window, not this iframe) and shouldn't ship to the front end,
+	 * so it lives in a dedicated stylesheet enqueued only here.
+	 * Source: assets/src/css/godam-elementor-preview.scss.
+	 *
+	 * @return void
+	 */
+	public function enqueue_preview_styles() {
+		$preview_css = RTGODAM_PATH . 'assets/build/css/godam-elementor-preview.css';
+		if ( ! file_exists( $preview_css ) ) {
+			return;
+		}
+		wp_enqueue_style(
+			'godam-elementor-preview',
+			RTGODAM_URL . 'assets/build/css/godam-elementor-preview.css',
+			array(),
+			filemtime( $preview_css )
+		);
 	}
 
 	/**

--- a/inc/classes/elementor-widgets/class-godam-audio.php
+++ b/inc/classes/elementor-widgets/class-godam-audio.php
@@ -255,21 +255,14 @@ class Godam_Audio extends Base {
 			return;
 		}
 
-		$icon_url = RTGODAM_URL . 'assets/images/godam-audio-filled.svg';
+		$icon_style = '--godam-preview-icon:url(' . esc_url( RTGODAM_URL . 'assets/images/godam-audio-filled.svg' ) . ');';
 		?>
-		<div
-			class="godam-audio-elementor-empty"
-			data-test-id="godam-audio-elementor-empty"
-			style="display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:6px;padding:40px 24px;border:1px dashed #c3c4c7;border-radius:8px;background:#f6f7f7;color:#1e1e1e;"
-		>
-			<span
-				aria-hidden="true"
-				style="width:40px;height:40px;margin-bottom:4px;opacity:.55;background:url('<?php echo esc_url( $icon_url ); ?>') center/contain no-repeat;"
-			></span>
-			<h3 style="margin:0;font-size:15px;font-weight:600;line-height:1.3;">
+		<div class="godam-audio-elementor-empty" data-test-id="godam-audio-elementor-empty">
+			<span class="godam-audio-elementor-empty__icon" aria-hidden="true" style="<?php echo esc_attr( $icon_style ); ?>"></span>
+			<h3 class="godam-audio-elementor-empty__title">
 				<?php esc_html_e( 'Add an audio file', 'godam' ); ?>
 			</h3>
-			<p style="margin:0;max-width:320px;font-size:13px;color:#646970;line-height:1.5;">
+			<p class="godam-audio-elementor-empty__desc">
 				<?php esc_html_e( 'Select an audio file in the Player Settings panel to embed a player on your page or post.', 'godam' ); ?>
 			</p>
 		</div>

--- a/inc/classes/elementor-widgets/class-godam-gallery.php
+++ b/inc/classes/elementor-widgets/class-godam-gallery.php
@@ -515,11 +515,9 @@ class Godam_Gallery extends Base {
 	 *
 	 * Mirrors the Gutenberg block's empty state (faux tiles + prompt) so the
 	 * widget reads clearly in the editor instead of showing a bare, confusing
-	 * box. The widget preview renders inside Elementor's preview iframe where the
-	 * plugin's editor stylesheet isn't loaded, so the styling ships as a small
-	 * self-contained <style> block (printed once per request, scoped to the
-	 * placeholder's classes) rather than long inline style attributes. Nothing
-	 * renders on the front end.
+	 * box. Styling is enqueued into the preview iframe (see
+	 * Elementor_Widgets::enqueue_preview_styles / godam-elementor-preview.scss).
+	 * Nothing renders on the front end.
 	 *
 	 * @access protected
 	 * @return void
@@ -536,21 +534,6 @@ class Godam_Gallery extends Base {
 			return;
 		}
 
-		// Print the scoped stylesheet only once per request even if several empty
-		// galleries render on the same page.
-		static $style_printed = false;
-		if ( ! $style_printed ) {
-			$style_printed = true;
-			?>
-			<style>
-				.godam-gallery-elementor-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:8px;padding:40px 24px;border:1px dashed #c3c4c7;border-radius:8px;background:#f6f7f7;color:#1e1e1e;}
-				.godam-gallery-elementor-empty__tiles{display:flex;gap:8px;margin-bottom:8px;}
-				.godam-gallery-elementor-empty__tile{width:48px;height:32px;border-radius:4px;background:#e0e0e0;}
-				.godam-gallery-elementor-empty__title{margin:0;font-size:15px;font-weight:600;line-height:1.3;}
-				.godam-gallery-elementor-empty__desc{margin:0;max-width:340px;font-size:13px;color:#646970;line-height:1.5;}
-			</style>
-			<?php
-		}
 		?>
 		<div class="godam-gallery-elementor-empty" data-test-id="godam-gallery-elementor-empty">
 			<div class="godam-gallery-elementor-empty__tiles" aria-hidden="true">

--- a/inc/classes/elementor-widgets/class-godam-image.php
+++ b/inc/classes/elementor-widgets/class-godam-image.php
@@ -129,11 +129,10 @@ class Godam_Image extends Base {
 	 * Editor-only empty-state placeholder.
 	 *
 	 * Mirrors the Gutenberg block's empty state so an image-less widget reads
-	 * clearly in the editor instead of showing a bare, confusing box. The widget
-	 * preview renders inside Elementor's preview iframe where the plugin's editor
-	 * stylesheet isn't loaded, so the styling ships as a small self-contained
-	 * <style> block (printed once per request, scoped to the placeholder's
-	 * classes). Nothing renders on the front end.
+	 * clearly in the editor instead of showing a bare, confusing box. Styling is
+	 * enqueued into the preview iframe (see Elementor_Widgets::enqueue_preview_styles
+	 * / godam-elementor-preview.scss); only the dynamic icon URL is passed inline
+	 * via the `--godam-preview-icon` custom property. Nothing renders on the front end.
 	 *
 	 * @access protected
 	 * @return void
@@ -150,60 +149,10 @@ class Godam_Image extends Base {
 			return;
 		}
 
-		// Print the scoped stylesheet only once per request even if several empty
-		// image widgets render on the same page.
-		static $style_printed = false;
-		if ( ! $style_printed ) {
-			$style_printed = true;
-			$icon_url      = RTGODAM_URL . 'assets/src/images/godam-image-filled.svg';
-			?>
-			<style>
-				.godam-image-elementor-empty {
-					display: flex;
-					flex-direction: column;
-					align-items: center;
-					justify-content: center;
-					text-align: center;
-					gap: 6px;
-					padding: 40px 24px;
-					border: 1px dashed #c3c4c7;
-					border-radius: 8px;
-					background: #f6f7f7;
-					color: #1e1e1e;
-				}
-				/* Dummy image preview: a framed box with a faint image glyph, echoing the block's placeholder. */
-				.godam-image-elementor-empty__preview {
-					width: 180px;
-					max-width: 60%;
-					aspect-ratio: 16 / 10;
-					margin-bottom: 12px;
-					border-radius: 6px;
-					background-color: #e6e7e9;
-					background-image: url('<?php echo esc_url( $icon_url ); ?>');
-					background-repeat: no-repeat;
-					background-position: center;
-					background-size: 44px auto;
-					box-shadow: inset 0 0 0 1px rgba( 0, 0, 0, .06 );
-				}
-				.godam-image-elementor-empty__title {
-					margin: 0;
-					font-size: 15px;
-					font-weight: 600;
-					line-height: 1.3;
-				}
-				.godam-image-elementor-empty__desc {
-					margin: 0;
-					max-width: 340px;
-					font-size: 13px;
-					color: #646970;
-					line-height: 1.5;
-				}
-			</style>
-			<?php
-		}
+		$icon_style = '--godam-preview-icon:url(' . esc_url( RTGODAM_URL . 'assets/src/images/godam-image-filled.svg' ) . ');';
 		?>
 		<div class="godam-image-elementor-empty" data-test-id="godam-image-elementor-empty">
-			<div class="godam-image-elementor-empty__preview" aria-hidden="true"></div>
+			<div class="godam-image-elementor-empty__preview" aria-hidden="true" style="<?php echo esc_attr( $icon_style ); ?>"></div>
 			<h3 class="godam-image-elementor-empty__title">
 				<?php esc_html_e( 'Add Image Here', 'godam' ); ?>
 			</h3>

--- a/inc/classes/elementor-widgets/class-godam-video.php
+++ b/inc/classes/elementor-widgets/class-godam-video.php
@@ -556,7 +556,7 @@ class GoDAM_Video extends Base {
 			'sources'           => isset( $widget_video_file['sources'] ) ? $widget_video_file['sources'] : array(),
 			'src'               => $widget_video_file['url'],
 			'transcoded_url'    => '',
-			'poster'            => $widget_poster_file['url'],
+			'poster'            => isset( $widget_poster_file['url'] ) ? $widget_poster_file['url'] : '',
 			'aspectRatio'       => $widget_aspect_ratio,
 			'autoplay'          => $widget_autoplay,
 			'controls'          => $widget_controls,

--- a/inc/classes/elementor-widgets/class-godam-video.php
+++ b/inc/classes/elementor-widgets/class-godam-video.php
@@ -363,6 +363,19 @@ class GoDAM_Video extends Base {
 			)
 		);
 
+		$this->add_control(
+			'show_transcription',
+			array(
+				'label'       => esc_html__( 'Show Transcription', 'godam' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'default'     => '',
+				'description' => esc_html__( 'Show the transcript panel toggle on the player (when a transcript is available).', 'godam' ),
+				'condition'   => array(
+					'video-file[url]!' => '',
+				),
+			)
+		);
+
 		if ( rtgodam_is_engagement_feature_enabled() ) {
 			$this->add_control(
 				'engagements',
@@ -474,23 +487,24 @@ class GoDAM_Video extends Base {
 	 * @access protected
 	 */
 	protected function render() {
-		$widget_video_file        = $this->get_settings_for_display( 'video-file' );
-		$widget_poster_file       = $this->get_settings_for_display( 'poster' );
-		$widget_autoplay          = 'yes' === $this->get_settings_for_display( 'autoplay' ) ? true : false;
-		$widget_controls          = 'yes' === $this->get_settings_for_display( 'controls' ) ? true : false;
-		$widget_muted             = 'yes' === $this->get_settings_for_display( 'muted' ) ? true : false;
-		$widget_loop              = 'yes' === $this->get_settings_for_display( 'loop' ) ? true : false;
-		$widget_show_caption      = 'yes' === $this->get_settings_for_display( 'enable_caption' );
-		$widget_caption           = $this->get_settings_for_display( 'caption' ) ?? '';
-		$widget_text_tracks       = $this->get_settings_for_display( 'text_tracks' ) ?? '';
-		$widget_performance_mode  = $this->get_settings_for_display( 'performance_mode' ) ?? 'balanced';
-		$widget_hover_select      = $this->get_settings_for_display( 'hover_select' ) ?? 'none';
-		$widget_show_share_button = 'yes' === $this->get_settings_for_display( 'show_share_button' );
-		$widget_engagements       = rtgodam_is_engagement_feature_enabled() && 'yes' === $this->get_settings_for_display( 'engagements' );
-		$widget_player_height     = $this->get_settings_for_display( 'player_height' ) ?? '';
-		$widget_aspect_ratio      = $this->get_settings_for_display( 'aspect_ratio' ) ?? 'responsive';
-		$widget_seo_override      = 'yes' === $this->get_settings_for_display( 'seo_override' );
-		$widget_seo               = array(
+		$widget_video_file         = $this->get_settings_for_display( 'video-file' );
+		$widget_poster_file        = $this->get_settings_for_display( 'poster' );
+		$widget_autoplay           = 'yes' === $this->get_settings_for_display( 'autoplay' ) ? true : false;
+		$widget_controls           = 'yes' === $this->get_settings_for_display( 'controls' ) ? true : false;
+		$widget_muted              = 'yes' === $this->get_settings_for_display( 'muted' ) ? true : false;
+		$widget_loop               = 'yes' === $this->get_settings_for_display( 'loop' ) ? true : false;
+		$widget_show_caption       = 'yes' === $this->get_settings_for_display( 'enable_caption' );
+		$widget_caption            = $this->get_settings_for_display( 'caption' ) ?? '';
+		$widget_text_tracks        = $this->get_settings_for_display( 'text_tracks' ) ?? '';
+		$widget_performance_mode   = $this->get_settings_for_display( 'performance_mode' ) ?? 'balanced';
+		$widget_hover_select       = $this->get_settings_for_display( 'hover_select' ) ?? 'none';
+		$widget_show_share_button  = 'yes' === $this->get_settings_for_display( 'show_share_button' );
+		$widget_show_transcription = 'yes' === $this->get_settings_for_display( 'show_transcription' );
+		$widget_engagements        = rtgodam_is_engagement_feature_enabled() && 'yes' === $this->get_settings_for_display( 'engagements' );
+		$widget_player_height      = $this->get_settings_for_display( 'player_height' ) ?? '';
+		$widget_aspect_ratio       = $this->get_settings_for_display( 'aspect_ratio' ) ?? 'responsive';
+		$widget_seo_override       = 'yes' === $this->get_settings_for_display( 'seo_override' );
+		$widget_seo                = array(
 			'contentUrl'       => $this->get_settings_for_display( 'seo_content_url' ) ?? '',
 			'headline'         => $this->get_settings_for_display( 'seo_content_headline' ) ?? '',
 			'description'      => $this->get_settings_for_display( 'seo_content_description' ) ?? '',
@@ -528,6 +542,7 @@ class GoDAM_Video extends Base {
 		}
 
 		if ( ! isset( $widget_video_file['url'] ) || empty( $widget_video_file['url'] ) ) {
+			$this->render_empty_state();
 			return;
 		}
 
@@ -537,29 +552,131 @@ class GoDAM_Video extends Base {
 		$widget_attachment_id = isset( $widget_video_file['id'] ) ? $widget_video_file['id'] : null;
 
 		$attributes = array(
-			'id'              => $widget_attachment_id,
-			'sources'         => isset( $widget_video_file['sources'] ) ? $widget_video_file['sources'] : array(),
-			'src'             => $widget_video_file['url'],
-			'transcoded_url'  => '',
-			'poster'          => $widget_poster_file['url'],
-			'aspectRatio'     => $widget_aspect_ratio,
-			'autoplay'        => $widget_autoplay,
-			'controls'        => $widget_controls,
-			'muted'           => $widget_muted,
-			'loop'            => $widget_loop,
-			'caption'         => $widget_caption,
-			'tracks'          => $formatted_tracks,
-			'performanceMode' => $widget_performance_mode,
-			'hoverSelect'     => $widget_hover_select,
-			'showShareButton' => $widget_show_share_button,
-			'engagements'     => $widget_engagements,
-			'playerHeight'    => $widget_player_height,
-			'seo'             => $widget_seo,
-			'seoOverride'     => $widget_seo_override,
+			'id'                => $widget_attachment_id,
+			'sources'           => isset( $widget_video_file['sources'] ) ? $widget_video_file['sources'] : array(),
+			'src'               => $widget_video_file['url'],
+			'transcoded_url'    => '',
+			'poster'            => $widget_poster_file['url'],
+			'aspectRatio'       => $widget_aspect_ratio,
+			'autoplay'          => $widget_autoplay,
+			'controls'          => $widget_controls,
+			'muted'             => $widget_muted,
+			'loop'              => $widget_loop,
+			'caption'           => $widget_caption,
+			'tracks'            => $formatted_tracks,
+			'performanceMode'   => $widget_performance_mode,
+			'hoverSelect'       => $widget_hover_select,
+			'showShareButton'   => $widget_show_share_button,
+			'showTranscription' => $widget_show_transcription,
+			'engagements'       => $widget_engagements,
+			'playerHeight'      => $widget_player_height,
+			'seo'               => $widget_seo,
+			'seoOverride'       => $widget_seo_override,
 		);
 
 		$is_elementor_widget = true;
 
+		// In the Elementor editor preview only, overlay static share / transcript
+		// indicators on top of the player so they read as persistent top-right
+		// icons — matching the Gutenberg block editor. The live player only adds
+		// these to the video.js control bar and gates the transcript button on an
+		// actual transcript, so they wouldn't reliably show while designing. The
+		// published front end is unaffected (this branch never runs there).
+		if ( $this->is_editor_preview() && ( $widget_show_share_button || $widget_show_transcription ) ) {
+			ob_start();
+			require RTGODAM_PATH . 'inc/templates/godam-player.php';
+			$godam_player_html = ob_get_clean();
+			$this->render_editor_button_overlay( $godam_player_html, $widget_show_share_button, $widget_show_transcription );
+			return;
+		}
+
 		require RTGODAM_PATH . 'inc/templates/godam-player.php';
+	}
+
+	/**
+	 * Whether we're rendering inside the Elementor editor or its preview iframe.
+	 *
+	 * @return bool
+	 */
+	protected function is_editor_preview() {
+		if ( ! class_exists( '\Elementor\Plugin' ) ) {
+			return false;
+		}
+		$plugin = \Elementor\Plugin::$instance;
+		return ( isset( $plugin->editor ) && $plugin->editor->is_edit_mode() )
+			|| ( isset( $plugin->preview ) && $plugin->preview->is_preview_mode() );
+	}
+
+	/**
+	 * Wrap the player markup with static top-right share / transcript icons for
+	 * the editor preview (mirrors the Gutenberg block editor). Uses the same
+	 * icons as the block; styling is self-contained (the preview iframe doesn't
+	 * load the plugin's editor stylesheet) and printed once per request. The
+	 * live player's own control-bar buttons are hidden within this wrapper so
+	 * the two never duplicate.
+	 *
+	 * @param string $player_html        The rendered player markup.
+	 * @param bool   $show_share         Whether the share indicator should show.
+	 * @param bool   $show_transcription Whether the transcript indicator should show.
+	 * @return void
+	 */
+	protected function render_editor_button_overlay( $player_html, $show_share, $show_transcription ) {
+		$share_svg      = '<svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z" /></svg>';
+		$transcript_svg = '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M5 3.5h14a1.5 1.5 0 0 1 1.5 1.5v14a1.5 1.5 0 0 1-1.5 1.5H5A1.5 1.5 0 0 1 3.5 19V5A1.5 1.5 0 0 1 5 3.5Z" stroke="currentColor" stroke-width="1.6" /><path d="M7 8h10M7 12h10M7 16h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" /></svg>';
+
+		$overlay = '';
+		// Transcript sits on top; share moves below it when both are shown
+		// (mirrors the block editor's stacking order).
+		if ( $show_transcription ) {
+			$overlay .= '<span class="godam-elementor-video-overlay__btn godam-elementor-video-overlay__btn--transcript" aria-hidden="true">' . $transcript_svg . '</span>';
+		}
+		if ( $show_share ) {
+			$below    = $show_transcription ? ' godam-elementor-video-overlay__btn--below' : '';
+			$overlay .= '<span class="godam-elementor-video-overlay__btn godam-elementor-video-overlay__btn--share' . $below . '" aria-hidden="true">' . $share_svg . '</span>';
+		}
+
+		// Styling lives in the enqueued preview stylesheet
+		// (assets/src/css/godam-elementor-preview.scss).
+		echo '<div class="godam-elementor-video-overlay">' . $player_html . $overlay . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $player_html is plugin-generated escaped markup; $overlay is static plugin markup.
+	}
+
+	/**
+	 * Editor-only empty-state placeholder.
+	 *
+	 * Mirrors the Gutenberg block's empty state (a dummy video preview + prompt)
+	 * so a video-less widget reads clearly in the editor instead of showing a
+	 * bare, confusing box — consistent with the GoDAM Image / Audio / Gallery
+	 * widgets. Styling is enqueued into the preview iframe (see
+	 * Elementor_Widgets::enqueue_preview_styles / godam-elementor-preview.scss);
+	 * only the dynamic icon URL is passed inline via a CSS custom property.
+	 * Nothing renders on the front end.
+	 *
+	 * @access protected
+	 * @return void
+	 */
+	protected function render_empty_state() {
+		if ( ! class_exists( '\Elementor\Plugin' ) ) {
+			return;
+		}
+
+		$plugin        = \Elementor\Plugin::$instance;
+		$is_editing    = isset( $plugin->editor ) && $plugin->editor->is_edit_mode();
+		$is_previewing = isset( $plugin->preview ) && $plugin->preview->is_preview_mode();
+		if ( ! $is_editing && ! $is_previewing ) {
+			return;
+		}
+
+		$icon_style = '--godam-preview-icon:url(' . esc_url( RTGODAM_URL . 'assets/images/godam-video-filled.svg' ) . ');';
+		?>
+		<div class="godam-video-elementor-empty" data-test-id="godam-video-elementor-empty">
+			<div class="godam-video-elementor-empty__preview" aria-hidden="true" style="<?php echo esc_attr( $icon_style ); ?>"></div>
+			<h3 class="godam-video-elementor-empty__title">
+				<?php esc_html_e( 'Add Video Here', 'godam' ); ?>
+			</h3>
+			<p class="godam-video-elementor-empty__desc">
+				<?php esc_html_e( 'Select a video in the Player Settings panel to get started.', 'godam' ); ?>
+			</p>
+		</div>
+		<?php
 	}
 }


### PR DESCRIPTION
# Feat: GoDAM Video (Elementor) — transcription toggle, editor-preview parity, and a dedicated preview stylesheet

Issue - rtCamp/godam-plugin-wp#21

## Summary

Rounds out the GoDAM **Video** Elementor widget and cleans up the editor-preview styling shared by all GoDAM Elementor widgets. Highlights:

- Adds a **Show Transcription** toggle to the Video widget (both share + transcription now default **off**).
- Makes the **share** and **transcription** indicators render on the video **in the Elementor editor preview**, matching the Gutenberg block editor's persistent top-right icons.
- Gives the Video widget a proper **empty state** (consistent with Image / Audio / Gallery).
- Fixes the auto-generated **thumbnail picker** not appearing in the panel (timing bug).
- Extracts all Elementor editor-preview CSS out of inline `<style>` blocks into a **dedicated, built stylesheet** enqueued into the preview iframe.

## What changed

### Video widget — `inc/classes/elementor-widgets/class-godam-video.php`

- **New "Show Transcription" control** (`show_transcription`), mapped to the block's `showTranscription` attribute in the render array (the shared player template already reads it). Both `show_share_button` and `show_transcription` now **default to off** (`''`).
- **Editor-preview overlay:** in the Elementor editor/preview only, `render()` wraps the player and overlays static top-right **share** and **transcript** icons (same SVGs the Gutenberg block editor uses) when the respective toggle is on — transcript on top, share below it when both are on. The live player only adds these to the video.js control bar (and gates the transcript button on an actual transcript), so they wouldn't reliably show while designing; the static indicators guarantee parity with the block editor. The live control-bar buttons are hidden inside the preview wrapper so nothing duplicates. The published front end is untouched — it still uses the real player, and `showShareButton` / `showTranscription` are passed through to it.
- **Empty state:** an image-less… video-less widget now shows a dummy 16:9 video placeholder ("Add Video Here" + prompt) instead of a bare box, consistent with the other GoDAM widgets.
- New helpers: `is_editor_preview()` and `render_editor_button_overlay()`.

### Thumbnail picker fix — `assets/src/js/elementor/editor.js`

The "Or pick an auto-generated thumbnail" grid sometimes never populated. `hydrateWidget()` scheduled the render with a single `setTimeout(100)`, but Elementor injects the conditional RAW_HTML picker control into the panel DOM asynchronously — if it wasn't there at 100 ms, `renderThumbnailPicker()` bailed and nothing re-triggered it (a passive panel open fires no settings change). Replaced the fixed delay with a **bounded poll** (up to ~2 s) that waits for the container, then renders once, and bails if the panel has since switched widgets. Side benefit: videos with no auto-thumbnails now correctly show the "none available" message instead of a blank gap.

### Dedicated preview stylesheet — `assets/src/css/godam-elementor-preview.scss` (new)

Previously the editor-preview affordances (empty states + the video overlay) used inline `<style>` blocks / inline `style=""` attributes, because the widgets render inside Elementor's **preview iframe**, where the plugin's editor-panel stylesheet (`godam-elementor-editor.css`, enqueued in the editor's main window) isn't loaded.

Moved all of that CSS into a dedicated SCSS that auto-builds to `assets/build/css/godam-elementor-preview.css` (any non-`_` file in `assets/src/css/` is picked up by the webpack `styles` config — no config change needed), and enqueue it **into the preview iframe** via `elementor/preview/enqueue_styles`. It covers the video overlay and the image / gallery / audio / video empty states.

Dynamic icon URLs (which depend on `RTGODAM_URL`, so they can't be hard-coded in a static SCSS) are passed per-element via a `--godam-preview-icon` CSS custom property, which the SCSS consumes with `background-image: var(--godam-preview-icon)`.

### Enqueue + cleanup — `inc/classes/class-elementor-widgets.php`

- New `enqueue_preview_styles()` hooked to `elementor/preview/enqueue_styles` (guarded on the built file existing).

### Consistency cleanup across sibling widgets

Removed the inline `<style>` blocks / inline `style` attributes from the Image, Gallery, and Audio empty states (`class-godam-image.php`, `class-godam-gallery.php`, `class-godam-audio.php`) and pointed them at the new stylesheet + `--godam-preview-icon` property. No visual change — just the same styling from a maintainable, built source.

## Why static indicators instead of the live player buttons (editor only)

The live GoDAM player adds share/transcript to the video.js control bar and gates the transcript button on a fetched transcript (`data-job_id`) — reasonable at runtime, but it means the buttons don't reliably show while an author is designing. The block editor solves this with persistent static top-right icons; this PR mirrors that in the Elementor preview so the two editors look the same. Front-end rendering is unchanged.

## Build

The SCSS and `editor.js` changes require a build:

```
npm run build:js
```

`assets/build/**` is gitignored, so reviewers must rebuild locally. The PHP changes (widget controls, render, enqueue) don't need a build on their own, but the preview stylesheet + thumbnail-picker fix do.

## Testing

**Show Transcription + overlay parity (editor preview)**
1. Drop a GoDAM Video widget → **Show share button** and **Show transcription** are both **off** by default.
2. Turn **Show share button** on → share icon appears top-right of the video in the preview.
3. Turn **Show transcription** on (share off) → transcript icon top-right.
4. Both on → transcript icon on top, share icon below it.
5. Both off → no icons.
6. Publish / view front end → player behaves as before (real share button / transcript panel per the player, the site-wide "Enable global video share" setting, and transcript availability).

**Thumbnail picker**
7. Open a Video widget whose video has auto-generated thumbnails → the "Or pick an auto-generated thumbnail" grid fills; clicking a tile sets the poster.
8. A video with no auto-thumbnails → shows "No auto-generated thumbnails available…" instead of a blank gap.
9. Switch quickly between two video widgets → the correct grid shows for the open one.

**Preview stylesheet / other widgets**
10. Image / Audio / Gallery / Video empty states still render correctly in the Elementor preview (styling now comes from the enqueued stylesheet).
11. Confirm nothing new loads or renders on the published front end.

## Related

Part of the GoDAM page-builder rollout (Video, Video Gallery, Audio, Document, Image across WPBakery and Elementor).

## Demo


https://github.com/user-attachments/assets/0dbe8d82-d512-420f-acdd-df11bc22f7f9

