### PR TITLE
Restrict Gravity Forms REST routes to authenticated users

### DIFF
--- a/inc/classes/rest-api/class-gf.php
+++ b/inc/classes/rest-api/class-gf.php
@@ -127,9 +127,13 @@ class GF extends Base {
 			return self::ALLOWED_FORM_FIELDS;
 		}
 
-		$fields = array_map( 'trim', explode( ',', $requested ) );
+		$fields = array_unique( array_map( 'trim', explode( ',', $requested ) ) );
+		$fields = array_values( array_intersect( $fields, self::ALLOWED_FORM_FIELDS ) );
 
-		return array_values( array_intersect( $fields, self::ALLOWED_FORM_FIELDS ) );
+		// Naming only disallowed fields would otherwise yield a list of empty
+		// objects; fall back so the response is always usable. Narrowing to the
+		// allowlist can never widen it.
+		return empty( $fields ) ? self::ALLOWED_FORM_FIELDS : $fields;
 	}
 
 	/**

--- a/inc/classes/rest-api/class-gf.php
+++ b/inc/classes/rest-api/class-gf.php
@@ -17,6 +17,27 @@ defined( 'ABSPATH' ) || exit;
 class GF extends Base {
 
 	/**
+	 * Fields the form collection is allowed to expose.
+	 *
+	 * A Gravity Forms form object also carries notifications, confirmations and
+	 * any settings an add-on has persisted into form meta. None of that may
+	 * reach the REST response, so the collection is narrowed to the three
+	 * fields the Video Editor's form picker actually renders.
+	 *
+	 * @var string[]
+	 */
+	public const ALLOWED_FORM_FIELDS = array( 'id', 'title', 'description' );
+
+	/**
+	 * Permission check — same capability the Video Editor page requires.
+	 *
+	 * @return bool
+	 */
+	public function forms_permissions_check() {
+		return current_user_can( 'upload_files' );
+	}
+
+	/**
 	 * Get REST routes.
 	 */
 	public function get_rest_routes() {
@@ -28,7 +49,7 @@ class GF extends Base {
 					array(
 						'methods'             => \WP_REST_Server::READABLE,
 						'callback'            => array( $this, 'get_gforms' ),
-						'permission_callback' => '__return_true',
+						'permission_callback' => array( $this, 'forms_permissions_check' ),
 						'args'                => $this->get_collection_params(),
 					),
 				),
@@ -40,7 +61,7 @@ class GF extends Base {
 					array(
 						'methods'             => \WP_REST_Server::READABLE,
 						'callback'            => array( $this, 'get_gform' ),
-						'permission_callback' => '__return_true',
+						'permission_callback' => array( $this, 'forms_permissions_check' ),
 						'args'                => array_merge(
 							$this->get_collection_params(), // Default collection params.
 							array(
@@ -79,21 +100,36 @@ class GF extends Base {
 		// Get all forms.
 		$gforms = \GFAPI::get_forms();
 
-		// Get the output fields.
-		$fields = $request->get_param( 'fields' );
+		$fields = self::resolve_requested_fields( $request->get_param( 'fields' ) );
 
-		// Filter fields.
-		if ( ! empty( $fields ) ) {
-			$fields = explode( ',', $fields );
-			$gforms = array_map(
-				function ( $gform ) use ( $fields ) {
-					return array_intersect_key( $gform, array_flip( $fields ) );
-				},
-				$gforms
-			);
-		}
+		$gforms = array_map(
+			function ( $gform ) use ( $fields ) {
+				return array_intersect_key( $gform, array_flip( $fields ) );
+			},
+			$gforms
+		);
 
 		return rest_ensure_response( $gforms );
+	}
+
+	/**
+	 * Narrow a caller-supplied `fields` list to the allowlist.
+	 *
+	 * Applied unconditionally: an omitted or unrecognised `fields` value must
+	 * never widen the response, so the caller can only ever narrow what the
+	 * allowlist already permits.
+	 *
+	 * @param string|null $requested Comma-separated field list from the request.
+	 * @return string[]
+	 */
+	public static function resolve_requested_fields( $requested ) {
+		if ( empty( $requested ) || ! is_string( $requested ) ) {
+			return self::ALLOWED_FORM_FIELDS;
+		}
+
+		$fields = array_map( 'trim', explode( ',', $requested ) );
+
+		return array_values( array_intersect( $fields, self::ALLOWED_FORM_FIELDS ) );
 	}
 
 	/**

--- a/pages/video-editor/redux/api/gravity-forms.js
+++ b/pages/video-editor/redux/api/gravity-forms.js
@@ -9,6 +9,10 @@ export const gravityFormsAPI = createApi( {
 	reducerPath: 'gravityFormsAPI',
 	baseQuery: fetchBaseQuery( {
 		baseUrl: window.pathJoin( [ restURL, '/godam/v1/' ] ),
+		prepareHeaders: ( headers ) => {
+			headers.set( 'X-WP-Nonce', window.godamRestRoute?.nonce || window.wpApiSettings?.nonce || '' );
+			return headers;
+		},
 	} ),
 	endpoints: ( builder ) => ( {
 		getGravityForms: builder.query( {

--- a/pages/video-editor/redux/api/gravity-forms.js
+++ b/pages/video-editor/redux/api/gravity-forms.js
@@ -10,7 +10,10 @@ export const gravityFormsAPI = createApi( {
 	baseQuery: fetchBaseQuery( {
 		baseUrl: window.pathJoin( [ restURL, '/godam/v1/' ] ),
 		prepareHeaders: ( headers ) => {
-			headers.set( 'X-WP-Nonce', window.godamRestRoute?.nonce || window.wpApiSettings?.nonce || '' );
+			const nonce = window.godamRestRoute?.nonce || window.wpApiSettings?.nonce;
+			if ( nonce ) {
+				headers.set( 'X-WP-Nonce', nonce );
+			}
 			return headers;
 		},
 	} ),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -123,5 +123,6 @@ if ( ! class_exists( 'WP_REST_Controller' ) ) {
 require_once dirname( __DIR__ ) . '/inc/traits/trait-singleton.php';
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-base.php';
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-video-editor.php';
+require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-gf.php';
 
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-onboarding-response.php';

--- a/tests/php/GravityFormsFieldAllowlistTest.php
+++ b/tests/php/GravityFormsFieldAllowlistTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Unit tests for the Gravity Forms collection field allowlist.
+ *
+ * Regression cover for the unauthenticated disclosure fixed in #1289: the
+ * `/godam/v1/gforms` response used to be narrowed only when the caller passed a
+ * `fields` parameter, so omitting it returned the whole form object —
+ * notifications, confirmations and any add-on settings held in form meta.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RTGODAM\Inc\REST_API\GF;
+
+/**
+ * @covers \RTGODAM\Inc\REST_API\GF::resolve_requested_fields
+ */
+class GravityFormsFieldAllowlistTest extends TestCase {
+
+	/** No `fields` parameter must still return only the allowlist, never everything. */
+	public function test_missing_fields_returns_allowlist() {
+		$this->assertSame( array( 'id', 'title', 'description' ), GF::resolve_requested_fields( null ) );
+	}
+
+	/** An empty string is the same case as omitting the parameter. */
+	public function test_empty_fields_returns_allowlist() {
+		$this->assertSame( array( 'id', 'title', 'description' ), GF::resolve_requested_fields( '' ) );
+	}
+
+	/** The Video Editor's own request is honoured unchanged. */
+	public function test_video_editor_request_is_honoured() {
+		$this->assertSame(
+			array( 'id', 'title', 'description' ),
+			GF::resolve_requested_fields( 'id,title,description' )
+		);
+	}
+
+	/** A caller may narrow the response further. */
+	public function test_caller_may_narrow_selection() {
+		$this->assertSame( array( 'id', 'title' ), GF::resolve_requested_fields( 'id,title' ) );
+	}
+
+	/** Privileged keys are dropped even when named explicitly. */
+	public function test_privileged_fields_are_rejected() {
+		$this->assertSame( array(), GF::resolve_requested_fields( 'notifications' ) );
+		$this->assertSame( array(), GF::resolve_requested_fields( 'confirmations,fields,feeds' ) );
+	}
+
+	/** The exact shape reported in #1289 — an add-on credential blob in form meta. */
+	public function test_addon_credential_key_is_rejected() {
+		$this->assertSame( array(), GF::resolve_requested_fields( 'atd-salesforce' ) );
+	}
+
+	/** Mixing an allowed field with a privileged one keeps only the allowed field. */
+	public function test_mixed_selection_keeps_only_allowed() {
+		$this->assertSame( array( 'id' ), GF::resolve_requested_fields( 'id,notifications' ) );
+	}
+
+	/** Whitespace around names must not smuggle a field past the allowlist. */
+	public function test_whitespace_is_trimmed() {
+		$this->assertSame( array( 'id', 'title' ), GF::resolve_requested_fields( ' id , title ' ) );
+	}
+
+	/** Matching is case-sensitive; a cased variant is not an allowed field. */
+	public function test_matching_is_case_sensitive() {
+		$this->assertSame( array(), GF::resolve_requested_fields( 'ID,Title' ) );
+	}
+
+	/** Non-string input (e.g. `fields[]=x`) falls back to the allowlist. */
+	public function test_non_string_input_returns_allowlist() {
+		$this->assertSame( array( 'id', 'title', 'description' ), GF::resolve_requested_fields( array( 'notifications' ) ) );
+	}
+
+	/** Result is a list, so it JSON-encodes as an array rather than an object. */
+	public function test_result_is_a_list() {
+		$this->assertSame( array( 'title' ), GF::resolve_requested_fields( 'notifications,title' ) );
+	}
+}

--- a/tests/php/GravityFormsFieldAllowlistTest.php
+++ b/tests/php/GravityFormsFieldAllowlistTest.php
@@ -43,15 +43,35 @@ class GravityFormsFieldAllowlistTest extends TestCase {
 		$this->assertSame( array( 'id', 'title' ), GF::resolve_requested_fields( 'id,title' ) );
 	}
 
-	/** Privileged keys are dropped even when named explicitly. */
+	/**
+	 * Privileged keys are dropped even when named explicitly.
+	 *
+	 * A selection naming nothing allowed falls back to the allowlist rather
+	 * than returning an empty set, which would render as a list of empty
+	 * objects. The privileged fields are absent either way.
+	 */
 	public function test_privileged_fields_are_rejected() {
-		$this->assertSame( array(), GF::resolve_requested_fields( 'notifications' ) );
-		$this->assertSame( array(), GF::resolve_requested_fields( 'confirmations,fields,feeds' ) );
+		foreach ( array( 'notifications', 'confirmations,fields,feeds' ) as $requested ) {
+			$resolved = GF::resolve_requested_fields( $requested );
+
+			$this->assertSame( array( 'id', 'title', 'description' ), $resolved );
+			foreach ( explode( ',', $requested ) as $privileged ) {
+				$this->assertNotContains( $privileged, $resolved );
+			}
+		}
 	}
 
 	/** The exact shape reported in #1289 — an add-on credential blob in form meta. */
 	public function test_addon_credential_key_is_rejected() {
-		$this->assertSame( array(), GF::resolve_requested_fields( 'atd-salesforce' ) );
+		$resolved = GF::resolve_requested_fields( 'atd-salesforce' );
+
+		$this->assertNotContains( 'atd-salesforce', $resolved );
+		$this->assertSame( array( 'id', 'title', 'description' ), $resolved );
+	}
+
+	/** Repeated names must not produce duplicate entries. */
+	public function test_duplicates_are_collapsed() {
+		$this->assertSame( array( 'id', 'title' ), GF::resolve_requested_fields( 'id,id,title,id' ) );
 	}
 
 	/** Mixing an allowed field with a privileged one keeps only the allowed field. */
@@ -66,7 +86,11 @@ class GravityFormsFieldAllowlistTest extends TestCase {
 
 	/** Matching is case-sensitive; a cased variant is not an allowed field. */
 	public function test_matching_is_case_sensitive() {
-		$this->assertSame( array(), GF::resolve_requested_fields( 'ID,Title' ) );
+		$resolved = GF::resolve_requested_fields( 'ID,Title' );
+
+		$this->assertNotContains( 'ID', $resolved );
+		$this->assertNotContains( 'Title', $resolved );
+		$this->assertSame( array( 'id', 'title', 'description' ), $resolved );
 	}
 
 	/** Non-string input (e.g. `fields[]=x`) falls back to the allowlist. */


### PR DESCRIPTION
This pull request addresses a security issue in the Gravity Forms REST API integration by restricting which form fields can be exposed, tightening permissions, and adding comprehensive unit tests to prevent regression. It also updates the frontend to send authentication headers and improves test bootstrapping for isolated environments.

**Security and Permissions:**
- Only the `id`, `title`, and `description` fields are now allowed in Gravity Forms REST API responses, preventing accidental disclosure of sensitive form data such as notifications, confirmations, or add-on settings. (`inc/classes/rest-api/class-gf.php`) [[1]](diffhunk://#diff-d1e8c3312a14bf396e4616058715843d4f6072b8f9d63bc0abd3ef82efc4a9fcR19-R39) [[2]](diffhunk://#diff-d1e8c3312a14bf396e4616058715843d4f6072b8f9d63bc0abd3ef82efc4a9fcL82-R134)
- REST API endpoints for Gravity Forms now require the `upload_files` capability, matching the Video Editor page's permission requirements. (`inc/classes/rest-api/class-gf.php`) [[1]](diffhunk://#diff-d1e8c3312a14bf396e4616058715843d4f6072b8f9d63bc0abd3ef82efc4a9fcL31-R52) [[2]](diffhunk://#diff-d1e8c3312a14bf396e4616058715843d4f6072b8f9d63bc0abd3ef82efc4a9fcL43-R64)

**Backend Logic and Tests:**
- Introduced the `resolve_requested_fields` method to strictly enforce the allowlist, regardless of the `fields` parameter in the request. (`inc/classes/rest-api/class-gf.php`)
- Added unit tests to ensure only allowed fields are ever returned, covering various edge cases and regression scenarios. (`tests/php/GravityFormsFieldAllowlistTest.php`)
- Added a stub for `WP_REST_Controller` to allow unit tests to run without a full WordPress environment. (`tests/stubs/class-wp-rest-controller.php`, `tests/bootstrap.php`) [[1]](diffhunk://#diff-8d73534f1024e96dff5f89df7ffe2e41c8bea712cf157f1da4358252c1183de5R1-R18) [[2]](diffhunk://#diff-96a82592013e5f4b91e682332583b7a4a6ca1ff0431d267c61179b1a21b167daR28-R33)

**Frontend Integration:**
- The frontend now always sends the correct REST API nonce for authentication with Gravity Forms endpoints, improving security for API requests. (`pages/video-editor/redux/api/gravity-forms.js`)…routes

GET /godam/v1/gforms was registered with __return_true and returned GFAPI::get_forms() verbatim. The response was narrowed only when the caller passed a `fields` parameter, so an unauthenticated request that omitted it received the complete form configuration: notification recipients and routing, confirmation URLs, the full field structure, and any settings an add-on had persisted into form meta — including credentials.

- Gate /gforms and /gform on current_user_can( 'upload_files' ), matching the capability the Video Editor page itself registers with.
- Narrow the collection to id, title and description on the server, unconditionally, so an omitted or unrecognised `fields` value can no longer widen the response.
- Send X-WP-Nonce from the Video Editor's Gravity Forms slice. Without it a cookie-authenticated request is evaluated as anonymous and the form picker breaks under the new capability check.

Adds unit cover for the allowlist. Authorisation itself needs the wp-phpunit harness the bootstrap notes as a follow-up.

Refs rtCamp/godam-core#1289