### PR TITLE
Fix the GoDAM Media Library breaking issues

### DIFF
--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -1,5 +1,3 @@
-/* global jQuery */
-
 /**
  * WordPress dependencies
  */
@@ -26,8 +24,6 @@ import MediaDateRangeFilter from './views/filters/media-date-range-filter-list-v
 import MediaListViewTableDragHandler from './views/attachment-list.js';
 
 import { isFolderOrgDisabled, isUploadPage, addManageMediaButton } from './utility.js';
-
-const $ = jQuery;
 
 /**
  * Destroys all Video.js player instances found within a given DOM element.
@@ -60,12 +56,12 @@ function destroyVideoJSPlayersInContainer( container ) {
 }
 
 /**
- * Elementor renders its media-frame menu asynchronously, so poll for it before
- * mounting the folder sidebar. MAX_ATTEMPTS × RETRY_DELAY_MS (≈ 2s) covers the
- * frame render without spinning indefinitely.
+ * Media frames render their menu asynchronously (the Elementor editor especially),
+ * so poll for it before mounting the folder sidebar. MAX_ATTEMPTS × RETRY_DELAY_MS
+ * (≈ 2s) covers the frame render without spinning indefinitely.
  */
-const ELEMENTOR_MENU_MAX_ATTEMPTS = 40;
-const ELEMENTOR_MENU_RETRY_DELAY_MS = 50;
+const MEDIA_FRAME_MENU_MAX_ATTEMPTS = 40;
+const MEDIA_FRAME_MENU_RETRY_DELAY_MS = 50;
 
 /**
  * Inject the folder-sidebar root into a media frame's menu and tell the React
@@ -105,40 +101,54 @@ function initializeMediaLibrarySidebar( frame ) {
 				document.dispatchEvent( new CustomEvent( 'media-frame-opened', { detail: { root: div } } ) );
 				return;
 			}
-			if ( attempts < ELEMENTOR_MENU_MAX_ATTEMPTS ) {
+			if ( attempts < MEDIA_FRAME_MENU_MAX_ATTEMPTS ) {
 				attempts++;
-				setTimeout( mountElementorSidebar, ELEMENTOR_MENU_RETRY_DELAY_MS );
+				setTimeout( mountElementorSidebar, MEDIA_FRAME_MENU_RETRY_DELAY_MS );
 			}
 		};
 		mountElementorSidebar();
 		return;
 	}
 
-	/**
-	 * Non-Elementor (WP admin / block editor) — unchanged. A timeout lets the
-	 * media frame finish rendering before injecting the root + dispatching.
-	 */
-	setTimeout( () => {
-		$( '.media-frame' ).removeClass( 'hide-menu' );
-
-		const visibleFrames = Array.from( document.querySelectorAll( '.media-frame' ) ).filter(
-			( mediaFrame ) => getComputedStyle( mediaFrame ).display !== 'none',
-		);
-
-		const activeFrame = visibleFrames[ visibleFrames.length - 1 ]; // most recently opened visible one
-
-		if ( activeFrame ) {
-			const menu = activeFrame.querySelector( '.media-frame-menu .media-menu' );
-			if ( menu ) {
-				menu.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( el ) => el.remove() );
-				const div = document.createElement( 'div' );
-				div.id = 'rt-transcoder-media-library-root';
-				menu.appendChild( div );
-			}
+	// Non-Elementor (WP admin / block editor / classic editor). Mount into THIS
+	// frame's own menu, retrying until it renders, then hand the exact root to the
+	// React app. The previous single 100ms timer + "last visible .media-frame" guess
+	// was racy: it fired before the menu existed, targeted the wrong frame when the
+	// grid and a picker coexisted, and — because it only ran on `initialize` — never
+	// re-ran when a reused frame was closed and reopened, so the folder sidebar
+	// vanished on the second open of the media-selector popup.
+	let attempts = 0;
+	const mountSidebar = () => {
+		const menu = frame.$el.find( '.media-frame-menu .media-menu' ).get( 0 );
+		if ( menu ) {
+			frame.$el.removeClass( 'hide-menu' );
+			menu.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( el ) => {
+				// Unmount a stale React root before discarding its node so repeated
+				// open/close cycles don't leak detached roots.
+				if ( el._reactRoot ) {
+					try {
+						el._reactRoot.unmount();
+					} catch ( e ) {
+						// Ignore unmount errors for an already-torn-down root.
+					}
+					el._reactRoot = null;
+				}
+				el.remove();
+			} );
+			const div = document.createElement( 'div' );
+			div.id = 'rt-transcoder-media-library-root';
+			menu.appendChild( div );
+			// Pass the exact root so the React app renders into THIS frame's sidebar
+			// instead of guessing which frame is active.
+			document.dispatchEvent( new CustomEvent( 'media-frame-opened', { detail: { root: div } } ) );
+			return;
 		}
-
-		document.dispatchEvent( new CustomEvent( 'media-frame-opened' ) );
-	}, 100 );
+		if ( attempts < MEDIA_FRAME_MENU_MAX_ATTEMPTS ) {
+			attempts++;
+			setTimeout( mountSidebar, MEDIA_FRAME_MENU_RETRY_DELAY_MS );
+		}
+	};
+	mountSidebar();
 }
 
 /**
@@ -271,8 +281,11 @@ class MediaLibrary {
 					// Initialize GoDAM functionality
 					this.on( 'content:render:godam', this.GoDAMCreate, this );
 
-					// Initialize sidebar immediately
-					initializeMediaLibrarySidebar( this );
+					// Mount the folder sidebar on every open, not just construction.
+					// The frame is reused across opens (initialize runs once), and the
+					// modal-close cleanup unmounts the sidebar's React root — so binding
+					// to `open` is what restores the sidebar when the popup is reopened.
+					this.on( 'open', () => initializeMediaLibrarySidebar( this ) );
 				},
 
 				// Include all other GoDAM methods from the shared object
@@ -290,7 +303,11 @@ class MediaLibrary {
 					// Initialize GoDAM functionality
 					this.on( 'content:render:godam', this.GoDAMCreate, this );
 
-					initializeMediaLibrarySidebar( this );
+					// Mount the folder sidebar on every open, not just construction.
+					// The frame is reused across opens (initialize runs once), and the
+					// modal-close cleanup unmounts the sidebar's React root — so binding
+					// to `open` is what restores the sidebar when the popup is reopened.
+					this.on( 'open', () => initializeMediaLibrarySidebar( this ) );
 				},
 
 				// Include all other GoDAM methods from the shared object

--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -4,13 +4,9 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * External dependencies
- */
-import videojs from 'video.js';
-
-/**
  * Internal dependencies
  */
+import { getLoadedVideoJs } from './videojs-loader.js';
 import '../../libs/jquery-ui-1.14.2.draggable/jquery-ui';
 import './transcoding-status';
 
@@ -36,6 +32,10 @@ import { isFolderOrgDisabled, isUploadPage, addManageMediaButton } from './utili
  * @param {HTMLElement} container - The DOM element to search for Video.js players.
  */
 function destroyVideoJSPlayersInContainer( container ) {
+	// Only relevant if Video.js was actually loaded (i.e. a player was created this
+	// session). If it was never loaded there are no Video.js players to dispose.
+	const videojs = getLoadedVideoJs();
+
 	if ( ! container || ! videojs ) {
 		return;
 	}
@@ -92,6 +92,10 @@ function initializeMediaLibrarySidebar( frame ) {
 				menu.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( el ) => el.remove() );
 				const div = document.createElement( 'div' );
 				div.id = 'rt-transcoder-media-library-root';
+				// Keep a per-frame reference to the wp.media frame on its own root,
+				// so the React sidebar can filter THIS frame's collection directly
+				// (via Backbone props) instead of poking shared grid-only DOM.
+				div._godamFrame = frame;
 				// Append into the menu's first element child (the .media-menu
 				// container). firstChild could be a whitespace text node, which
 				// cannot take children and would throw a HierarchyRequestError.
@@ -137,6 +141,10 @@ function initializeMediaLibrarySidebar( frame ) {
 			} );
 			const div = document.createElement( 'div' );
 			div.id = 'rt-transcoder-media-library-root';
+			// Keep a per-frame reference to the wp.media frame on its own root, so
+			// the React sidebar can filter THIS frame's collection directly (via
+			// Backbone props) instead of poking shared grid-only DOM.
+			div._godamFrame = frame;
 			menu.appendChild( div );
 			// Pass the exact root so the React app renders into THIS frame's sidebar
 			// instead of guessing which frame is active.

--- a/assets/src/js/media-library/videojs-loader.js
+++ b/assets/src/js/media-library/videojs-loader.js
@@ -1,0 +1,46 @@
+/**
+ * Lazy loader for Video.js in the media library.
+ *
+ * Video.js is a large dependency but is only needed inside the media library when a
+ * (virtual/GoDAM proxy) video attachment's detail panel is opened — which most sessions
+ * never do. Statically importing it pulled the whole library into the always-loaded
+ * media-library bundle. Loading it through a dynamic `import()` splits it into its own
+ * async chunk (webpackChunkName "videojs") that is fetched on demand and then cached, so
+ * the base bundle stays small.
+ */
+
+let cachedVideojs = null;
+let loadingPromise = null;
+
+/**
+ * Dynamically load (and cache) Video.js.
+ *
+ * @return {Promise<Function>} Resolves with the videojs factory function.
+ */
+export function loadVideoJs() {
+	if ( cachedVideojs ) {
+		return Promise.resolve( cachedVideojs );
+	}
+
+	if ( ! loadingPromise ) {
+		loadingPromise = import( /* webpackChunkName: "videojs" */ 'video.js' ).then( ( mod ) => {
+			cachedVideojs = mod.default || mod;
+			return cachedVideojs;
+		} );
+	}
+
+	return loadingPromise;
+}
+
+/**
+ * Synchronously return the already-loaded Video.js, or null if it hasn't been loaded yet.
+ *
+ * Use this where Video.js is only relevant if a player already exists (e.g. cleanup, or
+ * updating a poster on a player that must have been created earlier): if it was never
+ * loaded, there is nothing to act on and the caller can safely skip.
+ *
+ * @return {Function|null} The videojs factory, or null when not yet loaded.
+ */
+export function getLoadedVideoJs() {
+	return cachedVideojs;
+}

--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import DOMPurify from 'isomorphic-dompurify';
-import videojs from 'video.js';
 /**
  * WordPress dependencies
  */
@@ -15,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { addIcon, trashIcon, editIcon, barChartIcon } from '../media-library-icons';
 import { canManageAttachment } from '../utility';
+import { loadVideoJs, getLoadedVideoJs } from '../videojs-loader.js';
 
 const AttachmentDetailsTwoColumn = wp?.media?.view?.Attachment?.Details?.TwoColumn;
 
@@ -536,8 +536,10 @@ export default AttachmentDetailsTwoColumn?.extend( {
 		const virtual = this.model.get( 'virtual' );
 
 		// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
-		if ( undefined !== virtual && virtual ) {
-			const videoPlayer = videojs( 'videojs-player-' + this.model.get( 'id' ) );
+		// The player was created earlier, so Video.js is already loaded and cached here.
+		const posterVideojs = getLoadedVideoJs();
+		if ( undefined !== virtual && virtual && posterVideojs ) {
+			const videoPlayer = posterVideojs( 'videojs-player-' + this.model.get( 'id' ) );
 			videoPlayer.poster( selected );
 		}
 
@@ -709,8 +711,10 @@ export default AttachmentDetailsTwoColumn?.extend( {
 				const virtual = model.get( 'virtual' );
 
 				// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
-				if ( undefined !== virtual && virtual ) {
-					const videoPlayer = videojs( 'videojs-player-' + model.get( 'id' ) );
+				// The player was created earlier, so Video.js is already loaded and cached here.
+				const posterVideojs = getLoadedVideoJs();
+				if ( undefined !== virtual && virtual && posterVideojs ) {
+					const videoPlayer = posterVideojs( 'videojs-player-' + model.get( 'id' ) );
 					videoPlayer.poster( thumbnailURL );
 				}
 
@@ -1002,9 +1006,25 @@ export default AttachmentDetailsTwoColumn?.extend( {
 				` );
 
 				// Wait for DOM to fully render the core preview container.
-				setTimeout( () => {
+				setTimeout( async () => {
 					const videoElement = document.getElementById( videoId );
-					if ( videoElement && typeof videojs !== 'undefined' ) {
+					if ( ! videoElement ) {
+						return;
+					}
+
+					// Lazy-load Video.js only now that a video player is actually needed.
+					// Guard the async import: if the chunk fails to load (stale cache after an
+					// update, network hiccup) don't leave an unhandled rejection.
+					let videojs = null;
+					try {
+						videojs = await loadVideoJs();
+					} catch ( e ) {
+						return;
+					}
+
+					// The modal may have closed while the chunk was loading — re-check the
+					// element is still attached before initialising a player on it.
+					if ( videojs && videoElement.isConnected ) {
 						// Calculate initial dimensions using 16:9 aspect ratio as default
 						const viewContainer = this.$el.closest( '.media-modal-content' ).find( '.attachment-media-view' );
 						const availableWidth = viewContainer.length ? viewContainer.width() : window.innerWidth * 0.65;

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -318,7 +318,14 @@ class Assets {
 		}
 
 		wp_set_script_translations( 'easydam-media-library', 'godam', RTGODAM_PATH . 'languages' );
-		wp_enqueue_script( 'easydam-media-library' );
+
+		// Only load the heavy media-library bundle (~2.65 MB, bundles video.js) where the
+		// media library / wp.media modal is actually used. It was previously enqueued on
+		// every admin screen. Registration + localization above stay unconditional (cheap,
+		// and inert unless the handle is enqueued).
+		if ( godam_should_load_media_library_assets( $screen ) ) {
+			wp_enqueue_script( 'easydam-media-library' );
+		}
 
 		/**
 		 * Dependency library for the date range picker. Its only consumers (the media-library

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -1227,6 +1227,13 @@ class Pages {
 
 		wp_enqueue_style( 'wp-components' );
 
+		// The media-library React sidebar bundle (~1.1 MB) is the remaining work in this
+		// method; skip it on screens that never open the media library / wp.media modal.
+		// It was previously enqueued on every admin screen.
+		if ( ! godam_should_load_media_library_assets( $screen ) ) {
+			return;
+		}
+
 		// The bundle externalizes several @wordpress packages to wp.* globals
 		// (see the `pages` externals in webpack.config.js). On WP admin / the
 		// block editor these globals are already present, but in other contexts
@@ -1236,9 +1243,13 @@ class Pages {
 		// only the handles actually registered in the current context: a handle
 		// missing on older WP / non-standard admin screens would otherwise block
 		// the enqueue entirely.
+		// `media-views` is included so the bundle's modal-close hook (which patches
+		// wp.media.view.Modal in pages/media-library/index.js) has wp.media defined by the
+		// time it runs — otherwise the ordering is incidental and the hook can silently
+		// no-op, leaving React roots unmounted and UI state un-reset.
 		$media_library_deps = array_values(
 			array_filter(
-				array( 'wp-element', 'wp-i18n', 'wp-components', 'wp-api-fetch', 'wp-primitives', 'wp-data', 'wp-notices' ),
+				array( 'wp-element', 'wp-i18n', 'wp-components', 'wp-api-fetch', 'wp-primitives', 'wp-data', 'wp-notices', 'media-views' ),
 				static function ( $handle ) {
 					return wp_script_is( $handle, 'registered' );
 				}

--- a/inc/classes/media-library/class-media-folder-create-zip.php
+++ b/inc/classes/media-library/class-media-folder-create-zip.php
@@ -161,6 +161,9 @@ class Media_Folder_Create_Zip {
 			}
 		}
 
+		// Harden the directory: prevent listing/enumeration of the generated archives.
+		$this->protect_godam_dir( $godam_dir );
+
 		// Full path to the ZIP file.
 		$zip_path = $godam_dir . '/' . $zip_name;
 
@@ -353,14 +356,60 @@ class Media_Folder_Create_Zip {
 			gc_collect_cycles();
 		}
 
-		if ( function_exists( 'wp_cache_flush' ) ) {
-			wp_cache_flush();
+		// Free only the in-memory (runtime) object cache that accumulates while iterating
+		// attachments — NOT the entire persistent site cache. The previous wp_cache_flush()
+		// flushed every group in the object cache (hurting every other request on the site)
+		// just to reclaim memory for one download. wp_cache_flush_runtime() (WP 6.0+) drops
+		// the runtime cache without touching the persistent backend; on older WP we rely on
+		// gc_collect_cycles() plus the memory-threshold guard in the batch loop.
+		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+			wp_cache_flush_runtime();
+		}
+	}
+
+	/**
+	 * Harden the uploads/godam directory against enumeration.
+	 *
+	 * The generated ZIPs are static files served from this directory. A blank index.php
+	 * stops a visitor from listing the directory to discover archive filenames on both
+	 * Apache and nginx; combined with the random token in each ZIP name, direct guessing
+	 * becomes infeasible. (We deliberately do NOT write an `.htaccess` with
+	 * `Options -Indexes`: it's a no-op on nginx and, on Apache configs where AllowOverride
+	 * excludes Options, it 500s the whole directory — breaking the very downloads it would
+	 * protect. The index.php alone is enough.) The file is only written when missing.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $dir Absolute path to the godam upload directory.
+	 * @return void
+	 */
+	private function protect_godam_dir( $dir ) {
+		global $wp_filesystem;
+
+		if ( empty( $wp_filesystem ) || ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+
+			// WP_Filesystem() returns false when a non-direct transport needs credentials —
+			// but can still leave a non-connected object in $wp_filesystem, so gate on its
+			// return value rather than on emptiness of the global.
+			if ( ! WP_Filesystem() ) {
+				return;
+			}
+		}
+
+		if ( empty( $wp_filesystem ) || ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
+			return;
+		}
+
+		$index = trailingslashit( $dir ) . 'index.php';
+		if ( ! $wp_filesystem->exists( $index ) ) {
+			$wp_filesystem->put_contents( $index, "<?php\n// Silence is golden.\n", FS_CHMOD_FILE );
 		}
 	}
 
 	/**
 	 * Cleanup the ZIP file after a scheduled time.
-	 * 
+	 *
 	 * @since 1.3.0
 	 *
 	 * @param string $zip_path The path to the ZIP file to be cleaned up.

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -27,6 +27,147 @@ class Media_Library extends Base {
 	protected $rest_base = 'media-library';
 
 	/**
+	 * Setup hooks.
+	 *
+	 * Adds the base REST-route registration plus a server-side guard that enforces
+	 * folder "locked" state on the NATIVE wp/v2/media-folder term endpoints (rename,
+	 * delete, re-parent, create-under). Locking was previously enforced only in React,
+	 * so a direct REST call could still mutate a locked folder.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+		parent::setup_hooks();
+
+		add_filter( 'rest_pre_dispatch', array( $this, 'enforce_locked_media_folder' ), 10, 3 );
+
+		// Background builder for folder-ZIP downloads (see download_folder()). Runs via
+		// Action Scheduler when available, otherwise WP-Cron — both invoke this hook.
+		add_action( 'godam_build_folder_zip', array( $this, 'run_folder_zip_job' ), 10, 1 );
+	}
+
+	/**
+	 * Reject mutating REST requests against locked media-folder terms.
+	 *
+	 * Runs before dispatch on the native taxonomy routes:
+	 *   - POST/PUT/PATCH /wp/v2/media-folder/{id}  → rename / re-parent an existing folder
+	 *   - DELETE         /wp/v2/media-folder/{id}  → delete an existing folder
+	 *   - POST           /wp/v2/media-folder       → create a folder (blocked only when the
+	 *                                                target parent is locked, i.e. populating it)
+	 * Reads (GET) are always allowed — locking protects against modification, not viewing.
+	 *
+	 * @param mixed            $result  Pre-dispatch result (non-null short-circuits the request).
+	 * @param \WP_REST_Server  $server  Server instance (unused).
+	 * @param \WP_REST_Request $request The request being dispatched.
+	 * @return mixed Original $result, or a 403 WP_Error when the target folder is locked.
+	 */
+	public function enforce_locked_media_folder( $result, $server, $request ) {
+		// Let an already short-circuited result (e.g. another plugin's error) stand.
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		// Only guard the native media-folder collection or a single term.
+		if ( ! preg_match( '#^/wp/v2/media-folder(?:/(\d+))?$#', $request->get_route(), $matches ) ) {
+			return $result;
+		}
+
+		// Only mutating verbs.
+		if ( ! in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true ) ) {
+			return $result;
+		}
+
+		$term_id = isset( $matches[1] ) ? (int) $matches[1] : 0;
+
+		// Renaming / re-parenting / deleting a locked folder (or a child of one). A
+		// bookmark toggle is a personal flag rather than a modification of the folder's
+		// protected content, so it is still allowed on a locked folder.
+		if ( $term_id > 0 && $this->is_folder_locked( $term_id ) && ! $this->is_bookmark_only_folder_update( $request, $term_id ) ) {
+			return new \WP_Error(
+				'godam_folder_locked',
+				__( 'This folder is locked and cannot be modified.', 'godam' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Creating or moving a folder INTO a locked destination (populating it).
+		if ( 'DELETE' !== $request->get_method() ) {
+			$new_parent = $request->get_param( 'parent' );
+
+			if ( ! is_null( $new_parent ) && (int) $new_parent > 0 && $this->is_folder_locked( (int) $new_parent ) ) {
+				return new \WP_Error(
+					'godam_folder_locked',
+					__( 'The destination folder is locked and cannot be modified.', 'godam' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Whether a native media-folder update request only toggles the `bookmark` meta and
+	 * changes nothing else (name, slug, description, parent, or the `locked` meta itself).
+	 *
+	 * Bookmarking is a per-user convenience flag, not a modification of the folder's
+	 * protected content, so it stays allowed on a locked folder — but this must NOT become
+	 * a hole through which a locked folder is renamed, re-parented, or unlocked.
+	 *
+	 * @param \WP_REST_Request $request The request being dispatched.
+	 * @param int              $term_id The media-folder term id.
+	 * @return bool True if the request only changes the bookmark meta.
+	 */
+	private function is_bookmark_only_folder_update( $request, $term_id ) {
+		if ( 'DELETE' === $request->get_method() ) {
+			return false;
+		}
+
+		$term = get_term( $term_id, 'media-folder' );
+
+		if ( ! $term || is_wp_error( $term ) ) {
+			return false;
+		}
+
+		// Any change to the folder's own fields disqualifies it.
+		$name = $request->get_param( 'name' );
+		if ( ! is_null( $name ) && (string) $name !== (string) $term->name ) {
+			return false;
+		}
+
+		$slug = $request->get_param( 'slug' );
+		if ( ! is_null( $slug ) && (string) $slug !== (string) $term->slug ) {
+			return false;
+		}
+
+		$description = $request->get_param( 'description' );
+		if ( ! is_null( $description ) && (string) $description !== (string) $term->description ) {
+			return false;
+		}
+
+		$parent = $request->get_param( 'parent' );
+		if ( ! is_null( $parent ) && (int) $parent !== (int) $term->parent ) {
+			return false;
+		}
+
+		// The lock state itself must not change through this path (unlocking is a
+		// capability-gated operation handled by the bulk-lock endpoint).
+		$meta = $request->get_param( 'meta' );
+		if ( is_array( $meta ) && array_key_exists( 'locked', $meta ) ) {
+			$current_locked = get_term_meta( $term_id, 'locked', true );
+			$current_bool   = ( '1' === (string) $current_locked || 1 === $current_locked || true === $current_locked || 'true' === $current_locked );
+			$requested      = $meta['locked'];
+			$requested_bool = ( true === $requested || 1 === $requested || '1' === (string) $requested || 'true' === $requested );
+
+			if ( $current_bool !== $requested_bool ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Register custom REST API routes for Settings Pages.
 	 *
 	 * @return array Array of registered REST API routes
@@ -173,14 +314,35 @@ class Media_Library extends Base {
 				'args'      => array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'download_folder' ),
+					// Requires upload_files (Author+): generating a ZIP aggregates an entire
+					// folder's media into a downloadable archive, so Contributors (edit_posts
+					// only) must not be able to trigger it.
 					'permission_callback' => function () {
-						return current_user_can( 'edit_posts' );
+						return current_user_can( 'upload_files' );
 					},
 					'args'                => array(
 						'folder_id' => array(
 							'required'    => true,
 							'type'        => 'integer',
 							'description' => __( 'ID of the folder to create a ZIP file for.', 'godam' ),
+						),
+					),
+				),
+			),
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/download-folder-status/(?P<job_id>[A-Za-z0-9]+)',
+				'args'      => array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_folder_zip_status' ),
+					'permission_callback' => function () {
+						return current_user_can( 'upload_files' );
+					},
+					'args'                => array(
+						'job_id' => array(
+							'required'    => true,
+							'type'        => 'string',
+							'description' => __( 'ID of the ZIP build job to poll.', 'godam' ),
 						),
 					),
 				),
@@ -599,6 +761,55 @@ class Media_Library extends Base {
 		$attachment_ids = $request->get_param( 'attachment_ids' );
 		$folder_term_id = $request->get_param( 'folder_term_id' );
 
+		// IDOR guard: this route is gated only by the broad `edit_posts` capability, which
+		// does NOT prove the caller may edit these specific objects. Before touching any
+		// terms — in either the assign or the remove-from-folder path — verify every ID is
+		// genuinely an attachment and that the current user can edit that object. Without
+		// this, a user could move (or strip folders from) media they do not own, and the
+		// remove path would act on raw IDs of arbitrary post types.
+		if ( empty( $attachment_ids ) || ! is_array( $attachment_ids ) ) {
+			return new \WP_Error( 'invalid_attachment', __( 'No attachment IDs provided.', 'godam' ), array( 'status' => 400 ) );
+		}
+
+		// Prime the post + object-term caches once so the per-id checks below don't each
+		// hit the database (a large drag-move otherwise fired hundreds of queries).
+		_prime_post_caches( $attachment_ids );
+		update_object_term_cache( $attachment_ids, 'attachment' );
+
+		foreach ( $attachment_ids as $attachment_id ) {
+			if ( 'attachment' !== get_post_type( $attachment_id ) ) {
+				return new \WP_Error( 'invalid_attachment', __( 'Invalid attachment ID.', 'godam' ), array( 'status' => 400 ) );
+			}
+
+			if ( ! current_user_can( 'edit_post', $attachment_id ) ) {
+				return new \WP_Error(
+					'rest_forbidden',
+					__( 'You are not allowed to modify one or more of these attachments.', 'godam' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
+		// Moving an attachment OUT of a locked folder empties that (protected) folder —
+		// whether by removing it (folder 0) or by re-assigning it to a different folder,
+		// since wp_set_object_terms() replaces the assignment. Reject if any attachment
+		// currently lives in a locked folder other than the destination.
+		foreach ( $attachment_ids as $attachment_id ) {
+			$current_folders = wp_get_object_terms( $attachment_id, 'media-folder', array( 'fields' => 'ids' ) );
+
+			if ( is_array( $current_folders ) ) {
+				foreach ( $current_folders as $current_folder_id ) {
+					if ( (int) $current_folder_id !== (int) $folder_term_id && $this->is_folder_locked( $current_folder_id ) ) {
+						return new \WP_Error(
+							'godam_folder_locked',
+							__( 'One or more attachments belong to a locked folder and cannot be moved.', 'godam' ),
+							array( 'status' => 403 )
+						);
+					}
+				}
+			}
+		}
+
 		// if folder id is 0, remove the folder from the attachments.
 		if ( 0 === $folder_term_id ) {
 			foreach ( $attachment_ids as $attachment_id ) {
@@ -624,11 +835,16 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_term', __( 'Invalid folder term ID.', 'godam' ), array( 'status' => 400 ) );
 		}
 
-		foreach ( $attachment_ids as $attachment_id ) {
-			if ( get_post_type( $attachment_id ) !== 'attachment' ) {
-				return new \WP_Error( 'invalid_attachment', __( 'Invalid attachment ID.', 'godam' ), array( 'status' => 400 ) );
-			}
+		// Assigning attachments into a locked folder (or a child of one) populates it — reject.
+		if ( $this->is_folder_locked( $folder_term_id ) ) {
+			return new \WP_Error(
+				'godam_folder_locked',
+				__( 'This folder is locked and cannot be modified.', 'godam' ),
+				array( 'status' => 403 )
+			);
+		}
 
+		foreach ( $attachment_ids as $attachment_id ) {
 			$return = wp_set_object_terms( $attachment_id, $folder_term_id, 'media-folder' );
 
 			if ( is_wp_error( $return ) ) {
@@ -1141,17 +1357,139 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_folder', __( 'Invalid folder term ID.', 'godam' ), array( 'status' => 404 ) );
 		}
 
-		$result = Media_Folder_Create_Zip::get_instance()->create_zip( $folder_id, 'media-folder-' . $term->slug . '.zip' );
+		// The archive is built asynchronously. Building it in-request meant a folder with
+		// many/large files (batches of 50, files up to 500 MB) could exceed the PHP/web
+		// server time limit and fail the request. Instead we register a job, kick off a
+		// background build, and hand the client a job id to poll (get_folder_zip_status()).
+		$job_id = wp_generate_password( 32, false );
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
+		$job = array(
+			'status'    => 'queued',
+			'folder_id' => (int) $folder_id,
+			'user_id'   => get_current_user_id(),
+			'zip_url'   => '',
+			'zip_name'  => '',
+			'message'   => '',
+			'created'   => time(),
+			'updated'   => time(),
+		);
+
+		set_transient( $this->zip_job_transient_key( $job_id ), $job, HOUR_IN_SECONDS );
+
+		// Prefer Action Scheduler (bundled with WooCommerce and many plugins) for reliable
+		// async execution; fall back to WP-Cron nudged with spawn_cron(). Both paths invoke
+		// the `godam_build_folder_zip` hook with the job id (see setup_hooks()).
+		if ( function_exists( 'as_enqueue_async_action' ) ) {
+			as_enqueue_async_action( 'godam_build_folder_zip', array( $job_id ), 'godam' );
+		} else {
+			wp_schedule_single_event( time(), 'godam_build_folder_zip', array( $job_id ) );
+
+			if ( function_exists( 'spawn_cron' ) ) {
+				spawn_cron();
+			}
 		}
 
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'message' => __( 'ZIP file created successfully.', 'godam' ),
-				'data'    => $result,
+				'message' => __( 'Preparing ZIP file…', 'godam' ),
+				'data'    => array(
+					'job_id' => $job_id,
+					'status' => 'queued',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Transient key for a folder-ZIP build job.
+	 *
+	 * @param string $job_id Job identifier.
+	 * @return string Transient key.
+	 */
+	private function zip_job_transient_key( $job_id ) {
+		return 'godam_zip_job_' . $job_id;
+	}
+
+	/**
+	 * Background handler that builds a folder's ZIP and records the outcome on the job.
+	 *
+	 * Invoked via `godam_build_folder_zip` (Action Scheduler or WP-Cron). The client
+	 * discovers success/failure by polling get_folder_zip_status().
+	 *
+	 * @param string $job_id Job identifier.
+	 * @return void
+	 */
+	public function run_folder_zip_job( $job_id ) {
+		$key = $this->zip_job_transient_key( $job_id );
+		$job = get_transient( $key );
+
+		if ( ! is_array( $job ) ) {
+			return; // Unknown or expired job.
+		}
+
+		$job['status']  = 'processing';
+		$job['updated'] = time();
+		set_transient( $key, $job, HOUR_IN_SECONDS );
+
+		$folder_id = isset( $job['folder_id'] ) ? (int) $job['folder_id'] : 0;
+		$term      = $folder_id ? get_term( $folder_id, 'media-folder' ) : null;
+
+		if ( ! $term || is_wp_error( $term ) ) {
+			$job['status']  = 'failed';
+			$job['message'] = __( 'Invalid folder term ID.', 'godam' );
+			$job['updated'] = time();
+			set_transient( $key, $job, HOUR_IN_SECONDS );
+			return;
+		}
+
+		// Unguessable filename (see the ZIP hardening in Media_Folder_Create_Zip).
+		$zip_name = 'media-folder-' . $term->slug . '-' . wp_generate_password( 20, false ) . '.zip';
+		$result   = Media_Folder_Create_Zip::get_instance()->create_zip( $folder_id, $zip_name );
+
+		if ( is_wp_error( $result ) ) {
+			$job['status']  = 'failed';
+			$job['message'] = $result->get_error_message();
+		} else {
+			$job['status']   = 'completed';
+			$job['zip_url']  = isset( $result['zip_url'] ) ? $result['zip_url'] : '';
+			$job['zip_name'] = isset( $result['zip_name'] ) ? $result['zip_name'] : $zip_name;
+			$job['message']  = isset( $result['message'] ) ? $result['message'] : __( 'ZIP file created successfully.', 'godam' );
+		}
+
+		$job['updated'] = time();
+		set_transient( $key, $job, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Poll the status of a folder-ZIP build job.
+	 *
+	 * @param \WP_REST_Request $request REST API request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_folder_zip_status( $request ) {
+		$job_id = (string) $request->get_param( 'job_id' );
+		$job    = get_transient( $this->zip_job_transient_key( $job_id ) );
+
+		if ( ! is_array( $job ) ) {
+			return new \WP_Error( 'invalid_job', __( 'Unknown or expired download job.', 'godam' ), array( 'status' => 404 ) );
+		}
+
+		// A job may only be polled by the user who started it (admins excepted), so one
+		// user cannot read another's generated ZIP URL.
+		if ( isset( $job['user_id'] ) && get_current_user_id() !== (int) $job['user_id'] && ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'rest_forbidden', __( 'You are not allowed to access this download job.', 'godam' ), array( 'status' => 403 ) );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => array(
+					'status'   => isset( $job['status'] ) ? $job['status'] : 'queued',
+					'zip_url'  => isset( $job['zip_url'] ) ? $job['zip_url'] : '',
+					'zip_name' => isset( $job['zip_name'] ) ? $job['zip_name'] : '',
+					'message'  => isset( $job['message'] ) ? $job['message'] : '',
+				),
 			)
 		);
 	}
@@ -1177,6 +1515,18 @@ class Media_Library extends Base {
 
 		if ( empty( $folder_ids ) || ! is_array( $folder_ids ) ) {
 			return new \WP_Error( 'invalid_ids', __( 'No folder IDs provided or invalid format.', 'godam' ), array( 'status' => 400 ) );
+		}
+
+		// Reject the whole request if any target is locked (or a child of a locked folder),
+		// so a direct API call can't delete a protected folder — and we never partially delete.
+		foreach ( $folder_ids as $folder_id ) {
+			if ( is_numeric( $folder_id ) && (int) $folder_id > 0 && $this->is_folder_locked( $folder_id ) ) {
+				return new \WP_Error(
+					'godam_folder_locked',
+					__( 'One or more selected folders are locked and cannot be deleted.', 'godam' ),
+					array( 'status' => 403 )
+				);
+			}
 		}
 
 		$deleted_count = 0;
@@ -1238,6 +1588,43 @@ class Media_Library extends Base {
 	}
 
 	/**
+	 * Whether a media-folder term is locked, directly or through an ancestor.
+	 *
+	 * Folder locking is protective: a locked folder shields itself AND all of its
+	 * descendants from mutation. So a folder counts as locked if its own `locked`
+	 * term-meta is truthy or if any of its ancestors' is. Client-side gating (React)
+	 * is UX only; this is the authoritative server-side check.
+	 *
+	 * @param int $term_id Media-folder term ID.
+	 * @return bool True if the folder or one of its ancestors is locked.
+	 */
+	private function is_folder_locked( $term_id ) {
+		$term_id = (int) $term_id;
+
+		if ( $term_id <= 0 ) {
+			return false;
+		}
+
+		// The term itself plus every ancestor — a locked ancestor locks the branch.
+		$ids       = array( $term_id );
+		$ancestors = get_ancestors( $term_id, 'media-folder', 'taxonomy' );
+
+		if ( is_array( $ancestors ) ) {
+			$ids = array_merge( $ids, $ancestors );
+		}
+
+		foreach ( $ids as $id ) {
+			$locked_raw = get_term_meta( $id, 'locked', true );
+
+			if ( '1' === $locked_raw || 1 === $locked_raw || true === $locked_raw || 'true' === $locked_raw ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Update meta status for multiple folders.
 	 * This is a helper method used by bulk_update_folder_lock_status and bulk_update_folder_bookmark_status.
 	 *
@@ -1266,10 +1653,23 @@ class Media_Library extends Base {
 				continue;
 			}
 
+			// update_term_meta() returns false BOTH on a genuine failure and when the value
+			// is already what we're setting. Treat "already at the desired value" as success
+			// (a no-op), so re-locking an already-locked folder isn't a "failure"; only a real
+			// write failure (value differs but the update returned false) is recorded.
+			$current = get_term_meta( $folder_id, $meta_key, true );
+
+			if ( (string) $current === (string) $value ) {
+				++$updated_count;
+				continue;
+			}
+
 			$result = update_term_meta( $folder_id, $meta_key, $value );
 
 			if ( false === $result ) {
-				++$updated_count;
+				$failed_ids[] = $folder_id;
+				// translators: %s is the folder ID whose meta update failed.
+				$errors[] = sprintf( __( 'Failed to update folder %s.', 'godam' ), $folder_id );
 			} else {
 				++$updated_count;
 			}

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1448,6 +1448,52 @@ function rtgodam_convert_to_https_url( $urls ) {
 }
 
 /**
+ * Whether the current admin screen hosts the WordPress media library / a wp.media modal
+ * and therefore needs GoDAM's media-library integration.
+ *
+ * Single source of truth for the enqueue gates below. Covers the core screens that host
+ * the media grid or open a wp.media modal, plus every GoDAM admin page (all of them call
+ * wp_enqueue_media() and may open the modal — dashboard, media editor, analytics,
+ * settings, tools, help, what's-new).
+ *
+ * @param WP_Screen|null $screen Current screen object.
+ * @return bool True if the screen uses the media library / wp.media.
+ */
+function godam_is_media_library_screen( $screen ) {
+	if ( ! $screen ) {
+		return false;
+	}
+
+	// Core screens that host the media grid or a wp.media modal. `post`/`page` (as bases)
+	// also cover the Elementor and WPBakery editors, which run on post.php.
+	$media_bases = array(
+		'upload',      // Media Library (grid & list views).
+		'post',        // Add/Edit any post type.
+		'page',        // Add/Edit Page.
+		'attachment',  // Edit Media.
+		'widgets',     // Classic widgets (image widget uses wp.media).
+		'site-editor', // FSE.
+	);
+
+	if ( in_array( $screen->base, $media_bases, true ) || in_array( $screen->id, $media_bases, true ) ) {
+		return true;
+	}
+
+	// GoDAM's own admin pages (screen ids derive from the `rtgodam` menu slug).
+	$godam_pages = array(
+		'toplevel_page_rtgodam',
+		'godam_page_rtgodam_media_editor',
+		'godam_page_rtgodam_analytics',
+		'godam_page_rtgodam_settings',
+		'godam_page_rtgodam_tools',
+		'godam_page_rtgodam_help',
+		'godam_page_rtgodam_whats_new',
+	);
+
+	return in_array( $screen->id, $godam_pages, true );
+}
+
+/**
  * Check if auth detector scripts should be loaded on current screen.
  *
  * @param WP_Screen|null $screen Current screen object.
@@ -1455,34 +1501,32 @@ function rtgodam_convert_to_https_url( $urls ) {
  * @return bool True if auth detector scripts should load.
  */
 function godam_should_load_auth_detector_script( $screen ) {
-	if ( ! $screen ) {
-		return false;
-	}
+	return godam_is_media_library_screen( $screen );
+}
 
-	// Pages where media library/modal is directly accessible.
-	$media_screens = array(
-		'upload',     // Media Library page (grid & list views).
-		'post',       // Add/Edit Post.
-		'page',       // Add/Edit Page.
-		'attachment', // Edit Media page.
-	);
-
-	// Check if current screen is in the list.
-	if ( in_array( $screen->base, $media_screens, true ) || in_array( $screen->id, $media_screens, true ) ) {
-		return true;
-	}
-
-	// Check if on GoDAM admin pages (where media library/modal can be opened).
-	$godam_pages = array(
-		'toplevel_page_godam',             // Dashboard page.
-		'godam_page_rtgodam_media_editor', // Media Editor page.
-	);
-
-	if ( in_array( $screen->id, $godam_pages, true ) ) {
-		return true;
-	}
-
-	return false;
+/**
+ * Whether the (heavy) GoDAM media-library JS bundles should load on the current screen.
+ *
+ * The media-library.min.js (bundles video.js) and pages/media-library.min.js (React/Redux
+ * folder sidebar) were enqueued on EVERY admin screen via a global admin_enqueue_scripts
+ * hook. They are only needed where the media library / wp.media modal is actually used
+ * (see godam_is_media_library_screen()). Everywhere else the payload is pure overhead.
+ * Integrations that open wp.media on other screens can opt in via the filter below.
+ *
+ * @param WP_Screen|null $screen Current screen object.
+ * @return bool True if the media-library bundles should be enqueued.
+ */
+function godam_should_load_media_library_assets( $screen ) {
+	/**
+	 * Filters whether the GoDAM media-library JS bundles load on the current screen.
+	 *
+	 * Use this to force-load the bundles on custom screens that open wp.media (e.g.
+	 * term-edit screens with media fields).
+	 *
+	 * @param bool           $should_load Whether to enqueue the media-library bundles.
+	 * @param WP_Screen|null $screen      Current screen object.
+	 */
+	return (bool) apply_filters( 'godam_should_load_media_library_assets', godam_is_media_library_screen( $screen ), $screen );
 }
 
 // ---------------------------------------------------------------------------

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useState, useMemo, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
@@ -33,16 +33,10 @@ import SearchBar from './components/search-bar/SearchBar.jsx';
 const App = () => {
 	const dispatch = useDispatch();
 	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
-	const contextSelectedFolder = useSelector( ( state ) => state.FolderReducer.currentContextMenuFolder );
 	const isMultiSelecting = useSelector( ( state ) => state.FolderReducer.isMultiSelecting );
 	const currentSortOrder = useSelector( ( state ) => state.FolderReducer.sortOrder );
 	const { data: allMediaCount, refetch: refetchAllMediaCount } = useGetAllMediaCountQuery();
 	const { data: uncategorizedCount, refetch: refetchUncategorizedCount } = useGetCategoryMediaCountQuery( { folderId: 0 } );
-
-	const allFolders = useSelector( ( state ) => state.FolderReducer.folders );
-	const currentFolder = useMemo( () => {
-		return allFolders.find( ( folder ) => folder.id === selectedFolder?.id );
-	}, [ allFolders, selectedFolder ] );
 
 	const [ contextMenu, setContextMenu ] = useState( {
 		visible: false,
@@ -166,8 +160,14 @@ const App = () => {
 						variant="primary"
 						text={ __( 'New Folder', 'godam' ) }
 						className="button--full mb-spacing new-folder-button"
-						onClick={ () => dispatch( openModal( 'folderCreation' ) ) }
-						disabled={ selectedFolder?.meta?.locked || currentFolder?.meta?.locked || contextSelectedFolder?.meta?.locked }
+						onClick={ () => {
+							// Create at the ROOT from the top-level button. FolderCreationModal
+							// derives the new folder's parent from currentContextMenuFolder, which
+							// a prior right-click leaves set — without this clear, the top button
+							// would nest the folder under the last right-clicked folder.
+							dispatch( setCurrentContextMenuFolder( null ) );
+							dispatch( openModal( 'folderCreation' ) );
+						} }
 					/>
 				</div>
 				<div className="button-group mb-spacing">

--- a/pages/media-library/components/context-menu/ContextMenu.jsx
+++ b/pages/media-library/components/context-menu/ContextMenu.jsx
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { openModal, updateSnackbar, updateBookmarks, lockFolder } from '../../redux/slice/folders';
-import { useDownloadZipMutation, useUpdateFolderMutation, useBulkLockFoldersMutation, useBulkBookmarkFoldersMutation } from '../../redux/api/folders';
+import { useDownloadZipMutation, useUpdateFolderMutation, useBulkLockFoldersMutation, useBulkBookmarkFoldersMutation, pollZipJobStatus } from '../../redux/api/folders';
 import {
 	BookmarkStarIcon,
 	DeleteIcon,
@@ -212,29 +212,29 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 				} ),
 			);
 
+			// The archive is now built in the background: start the job, then poll until
+			// it is ready (large folders no longer time out the request).
 			const response = await downloadZipMutation( { folderId: id } ).unwrap();
 
-			if ( ! response?.success ) {
-				throw new Error( response?.message || __( 'Failed to create ZIP file', 'godam' ) );
+			if ( ! response?.success || ! response?.data?.job_id ) {
+				throw new Error( response?.message || __( 'Failed to start ZIP creation', 'godam' ) );
 			}
 
-			const { data } = response;
+			const result = await pollZipJobStatus( response.data.job_id );
 
-			if ( ! data?.zip_url ) {
-				throw new Error( __( 'Invalid response: missing ZIP URL', 'godam' ) );
+			if ( result.status !== 'completed' || ! result.zip_url ) {
+				throw new Error( result.message || __( 'Failed to create ZIP file', 'godam' ) );
 			}
 
 			downloadFile(
-				data.zip_url,
-				data.zip_name || `${ currentFolder?.name || 'folder' }.zip`,
+				result.zip_url,
+				result.zip_name || `${ currentFolder?.name || 'folder' }.zip`,
 				true,
 			);
 
-			const successMessage = data?.message;
-
 			dispatch(
 				updateSnackbar( {
-					message: successMessage,
+					message: result.message || __( 'ZIP file created successfully.', 'godam' ),
 					type: 'success',
 				} ),
 			);

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -167,7 +167,19 @@ const FolderTree = ( { handleContextMenu } ) => {
 			const activeIndex = clonedItems.findIndex( ( { id } ) => id === active.id );
 			const activeTreeItem = clonedItems[ activeIndex ];
 
-			await updateFolderMutation( { ...activeTreeItem, parent } );
+			// Persist the move first and only commit it to the local tree on success.
+			// Without .unwrap() a server rejection (e.g. locked destination, permission)
+			// resolved silently and the tree kept the optimistic move even though the
+			// server never applied it.
+			try {
+				await updateFolderMutation( { ...activeTreeItem, parent } ).unwrap();
+			} catch ( moveError ) {
+				dispatch( updateSnackbar( {
+					message: moveError?.data?.message || __( 'Failed to move folder', 'godam' ),
+					type: 'fail',
+				} ) );
+				return;
+			}
 
 			clonedItems[ activeIndex ] = { ...activeTreeItem, depth, parent };
 

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -67,10 +67,17 @@ const FolderTree = ( { handleContextMenu } ) => {
 	const [ updateFolderMutation ] = useUpdateFolderMutation();
 
 	useEffect( () => {
-		if ( folders ) {
-			dispatch( setTree( openLocalStorageItem( folders?.data ) ) );
+		// Only sync once the query has settled — syncing an in-flight (stale) response
+		// could momentarily re-introduce a just-deleted folder. On the first page we
+		// REPLACE the list so server-side removals (deletes) are reflected; on load-more
+		// pages we append, preserving the already-loaded pages.
+		if ( folders && ! isFetching ) {
+			dispatch( setTree( {
+				folders: openLocalStorageItem( folders?.data ),
+				replace: currentPage === 1,
+			} ) );
 
-			if ( Array.isArray( folders?.data ) && ! isFetching ) {
+			if ( Array.isArray( folders?.data ) ) {
 				// If no folders are returned, reset to the first page
 				dispatch( updatePage( { totalPages: folders.totalPages } ) );
 			}

--- a/pages/media-library/components/modal/DeleteModal.jsx
+++ b/pages/media-library/components/modal/DeleteModal.jsx
@@ -56,17 +56,21 @@ const DeleteModal = () => {
 			// folder from the tree even though it still exists on the server. unwrap()
 			// re-throws the error payload so failures reach the catch (matching how
 			// Rename/Create already handle their mutations).
+			let partialMessage = null;
+
 			if ( ! isMultiSelecting ) {
 				await deleteFolderMutation( selectedFolder.id ).unwrap();
 			} else if ( multiSelectedFolderIds && multiSelectedFolderIds.length ) {
 				// The bulk endpoint returns HTTP 200 with `errors` on *partial* failure, so
-				// .unwrap() alone won't throw — inspect the payload and surface it as a
-				// failure rather than reporting "deleted successfully" and dropping every
-				// selected folder from the tree.
+				// .unwrap() alone won't throw. On a partial failure we still remove the whole
+				// selection optimistically and surface a WARNING (not "deleted successfully");
+				// the invalidation refetch below re-adds any folder that wasn't actually
+				// deleted, so successfully-deleted folders don't linger (even on load-more
+				// pages, where the reducer removes them from the flat list).
 				const bulkResult = await bulkDeleteFoldersMutation( multiSelectedFolderIds ).unwrap();
 
 				if ( bulkResult?.errors?.length ) {
-					throw new Error( bulkResult.message || __( 'Some folders could not be deleted', 'godam' ) );
+					partialMessage = bulkResult.message || __( 'Some folders could not be deleted', 'godam' );
 				}
 			}
 
@@ -74,8 +78,8 @@ const DeleteModal = () => {
 
 			dispatch( updateSnackbar(
 				{
-					message: isMultiSelecting ? __( 'Folders deleted successfully', 'godam' ) : __( 'Folder deleted successfully', 'godam' ),
-					type: 'success',
+					message: partialMessage || ( isMultiSelecting ? __( 'Folders deleted successfully', 'godam' ) : __( 'Folder deleted successfully', 'godam' ) ),
+					type: partialMessage ? 'fail' : 'success',
 				},
 			) );
 

--- a/pages/media-library/components/modal/DeleteModal.jsx
+++ b/pages/media-library/components/modal/DeleteModal.jsx
@@ -50,10 +50,24 @@ const DeleteModal = () => {
 		setIsLoading( true );
 
 		try {
+			// `.unwrap()` is required: RTK Query mutations RESOLVE (do not throw) on
+			// HTTP 4xx/5xx, so without it a server rejection would fall through to the
+			// success path below — showing "deleted successfully" and dropping the
+			// folder from the tree even though it still exists on the server. unwrap()
+			// re-throws the error payload so failures reach the catch (matching how
+			// Rename/Create already handle their mutations).
 			if ( ! isMultiSelecting ) {
-				await deleteFolderMutation( selectedFolder.id );
+				await deleteFolderMutation( selectedFolder.id ).unwrap();
 			} else if ( multiSelectedFolderIds && multiSelectedFolderIds.length ) {
-				await bulkDeleteFoldersMutation( multiSelectedFolderIds );
+				// The bulk endpoint returns HTTP 200 with `errors` on *partial* failure, so
+				// .unwrap() alone won't throw — inspect the payload and surface it as a
+				// failure rather than reporting "deleted successfully" and dropping every
+				// selected folder from the tree.
+				const bulkResult = await bulkDeleteFoldersMutation( multiSelectedFolderIds ).unwrap();
+
+				if ( bulkResult?.errors?.length ) {
+					throw new Error( bulkResult.message || __( 'Some folders could not be deleted', 'godam' ) );
+				}
 			}
 
 			dispatch( deleteFolder() );
@@ -69,7 +83,7 @@ const DeleteModal = () => {
 		} catch ( error ) {
 			dispatch( updateSnackbar(
 				{
-					message: __( 'Failed to delete folder', 'godam' ),
+					message: error?.message || error?.data?.message || __( 'Failed to delete folder', 'godam' ),
 					type: 'fail',
 				},
 			) );

--- a/pages/media-library/components/search-bar/SearchBar.jsx
+++ b/pages/media-library/components/search-bar/SearchBar.jsx
@@ -144,11 +144,14 @@ const SearchBar = () => {
 	 * Triggers filter changes, updates selected folder, expands parent folders,
 	 * and resets the search UI.
 	 *
-	 * @param {string} folderId The ID of the selected folder.
+	 * @param {Object} folder The selected folder object (including its meta).
 	 */
-	const handleFolderSelect = ( folderId ) => {
+	const handleFolderSelect = ( folder ) => {
+		const folderId = folder?.id;
 		triggerFilterChange( folderId );
-		dispatch( changeSelectedFolder( { item: { id: folderId } } ) );
+		// Pass the whole folder (incl. meta) so its lock/bookmark state is preserved in
+		// state — selecting by id alone stripped the meta and defeated lock checks.
+		dispatch( changeSelectedFolder( { item: folder } ) );
 		dispatch( expandParents( { id: folderId } ) );
 
 		setSearchTerm( '' );
@@ -196,7 +199,7 @@ const SearchBar = () => {
 										<li key={ folder.id }>
 											<Button
 												className="search-result-item"
-												onClick={ () => handleFolderSelect( folder.id ) }
+												onClick={ () => handleFolderSelect( folder ) }
 											>
 												{ folder.name }
 											</Button>

--- a/pages/media-library/data/media-grid.js
+++ b/pages/media-library/data/media-grid.js
@@ -11,7 +11,49 @@ function getActiveMediaFrame() {
 }
 
 /**
- * This function triggers the select box change outside of the react component.
+ * Map a sidebar folder id to the `media-folder` Backbone query prop value.
+ * Mirrors the toolbar select's filter map: -1 = all, 0 = uncategorized,
+ * otherwise the numeric term id.
+ *
+ * @param {number|string} itemId Folder id from the sidebar.
+ * @return {number} The `media-folder` prop value.
+ */
+function normalizeFolderProp( itemId ) {
+	if ( itemId === 'all' || itemId === -1 || itemId === '-1' ) {
+		return -1;
+	}
+	if ( itemId === 'uncategorized' || itemId === 0 || itemId === '0' ) {
+		return 0;
+	}
+	const numeric = parseInt( itemId, 10 );
+	return Number.isNaN( numeric ) ? -1 : numeric;
+}
+
+/**
+ * Resolve the wp.media Attachments collection backing the active media frame.
+ * The frame is stashed on its own sidebar root (see
+ * assets/src/js/media-library/index.js) so we target THIS frame's collection,
+ * not a shared id / "last visible" guess.
+ *
+ * @param {Element} activeFrame The active `.media-frame` element.
+ * @return {Object|null} The Backbone Attachments collection (with `.props`), or null.
+ */
+function getActiveFrameCollection( activeFrame ) {
+	const root = activeFrame && activeFrame.querySelector( '#rt-transcoder-media-library-root' );
+	const frame = root && root._godamFrame;
+
+	if ( ! frame || typeof frame.state !== 'function' ) {
+		return null;
+	}
+
+	const state = frame.state();
+	const collection = ( state && typeof state.get === 'function' ) ? state.get( 'library' ) : null;
+
+	return ( collection && collection.props ) ? collection : null;
+}
+
+/**
+ * Apply a folder filter outside of the React component.
  *
  * @param {number} itemId The ID of the folder to be selected
  */
@@ -41,7 +83,19 @@ function triggerFilterChange( itemId ) {
 		return;
 	}
 
-	// Find the select box within the active frame
+	// In a media-picker modal, drive filtering through the frame's own Backbone
+	// query props. Setting the `media-folder` prop re-fetches the collection the
+	// modal renders — this is what the toolbar select does on change, but it works
+	// even when that grid-only DOM (#media-folder-filter / #post-query-submit) is
+	// absent, which is exactly why folder clicks used to silently no-op in the picker.
+	const collection = getActiveFrameCollection( activeFrame );
+
+	if ( collection ) {
+		collection.props.set( { 'media-folder': normalizeFolderProp( itemId ) } );
+		return;
+	}
+
+	// Fallback: the legacy grid-DOM path (standalone list/grid toolbar).
 	const selectBox = activeFrame.querySelector( '#media-folder-filter' );
 
 	if ( selectBox ) {

--- a/pages/media-library/index.js
+++ b/pages/media-library/index.js
@@ -84,116 +84,56 @@ function resetSidebarIfAllModalsClosed() {
  * and reset the React state to ensure fresh UI state for new modal instances
  */
 function setupMediaModalCloseDetection() {
-	// Track active media modal instances to detect when they close
-	let lastModalCount = 0;
+	// The authoritative "modal closed" signal is wp.media's own Modal.close(). The
+	// previous implementation ALSO ran a document.body subtree MutationObserver and a
+	// 500ms setInterval for the entire page lifetime — neither was ever disconnected/
+	// cleared — purely as fallbacks. That is needlessly chatty (especially in the block
+	// editor, where document.body mutates constantly). Rely on the single frame event.
+	if ( typeof wp === 'undefined' || ! wp.media || ! wp.media.view || ! wp.media.view.Modal ) {
+		return;
+	}
 
-	// Use MutationObserver to detect when modal elements are removed from DOM
-	const observer = new MutationObserver( ( mutations ) => {
-		mutations.forEach( ( mutation ) => {
-			if ( mutation.type === 'childList' ) {
-				// Check if any media modal elements were removed
-				mutation.removedNodes.forEach( ( node ) => {
-					if ( node.nodeType === Node.ELEMENT_NODE ) {
-						// Check if this is a media modal that was removed
-						if ( node.classList && node.classList.contains( 'media-modal' ) ) {
-							// Clean up React roots before resetting state
-							const rootElements = node.querySelectorAll( '#rt-transcoder-media-library-root' );
-							rootElements.forEach( ( element ) => {
-								if ( element._reactRoot ) {
-									try {
-										element._reactRoot.unmount();
-									} catch ( e ) {
-										// Ignore unmounting errors
-									}
-									element._reactRoot = null;
-								}
-							} );
+	// Guard against double-wrapping if this bundle is evaluated more than once.
+	if ( wp.media.view.Modal.prototype._godamClosePatched ) {
+		return;
+	}
+	wp.media.view.Modal.prototype._godamClosePatched = true;
 
-							// Media modal removed — reset only if no modal remains open.
-							resetSidebarIfAllModalsClosed();
-						// Also check if it contains media modal children
-						} else if ( node.querySelector && node.querySelector( '.media-modal' ) ) {
-							// Clean up any React roots in child modals
-							const rootElements = node.querySelectorAll( '#rt-transcoder-media-library-root' );
-							rootElements.forEach( ( element ) => {
-								if ( element._reactRoot ) {
-									try {
-										element._reactRoot.unmount();
-									} catch ( e ) {
-										// Ignore unmounting errors
-									}
-									element._reactRoot = null;
-								}
-							} );
+	const originalClose = wp.media.view.Modal.prototype.close;
+	wp.media.view.Modal.prototype.close = function( ...args ) {
+		// Capture the closing modal's element before the async cleanup runs.
+		const modalEl = this.el;
 
-							// Nested media modal removed — reset only if no modal remains open.
-							resetSidebarIfAllModalsClosed();
+		// Call original close method
+		const result = originalClose.apply( this, args );
+
+		// Clean up the React root in THIS closing modal before it is hidden/removed.
+		// Scoped to the closing modal so closing one frame never tears down a sibling
+		// frame's still-visible sidebar.
+		setTimeout( () => {
+			// Skip cleanup if the modal was reopened within this delay (still visible) —
+			// otherwise we would unmount a freshly-mounted sidebar.
+			const modalHidden = ! modalEl || ! modalEl.isConnected || getComputedStyle( modalEl ).display === 'none';
+
+			if ( modalHidden && modalEl ) {
+				modalEl.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( element ) => {
+					if ( element._reactRoot ) {
+						try {
+							element._reactRoot.unmount();
+						} catch ( e ) {
+							// Ignore unmounting errors
 						}
+						element._reactRoot = null;
 					}
 				} );
 			}
-		} );
-	} );
 
-	// Observe changes to the document body
-	observer.observe( document.body, {
-		childList: true,
-		subtree: true,
-	} );
-
-	// Also detect modal state changes by checking visibility periodically
-	// This is a fallback for cases where DOM removal isn't detected
-	setInterval( () => {
-		const currentModalCount = document.querySelectorAll( '.media-modal:not([style*="display: none"])' ).length;
-
-		// If modal count decreased a modal was closed — reset only once the last one
-		// is gone so closing a nested modal doesn't clobber the picker in use.
-		if ( currentModalCount < lastModalCount ) {
+			// Reset React state only once the last media modal has closed.
 			resetSidebarIfAllModalsClosed();
-		}
+		}, 100 ); // Small delay to ensure modal is fully closed
 
-		lastModalCount = currentModalCount;
-	}, 500 ); // Check every 500ms
-
-	// Listen for WordPress media frame close events if available
-	if ( typeof wp !== 'undefined' && wp.media ) {
-		// Hook into wp.media to detect when frames are closed
-		const originalClose = wp.media.view.Modal.prototype.close;
-		wp.media.view.Modal.prototype.close = function( ...args ) {
-			// Capture the closing modal's element before the async cleanup runs.
-			const modalEl = this.el;
-
-			// Call original close method
-			const result = originalClose.apply( this, args );
-
-			// Clean up the React root in THIS closing modal before it is hidden/removed.
-			// Scoped to the closing modal so closing one frame never tears down a sibling
-			// frame's still-visible sidebar.
-			setTimeout( () => {
-				// Skip cleanup if the modal was reopened within this delay (still visible) —
-				// otherwise we would unmount a freshly-mounted sidebar.
-				const modalHidden = ! modalEl || ! modalEl.isConnected || getComputedStyle( modalEl ).display === 'none';
-
-				if ( modalHidden && modalEl ) {
-					modalEl.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( element ) => {
-						if ( element._reactRoot ) {
-							try {
-								element._reactRoot.unmount();
-							} catch ( e ) {
-								// Ignore unmounting errors
-							}
-							element._reactRoot = null;
-						}
-					} );
-				}
-
-				// Reset React state only once the last media modal has closed.
-				resetSidebarIfAllModalsClosed();
-			}, 100 ); // Small delay to ensure modal is fully closed
-
-			return result;
-		};
-	}
+		return result;
+	};
 }
 
 /**

--- a/pages/media-library/index.js
+++ b/pages/media-library/index.js
@@ -53,6 +53,33 @@ document.addEventListener( 'media-frame-opened', initializeMediaLibrary );
 setupMediaModalCloseDetection();
 
 /**
+ * Whether any WordPress media modal is currently visible.
+ *
+ * @return {boolean} True if at least one `.media-modal` is displayed.
+ */
+function isAnyMediaModalOpen() {
+	return Array.from( document.querySelectorAll( '.media-modal' ) )
+		.some( ( modal ) => getComputedStyle( modal ).display !== 'none' );
+}
+
+/**
+ * Reset the folder sidebar's UI state and resync the WP media query — but ONLY
+ * when no media modal remains open. Closing a nested modal (e.g. an attachment
+ * details overlay) while the picker the user is working in is still open must not
+ * wipe the active folder selection, which the previous unconditional reset did.
+ */
+function resetSidebarIfAllModalsClosed() {
+	if ( isAnyMediaModalOpen() ) {
+		return;
+	}
+
+	store.dispatch( resetUIState() );
+
+	// Resync the WordPress media query back to "all".
+	triggerFilterChange( 'all' );
+}
+
+/**
  * Set up detection for when WordPress media modals are closed
  * and reset the React state to ensure fresh UI state for new modal instances
  */
@@ -82,11 +109,8 @@ function setupMediaModalCloseDetection() {
 								}
 							} );
 
-							// Media modal was closed, reset React state
-							store.dispatch( resetUIState() );
-
-							// Also trigger WordPress media filter change to sync
-							triggerFilterChange( 'all' );
+							// Media modal removed — reset only if no modal remains open.
+							resetSidebarIfAllModalsClosed();
 						// Also check if it contains media modal children
 						} else if ( node.querySelector && node.querySelector( '.media-modal' ) ) {
 							// Clean up any React roots in child modals
@@ -102,10 +126,8 @@ function setupMediaModalCloseDetection() {
 								}
 							} );
 
-							store.dispatch( resetUIState() );
-
-							// Also trigger WordPress media filter change to sync
-							triggerFilterChange( 'all' );
+							// Nested media modal removed — reset only if no modal remains open.
+							resetSidebarIfAllModalsClosed();
 						}
 					}
 				} );
@@ -124,12 +146,10 @@ function setupMediaModalCloseDetection() {
 	setInterval( () => {
 		const currentModalCount = document.querySelectorAll( '.media-modal:not([style*="display: none"])' ).length;
 
-		// If modal count decreased, a modal was closed
+		// If modal count decreased a modal was closed — reset only once the last one
+		// is gone so closing a nested modal doesn't clobber the picker in use.
 		if ( currentModalCount < lastModalCount ) {
-			store.dispatch( resetUIState() );
-
-			// Also trigger WordPress media filter change to sync
-			triggerFilterChange( 'all' );
+			resetSidebarIfAllModalsClosed();
 		}
 
 		lastModalCount = currentModalCount;
@@ -140,29 +160,35 @@ function setupMediaModalCloseDetection() {
 		// Hook into wp.media to detect when frames are closed
 		const originalClose = wp.media.view.Modal.prototype.close;
 		wp.media.view.Modal.prototype.close = function( ...args ) {
+			// Capture the closing modal's element before the async cleanup runs.
+			const modalEl = this.el;
+
 			// Call original close method
 			const result = originalClose.apply( this, args );
 
-			// Clean up React roots in modal elements before they're removed
+			// Clean up the React root in THIS closing modal before it is hidden/removed.
+			// Scoped to the closing modal so closing one frame never tears down a sibling
+			// frame's still-visible sidebar.
 			setTimeout( () => {
-				// Find all React root elements in closing modals and clean them up
-				const modalElements = document.querySelectorAll( '.media-modal #rt-transcoder-media-library-root' );
-				modalElements.forEach( ( element ) => {
-					if ( element._reactRoot ) {
-						try {
-							element._reactRoot.unmount();
-						} catch ( e ) {
-							// Ignore unmounting errors
+				// Skip cleanup if the modal was reopened within this delay (still visible) —
+				// otherwise we would unmount a freshly-mounted sidebar.
+				const modalHidden = ! modalEl || ! modalEl.isConnected || getComputedStyle( modalEl ).display === 'none';
+
+				if ( modalHidden && modalEl ) {
+					modalEl.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( element ) => {
+						if ( element._reactRoot ) {
+							try {
+								element._reactRoot.unmount();
+							} catch ( e ) {
+								// Ignore unmounting errors
+							}
+							element._reactRoot = null;
 						}
-						element._reactRoot = null;
-					}
-				} );
+					} );
+				}
 
-				// Reset React state after modal closes
-				store.dispatch( resetUIState() );
-
-				// Also trigger WordPress media filter change to sync
-				triggerFilterChange( 'all' );
+				// Reset React state only once the last media modal has closed.
+				resetSidebarIfAllModalsClosed();
 			}, 100 ); // Small delay to ensure modal is fully closed
 
 			return result;

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -64,6 +64,7 @@ export async function pollZipJobStatus( jobId, { intervalMs = 2000, timeoutMs = 
 export const folderApi = createApi( {
 	reducerPath: 'folderApi',
 	baseQuery: fetchBaseQuery( { baseUrl: restURL } ),
+	tagTypes: [ 'Folder' ],
 	endpoints: ( builder ) => ( {
 		getAllMediaCount: builder.query( {
 			async queryFn( arg, api, extraOptions, baseQuery ) {
@@ -141,6 +142,7 @@ export const folderApi = createApi( {
 					totalPages: totalPages ? parseInt( totalPages, 10 ) : 0,
 				};
 			},
+			providesTags: [ 'Folder' ],
 		} ),
 		createFolder: builder.mutation( {
 			query: ( data ) => ( {
@@ -151,6 +153,10 @@ export const folderApi = createApi( {
 					'X-WP-Nonce': window.MediaLibrary.nonce,
 				},
 			} ),
+			// NOTE: intentionally NOT invalidating 'Folder' here. The createFolder reducer
+			// pushes the new folder optimistically; a refetch would replace page 1 with the
+			// server's first 20 (name ASC) and drop a freshly-created folder that sorts onto
+			// a later page until Load More / reload.
 		} ),
 		updateFolder: builder.mutation( {
 			query: ( data ) => ( {
@@ -173,6 +179,7 @@ export const folderApi = createApi( {
 					'X-WP-Nonce': window.MediaLibrary.nonce,
 				},
 			} ),
+			invalidatesTags: [ 'Folder' ],
 		} ),
 		bulkDeleteFolders: builder.mutation( {
 			query: ( folderIds ) => ( {
@@ -184,6 +191,7 @@ export const folderApi = createApi( {
 					'Content-Type': 'application/json',
 				},
 			} ),
+			invalidatesTags: [ 'Folder' ],
 		} ),
 		bulkLockFolders: builder.mutation( {
 			query: ( { folderIds, lockedStatus } ) => ( {

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -4,11 +4,62 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { getCurrentMimeTypeFilter } from '../../data/utilities';
 
 const restURL = window.godamRestRoute?.url || window.wpApiSettings?.root || '/wp-json/';
+
+/**
+ * Poll a folder-ZIP build job until it finishes.
+ *
+ * The download endpoint now returns a job id immediately and builds the archive in the
+ * background (so large folders no longer time out the request). This polls the status
+ * endpoint until the job is `completed` or `failed`, or the timeout is reached.
+ *
+ * @param {string} jobId                      The job id returned by the downloadZip mutation.
+ * @param {Object} [options]                  Polling options.
+ * @param {number} [options.intervalMs=2000]  Delay between polls.
+ * @param {number} [options.timeoutMs=180000] Give up after this long.
+ * @return {Promise<Object>} Resolves with { status, zip_url, zip_name, message }.
+ */
+export async function pollZipJobStatus( jobId, { intervalMs = 2000, timeoutMs = 180000 } = {} ) {
+	const url = `${ restURL }godam/v1/media-library/download-folder-status/${ jobId }`;
+	const start = Date.now();
+
+	while ( Date.now() - start < timeoutMs ) {
+		try {
+			const res = await fetch( url, {
+				headers: { 'X-WP-Nonce': window.MediaLibrary.nonce },
+			} );
+			const json = await res.json();
+
+			// A WP_Error (e.g. 404 unknown/expired job, 403 not-owner) serialises as
+			// { code, message, data: { status: <httpCode> } } — so `res.ok` is the reliable
+			// signal, not `data.status` (which would be the HTTP code, not the job status).
+			if ( ! res.ok ) {
+				return { status: 'failed', message: json?.message || __( 'Failed to prepare the ZIP file.', 'godam' ) };
+			}
+
+			const data = json?.data || {};
+
+			if ( data.status === 'completed' || data.status === 'failed' ) {
+				return data;
+			}
+		} catch ( e ) {
+			// Transient network error — keep polling until the timeout.
+		}
+
+		await new Promise( ( resolve ) => setTimeout( resolve, intervalMs ) );
+	}
+
+	return { status: 'failed', message: __( 'Timed out while preparing the ZIP file.', 'godam' ) };
+}
 
 export const folderApi = createApi( {
 	reducerPath: 'folderApi',
@@ -24,6 +75,12 @@ export const folderApi = createApi( {
 						_fields: 'id',
 						per_page: 1,
 						...mimeTypeParams,
+					},
+					// Send the REST nonce so the count runs as the current user (matching the
+					// grid). Without it the request is anonymous and only counts public media,
+					// undercounting when private/pending attachments exist.
+					headers: {
+						'X-WP-Nonce': window.MediaLibrary.nonce,
 					},
 				} );
 
@@ -186,7 +243,10 @@ export const folderApi = createApi( {
 						search: searchTerm,
 						page,
 						per_page: perPage,
-						_fields: 'id,name',
+						// Include parent + meta so a folder selected from search keeps its
+						// lock/bookmark state. With only id,name the selected folder lost its
+						// meta, defeating the locked-folder checks downstream.
+						_fields: 'id,name,parent,meta',
 					},
 					headers: {
 						'X-WP-Nonce': window.MediaLibrary.nonce,

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -181,24 +181,45 @@ const slice = createSlice( {
 			state.multiSelectedFolderIds = [];
 		},
 		setTree: ( state, action ) => {
-			const newFolders = action.payload;
+			const payload = action.payload;
 
-			if ( state.folders.length > 0 ) {
-				const folderMap = new Map( state.folders.map( ( folder ) => [ folder.id, folder ] ) );
+			// Backward compatible: an array payload keeps the legacy merge/append behavior
+			// (drag-reorder / count updates always pass the full current list). An object
+			// payload `{ folders, replace }` lets callers REPLACE the list so removals are
+			// reflected. The merge branch can only add/update — it never removes — so a
+			// deleted folder used to reappear (whenever this ran with the still-cached query
+			// data) and only cleared on a hard refresh, where state started empty.
+			const newFolders = Array.isArray( payload ) ? payload : ( payload?.folders || [] );
+			const replace = ! Array.isArray( payload ) && Boolean( payload?.replace );
 
-				newFolders.forEach( ( folder ) => {
-					if ( folderMap.has( folder.id ) ) {
-						// Update existing folder
-						Object.assign( folderMap.get( folder.id ), folder );
-					} else {
-						// Add new folder
-						state.folders.push( folder );
-					}
-				} );
-			} else {
-				// No existing folders, just set
-				state.folders = newFolders;
+			if ( replace || state.folders.length === 0 ) {
+				// Sort a mutable copy: `newFolders` comes straight from the RTK Query cache,
+				// which is frozen (read-only), so sorting it in place throws. The server
+				// always returns name ASC; re-applying the active sort keeps a "By Name (Z-A)"
+				// selection from silently resetting to A-Z when the list is replaced.
+				const sorted = [ ...newFolders ];
+
+				if ( 'name-desc' === state.sortOrder ) {
+					sorted.sort( ( a, b ) => a.name.localeCompare( b.name ) * -1 );
+				} else if ( 'name-asc' === state.sortOrder ) {
+					sorted.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+				}
+
+				state.folders = sorted;
+				return;
 			}
+
+			const folderMap = new Map( state.folders.map( ( folder ) => [ folder.id, folder ] ) );
+
+			newFolders.forEach( ( folder ) => {
+				if ( folderMap.has( folder.id ) ) {
+					// Update existing folder
+					Object.assign( folderMap.get( folder.id ), folder );
+				} else {
+					// Add new folder
+					state.folders.push( folder );
+				}
+			} );
 		},
 
 		toggleMultiSelectMode: ( state ) => {
@@ -396,11 +417,11 @@ const slice = createSlice( {
 				type: 'success',
 			};
 
-			// Reset page to first page
-			state.page.current = 1;
-
-			// Note: We preserve folders, bookmarks, lockedFolders, and sortOrder
-			// for performance and user experience
+			// NOTE: page.current is intentionally NOT reset here. We preserve the loaded
+			// folders (and bookmarks/lockedFolders/sortOrder) across modal open/close for
+			// performance and UX — resetting the page to 1 while keeping those folders made
+			// the sync effect re-fetch page 1 and REPLACE the tree with just the first page,
+			// collapsing everything the user had loaded via "Load more".
 		},
 	},
 } );

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -17,7 +17,7 @@ if ( folderId ) {
 			selectedFolderId = 0;
 			break;
 		default:
-			selectedFolderId = parseInt( folderId );
+			selectedFolderId = parseInt( folderId, 10 );
 			break;
 	}
 }
@@ -101,10 +101,34 @@ const slice = createSlice( {
 				return;
 			}
 
-			const folder = state.folders.find( ( item ) => item.id === state.currentContextMenuFolder.id );
+			const id = state.currentContextMenuFolder.id;
+			const name = action.payload.name;
+
+			const folder = state.folders.find( ( item ) => item.id === id );
 
 			if ( folder ) {
-				folder.name = action.payload.name;
+				folder.name = name;
+			}
+
+			// The Bookmark/Locked tabs and the current selection hold separate copies of the
+			// folder, so update them too — otherwise a rename shows stale names in those views.
+			const bookmarked = state.bookmarks.find( ( item ) => item.id === id );
+			if ( bookmarked ) {
+				bookmarked.name = name;
+			}
+
+			const locked = state.lockedFolders.find( ( item ) => item.id === id );
+			if ( locked ) {
+				locked.name = name;
+			}
+
+			if ( state.selectedFolder && state.selectedFolder.id === id ) {
+				state.selectedFolder.name = name;
+			}
+
+			// The rename modal renders currentContextMenuFolder.name, so keep it current too.
+			if ( state.currentContextMenuFolder && state.currentContextMenuFolder.id === id ) {
+				state.currentContextMenuFolder.name = name;
 			}
 		},
 		deleteFolder: ( state ) => {
@@ -132,6 +156,22 @@ const slice = createSlice( {
 			}
 
 			state.folders = state.folders.filter( ( item ) => ! idsToDelete.has( item.id ) );
+
+			// Keep the bookmark/locked tab lists in sync so deleted folders don't linger there.
+			state.bookmarks = state.bookmarks.filter( ( item ) => ! idsToDelete.has( item.id ) );
+			state.lockedFolders = state.lockedFolders.filter( ( item ) => ! idsToDelete.has( item.id ) );
+
+			// If the selected folder was deleted (or was a descendant of a deleted folder),
+			// reset the selection to "All" — otherwise the grid keeps filtering by a folder
+			// that no longer exists.
+			if ( state.selectedFolder && idsToDelete.has( state.selectedFolder.id ) ) {
+				state.selectedFolder = { id: -1 };
+
+				// Mirror to the global the way changeSelectedFolder does, creating it if
+				// it doesn't exist yet so the reset isn't silently dropped.
+				window.godam = window.godam || {};
+				window.godam.selectedFolder = state.selectedFolder;
+			}
 
 			state.currentContextMenuFolder = {
 				id: -1,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,6 +105,19 @@ const mediaLibrary = {
 	entry: {
 		'media-library': path.resolve( process.cwd(), 'assets', 'src', 'js', 'media-library', 'index.js' ),
 	},
+	// This entry now code-splits video.js into an async chunk (see videojs-loader). It
+	// shares the assets/build/js output dir and the default `webpackChunkgodam` global
+	// with godamPlayerFrontend / godamImageLayersFrontend, which ALSO emit video.js-family
+	// async chunks. Give this compilation its own runtime global (uniqueName) and prefixed,
+	// content-hashed chunk filenames so its async chunks can't collide with theirs on disk
+	// or clobber each other's chunk-loading runtime (the "TypeError: o[t] is not a function"
+	// class of bug documented on godamImageLayersFrontend below). The content hash also
+	// avoids a browser serving a stale videojs chunk after a plugin update.
+	output: {
+		...sharedConfig.output,
+		uniqueName: 'godamMediaLibrary',
+		chunkFilename: 'media-library-[name].[contenthash].min.js',
+	},
 };
 
 const godamPlayerFrontend = {


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam-plugin-wp/issues/23

This pull request improves the reliability and correctness of the media library sidebar integration, especially in environments where multiple media modals can be open (such as the WordPress block editor, classic editor, and Elementor). The changes ensure the sidebar is mounted and unmounted at the right times and that UI state is only reset when all media modals are closed, preventing accidental loss of user context.

**Media frame sidebar mounting and lifecycle improvements:**

* Refactored the sidebar mounting logic to retry until the correct menu is available, target the specific frame being opened, and unmount stale React roots to prevent memory leaks. The sidebar is now mounted on every frame open event, not just on construction, fixing issues where the sidebar would disappear on reopening the modal. [[1]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0L63-R64) [[2]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0L108-R151) [[3]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0L274-R288) [[4]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0L293-R310)

**Robust UI state reset handling for multiple/nested modals:**

* Introduced logic to detect when any media modal is still open and only reset the sidebar's UI state and resync the WordPress media query when all modals are closed. This prevents the active folder selection from being wiped when closing nested modals. [[1]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aR55-R81) [[2]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aL85-R113) [[3]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aL105-R130) [[4]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aL127-R152) [[5]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aR163-R178) [[6]](diffhunk://#diff-95a863383c43c78a2b03e33ac44d350b813a2ae897d004d008d631252e8a590aR188-R191)

**Code cleanup and variable renaming:**

* Renamed variables from `ELEMENTOR_MENU_*` to `MEDIA_FRAME_MENU_*` to clarify that the logic applies to all media frames, not just Elementor. [[1]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0L63-R64) [[2]](diffhunk://#diff-c96ea6334c321bd29a6e93f99ac0b39070d7d6995c8acd4497cfff409f37bfb0L108-R151)

These changes significantly improve the sidebar's stability and user experience in complex modal scenarios.