### PR TITLE
fix(analytics): give the date-range calendar its space, drop the dead panel width

### DIFF
--- a/pages/analytics/components/DateRangePicker/index.js
+++ b/pages/analytics/components/DateRangePicker/index.js
@@ -148,7 +148,13 @@ function monthGrid( viewDate ) {
 	const month = viewDate.getMonth();
 	const first = new Date( year, month, 1 );
 	const gridStartDay = 1 - first.getDay();
-	return Array.from( { length: 42 }, ( _, i ) => {
+	// Only the weeks the month actually touches (Figma). A fixed six-row grid
+	// renders a trailing row of next-month days on most months, which is dead
+	// space: e.g. July 2026 needs five rows and got a greyed-out "2..8" sixth.
+	// Day 0 of the next month is the last day of this one.
+	const daysInMonth = new Date( year, month + 1, 0 ).getDate();
+	const weeks = Math.ceil( ( first.getDay() + daysInMonth ) / 7 );
+	return Array.from( { length: weeks * 7 }, ( _, i ) => {
 		// Calendar arithmetic (not fixed-ms): keeps every cell at local
 		// midnight so a DST fall-back in the month can't drift later cells to
 		// 23:00 of the prior day (which would duplicate a day number and
@@ -175,7 +181,10 @@ const DateRangePicker = ( { value = {}, onChange, testIdPrefix = 'godam-analytic
 	return (
 		<Dropdown
 			className="godam-daterange-dropdown godam-period-dropdown"
-			popoverProps={ { placement: 'bottom-end' } }
+			// The class has to travel to the popover (portaled out of this
+			// subtree) so its default single-card chrome can be swapped for the
+			// two-panel Figma layout.
+			popoverProps={ { placement: 'bottom-end', className: 'godam-daterange-popover' } }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					variant="secondary"
@@ -365,6 +374,7 @@ const DateRangePanel = ( { value, activeKey, testIdPrefix, onSelect } ) => {
 					className="godam-daterange__custom-toggle"
 					isSelected={ showCalendar }
 					icon={ calendar }
+					iconPosition="left"
 					onClick={ () => setShowCalendar( true ) }
 					data-test-id={ `${ testIdPrefix }-custom` }
 				>
@@ -376,4 +386,4 @@ const DateRangePanel = ( { value, activeKey, testIdPrefix, onSelect } ) => {
 };
 
 export default DateRangePicker;
-export { PRESETS, spanDays, matchPreset, triggerLabelFor, toISO, fromISO };
+export { PRESETS, spanDays, matchPreset, triggerLabelFor, toISO, fromISO, monthGrid };

--- a/pages/analytics/components/DateRangePicker/index.test.js
+++ b/pages/analytics/components/DateRangePicker/index.test.js
@@ -12,6 +12,7 @@ import {
 	triggerLabelFor,
 	toISO,
 	fromISO,
+	monthGrid,
 } from './index';
 
 describe( 'DateRangePicker helpers', () => {
@@ -67,6 +68,34 @@ describe( 'DateRangePicker helpers', () => {
 			expect(
 				matchPreset( { startDate: '2020-01-01', endDate: '2020-01-05' } ),
 			).toBe( 'custom' );
+		} );
+	} );
+
+	describe( 'monthGrid', () => {
+		// Only the weeks the month actually touches, so no month renders a
+		// trailing row made entirely of next-month days.
+		it.each( [
+			[ 'July 2026 (Wed start, 31 days)', 2026, 6, 5, '2026-06-28', '2026-08-01' ],
+			[ 'August 2026 (Sat start, 31 days)', 2026, 7, 6, '2026-07-26', '2026-09-05' ],
+			[ 'February 2026 (Sun start, 28 days)', 2026, 1, 4, '2026-02-01', '2026-02-28' ],
+		] )( 'spans only the weeks touched by %s', ( _label, year, month, weeks, firstCell, lastCell ) => {
+			const grid = monthGrid( new Date( year, month, 1 ) );
+			expect( grid ).toHaveLength( weeks * 7 );
+			expect( toISO( grid[ 0 ].date ) ).toBe( firstCell );
+			expect( toISO( grid[ grid.length - 1 ].date ) ).toBe( lastCell );
+			// Every row starts on a Sunday, and the month's own days are flagged.
+			expect( grid[ 0 ].date.getDay() ).toBe( 0 );
+			expect( grid.filter( ( d ) => d.inMonth ) ).toHaveLength(
+				new Date( year, month + 1, 0 ).getDate(),
+			);
+		} );
+
+		it( 'never ends on a row of only next-month days', () => {
+			for ( let month = 0; month < 12; month++ ) {
+				const grid = monthGrid( new Date( 2026, month, 1 ) );
+				const lastRow = grid.slice( -7 );
+				expect( lastRow.some( ( d ) => d.inMonth ) ).toBe( true );
+			}
 		} );
 	} );
 

--- a/pages/analytics/components/DateRangePicker/style.scss
+++ b/pages/analytics/components/DateRangePicker/style.scss
@@ -3,16 +3,20 @@
  *
  * Reuses the shared `.godam-period-dropdown` toggle styling; adds the popover
  * body layout (custom calendar on the left, preset list on the right) matching
- * the Figma "Analytics Final" flow: two separate rounded panels side by side,
- * a 7 x 40px day grid, and a continuous shaded band across a selected range.
+ * the Figma "Analytics Final" flow: two separate rounded panels side by side, a
+ * 7 x 40px fixed-track day grid, and a continuous shaded band across a range.
  * Accent colour follows the WP admin scheme via `--wp-admin-theme-color`
  * (never a hard-coded brand value).
  */
 
-// Figma proportions: calendar panel ~312px, preset list ~188px, 8px apart.
+// Figma proportions: calendar panel ~314px, preset list ~188px, 8px apart. The
+// panels are border-box, so the calendar width has to carry its padding AND its
+// border for the seven columns to land on exact 40px pixel boundaries.
 $godam-daterange-cell: 40px;
 $godam-daterange-calendar-padding: 16px;
-$godam-daterange-calendar-width: ($godam-daterange-cell * 7) + ($godam-daterange-calendar-padding * 2);
+$godam-daterange-border-width: 1px;
+$godam-daterange-calendar-chrome: $godam-daterange-calendar-padding + $godam-daterange-border-width;
+$godam-daterange-calendar-width: ($godam-daterange-cell * 7) + ($godam-daterange-calendar-chrome * 2);
 $godam-daterange-presets-width: 188px;
 $godam-daterange-border: #e0e0e0;
 
@@ -42,7 +46,7 @@ $godam-daterange-border: #e0e0e0;
 		flex: 0 0 auto;
 		box-sizing: border-box;
 		background: #fff;
-		border: 1px solid $godam-daterange-border;
+		border: $godam-daterange-border-width solid $godam-daterange-border;
 		border-radius: 8px;
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
 	}
@@ -92,9 +96,11 @@ $godam-daterange-border: #e0e0e0;
 		color: #1e1e1e;
 	}
 
+	// Same fixed track width as the day grid below, so each label sits dead
+	// centre over its column instead of drifting on fractional `1fr` tracks.
 	&__weekdays {
 		display: grid;
-		grid-template-columns: repeat(7, 1fr);
+		grid-template-columns: repeat(7, $godam-daterange-cell);
 		margin-bottom: 8px;
 
 		span {
@@ -105,11 +111,13 @@ $godam-daterange-border: #e0e0e0;
 		}
 	}
 
-	// No column gap: range days have to butt up against each other so the
-	// shaded band reads as one continuous run (Figma), like the row bands.
+	// Fixed 40px tracks, not `1fr`: fractional track widths put the shaded
+	// range band's edges on sub-pixel boundaries, which shows up as hairlines
+	// between adjacent days. No column gap either, so the band reads as one
+	// continuous run (Figma), like the row bands.
 	&__grid {
 		display: grid;
-		grid-template-columns: repeat(7, 1fr);
+		grid-template-columns: repeat(7, $godam-daterange-cell);
 		row-gap: 8px;
 	}
 

--- a/pages/analytics/components/DateRangePicker/style.scss
+++ b/pages/analytics/components/DateRangePicker/style.scss
@@ -3,57 +3,114 @@
  *
  * Reuses the shared `.godam-period-dropdown` toggle styling; adds the popover
  * body layout (custom calendar on the left, preset list on the right) matching
- * the Figma "Analytics Final" flow. Accent colour follows the WP admin scheme
- * via `--wp-admin-theme-color` (never a hard-coded brand value).
+ * the Figma "Analytics Final" flow: two separate rounded panels side by side,
+ * a 7 x 40px day grid, and a continuous shaded band across a selected range.
+ * Accent colour follows the WP admin scheme via `--wp-admin-theme-color`
+ * (never a hard-coded brand value).
  */
+
+// Figma proportions: calendar panel ~312px, preset list ~188px, 8px apart.
+$godam-daterange-cell: 40px;
+$godam-daterange-calendar-padding: 16px;
+$godam-daterange-calendar-width: ($godam-daterange-cell * 7) + ($godam-daterange-calendar-padding * 2);
+$godam-daterange-presets-width: 188px;
+$godam-daterange-border: #e0e0e0;
+
+// The popover chrome is neutralised so the calendar and the preset list read as
+// two separate panels (Figma), each carrying its own border and shadow. The
+// padding keeps those shadows clear of the popover's own `overflow: auto` box,
+// which WP sets inline alongside the flip/shift max-height — and needs the
+// extra `.components-popover` class to outrank WP's own zero-padding rule.
+.components-popover.godam-daterange-popover .components-popover__content {
+	background: transparent;
+	box-shadow: none;
+	border-radius: 0;
+	padding: 4px;
+}
 
 .godam-daterange {
 	display: flex;
-	align-items: stretch;
+	align-items: flex-start;
+	gap: 8px;
 
-	// Preset list on the right, fixed comfortable width.
+	// Both columns are fixed-width and must never flex. WP sizes the popover
+	// content to `width: min-content`, so a shrinkable column collapses to its
+	// own min-content width: that is what squeezed the calendar down to ~140px
+	// (19px-wide day cells) while the preset list kept ~400px of dead space.
+	&__calendar,
 	&__presets {
-		min-width: 140px;
-		padding: 4px;
+		flex: 0 0 auto;
+		box-sizing: border-box;
+		background: #fff;
+		border: 1px solid $godam-daterange-border;
+		border-radius: 8px;
+		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+	}
+
+	// Preset list on the right, sized to its labels.
+	&__presets {
+		width: $godam-daterange-presets-width;
+		padding: 8px;
+
+		// WP floors every menu item at 160px and pushes a trailing icon to the
+		// far edge with `margin-right: auto`; both fight a fixed-width column.
+		.components-menu-item__item {
+			min-width: 0;
+		}
+
+		// Figma spaces the preset rows more generously than the WP default.
+		.components-menu-item__button {
+			min-height: 40px;
+		}
 	}
 
 	// Calendar sits to the left of the presets when custom mode is open.
 	&__calendar {
-		padding: 12px;
-		border-right: 1px solid #e0e0e0;
-		width: 300px;
+		width: $godam-daterange-calendar-width;
+		padding: $godam-daterange-calendar-padding;
 	}
 
 	&__cal-head {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		margin-bottom: 8px;
+		margin-bottom: 12px;
+
+		// Figma frames both month steppers in a bordered 30px square.
+		.components-button.has-icon {
+			width: 30px;
+			height: 30px;
+			min-width: 30px;
+			border: 1px solid $godam-daterange-border;
+			border-radius: 6px;
+		}
 	}
 
 	&__cal-title {
 		font-weight: 600;
-		font-size: 13px;
+		font-size: 14px;
+		color: #1e1e1e;
 	}
 
 	&__weekdays {
 		display: grid;
 		grid-template-columns: repeat(7, 1fr);
-		gap: 2px;
-		margin-bottom: 4px;
+		margin-bottom: 8px;
 
 		span {
 			text-align: center;
-			font-size: 11px;
+			font-size: 12px;
 			color: #757575;
 			padding: 4px 0;
 		}
 	}
 
+	// No column gap: range days have to butt up against each other so the
+	// shaded band reads as one continuous run (Figma), like the row bands.
 	&__grid {
 		display: grid;
 		grid-template-columns: repeat(7, 1fr);
-		gap: 2px;
+		row-gap: 8px;
 	}
 
 	&__day {
@@ -62,9 +119,9 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-size: 12px;
-		height: 32px;
-		border-radius: 4px;
+		font-size: 13px;
+		height: 36px;
+		border-radius: 6px;
 		cursor: pointer;
 		color: #1e1e1e;
 
@@ -76,7 +133,9 @@
 			outline-offset: 1px;
 		}
 
-		&:hover:not(.is-disabled) {
+		// Endpoints are excluded: their label is white, and a 12% tint behind it
+		// is unreadable, so hovering a selected day used to blank out its number.
+		&:hover:not(.is-disabled):not(.is-endpoint) {
 			background: color-mix(in srgb, var(--wp-admin-theme-color, #3a58bf) 12%, transparent);
 		}
 
@@ -99,12 +158,17 @@
 		&.is-endpoint {
 			background: var(--wp-admin-theme-color, #3a58bf);
 			color: #fff;
-			border-radius: 4px;
+			border-radius: 6px;
+
+			// Darken instead of tinting, so the white label keeps its contrast.
+			&:hover {
+				background: color-mix(in srgb, var(--wp-admin-theme-color, #3a58bf) 85%, #000);
+			}
 		}
 	}
 
 	&__custom-toggle {
-		border-top: 1px solid #e0e0e0;
+		border-top: 1px solid $godam-daterange-border;
 		margin-top: 4px;
 	}
 }


### PR DESCRIPTION
## What

The shared analytics date-range popover rendered nothing like the Figma [Analytics Final](https://www.figma.com/design/lCOpmaeciZ1x65qyhBJ9NO/?node-id=746-6186) flow. The calendar was squeezed to ~140px (19px-wide day cells, effectively unreadable) while the preset list sat at ~405px with most of it blank, the "Date Range" icon pushed to the far edge.

`DateRangePicker` is one component used on nine surfaces, so this fixes all of them at once.

## Why it happened

WP sizes `.components-popover__content` to `width: min-content`, and neither column in `.godam-daterange` was pinned:

| column | min-content | max-content | rendered |
|---|---|---|---|
| calendar | 141px | 300px | **141px** |
| presets | 238px | 974px | **405px** |

The preset list's min-content width is large (WP floors `.components-menu-item__item` at 160px and pushes trailing icons out with `margin-right: auto`), so with `min-content` sizing the calendar absorbed the whole shortfall and collapsed.

## What changed

Both columns are now fixed and non-shrinking, so the popover width is deterministic wherever it renders: calendar **314px**, presets **188px**, 8px apart as two rounded panels per the design. The day grid and weekday header run on fixed `repeat(7, 40px)` tracks and the calendar width carries its padding plus border, so every cell lands on an exact pixel boundary (measured: cell offsets `0, 40, 80 ... 240`, weekday-centre delta `0.000px`). Fractional `1fr` tracks put the range band's edges on sub-pixels, which shows as hairlines between adjacent days.

- day grid drops its column gap, so a selected range paints one continuous band instead of stripes
- month grid renders only the weeks the month touches; a trailing all-next-month row was dead space (Figma shows five rows for a five-row month)
- `Date Range` icon moves to the left of its label, as designed
- hovering a selected endpoint no longer paints a 12% tint over it, which left the white day number unreadable (pre-existing contrast bug)
- month steppers get the bordered square frame from the design

No markup, props, data-test-ids, or query behaviour changed. Accent colours still follow `--wp-admin-theme-color`.

## Testing

Verified live on `godam-dev.local` (Chrome, 1470px viewport) by opening every picker instance and measuring the rendered geometry. All ten report popover 518px / calendar 314px / presets 188px, no clipping and no scrollbars:

- Dashboard: viewers gauge, insights, playback performance, top videos, Reel Pops section
- Per-video analytics: insights, viewer retention, placements, video layer timeline, playback performance

The Reel Pops section picker is the `godam-for-woo` consumer that borrows this component through `window.GoDAM`, so the cross-plugin path is covered by the same verification.

Unit tests: `monthGrid` is now exported and covered for a 4-week month (Feb 2026), a 5-week month (Jul 2026) and a 6-week month (Aug 2026), plus an invariant that no month ends on a row of only next-month days. 12 tests pass; `lint:js` and `lint:css` clean.

## Automation impact

`data-test-id` hooks are unchanged (`*-toggle`, `*-panel`, `*-preset-<key>`, `*-custom`). Suites that assert a fixed 42 day cells need updating to the per-month week count.

## Screenshots

<img width="2324" height="878" alt="image" src="https://github.com/user-attachments/assets/799d3406-bf00-4827-9a10-7ab5adfca6cb" />