### PR TITLE
fix: stop translating during plugins_loaded (_load_textdomain_just_in_time)

### DIFF
--- a/.github/workflows/php_unit_tests_on_pull_request.yml
+++ b/.github/workflows/php_unit_tests_on_pull_request.yml
@@ -18,10 +18,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # 8.4, not the plugin's minimum of 7.4: composer.lock pins dev tools that
+      # require PHP ^8.4 (doctrine/instantiator, symfony/finder), so
+      # `composer install` fails its platform check on anything older. This
+      # constrains the test toolchain only — runtime PHP support is unaffected.
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer
 

--- a/.github/workflows/php_unit_tests_on_pull_request.yml
+++ b/.github/workflows/php_unit_tests_on_pull_request.yml
@@ -1,0 +1,37 @@
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+name: PHP Unit Tests
+
+permissions:
+  contents: read
+
+jobs:
+  runPHPUnitTests:
+    name: Run PHP unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer
+
+      # Dev dependencies are required here: the deploy and plugin-check
+      # workflows install with --no-dev, so phpunit is absent in those.
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      # Pure unit tests via tests/bootstrap.php stubs — no WordPress install and
+      # no database, so no service containers are needed. Includes the #465
+      # hook-timing guards, which only prevent a regression if CI runs them.
+      - name: Run PHP unit tests
+        run: composer phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog #
 
+## v2.1.1 (August 5, 2026) ##
+
+- Fix: Removed every GoDAM translation call that ran before the `init` action, so WordPress 6.7+ no longer reports `Function _load_textdomain_just_in_time was called incorrectly` for the `godam` text domain. Covers the WPForms and Fluent Forms field registrations, the add-on compatibility and dependency notices, and the media library transcode status column.
+- Tweak: The media library transcode status column no longer re-verifies the API key over HTTP on front-end, REST and cron requests.
+- Fix: The translation template is now built from source instead of compiled assets, adding 47 strings that could not previously be translated and dropping stale ones that no longer exist in the plugin.
+- Chore: PHP unit tests now run on every pull request.
+
 ## v2.1.0 (July 30, 2026) ##
 
 - Feat: Interactive Image Hotspots — turn any image into an interactive, shoppable visual. The new Image editor lets you add clickable Hotspot layers to any image, then embed it anywhere with the new GoDAM Image block.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested up to: 7.0
 
 Requires PHP: 7.4
 
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/admin/godam-transcoder-functions.php
+++ b/admin/godam-transcoder-functions.php
@@ -371,13 +371,35 @@ function rtgodam_add_status_columns_content( $column_name, $post_id ) {
 	}
 }
 
-$godam_user_data           = rtgodam_get_user_data();
-$godam_is_api_key_verified = isset( $godam_user_data['valid_api_key'] ) ? $godam_user_data['valid_api_key'] : false;
+/**
+ * Register the transcode status column on the media list table.
+ *
+ * Hooked to `admin_init` instead of running at file load. Resolving the API key
+ * can call `rtgodam_verify_api_key()`, which translates, and at file load that
+ * happens before `init` — which WordPress 6.7+ reports as
+ * `_load_textdomain_just_in_time was called incorrectly`. It is easy to miss
+ * because the key is only re-verified once the cached user data is older than an
+ * hour, so most requests never reach the translation.
+ *
+ * Running here also keeps that remote call off front-end, REST and cron
+ * requests, for a column that only ever renders in wp-admin.
+ *
+ * @since 2.1.1
+ *
+ * @see https://github.com/rtCamp/godam/issues/465
+ *
+ * @return void
+ */
+function rtgodam_register_media_status_columns() {
+	if ( ! rtgodam_is_api_key_valid() ) {
+		return;
+	}
 
-if ( $godam_is_api_key_verified ) {
 	add_filter( 'manage_media_columns', 'rtgodam_add_status_columns_head' );
 	add_action( 'manage_media_custom_column', 'rtgodam_add_status_columns_content', 10, 2 );
 }
+
+add_action( 'admin_init', 'rtgodam_register_media_status_columns' );
 
 /**
  * Set sortable status column in media admin page

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"npm run lint:staged"
 		],
 		"phpunit": "phpunit",
-		"pot": "WP_CLI_PHP_ARGS='-d memory_limit=1024M' ./vendor/bin/wp i18n make-pot . --exclude=\"assets/src,assets/node_modules,tests,vendor\" ./languages/godam.pot"
+		"pot": "WP_CLI_PHP_ARGS='-d memory_limit=1024M' ./vendor/bin/wp i18n make-pot . --exclude=\"assets/build,assets/node_modules,node_modules,tests,vendor\" ./languages/godam.pot"
 	},
 	"require": {
 		"woocommerce/action-scheduler": "^3.9"

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '2.1.0' );
+	define( 'RTGODAM_VERSION', '2.1.1' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/inc/classes/addons/class-abstract-addon.php
+++ b/inc/classes/addons/class-abstract-addon.php
@@ -92,7 +92,7 @@ abstract class Abstract_Addon {
 	 */
 	public function dependencies_met() {
 		foreach ( $this->get_dependencies() as $dep ) {
-			if ( is_callable( $dep['check'] ) && ! call_user_func( $dep['check'] ) ) {
+			if ( is_callable( $dep['check'] ) && ! $dep['check']() ) {
 				return false;
 			}
 		}
@@ -111,9 +111,19 @@ abstract class Abstract_Addon {
 		$messages = array();
 
 		foreach ( $this->get_dependencies() as $dep ) {
-			if ( is_callable( $dep['check'] ) && ! call_user_func( $dep['check'] ) ) {
-				$messages[] = is_callable( $dep['message'] ) ? call_user_func( $dep['message'] ) : $dep['message'];
+			if ( ! is_callable( $dep['check'] ) || $dep['check']() ) {
+				continue;
 			}
+
+			$message = $dep['message'] ?? '';
+
+			// A message string is never invoked, even when it happens to match a
+			// function name: only a closure or other non-string callable is.
+			if ( ! is_string( $message ) && is_callable( $message ) ) {
+				$message = $message();
+			}
+
+			$messages[] = (string) $message;
 		}
 
 		return $messages;

--- a/inc/classes/addons/class-abstract-addon.php
+++ b/inc/classes/addons/class-abstract-addon.php
@@ -69,9 +69,17 @@ abstract class Abstract_Addon {
 	 * Each entry is an associative array:
 	 *   'name'      => (string) Human-readable dependency name.
 	 *   'check'     => (callable) Returns true when the dependency is satisfied.
-	 *   'message'   => (string) Admin notice text when the dependency is missing.
+	 *   'message'   => (string|callable) Admin notice text when the dependency is
+	 *                  missing, or a callback returning it.
 	 *
-	 * @return array<int, array{name: string, check: callable, message: string}>
+	 * This runs during `plugins_loaded`, before any text domain is loaded, so an
+	 * add-on must NOT translate here: pass a callback as 'message' and translate
+	 * inside it. Translating directly makes WordPress 6.7+ report
+	 * `_load_textdomain_just_in_time was called incorrectly` on every request.
+	 *
+	 * @see https://github.com/rtCamp/godam/issues/465
+	 *
+	 * @return array<int, array{name: string, check: callable, message: string|callable}>
 	 */
 	public function get_dependencies() {
 		return array();
@@ -94,6 +102,9 @@ abstract class Abstract_Addon {
 	/**
 	 * Get missing dependency messages.
 	 *
+	 * A 'message' may be a callback so the add-on can translate it here, when the
+	 * notice is rendered, instead of during `plugins_loaded`.
+	 *
 	 * @return string[]
 	 */
 	public function get_missing_dependency_messages() {
@@ -101,7 +112,7 @@ abstract class Abstract_Addon {
 
 		foreach ( $this->get_dependencies() as $dep ) {
 			if ( is_callable( $dep['check'] ) && ! call_user_func( $dep['check'] ) ) {
-				$messages[] = $dep['message'];
+				$messages[] = is_callable( $dep['message'] ) ? call_user_func( $dep['message'] ) : $dep['message'];
 			}
 		}
 

--- a/inc/classes/addons/class-addon-registry.php
+++ b/inc/classes/addons/class-addon-registry.php
@@ -307,10 +307,16 @@ class Addon_Registry {
 	 * @return void
 	 */
 	private function show_admin_notice( callable $message_callback ) {
+		// `boot_addons()` runs on every request type. Front-end, REST and cron
+		// requests never fire `admin_notices`, so don't queue a callback there.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		add_action(
 			'admin_notices',
 			static function () use ( $message_callback ) {
-				$message = $message_callback();
+				$message = (string) $message_callback();
 
 				if ( '' === $message ) {
 					return;

--- a/inc/classes/addons/class-addon-registry.php
+++ b/inc/classes/addons/class-addon-registry.php
@@ -61,7 +61,19 @@ class Addon_Registry {
 		do_action( 'godam_register_addons', $this );
 
 		$this->boot_addons();
-		$this->warn_incompatible_addons();
+
+		/**
+		 * The compatibility check builds translated notice text, so it has to run
+		 * after translations are available. Running it here (plugins_loaded) makes
+		 * every `__()` below a just-in-time text domain load, which WordPress 6.7+
+		 * reports as `_load_textdomain_just_in_time was called incorrectly`.
+		 *
+		 * `admin_init` runs after `init` and only on admin requests, which is the
+		 * only place the notice can render anyway.
+		 *
+		 * @see https://github.com/rtCamp/godam/issues/465
+		 */
+		add_action( 'admin_init', array( $this, 'warn_incompatible_addons' ) );
 	}
 
 	/**
@@ -74,15 +86,12 @@ class Addon_Registry {
 	 * surface a dismissible admin notice pointing the user at the update. The
 	 * minimum-version map is filterable so future add-ons can declare their own.
 	 *
+	 * Hooked to `admin_init`, so it is admin-only by construction and runs late
+	 * enough to translate safely.
+	 *
 	 * @return void
 	 */
-	private function warn_incompatible_addons() {
-		// The notice only ever renders in wp-admin, so skip the whole check on
-		// front-end / REST / cron requests instead of running it every load.
-		if ( ! is_admin() ) {
-			return;
-		}
-
+	public function warn_incompatible_addons() {
 		/**
 		 * Minimum add-on version compatible with the current GoDAM version,
 		 * keyed by the slug the add-on registers under.
@@ -150,7 +159,7 @@ class Addon_Registry {
 	 * admin_notices hook intact (Pages::handle_admin_head only strips it on
 	 * GoDAM's own screens), so a plain admin_notices callback is enough.
 	 *
-	 * The screen is not known yet when this runs (plugins_loaded), so the screen
+	 * The screen is not known yet when this runs (admin_init), so the screen
 	 * check happens inside the admin_notices callback, by which point
 	 * get_current_screen() is populated.
 	 *
@@ -214,21 +223,27 @@ class Addon_Registry {
 			// Check GoDAM version compatibility.
 			if ( ! $addon->is_godam_version_compatible() ) {
 				$this->show_admin_notice(
-					sprintf(
-						/* translators: 1: Add-on name, 2: Required GoDAM version */
-						esc_html__( '%1$s requires GoDAM %2$s or higher. Please update the GoDAM plugin.', 'godam' ),
-						'<strong>' . esc_html( $addon->get_name() ) . '</strong>',
-						esc_html( $addon->get_minimum_godam_version() )
-					)
+					static function () use ( $addon ) {
+						return sprintf(
+							/* translators: 1: Add-on name, 2: Required GoDAM version */
+							esc_html__( '%1$s requires GoDAM %2$s or higher. Please update the GoDAM plugin.', 'godam' ),
+							'<strong>' . esc_html( $addon->get_name() ) . '</strong>',
+							esc_html( $addon->get_minimum_godam_version() )
+						);
+					}
 				);
 				continue;
 			}
 
 			// Check add-on-specific dependencies (e.g. WooCommerce active).
 			if ( ! $addon->dependencies_met() ) {
-				foreach ( $addon->get_missing_dependency_messages() as $msg ) {
-					$this->show_admin_notice( $msg );
-				}
+				// One notice per add-on: asking for the messages here, just to
+				// count them, would translate them during `plugins_loaded`.
+				$this->show_admin_notice(
+					static function () use ( $addon ) {
+						return implode( '<br />', $addon->get_missing_dependency_messages() );
+					}
+				);
 				continue;
 			}
 
@@ -281,14 +296,26 @@ class Addon_Registry {
 	/**
 	 * Helper: queue an admin notice.
 	 *
-	 * @param string $message HTML notice content.
+	 * Callers run during `plugins_loaded`, where translation functions are not
+	 * safe to call yet, so the message is passed as a callback and built when the
+	 * notice actually renders.
+	 *
+	 * @see https://github.com/rtCamp/godam/issues/465
+	 *
+	 * @param callable $message_callback Returns the HTML notice content.
 	 *
 	 * @return void
 	 */
-	private function show_admin_notice( $message ) {
+	private function show_admin_notice( callable $message_callback ) {
 		add_action(
 			'admin_notices',
-			function () use ( $message ) {
+			static function () use ( $message_callback ) {
+				$message = $message_callback();
+
+				if ( '' === $message ) {
+					return;
+				}
+
 				printf( '<div class="notice notice-error"><p>%s</p></div>', wp_kses_post( $message ) );
 			}
 		);

--- a/inc/classes/fluentforms/class-init.php
+++ b/inc/classes/fluentforms/class-init.php
@@ -67,9 +67,17 @@ class Init {
 	public function load_fluentforms_classes() {
 
 		/**
-		 * Load the new field on `fluentform/loaded`.
+		 * Load the field on `init`.
+		 *
+		 * It used to load on `fluentform/loaded`, which fires during
+		 * `plugins_loaded`. The recorder field translates its labels in the
+		 * constructor, so the field was translating before any text domain was
+		 * available, which WordPress 6.7+ reports as
+		 * `_load_textdomain_just_in_time was called incorrectly`.
+		 *
+		 * @see https://github.com/rtCamp/godam/issues/465
 		 */
-		add_action( 'fluentform/loaded', array( $this, 'on_fluentforms_loaded' ) );
+		add_action( 'init', array( $this, 'on_fluentforms_loaded' ) );
 
 		/**
 		 * Filter to exclude godam scripts on fluent forms pages.

--- a/inc/classes/wpforms/class-wpforms-integration.php
+++ b/inc/classes/wpforms/class-wpforms-integration.php
@@ -38,7 +38,21 @@ class WPForms_Integration {
 
 			add_action( 'wpforms_frontend_confirmation_message_before', array( $this, 'load_godam_recorder_script_on_success' ), 10, 4 );
 
-			add_action( 'wpforms_loaded', array( $this, 'init_godam_video_field' ) );
+			/**
+			 * Initialize the GoDAM video field on `init`.
+			 *
+			 * It used to initialize on `wpforms_loaded`, which fires during
+			 * `plugins_loaded`. `WPForms_Field::__construct()` calls the field's
+			 * `init()`, which translates its labels, so the field was translating
+			 * before any text domain was available, which WordPress 6.7+ reports
+			 * as `_load_textdomain_just_in_time was called incorrectly`.
+			 *
+			 * `init` is also where WPForms itself registers its own fields
+			 * (see WPForms\Loader::populate_fields()).
+			 *
+			 * @see https://github.com/rtCamp/godam/issues/465
+			 */
+			add_action( 'init', array( $this, 'init_godam_video_field' ) );
 
 			add_action( 'wpforms_process_entry_saved', array( $this, 'send_saved_files_for_transcoding' ), 10, 4 );
 

--- a/languages/godam.pot
+++ b/languages/godam.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: GoDAM 2.1.0\n"
+"Project-Id-Version: GoDAM 2.1.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/godam\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-30T08:25:17+00:00\n"
+"POT-Creation-Date: 2026-08-05T06:28:27+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.11.0\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: godam\n"
 
 #. Plugin Name of the plugin
@@ -25,7 +25,6 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:371
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:382
 #: pages/video-editor/components/forms/CF7.js:22
-#: assets/build/pages/video-editor.min.js:21935
 msgid "GoDAM"
 msgstr ""
 
@@ -59,8 +58,6 @@ msgstr ""
 #: admin/js/godam-retranscode-media.js:6
 #: pages/tools/App.js:22
 #: pages/tools/components/tabs/RetranscodeTab.jsx:353
-#: assets/build/pages/tools.min.js:1470
-#: assets/build/pages/tools.min.js:2785
 msgid "Retranscode Media"
 msgstr ""
 
@@ -72,6 +69,7 @@ msgstr ""
 #. translators: Link to the media page.
 #: admin/class-rtgodam-retranscodemedia.php:183
 #: admin/class-rtgodam-retranscodemedia.php:395
+#, php-format
 msgid "Unable to find any media. Are you sure <a href='%s'>some exist</a>?"
 msgstr ""
 
@@ -82,6 +80,7 @@ msgstr ""
 #. translators: The URL to go back to the previous page.
 #: admin/class-rtgodam-retranscodemedia.php:206
 #: admin/class-rtgodam-retranscodemedia.php:475
+#, php-format
 msgid "To go back to the previous page, <a href=\"%s\">click here</a>."
 msgstr ""
 
@@ -120,11 +119,13 @@ msgstr ""
 
 #. translators: Count of media which were successfully and media which were failed transcoded with the time in seconds and previout page link.
 #: admin/class-rtgodam-retranscodemedia.php:478
+#, php-format
 msgid "All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were %3$s failure(s). To try transcoding the failed media again, <a href=\"%4$s\">click here</a>. %5$s"
 msgstr ""
 
 #. translators: Count of media which were successfully transcoded with the time in seconds and previout page link.
 #: admin/class-rtgodam-retranscodemedia.php:480
+#, php-format
 msgid "All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were 0 failures. %3$s"
 msgstr ""
 
@@ -143,16 +144,19 @@ msgstr ""
 
 #. translators: Total count of the media.
 #: admin/class-rtgodam-retranscodemedia.php:496
+#, php-format
 msgid "Total Media: %s"
 msgstr ""
 
 #. translators: Count of media which were successfully sent to the transcoder server.
 #: admin/class-rtgodam-retranscodemedia.php:501
+#, php-format
 msgid "Media Sent for Retranscoding: %s"
 msgstr ""
 
 #. translators: Count of media which were failed while sending to the transcoder server.
 #: admin/class-rtgodam-retranscodemedia.php:506
+#, php-format
 msgid "Failed While Sending: %s"
 msgstr ""
 
@@ -166,6 +170,7 @@ msgstr ""
 
 #. translators: Placeholder is for admin media section link.
 #: admin/class-rtgodam-retranscodemedia.php:528
+#, php-format
 msgid "You can retranscode specific media files (rather than ALL media) from the <a href='%s'>Media</a> page using Bulk Action via drop down or mouse hover a specific media (audio/video) file."
 msgstr ""
 
@@ -179,6 +184,7 @@ msgstr ""
 
 #. translators: Media name, Media ID and message for failed transcode.
 #: admin/class-rtgodam-retranscodemedia.php:555
+#, php-format
 msgid "&quot;%1$s&quot; (ID %2$s) failed to send. The error message was: %3$s"
 msgstr ""
 
@@ -190,16 +196,19 @@ msgstr ""
 #: admin/class-rtgodam-transcoder-admin.php:86
 #: admin/class-rtgodam-transcoder-admin.php:148
 #: admin/class-rtgodam-transcoder-admin.php:163
+#, php-format
 msgid "Enjoy using our <strong>DAM and Media Editor</strong> features for free! To unlock Transcoding, Analytics and more, <a href=\"%s\">please activate your API key.</a>"
 msgstr ""
 
 #. translators: %d: Number of days until trial ends
 #: admin/class-rtgodam-transcoder-admin.php:111
+#, php-format
 msgid "Your product is under trial. You will be charged after <strong>%d days</strong>. If you wish to cancel, please visit <a href=\"https://app.godam.io/subscription/my-account\" target=\"_blank\">your subscription settings</a>."
 msgstr ""
 
 #. translators: %d: Number of days until transcoded videos are deleted after subscription ends
 #: admin/class-rtgodam-transcoder-admin.php:135
+#, php-format
 msgid "Your subscription has ended. No further transcoding can be done. Transcoded videos will be removed after <strong>%d days</strong>, and Pro features will not be accessible. After the 30-day grace period, already transcoded videos will no longer be served from the CDN. Renew your subscription to keep it up and running."
 msgstr ""
 
@@ -217,16 +226,9 @@ msgstr ""
 #: admin/godam-transcoder-functions.php:319
 #: inc/classes/class-media-library-ajax.php:1245
 #: inc/templates/video-preview.php:63
+#: assets/src/js/media-library/views/attachment.js:178
 #: pages/godam/components/GoDAMHeader.jsx:74
 #: pages/whats-new/components/Header.js:19
-#: assets/build/js/media-library.min.js:11566
-#: assets/build/pages/analytics.min.js:16336
-#: assets/build/pages/dashboard.min.js:4407
-#: assets/build/pages/godam.min.js:10393
-#: assets/build/pages/help.min.js:683
-#: assets/build/pages/tools.min.js:769
-#: assets/build/pages/video-editor.min.js:15718
-#: assets/build/pages/whats-new.min.js:751
 msgid "GoDAM Logo"
 msgstr ""
 
@@ -239,7 +241,6 @@ msgstr ""
 #: admin/class-rtgodam-transcoder-admin.php:622
 #: admin/class-rtgodam-transcoder-admin.php:661
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:82
-#: assets/build/pages/godam.min.js:11622
 msgid "Learn More"
 msgstr ""
 
@@ -268,16 +269,19 @@ msgstr ""
 
 #. translators: %1$s: bandwidth percentage, %2$s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:522
+#, php-format
 msgid "Your bandwidth (%1$s%%) and storage (%2$s%%) usage have exceeded your plan limits."
 msgstr ""
 
 #. translators: %s: bandwidth percentage
 #: admin/class-rtgodam-transcoder-admin.php:529
+#, php-format
 msgid "Your bandwidth usage (%s%%) has exceeded your plan limit."
 msgstr ""
 
 #. translators: %s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:535
+#, php-format
 msgid "Your storage usage (%s%%) has exceeded your plan limit."
 msgstr ""
 
@@ -298,22 +302,24 @@ msgstr ""
 #: admin/class-rtgodam-transcoder-admin.php:625
 #: admin/class-rtgodam-transcoder-admin.php:664
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
-#: assets/build/pages/godam.min.js:12848
 msgid "Refresh Status"
 msgstr ""
 
 #. translators: %1$s: bandwidth percentage, %2$s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:585
+#, php-format
 msgid "Your bandwidth (%1$s%%) and storage (%2$s%%) usage are approaching your plan limits."
 msgstr ""
 
 #. translators: %s: bandwidth percentage
 #: admin/class-rtgodam-transcoder-admin.php:592
+#, php-format
 msgid "Your bandwidth usage (%s%%) is approaching your plan limit."
 msgstr ""
 
 #. translators: %s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:598
+#, php-format
 msgid "Your storage usage (%s%%) is approaching your plan limit."
 msgstr ""
 
@@ -331,6 +337,7 @@ msgstr ""
 
 #. translators: %s: bandwidth percentage
 #: admin/class-rtgodam-transcoder-admin.php:642
+#, php-format
 msgid "Your bandwidth usage (%s%%) has exceeded your plan limit. Videos might not be served from CDN on frontend."
 msgstr ""
 
@@ -372,6 +379,7 @@ msgstr ""
 
 #. translators: %s: PostHog privacy policy URL
 #: admin/class-rtgodam-transcoder-admin.php:727
+#, php-format
 msgid "We are using PostHog to collect anonymous data. <a href=\"%s\" target=\"_blank\">Learn more</a>. This can be disabled from the settings on the Help page."
 msgstr ""
 
@@ -385,36 +393,43 @@ msgstr ""
 
 #. translators: %s: URL to settings page
 #: admin/class-rtgodam-transcoder-admin.php:778
+#, php-format
 msgid "Your GoDAM API key has expired. Transcoding and other Pro features are currently disabled. Please <a href=\"%s\">renew your subscription</a> to restore access."
 msgstr ""
 
 #. translators: %s: URL to settings page
 #: admin/class-rtgodam-transcoder-admin.php:783
+#, php-format
 msgid "Temporarily unable to verify your GoDAM API key. Transcoding may not work. Please <a href=\"%s\">check your settings</a> or try refreshing the status."
 msgstr ""
 
 #. translators: %s: URL to settings page
 #: admin/class-rtgodam-transcoder-admin.php:792
+#, php-format
 msgid "There is an issue with your GoDAM API key. Transcoding may not work. Please <a href=\"%s\">check your settings</a>."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
 #: admin/class-rtgodam-transcoder-admin.php:891
+#, php-format
 msgid "<strong>Shoppable video for WooCommerce is live!</strong> %1$sActivate%2$s to start selling directly from your videos."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
 #: admin/class-rtgodam-transcoder-admin.php:899
+#, php-format
 msgid "<strong>GoDAM now supports WooCommerce!</strong> %1$sInstall WooCommerce%2$s to start using shoppable videos with GoDAM."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
 #: admin/class-rtgodam-transcoder-admin.php:907
+#, php-format
 msgid "<strong>Add shoppable videos to your WooCommerce store!</strong> %1$sUpgrade your plan%2$s to unlock this feature."
 msgstr ""
 
 #. translators: %s: storage usage percent
 #: admin/class-rtgodam-transcoder-handler.php:266
+#, php-format
 msgid "Storage exceeded (%s%%)."
 msgstr ""
 
@@ -429,6 +444,7 @@ msgstr ""
 
 #. translators: 1: max retry attempts, 2: retry interval in minutes
 #: admin/class-rtgodam-transcoder-handler.php:505
+#, php-format
 msgid "GoDAM Central returned a server error. Transcoding will be retried automatically (up to %1$d times, every %2$d minutes)."
 msgstr ""
 
@@ -446,6 +462,7 @@ msgstr ""
 
 #. translators: Return an error if the value is neither a string nor an array.
 #: admin/class-rtgodam-transcoder-rest-routes.php:198
+#, php-format
 msgid "%s must be a valid URL or an array of URLs."
 msgstr ""
 
@@ -459,6 +476,7 @@ msgstr ""
 
 #. translators: %s is replaced with the attachment ID for which subsizes generation failed.
 #: admin/class-rtgodam-transcoder-rest-routes.php:327
+#, php-format
 msgid "GoDAM: Failed to request image subsizes for attachment ID %s. The transcoded image URL has been saved; subsizes may be retried separately."
 msgstr ""
 
@@ -499,7 +517,7 @@ msgid "Transcription callback received."
 msgstr ""
 
 #: admin/class-rtgodam-transcoder-rest-routes.php:534
-#: admin/godam-transcoder-functions.php:427
+#: admin/godam-transcoder-functions.php:449
 #: inc/classes/rest-api/class-media-library.php:336
 #: inc/classes/rest-api/class-transcoding.php:335
 msgid "API key is required."
@@ -529,22 +547,22 @@ msgid "Transcoded CDN URL"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:73
-#: assets/build/js/media-library.min.js:11117
+#: assets/src/js/media-library/views/attachment-details.js:157
 msgid "Transcoded CDN URL (MPD)"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:87
-#: assets/build/js/media-library.min.js:11119
+#: assets/src/js/media-library/views/attachment-details.js:159
 msgid "The URL of the transcoded file is generated automatically and cannot be edited."
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:95
-#: assets/build/js/media-library.min.js:11129
+#: assets/src/js/media-library/views/attachment-details.js:169
 msgid "Transcoded CDN URL (HLS)"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:104
-#: assets/build/js/media-library.min.js:11131
+#: assets/src/js/media-library/views/attachment-details.js:171
 msgid "The HLS URL of the transcoded file is generated automatically and cannot be edited."
 msgstr ""
 
@@ -558,6 +576,7 @@ msgstr ""
 
 #. translators: %1$s URL to the settings page, %2$s API key label.
 #: admin/godam-transcoder-actions.php:123
+#, php-format
 msgid "Activate the <a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> to enable transcoding and adaptive bitrate streaming."
 msgstr ""
 
@@ -576,42 +595,40 @@ msgid "Media is transcoded."
 msgstr ""
 
 #: admin/godam-transcoder-functions.php:345
-#: assets/build/js/media-library.min.js:9201
+#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:190
 msgid "Transcoding failed, please try again."
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:436
+#: admin/godam-transcoder-functions.php:458
 msgid "API key verification is blocked for localhost environments. To use production API keys on localhost, please add the following constant to your wp-config.php file: define('RTGODAM_API_KEY', 'your-api-key-here');"
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:445
+#: admin/godam-transcoder-functions.php:467
 msgid "The provided API key does not match the RTGODAM_API_KEY constant defined in wp-config.php."
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:541
+#: admin/godam-transcoder-functions.php:563
 msgid "API key verified and stored successfully!"
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:548
+#: admin/godam-transcoder-functions.php:570
 #: inc/classes/enums/class-api-key-status.php:84
 msgid "Unable to verify API key. Please try again later."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:150
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/render.php:150
+#: assets/src/blocks/godam-audio/edit.js:686
 msgid "Audio thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:157
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/render.php:157
+#: assets/src/blocks/godam-audio/edit.js:692
 #: pages/video-editor/components/audio/AudioCardPreview.js:70
 #: pages/video-editor/VideoEditor.js:649
-#: assets/build/pages/video-editor.min.js:17286
-#: assets/build/pages/video-editor.min.js:19347
 msgid "Untitled audio"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:186
+#: assets/src/blocks/godam-audio/render.php:186
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:158
 #: inc/classes/sureforms/class-form-submit.php:377
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:48
@@ -619,86 +636,82 @@ msgstr ""
 msgid "Your browser does not support the audio element."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:191
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
+#: assets/src/blocks/godam-audio/render.php:191
+#: assets/src/blocks/godam-audio/player.js:50
+#: assets/src/blocks/godam-audio/view.js:254
 #: pages/video-editor/components/audio/AudioCardPreview.js:200
-#: assets/build/pages/video-editor.min.js:19477
 msgid "Play"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:202
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/render.php:202
+#: assets/src/blocks/godam-audio/player.js:72
 #: pages/video-editor/components/audio/AudioCardPreview.js:217
-#: assets/build/pages/video-editor.min.js:19494
 msgid "Seek"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:242
+#: assets/src/blocks/godam-audio/render.php:242
 #: inc/classes/elementor-widgets/class-godam-video.php:110
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/tabs.js:136
+#: assets/src/blocks/godam-player/track-uploader.js:32
 #: pages/video-editor/components/audio/AudioCardPreview.js:244
 #: pages/video-editor/components/editor-shell/EditorTabRail.js:21
-#: assets/build/pages/video-editor.min.js:19521
-#: assets/build/pages/video-editor.min.js:21415
 msgid "Chapters"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:247
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/render.php:247
+#: assets/src/blocks/godam-audio/tabs.js:147
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:282
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:349
 #: pages/video-editor/components/audio/AudioCardPreview.js:253
 #: pages/video-editor/components/transcription/Transcription.js:170
-#: assets/build/pages/video-editor.min.js:19530
-#: assets/build/pages/video-editor.min.js:26095
 msgid "Transcript"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:251
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/render.php:251
+#: assets/src/blocks/godam-audio/tabs.js:155
 #: pages/video-editor/components/audio/AudioCardPreview.js:260
-#: assets/build/pages/video-editor.min.js:19537
 msgid "Toggle panel"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:277
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/render.php:277
+#: assets/src/blocks/godam-audio/tabs.js:167
 #: pages/video-editor/components/audio/AudioCardPreview.js:272
-#: assets/build/pages/video-editor.min.js:19549
 msgid "No chapters to show"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:285
+#: assets/src/blocks/godam-audio/render.php:285
 msgid "Loading transcript…"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:287
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
+#: assets/src/blocks/godam-audio/render.php:287
+#: assets/src/blocks/godam-audio/tabs.js:187
+#: assets/src/blocks/godam-audio/view.js:116
 #: pages/video-editor/components/audio/AudioCardPreview.js:297
-#: assets/build/pages/video-editor.min.js:19574
 msgid "No transcript to show"
 msgstr ""
 
 #. translators: %d: number of pages
-#: assets/build/blocks/godam-pdf/render.php:131
+#: assets/src/blocks/godam-pdf/render.php:149
+#, php-format
 msgid "%d page"
 msgid_plural "%d pages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %s: PDF download URL
-#: assets/build/blocks/godam-pdf/render.php:178
+#: assets/src/blocks/godam-pdf/render.php:196
+#, php-format
 msgid "Your browser does not support PDFs. <a href=\"%s\">Download the PDF</a>."
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:20
+#: assets/src/blocks/sureforms/blocks/recorder/render.php:20
 #: inc/classes/fluentforms/fields/class-recorder-field.php:83
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:121
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:165
 msgid "GoDAM Recorder"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:24
+#: assets/src/blocks/sureforms/blocks/recorder/render.php:24
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:345
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:508
 #: inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php:25
@@ -706,42 +719,43 @@ msgstr ""
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:221
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:153
 #: inc/classes/wpforms/wpforms-field-godam-record-frontend.php:61
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:341
 msgid "Start Recording"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:29
+#: assets/src/blocks/sureforms/blocks/recorder/render.php:29
 #: inc/classes/sureforms/class-form-submit.php:80
 msgid "The field is required"
 msgstr ""
 
 #. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:117
+#: assets/src/blocks/sureforms/blocks/recorder/render.php:117
+#, php-format
 msgid "Maximum allowed on this server: %d MB"
 msgstr ""
 
 #: godam.php:108
 #: inc/classes/class-pages.php:242
 #: inc/classes/class-pages.php:243
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:607
 #: pages/video-editor/components/appearance/Appearance.js:124
 #: pages/video-editor/components/editor-shell/EditorTabRail.js:19
-#: assets/build/pages/video-editor.min.js:18976
-#: assets/build/pages/video-editor.min.js:21413
 msgid "Settings"
 msgstr ""
 
-#: inc/classes/addons/class-addon-registry.php:97
+#: inc/classes/addons/class-addon-registry.php:106
 msgid "GoDAM for WooCommerce"
 msgstr ""
 
 #. translators: 1: Add-on name, 2: opening link tag, 3: closing link tag
-#: inc/classes/addons/class-addon-registry.php:133
+#: inc/classes/addons/class-addon-registry.php:142
+#, php-format
 msgid "%1$s is out of date and may not work correctly with this version of GoDAM. %2$sUpdate it to the latest version%3$s."
 msgstr ""
 
 #. translators: 1: Add-on name, 2: Required GoDAM version
-#: inc/classes/addons/class-addon-registry.php:219
+#: inc/classes/addons/class-addon-registry.php:229
+#, php-format
 msgid "%1$s requires GoDAM %2$s or higher. Please update the GoDAM plugin."
 msgstr ""
 
@@ -789,7 +803,6 @@ msgstr ""
 
 #: inc/classes/class-media-library-ajax.php:724
 #: pages/media-library/App.js:214
-#: assets/build/pages/media-library.min.js:5865
 msgid "Uncategorized"
 msgstr ""
 
@@ -844,6 +857,7 @@ msgstr ""
 
 #. translators: %1$s is the name of the Transcoder plugin, %2$s is the name of the GoDAM plugin.
 #: inc/classes/class-media-tracker.php:209
+#, php-format
 msgid "Please deactivate the <strong>%1$s</strong> plugin to ensure the <strong>%2$s</strong> plugin functions correctly."
 msgstr ""
 
@@ -857,6 +871,7 @@ msgstr ""
 
 #. translators: 1: posts scanned so far, 2: total posts to scan
 #: inc/classes/class-media-usage-backfill.php:111
+#, php-format
 msgid "(%1$d of %2$d posts scanned)"
 msgstr ""
 
@@ -871,24 +886,21 @@ msgstr ""
 #: inc/classes/class-pages.php:199
 #: inc/classes/class-pages.php:200
 #: pages/dashboard/Dashboard.js:307
-#: assets/build/pages/dashboard.min.js:3349
 msgid "Dashboard"
 msgstr ""
 
 #: inc/classes/class-pages.php:209
 #: inc/classes/class-pages.php:210
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:648
-#: assets/build/pages/video-editor.min.js:27012
 msgid "Media Editor"
 msgstr ""
 
 #: inc/classes/class-pages.php:219
 #: inc/classes/class-pages.php:220
 #: inc/templates/video-preview.php:74
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:767
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:774
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:320
-#: assets/build/js/media-library.min.js:10525
-#: assets/build/js/media-library.min.js:10532
-#: assets/build/pages/video-editor.min.js:21777
 msgid "Analytics"
 msgstr ""
 
@@ -906,9 +918,6 @@ msgstr ""
 #: inc/classes/class-pages.php:269
 #: pages/dashboard/components/MarketingCarousel.jsx:94
 #: pages/godam/components/GoDAMFooter.jsx:31
-#: assets/build/pages/godam.min.js:10241
-#: assets/build/pages/help.min.js:531
-#: assets/build/pages/tools.min.js:617
 msgid "What's New"
 msgstr ""
 
@@ -960,6 +969,7 @@ msgstr ""
 
 #. translators: %d is the maximum number of retry attempts.
 #: inc/classes/cron-jobs/class-retranscode-failed-media.php:120
+#, php-format
 msgid "Transcoding failed after %d retry attempts. GoDAM Central returned a server error on each attempt."
 msgstr ""
 
@@ -973,6 +983,7 @@ msgstr ""
 
 #. translators: 1: number of media items queued, 2: retry interval in minutes, 3: max retries, 4: Media Library link
 #: inc/classes/cron-jobs/class-retranscode-failed-media.php:176
+#, php-format
 msgid "%1$d media file(s) could not be sent to the GoDAM transcoding server and have been queued for automatic retry (every %2$d minutes, up to %3$d attempts). Visit the %4$s to see their status."
 msgstr ""
 
@@ -982,7 +993,6 @@ msgstr ""
 
 #: inc/classes/elementor-controls/class-godam-media.php:140
 #: pages/analytics/Analytics.js:777
-#: assets/build/pages/analytics.min.js:9941
 msgid "Choose Video"
 msgstr ""
 
@@ -1004,15 +1014,15 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:227
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:297
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:70
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:564
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:216
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:262
+#: assets/src/blocks/godam-gallery-v2/edit.js:247
+#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:87
+#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:67
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:111
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:361
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:122
-#: assets/build/js/wpbakery-document-selector-param.min.js:87
-#: assets/build/js/wpbakery-image-selector-param.min.js:67
-#: assets/build/js/wpbakery-video-selector-param.min.js:280
-#: assets/build/js/wpbakery-video-selector-param.min.js:530
-#: assets/build/pages/godam.min.js:11364
 msgid "Remove"
 msgstr ""
 
@@ -1028,7 +1038,6 @@ msgstr ""
 #: inc/classes/elementor-controls/class-godam-media.php:217
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:65
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:112
-#: assets/build/pages/godam.min.js:11354
 msgid "Upload"
 msgstr ""
 
@@ -1056,7 +1065,7 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:70
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:101
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:416
 msgid "Audio Title"
 msgstr ""
 
@@ -1071,13 +1080,11 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:115
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:115
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:347
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:9921
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:425
+#: assets/src/blocks/godam-pdf/edit.js:553
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:264
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:183
 #: pages/video-editor/components/cta/CardCTA.js:445
-#: assets/build/blocks/godam-player/index.js:9378
-#: assets/build/pages/video-editor.min.js:20916
 msgid "Description"
 msgstr ""
 
@@ -1088,13 +1095,10 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:95
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:129
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-player/index.js:11293
+#: assets/src/blocks/godam-audio/edit.js:503
+#: assets/src/blocks/godam-player/edit.js:1053
 #: pages/video-editor/components/appearance/Appearance.js:241
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:503
-#: assets/build/blocks/godam-player/index.js:10747
-#: assets/build/pages/video-editor.min.js:19093
-#: assets/build/pages/video-editor.min.js:26867
 msgid "Thumbnail"
 msgstr ""
 
@@ -1106,18 +1110,16 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:268
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:143
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:77
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-player/index.js:10097
-#: assets/build/blocks/godam-player/index.js:9525
+#: assets/src/blocks/godam-audio/edit.js:611
+#: assets/src/blocks/godam-player/edit-common-settings.js:93
 msgid "Autoplay"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:112
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:150
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:84
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-player/index.js:10064
-#: assets/build/blocks/godam-player/index.js:9492
+#: assets/src/blocks/godam-audio/edit.js:134
+#: assets/src/blocks/godam-player/edit-common-settings.js:61
 msgid "Autoplay may cause usability issues for some users."
 msgstr ""
 
@@ -1125,7 +1127,7 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:280
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:159
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:93
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:620
 msgid "Loop"
 msgstr ""
 
@@ -1136,19 +1138,20 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:141
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:181
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:636
 msgid "Auto"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:142
 #: inc/classes/elementor-widgets/class-godam-video.php:111
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:179
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:637
+#: assets/src/blocks/godam-player/track-uploader.js:33
 msgid "Metadata"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:143
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:638
 msgctxt "Preload value"
 msgid "None"
 msgstr ""
@@ -1174,7 +1177,7 @@ msgid "Show the chapters panel (when chapters are available)."
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:263
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:447
 msgid "Add an audio file"
 msgstr ""
 
@@ -1193,7 +1196,7 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:57
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:75
-#: assets/build/js/wpbakery-document-selector-param.min.js:34
+#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:34
 msgid "Select Document"
 msgstr ""
 
@@ -1203,12 +1206,12 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:72
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:101
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:544
 msgid "Doc Title"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:75
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:546
 msgid "Add document title"
 msgstr ""
 
@@ -1222,22 +1225,20 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:99
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:129
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:567
 #: pages/analytics/helper.js:533
-#: assets/build/pages/analytics.min.js:13402
-#: assets/build/pages/dashboard.min.js:2627
 msgid "View"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:103
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:132
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:575
 msgid "Default View"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:104
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:133
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:579
 msgid "Card View"
 msgstr ""
 
@@ -1247,7 +1248,7 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:116
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:147
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:714
 msgid "Height (px)"
 msgstr ""
 
@@ -1272,6 +1273,7 @@ msgid "Caption"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:257
+#: assets/src/blocks/godam-pdf/edit.js:421
 msgid "Unsupported file format"
 msgstr ""
 
@@ -1286,7 +1288,7 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:56
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:71
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:860
 msgid "Gallery Settings"
 msgstr ""
 
@@ -1314,9 +1316,8 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:103
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:380
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:30
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:11362
-#: assets/build/blocks/godam-player/index.js:10821
+#: assets/src/blocks/godam-gallery-v2/edit.js:1352
+#: assets/src/blocks/godam-player/edit.js:1127
 msgid "Video"
 msgstr ""
 
@@ -1327,7 +1328,6 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-gallery.php:99
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:92
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:71
-#: assets/build/pages/video-editor.min.js:26435
 msgid "Videos"
 msgstr ""
 
@@ -1336,7 +1336,7 @@ msgid "Add rows and pick a video for each. Order in the list determines display 
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:115
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1051
 msgid "Number of videos"
 msgstr ""
 
@@ -1347,30 +1347,24 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:141
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:126
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1064
 msgid "Date"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:142
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:127
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1065
 #: pages/dashboard/components/TopVideosTable.js:192
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:117
-#: assets/build/pages/dashboard.min.js:3868
-#: assets/build/pages/video-editor.min.js:21574
 msgid "Title"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:143
 #: inc/classes/elementor-widgets/class-godam-video.php:228
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:128
-#: assets/build/blocks/godam-player/index.js:9935
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:283
 #: pages/analytics/helper.js:537
 #: pages/video-editor/components/layers/HotspotLayer.js:509
-#: assets/build/blocks/godam-player/index.js:9397
-#: assets/build/pages/analytics.min.js:13406
-#: assets/build/pages/dashboard.min.js:2631
-#: assets/build/pages/video-editor.min.js:24457
 msgid "Duration"
 msgstr ""
 
@@ -1378,32 +1372,30 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:129
 #: pages/dashboard/components/TopVideosTable.js:194
 #: pages/dashboard/components/TopVideosTable.js:271
-#: assets/build/pages/dashboard.min.js:3870
-#: assets/build/pages/dashboard.min.js:3947
 msgid "Size"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:155
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:141
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1074
 msgid "Order"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:159
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:144
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1078
 msgid "Descending"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:160
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:145
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1082
 msgid "Ascending"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:184
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:157
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1093
 msgid "Media Folder"
 msgstr ""
 
@@ -1413,65 +1405,56 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:206
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:170
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1103
 msgid "Author"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:220
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:183
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1112
 #: pages/analytics/components/DateRangePicker/index.js:381
-#: assets/build/pages/analytics.min.js:11927
-#: assets/build/pages/dashboard.min.js:1925
-#: assets/build/pages/shared-components.min.js:427
 msgid "Date Range"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:224
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:186
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1115
 #: pages/analytics/components/DateRangePicker/index.js:88
 #: pages/analytics/components/DateRangePicker/index.js:89
-#: assets/build/pages/analytics.min.js:11644
-#: assets/build/pages/analytics.min.js:11645
-#: assets/build/pages/dashboard.min.js:1642
-#: assets/build/pages/dashboard.min.js:1643
-#: assets/build/pages/shared-components.min.js:144
-#: assets/build/pages/shared-components.min.js:145
 msgid "All Time"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:225
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:187
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1116
 msgid "Last 7 Days"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:226
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:188
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1117
 msgid "Last 30 Days"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:227
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:189
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1118
 msgid "Last 90 Days"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:228
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:190
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1120
 msgid "Custom Range"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:239
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1143
 msgid "Start Date"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:254
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1173
 msgid "End Date"
 msgstr ""
 
@@ -1486,9 +1469,8 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:324
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:227
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:144
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:10221
-#: assets/build/blocks/godam-player/index.js:9655
+#: assets/src/blocks/godam-gallery-v2/edit.js:1022
+#: assets/src/blocks/godam-player/edit-common-settings.js:214
 msgid "Balanced"
 msgstr ""
 
@@ -1496,9 +1478,8 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:325
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:228
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:145
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:10218
-#: assets/build/blocks/godam-player/index.js:9654
+#: assets/src/blocks/godam-gallery-v2/edit.js:1018
+#: assets/src/blocks/godam-player/edit-common-settings.js:213
 msgid "Priority"
 msgstr ""
 
@@ -1510,33 +1491,31 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-gallery.php:290
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:72
 #: pages/video-editor/components/appearance/Appearance.js:129
-#: assets/build/pages/video-editor.min.js:18981
 msgid "Display Settings"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:297
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:240
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:11245
-#: assets/build/blocks/godam-player/index.js:10714
+#: assets/src/blocks/godam-gallery-v2/edit.js:867
+#: assets/src/blocks/godam-player/edit.js:1020
 msgid "Layout"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:301
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:243
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:894
 msgid "Grid"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:302
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:245
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:899
 msgid "List"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:303
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:244
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:889
 msgid "Carousel"
 msgstr ""
 
@@ -1562,13 +1541,12 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:325
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:266
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:907
 msgid "View Ratio"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:329
-#: assets/build/blocks/godam-player/index.js:11110
-#: assets/build/blocks/godam-player/index.js:10569
+#: assets/src/blocks/godam-player/edit.js:875
 msgid "16:9"
 msgstr ""
 
@@ -1595,19 +1573,20 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:350
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:290
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:962
+#: assets/src/blocks/godam-gallery-v2/edit.js:966
 msgid "Interaction"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:354
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:293
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:976
 msgid "Play on hover"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:355
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:294
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:971
 msgid "Autoplay all videos"
 msgstr ""
 
@@ -1628,13 +1607,13 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:377
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:315
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1206
 msgid "Enable More Items"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:389
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:327
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1213
 msgid "More Items Behavior"
 msgstr ""
 
@@ -1653,7 +1632,7 @@ msgid "Show Engagements"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:545
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1264
 msgid "Create your media gallery"
 msgstr ""
 
@@ -1667,7 +1646,7 @@ msgid "Image"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-image.php:54
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:222
 msgid "Image Selection"
 msgstr ""
 
@@ -1675,8 +1654,6 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:66
 #: pages/video-editor/components/cta/CardCTA.js:347
 #: pages/video-editor/components/cta/CardCTA.js:391
-#: assets/build/pages/video-editor.min.js:20818
-#: assets/build/pages/video-editor.min.js:20862
 msgid "Image"
 msgstr ""
 
@@ -1685,17 +1662,17 @@ msgid "Select an image. Hotspot and product layers authored in the GoDAM image e
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-image.php:72
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:231
 msgid "Show image layers"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-image.php:78
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:234
 msgid "Overlays the hotspot / product layers authored in the GoDAM image editor."
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-image.php:157
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:246
 msgid "Add Image Here"
 msgstr ""
 
@@ -1717,6 +1694,7 @@ msgid "Select video file"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:62
+#: assets/src/blocks/godam-player/track-uploader.js:149
 msgid "Add Video Caption"
 msgstr ""
 
@@ -1724,8 +1702,6 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-video.php:126
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:29
 #: pages/video-editor/components/forms/CF7.js:26
-#: assets/build/pages/godam.min.js:12225
-#: assets/build/pages/video-editor.min.js:21939
 msgid "Default"
 msgstr ""
 
@@ -1743,11 +1719,13 @@ msgid "Text track file"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:90
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/godam-player/track-uploader.js:77
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:167
 msgid "Label"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:91
+#: assets/src/blocks/godam-player/track-uploader.js:80
 msgid "Title of track"
 msgstr ""
 
@@ -1756,22 +1734,27 @@ msgid "Source Language"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:98
+#: assets/src/blocks/godam-player/track-uploader.js:87
 msgid "Language tag (en, fr, etc.)"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:104
+#: assets/src/blocks/godam-player/track-uploader.js:91
 msgid "Kind"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:107
+#: assets/src/blocks/godam-player/track-uploader.js:29
 msgid "Subtitles"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:108
+#: assets/src/blocks/godam-player/track-uploader.js:30
 msgid "Captions"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:109
+#: assets/src/blocks/godam-player/track-uploader.js:31
 msgid "Descriptions"
 msgstr ""
 
@@ -1784,8 +1767,7 @@ msgid "SEO Settings"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:141
-#: assets/build/blocks/godam-player/index.js:9882
-#: assets/build/blocks/godam-player/index.js:9330
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:216
 msgid "Override default SEO"
 msgstr ""
 
@@ -1802,14 +1784,12 @@ msgid "You have overridden the default SEO. Changes to this video in the media l
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:176
-#: assets/build/blocks/godam-player/index.js:9907
-#: assets/build/blocks/godam-player/index.js:9362
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:248
 msgid "Content URL"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:179
-#: assets/build/blocks/godam-player/index.js:9910
-#: assets/build/blocks/godam-player/index.js:9365
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:251
 msgid "URL of the video content can be MOV, MP4, MPD. Example: https://www.example.com/video.mp4"
 msgstr ""
 
@@ -1819,45 +1799,38 @@ msgid "Headline"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:193
-#: assets/build/blocks/godam-player/index.js:9917
-#: assets/build/blocks/godam-player/index.js:9373
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:259
 msgid "Title of the video"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:212
-#: assets/build/blocks/godam-player/index.js:9928
-#: assets/build/blocks/godam-player/index.js:9389
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:275
 msgid "Upload Date"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:230
-#: assets/build/blocks/godam-player/index.js:9937
-#: assets/build/blocks/godam-player/index.js:9399
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:285
 msgid "ISO 8601 format. Example: PT1H30M"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:242
-#: assets/build/blocks/godam-player/index.js:9942
-#: assets/build/blocks/godam-player/index.js:9405
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:291
 msgid "Video Thumbnail URL"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:255
-#: assets/build/blocks/godam-player/index.js:9949
-#: assets/build/blocks/godam-player/index.js:9413
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:299
 msgid "Is Family Friendly"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:257
-#: assets/build/blocks/godam-player/index.js:9952
-#: assets/build/blocks/godam-player/index.js:9416
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:302
 msgid "Is the video suitable for all audiences?"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:292
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:109
-#: assets/build/blocks/godam-player/index.js:10117
-#: assets/build/blocks/godam-player/index.js:9545
+#: assets/src/blocks/godam-player/edit-common-settings.js:113
 msgid "Muted"
 msgstr ""
 
@@ -1866,8 +1839,7 @@ msgid "Forced on when Autoplay is enabled — most browsers block autoplay with 
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:308
-#: assets/build/blocks/godam-player/index.js:10127
-#: assets/build/blocks/godam-player/index.js:9555
+#: assets/src/blocks/godam-player/edit-common-settings.js:123
 msgid "Playback controls"
 msgstr ""
 
@@ -1889,8 +1861,7 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:342
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:175
-#: assets/build/blocks/godam-player/index.js:11091
-#: assets/build/blocks/godam-player/index.js:10553
+#: assets/src/blocks/godam-player/edit.js:859
 msgid "Start Preview"
 msgstr ""
 
@@ -1917,15 +1888,13 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:396
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:187
-#: assets/build/blocks/godam-player/index.js:11098
-#: assets/build/blocks/godam-player/index.js:10562
+#: assets/src/blocks/godam-player/edit.js:868
 msgid "Aspect Ratio"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:400
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:190
-#: assets/build/blocks/godam-player/index.js:11107
-#: assets/build/blocks/godam-player/index.js:10568
+#: assets/src/blocks/godam-player/edit.js:874
 msgid "Original"
 msgstr ""
 
@@ -1936,8 +1905,7 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:403
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:194
-#: assets/build/blocks/godam-player/index.js:11104
-#: assets/build/blocks/godam-player/index.js:10566
+#: assets/src/blocks/godam-player/edit.js:872
 msgid "Choose the aspect ratio for the video player."
 msgstr ""
 
@@ -1953,9 +1921,8 @@ msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:426
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:158
-#: assets/build/blocks/godam-player/index.js:9540
-#: assets/build/blocks/godam-player/index.js:8990
-#: assets/build/js/media-library.min.js:10158
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:135
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:411
 msgid "Video Thumbnail"
 msgstr ""
 
@@ -1972,14 +1939,12 @@ msgid "No auto-generated thumbnails available for this video."
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:460
-#: assets/build/blocks/godam-player/index.js:10160
-#: assets/build/blocks/godam-player/index.js:9590
+#: assets/src/blocks/godam-player/edit-common-settings.js:149
 msgid "Show caption"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:674
-#: assets/build/blocks/godam-player/index.js:11336
-#: assets/build/blocks/godam-player/index.js:10794
+#: assets/src/blocks/godam-player/edit.js:1100
 msgid "Add Video Here"
 msgstr ""
 
@@ -2030,6 +1995,7 @@ msgstr ""
 
 #. translators: %s is the max file size in MB
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:357
+#, php-format
 msgid "Max file size: %s MB"
 msgstr ""
 
@@ -2037,7 +2003,7 @@ msgstr ""
 #: inc/classes/fluentforms/fields/class-recorder-field.php:246
 #: inc/classes/gravity-forms/class-init.php:172
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:197
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:198
 msgid "Choose file selector"
 msgstr ""
 
@@ -2057,7 +2023,7 @@ msgstr ""
 #: inc/classes/gravity-forms/class-init.php:188
 #: inc/classes/ninja-forms/config/field-settings.php:52
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:205
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:221
 msgid "Webcam"
 msgstr ""
 
@@ -2065,7 +2031,7 @@ msgstr ""
 #: inc/classes/fluentforms/fields/class-recorder-field.php:258
 #: inc/classes/gravity-forms/class-init.php:195
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:206
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:228
 msgid "Screencast"
 msgstr ""
 
@@ -2075,9 +2041,8 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:66
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:207
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:30
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:235
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:73
-#: assets/build/pages/video-editor.min.js:26437
 msgid "Audio"
 msgstr ""
 
@@ -2099,9 +2064,6 @@ msgstr ""
 #: pages/video-editor/components/forms/EverestForm.js:42
 #: pages/video-editor/components/SidebarLayers.js:97
 #: pages/video-editor/utils/layerTypes.js:45
-#: assets/build/pages/video-editor.min.js:17901
-#: assets/build/pages/video-editor.min.js:22038
-#: assets/build/pages/video-editor.min.js:29926
 msgid "Everest Forms"
 msgstr ""
 
@@ -2110,7 +2072,7 @@ msgstr ""
 #: inc/classes/gravity-forms/class-init.php:336
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:613
 #: inc/classes/sureforms/class-form-submit.php:266
-#: inc/classes/wpforms/class-wpforms-integration.php:199
+#: inc/classes/wpforms/class-wpforms-integration.php:213
 msgid "Transcoding data not set"
 msgstr ""
 
@@ -2143,7 +2105,8 @@ msgstr ""
 #: inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php:76
 #: inc/classes/fluentforms/fields/class-recorder-field.php:431
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:259
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:254
+#, php-format,js-format
 msgid "Maximum allowed on this server: %s MB"
 msgstr ""
 
@@ -2160,7 +2123,7 @@ msgstr ""
 
 #: inc/classes/fluentforms/fields/class-recorder-field.php:250
 #: inc/classes/gravity-forms/class-init.php:181
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:214
 msgid "Local files"
 msgstr ""
 
@@ -2211,26 +2174,31 @@ msgstr ""
 
 #. translators: %s is the allowed file types.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:152
+#, php-format
 msgid "Accepted file types: %s"
 msgstr ""
 
 #. translators: %s is the maximum file size allowed.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:158
+#, php-format
 msgid "Max. file size: %s"
 msgstr ""
 
 #. translators: %s is the maximum duration.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:165
+#, php-format
 msgid "Max. duration: %s"
 msgstr ""
 
 #. translators: %s is the maximum number of files allowed.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:175
+#, php-format
 msgid "Max. files: %s"
 msgstr ""
 
 #. translators: %d is the number of files.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:264
+#, php-format
 msgid "%d files"
 msgstr ""
 
@@ -2311,6 +2279,7 @@ msgstr ""
 
 #. translators: %d is the error code returned by ZipArchive::open()
 #: inc/classes/media-library/class-media-folder-create-zip.php:175
+#, php-format
 msgid "Failed to create ZIP file. Error code: %d"
 msgstr ""
 
@@ -2320,6 +2289,7 @@ msgstr ""
 
 #. translators: %1$d: added files, %2$d: skipped files, %3$d: total attachments
 #: inc/classes/media-library/class-media-folder-create-zip.php:267
+#, php-format
 msgid "ZIP file created successfully. %1$d files added, %2$d files skipped out of %3$d total attachments."
 msgstr ""
 
@@ -2342,6 +2312,7 @@ msgstr ""
 
 #. translators: %d is the Metform ID
 #: inc/classes/metform/class-metform-rest-api.php:152
+#, php-format
 msgid "Unable to find the Metform with ID:%d"
 msgstr ""
 
@@ -2371,6 +2342,7 @@ msgstr ""
 
 #. Translators: %s: Maximum allowed file size in MB.
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:443
+#, php-format
 msgid "File exceeds maximum file size. File must be under %sMB."
 msgstr ""
 
@@ -2379,9 +2351,6 @@ msgstr ""
 #: pages/video-editor/components/forms/NinjaForm.js:43
 #: pages/video-editor/components/SidebarLayers.js:103
 #: pages/video-editor/utils/layerTypes.js:46
-#: assets/build/pages/video-editor.min.js:17907
-#: assets/build/pages/video-editor.min.js:22809
-#: assets/build/pages/video-editor.min.js:29927
 msgid "Ninja Forms"
 msgstr ""
 
@@ -2396,6 +2365,7 @@ msgstr ""
 
 #. translators: %d is the Ninja Form ID
 #: inc/classes/ninja-forms/class-ninja-forms-rest-api.php:130
+#, php-format
 msgid "Unable to find the Ninja Form with ID:%d"
 msgstr ""
 
@@ -2501,14 +2471,13 @@ msgstr ""
 #. translators: %d: WordPress post ID.
 #: inc/classes/rest-api/class-analytics.php:474
 #: pages/analytics/components/Placements/index.js:173
-#: assets/build/pages/analytics.min.js:12109
+#, php-format,js-format
 msgid "Post #%d"
 msgstr ""
 
 #: inc/classes/rest-api/class-analytics.php:475
 #: inc/classes/rest-api/class-analytics.php:536
 #: pages/analytics/components/Placements/index.js:273
-#: assets/build/pages/analytics.min.js:12209
 msgid "Deleted page"
 msgstr ""
 
@@ -2518,6 +2487,7 @@ msgstr ""
 
 #. translators: %d: WordPress post ID.
 #: inc/classes/rest-api/class-analytics.php:535
+#, php-format
 msgid "Post #%d (deleted)"
 msgstr ""
 
@@ -2529,6 +2499,7 @@ msgstr ""
 
 #. translators: %s is the error message from the API response.
 #: inc/classes/rest-api/class-analytics.php:754
+#, php-format
 msgid "Error fetching history data: %s"
 msgstr ""
 
@@ -2548,6 +2519,7 @@ msgstr ""
 #: inc/classes/rest-api/class-dynamic-gallery.php:170
 #: inc/templates/godam-video-gallery.php:421
 #: inc/templates/godam-video-gallery.php:487
+#, php-format
 msgid "Open video: %s"
 msgstr ""
 
@@ -2628,11 +2600,13 @@ msgstr ""
 
 #. translators: 1: Parameter.
 #: inc/classes/rest-api/class-engagement.php:957
+#, php-format
 msgid "%1$s is invalid."
 msgstr ""
 
 #. translators: 1: Parameter.
 #: inc/classes/rest-api/class-engagement.php:967
+#, php-format
 msgid "%1$s is empty."
 msgstr ""
 
@@ -2739,6 +2713,7 @@ msgstr ""
 
 #. translators: %s is the field label.
 #: inc/classes/rest-api/class-jetpack.php:711
+#, php-format
 msgid "Valid %s is required."
 msgstr ""
 
@@ -2752,6 +2727,7 @@ msgstr ""
 
 #. translators: %d is the number of errors, %s is the error text, %s is the list of errors.
 #: inc/classes/rest-api/class-jetpack.php:722
+#, php-format
 msgid "Please make sure all fields are valid. You need to fix %1$d %2$s:<br>%3$s"
 msgstr ""
 
@@ -2881,6 +2857,7 @@ msgstr ""
 #. translators: %s is the HTTP status code from the GoDAM API response.
 #: inc/classes/rest-api/class-media-library.php:797
 #: inc/classes/rest-api/class-media-library.php:1504
+#, php-format
 msgid "GoDAM API returned HTTP status: %s"
 msgstr ""
 
@@ -2939,37 +2916,44 @@ msgstr ""
 #. translators: %s is the invalid folder ID.
 #: inc/classes/rest-api/class-media-library.php:1188
 #: inc/classes/rest-api/class-media-library.php:1257
+#, php-format
 msgid "Invalid folder ID: %s"
 msgstr ""
 
 #. translators: %s is the invalid folder ID.
 #: inc/classes/rest-api/class-media-library.php:1196
 #: inc/classes/rest-api/class-media-library.php:1265
+#, php-format
 msgid "Folder ID %s not found or invalid."
 msgstr ""
 
 #. translators: %s is the invalid folder ID where delete failed.
 #: inc/classes/rest-api/class-media-library.php:1204
+#, php-format
 msgid "Failed to delete folder %s"
 msgstr ""
 
 #. translators: %s is the ID of folder not found.
 #: inc/classes/rest-api/class-media-library.php:1207
+#, php-format
 msgid "Folder ID %s not found during deletion attempt."
 msgstr ""
 
 #. translators: %s is the invalid folder ID.
 #: inc/classes/rest-api/class-media-library.php:1210
+#, php-format
 msgid "Folder ID %s cannot be deleted (possibly uncategorized or default term)."
 msgstr ""
 
 #. translators: %d is the number of folders deleted.
 #: inc/classes/rest-api/class-media-library.php:1221
+#, php-format
 msgid "%d folder(s) deleted successfully."
 msgstr ""
 
 #. translators: %1$d is the number of folders deleted, %2$s are the errors.
 #: inc/classes/rest-api/class-media-library.php:1229
+#, php-format
 msgid "Error deleting some folders. Deleted: %1$d. Errors: %2$s"
 msgstr ""
 
@@ -2983,21 +2967,25 @@ msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1318
+#, php-format
 msgid "%d folder(s) locked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1320
+#, php-format
 msgid "%d folder(s) unlocked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1334
+#, php-format
 msgid "Some folders locked, but issues occurred with others. Locked: %d."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1336
+#, php-format
 msgid "Some folders unlocked, but issues occurred with others. Unlocked: %d."
 msgstr ""
 
@@ -3007,21 +2995,25 @@ msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1376
+#, php-format
 msgid "%d folder(s) bookmarked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1378
+#, php-format
 msgid "%d folder(s) unbookmarked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1392
+#, php-format
 msgid "Some folders bookmarked, but issues occurred with others. Bookmarked: %d."
 msgstr ""
 
 #. translators: %d number of folders.
 #: inc/classes/rest-api/class-media-library.php:1394
+#, php-format
 msgid "Some folders unbookmarked, but issues occurred with others. Unbookmarked: %d."
 msgstr ""
 
@@ -3031,6 +3023,7 @@ msgstr ""
 
 #. translators: %s is the error message from the GoDAM API request.
 #: inc/classes/rest-api/class-media-library.php:1489
+#, php-format
 msgid "GoDAM API request failed: %s"
 msgstr ""
 
@@ -3222,6 +3215,7 @@ msgstr ""
 
 #. translators: %s is the storage usage percentage.
 #: inc/classes/rest-api/class-transcoding.php:369
+#, php-format
 msgid "Storage limit exceeded (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
 msgstr ""
 
@@ -3231,36 +3225,43 @@ msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:518
+#, php-format
 msgid "%1$s (ID %2$d) transcoding request failed. Transcoding requests are not allowed in the localhost environment."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:538
+#, php-format
 msgid "%1$s (ID %2$d) is virtual media from GoDAM Central. Please retranscode this media on GoDAM Central."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:558
+#, php-format
 msgid "%1$s (ID %2$d) is migrated Vimeo video. Please retranscode this video on GoDAM Central."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID, 3: storage usage percent.
 #: inc/classes/rest-api/class-transcoding.php:581
+#, php-format
 msgid "%1$s (ID %2$d) cannot be retranscoded. Storage limit exceeded (%3$s%%). Please upgrade your plan to continue transcoding."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:602
+#, php-format
 msgid "%1$s (ID %2$d) cannot be transcoded. HTTP authentication is enabled on your site. Please disable it to allow transcoding."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:652
+#, php-format
 msgid "%1$s (ID %2$d) transcoding request failed. Unknown error"
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
 #: inc/classes/rest-api/class-transcoding.php:668
+#, php-format
 msgid "%1$s (ID %2$d) transcoding request was sent successfully"
 msgstr ""
 
@@ -3336,6 +3337,7 @@ msgstr ""
 
 #. translators: %1$d is the number of posts processed, %2$d is the total number of posts to process and %3$d is the migration name
 #: inc/classes/rest-api/class-video-migration.php:123
+#, php-format
 msgid "Processed %1$d of %2$d posts. %3$s aborted."
 msgstr ""
 
@@ -3361,6 +3363,7 @@ msgstr ""
 
 #. translators: %d is the number of batches scheduled for processing
 #: inc/classes/rest-api/class-video-migration.php:414
+#, php-format
 msgid "Scheduled %d batches for processing"
 msgstr ""
 
@@ -3370,16 +3373,19 @@ msgstr ""
 
 #. translators: %1$d is the number of posts processed, %2$d is the total number of posts, %3$d is the progress percentage
 #: inc/classes/rest-api/class-video-migration.php:541
+#, php-format
 msgid "Processed %1$d/%2$d posts (%3$d%% complete)"
 msgstr ""
 
 #. translators: 1: total posts processed, 2: migrated Vimeo embeds, 3: total Vimeo embeds found
 #: inc/classes/rest-api/class-video-migration.php:554
+#, php-format
 msgid "Migration completed! Processed %1$d posts. Migrated %2$d out of %3$d Vimeo Embed Blocks found."
 msgstr ""
 
 #. translators: %d is the total number of posts processed
 #: inc/classes/rest-api/class-video-migration.php:562
+#, php-format
 msgid "Migration completed! Processed %d posts."
 msgstr ""
 
@@ -3389,6 +3395,7 @@ msgstr ""
 
 #. translators: %s: error message
 #: inc/classes/rest-api/class-video-migration.php:1153
+#, php-format
 msgid "Error fetching video info: %s"
 msgstr ""
 
@@ -3559,7 +3566,7 @@ msgid "Loop the audio playback continuously."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:178
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:635
 msgid "Browser default"
 msgstr ""
 
@@ -3581,8 +3588,10 @@ msgid "Design Options"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:66
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/js/wpbakery-document-selector-param.min.js:65
+#: assets/src/blocks/godam-pdf/edit.js:198
+#: assets/src/blocks/godam-pdf/edit.js:327
+#: assets/src/blocks/godam-pdf/edit.js:399
+#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:65
 msgid "Document"
 msgstr ""
 
@@ -3632,7 +3641,6 @@ msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:75
 #: pages/video-editor/components/cta/CardCTA.js:357
-#: assets/build/pages/video-editor.min.js:20828
 msgid "Select Image"
 msgstr ""
 
@@ -3657,21 +3665,20 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:180
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:214
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:286
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:543
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:201
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:246
+#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:63
+#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:49
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:91
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:341
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:112
-#: assets/build/js/wpbakery-document-selector-param.min.js:63
-#: assets/build/js/wpbakery-image-selector-param.min.js:49
-#: assets/build/js/wpbakery-video-selector-param.min.js:260
-#: assets/build/js/wpbakery-video-selector-param.min.js:510
-#: assets/build/pages/godam.min.js:11354
 msgid "Replace"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:102
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:136
 #: pages/analytics/index.js:37
-#: assets/build/js/wpbakery-video-selector-param.min.js:305
-#: assets/build/pages/analytics.min.js:102308
 msgid "Select video"
 msgstr ""
 
@@ -3682,13 +3689,13 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:180
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:267
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:286
-#: assets/build/js/wpbakery-image-selector-param.min.js:30
-#: assets/build/js/wpbakery-image-selector-param.min.js:107
+#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:30
+#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:107
 msgid "Select image"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-params.php:214
-#: assets/build/js/wpbakery-document-selector-param.min.js:125
+#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:125
 msgid "Select document"
 msgstr ""
 
@@ -3770,9 +3777,8 @@ msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:349
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:219
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:10248
-#: assets/build/blocks/godam-player/index.js:9677
+#: assets/src/blocks/godam-gallery-v2/edit.js:1032
+#: assets/src/blocks/godam-player/edit-common-settings.js:236
 msgid "Enable Likes & Comments"
 msgstr ""
 
@@ -3782,7 +3788,6 @@ msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:369
 #: pages/analytics/components/Placements/index.js:33
-#: assets/build/pages/analytics.min.js:11969
 msgid "Video Gallery"
 msgstr ""
 
@@ -3796,6 +3801,7 @@ msgstr ""
 
 #. translators: 1: taxonomy term name, 2: term ID.
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:411
+#, php-format
 msgid "%1$s (#%2$d)"
 msgstr ""
 
@@ -3804,8 +3810,8 @@ msgid "All authors"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:66
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/js/wpbakery-video-selector-param.min.js:251
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:271
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:82
 msgid "Select Video"
 msgstr ""
 
@@ -3822,8 +3828,7 @@ msgid "Mute the video by default."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:125
-#: assets/build/blocks/godam-player/index.js:11254
-#: assets/build/blocks/godam-player/index.js:10722
+#: assets/src/blocks/godam-player/edit.js:1028
 msgid "Playback Controls"
 msgstr ""
 
@@ -3840,15 +3845,13 @@ msgid "Select a custom thumbnail image for the video."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:178
-#: assets/build/blocks/godam-player/index.js:11085
-#: assets/build/blocks/godam-player/index.js:10550
+#: assets/src/blocks/godam-player/edit.js:856
 msgid "Choose the action to perform on video hover."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:226
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:10251
-#: assets/build/blocks/godam-player/index.js:9680
+#: assets/src/blocks/godam-gallery-v2/edit.js:1035
+#: assets/src/blocks/godam-player/edit-common-settings.js:239
 msgid "Engagement will only be visible for transcoded videos"
 msgstr ""
 
@@ -3927,6 +3930,7 @@ msgstr ""
 
 #. translators: %s : Maximum file upload size in human readable format.
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:266
+#, php-format
 msgid "Maximum allowed on this server: %s "
 msgstr ""
 
@@ -3962,8 +3966,8 @@ msgstr ""
 msgid "A PHP extension stopped the file upload."
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-integration.php:168
-#: inc/classes/wpforms/class-wpforms-integration.php:169
+#: inc/classes/wpforms/class-wpforms-integration.php:182
+#: inc/classes/wpforms/class-wpforms-integration.php:183
 msgid "Untitled Form"
 msgstr ""
 
@@ -3973,11 +3977,13 @@ msgstr ""
 
 #. translators: %s: Content type (Audio or Video)
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:50
+#, php-format
 msgid "%s transcoding process has not started."
 msgstr ""
 
 #. translators: %s: Content type (Audio or Video)
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:57
+#, php-format
 msgid "%s saved and transcoded successfully on GoDAM"
 msgstr ""
 
@@ -3992,8 +3998,6 @@ msgstr ""
 #: inc/helpers/custom-functions.php:210
 #: pages/video-editor/components/cta/CardCTA.js:460
 #: pages/video-editor/components/layers/CTALayer.js:129
-#: assets/build/pages/video-editor.min.js:20931
-#: assets/build/pages/video-editor.min.js:23642
 msgid "Check now"
 msgstr ""
 
@@ -4003,17 +4007,18 @@ msgstr ""
 
 #: inc/helpers/custom-functions.php:235
 #: pages/video-editor/components/layers/CTALayer.js:108
-#: assets/build/pages/video-editor.min.js:23621
 msgid "No Image"
 msgstr ""
 
 #. translators: %s: storage usage percentage
 #: inc/helpers/custom-functions.php:429
+#, php-format
 msgid "Storage limit exceeded (%s%%). Please upgrade your plan to continue."
 msgstr ""
 
 #. translators: %s: bandwidth usage percentage
 #: inc/helpers/custom-functions.php:438
+#, php-format
 msgid "Bandwidth limit exceeded (%s%%). Please upgrade your plan to continue."
 msgstr ""
 
@@ -4031,6 +4036,7 @@ msgstr ""
 
 #. translators: %s: Entry ID for which transcoding failed
 #: inc/helpers/custom-functions.php:939
+#, php-format
 msgid "Transcoding failed | entry Id: %s"
 msgstr ""
 
@@ -4039,6 +4045,8 @@ msgid "s"
 msgstr ""
 
 #: inc/helpers/custom-functions.php:1009
+#: assets/src/js/godam-player/engagement.js:899
+#: assets/src/js/godam-player/engagement.js:906
 msgid "Anonymous"
 msgstr ""
 
@@ -4063,22 +4071,20 @@ msgid "Video not found"
 msgstr ""
 
 #: inc/templates/godam-video-gallery.php:251
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:163
+#: assets/src/blocks/godam-gallery-v2/edit.js:716
 #: pages/analytics/Analytics.js:567
 #: pages/video-editor/VideoEditor.js:651
-#: assets/build/pages/analytics.min.js:9731
-#: assets/build/pages/video-editor.min.js:17288
 msgid "Untitled video"
 msgstr ""
 
 #: inc/templates/godam-video-gallery.php:395
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1326
 msgid "No videos found"
 msgstr ""
 
 #: inc/templates/godam-video-gallery.php:396
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1328
 msgid "Try changing the selected folder, author, or dates."
 msgstr ""
 
@@ -4086,8 +4092,6 @@ msgstr ""
 #: inc/templates/godam-video-gallery.php:471
 #: pages/media-library/components/folder-tree/FolderTree.jsx:430
 #: pages/media-library/components/search-bar/SearchBar.jsx:213
-#: assets/build/pages/media-library.min.js:6896
-#: assets/build/pages/media-library.min.js:8031
 msgid "Load More"
 msgstr ""
 
@@ -4098,6 +4102,7 @@ msgstr ""
 
 #. translators: %s: video ID.
 #: inc/templates/video-embed.php:33
+#, php-format
 msgid "Video Embed: Attachment(%s)"
 msgstr ""
 
@@ -4115,24 +4120,24 @@ msgstr ""
 
 #. translators: 1: media type label (e.g. "Image Preview"), 2: attachment ID.
 #: inc/templates/video-preview.php:41
+#, php-format
 msgid "%1$s: Attachment(%2$s)"
 msgstr ""
 
 #: inc/templates/video-preview.php:82
-#: assets/build/js/media-library.min.js:10506
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:748
 msgid "Edit Image"
 msgstr ""
 
 #: inc/templates/video-preview.php:84
-#: assets/build/js/media-library.min.js:10559
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:801
 msgid "Edit Audio"
 msgstr ""
 
 #: inc/templates/video-preview.php:86
-#: assets/build/blocks/godam-player/index.js:11184
-#: assets/build/blocks/godam-player/index.js:10646
-#: assets/build/js/media-library.min.js:10523
-#: assets/build/js/media-library.min.js:10531
+#: assets/src/blocks/godam-player/edit.js:952
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:765
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:773
 msgid "Edit Video"
 msgstr ""
 
@@ -4177,627 +4182,583 @@ msgid "Unified GoDAM Central media library"
 msgstr ""
 
 #: inc/templates/video-preview.php:139
-#: assets/build/blocks/godam-player/index.js:11221
+#: assets/src/blocks/godam-player/edit.js:993
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:310
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:55
-#: assets/build/blocks/godam-player/index.js:10687
-#: assets/build/pages/godam.min.js:11696
-#: assets/build/pages/godam.min.js:12026
 msgid "Upgrade to Pro"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: pages/video-editor/components/audio/AudioCardPreview.js:200
-#: assets/build/pages/video-editor.min.js:19477
-msgid "Pause"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: pages/video-editor/components/audio/AudioCardPreview.js:304
-#: assets/build/pages/video-editor.min.js:19581
-msgid "Copied"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: pages/video-editor/components/audio/AudioCardPreview.js:304
-#: assets/build/pages/video-editor.min.js:19581
-msgid "Copy transcript"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:158
 msgid "Only audio files are allowed in the GoDAM Audio block."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:252
 msgid "Only image files are allowed for the GoDAM Audio thumbnail."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
-msgid "Customize Audio"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/index.js:2
-msgid "Replace audio file"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/index.js:2
-msgid "Remove audio"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-msgid "Add a title…"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-msgid "Add a short description…"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:355
 msgid "Add Audio File"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:373
+msgid "Customize Audio"
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:390
+#: assets/src/blocks/godam-audio/edit.js:666
+msgid "Replace audio file"
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:406
+#: assets/src/blocks/godam-audio/edit.js:677
+msgid "Remove audio"
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:417
+msgid "Add a title…"
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:426
+msgid "Add a short description…"
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:439
+#: assets/src/blocks/godam-audio/edit.js:498
 msgid "Audio Selection"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:450
+msgid "Upload an audio file to embed a player on your page or post."
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:465
+msgid "+ Upload Audio"
+msgstr ""
+
+#: assets/src/blocks/godam-audio/edit.js:506
 #: pages/video-editor/components/appearance/ThumbnailSelector.jsx:126
-#: assets/build/pages/video-editor.min.js:19232
 msgid "Select thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:517
 msgid "Edit or replace the thumbnail."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:523
 msgid "Thumbnail preview"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:1
+#: assets/src/blocks/godam-audio/edit.js:543
 msgid "Set thumbnail"
 msgstr ""
 
 #. translators: %s: thumbnail image URL.
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:549
+#, js-format
 msgid "The current thumbnail url is %s."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:552
 msgid "There is no thumbnail currently selected."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:576
 #: pages/video-editor/components/editor-shell/EditorTabRail.js:20
 #: pages/video-editor/components/transcription/Transcription.js:176
-#: assets/build/pages/video-editor.min.js:21414
-#: assets/build/pages/video-editor.min.js:26101
 msgid "Transcription"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:579
 msgid "Show transcript"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:586
 msgid "Show chapters"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-player/index.js:9632
+#: assets/src/blocks/godam-audio/edit.js:602
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:233
+#: assets/src/blocks/godam-player/track-uploader.js:57
+#: assets/src/js/godam-player/engagement.js:946
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:553
-#: assets/build/blocks/godam-player/index.js:9096
-#: assets/build/pages/video-editor.min.js:26917
 msgid "Edit"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:628
 msgctxt "noun; Audio block parameter"
 msgid "Preload"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
+#: assets/src/blocks/godam-audio/edit.js:650
 msgid "The audio file for this block was deleted from the Media Library. Replace it with another file or remove the block."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
-msgid "Upload an audio file to embed a player on your page or post."
+#: assets/src/blocks/godam-audio/player.js:50
+#: assets/src/blocks/godam-audio/view.js:250
+#: pages/video-editor/components/audio/AudioCardPreview.js:200
+msgid "Pause"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/index.js:2
-msgid "+ Upload Audio"
+#: assets/src/blocks/godam-audio/tabs.js:194
+#: assets/src/blocks/godam-audio/view.js:135
+#: pages/video-editor/components/audio/AudioCardPreview.js:304
+msgid "Copied"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-audio/tabs.js:194
+#: assets/src/blocks/godam-audio/view.js:124
+#: assets/src/blocks/godam-audio/view.js:140
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:357
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:359
+#: pages/video-editor/components/audio/AudioCardPreview.js:304
+msgid "Copy transcript"
+msgstr ""
+
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:78
+#: assets/src/blocks/godam-gallery-v2/edit.js:598
 msgid "Only video files can be added to the gallery."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:95
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:125
 msgid "This video is already in the gallery."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
+#: assets/src/blocks/godam-gallery-v2-item/edit.js:330
 msgid "Choose a video to add this gallery item."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:62
 msgid "Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:63
 msgid "For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:207
 #: pages/media-library/components/folder-tree/FolderTree.jsx:387
 #: pages/media-library/components/folder-tree/FolderTree.jsx:430
 #: pages/video-editor/components/cta/CardCTA.js:369
-#: assets/build/pages/media-library.min.js:6853
-#: assets/build/pages/media-library.min.js:6896
-#: assets/build/pages/video-editor.min.js:20840
 msgid "Loading…"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:299
+#: assets/src/blocks/godam-gallery-v2/edit.js:301
 msgid "Add New Video"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:606
+#: assets/src/blocks/godam-gallery-v2/edit.js:645
 msgid "Duplicate videos were skipped."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:742
 msgid "Start date cannot be later than end date."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:747
 msgid "End date cannot be earlier than start date."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:767
 msgid "Source"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:774
 msgid "Gallery Source"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:785
 msgid "Handpicked"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:789
 msgid "Query"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:11236
-#: assets/build/blocks/godam-player/index.js:10706
+#: assets/src/blocks/godam-gallery-v2/edit.js:797
+#: assets/src/blocks/godam-player/edit.js:1012
 msgid "Video Selection"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:802
 msgid "Videos play on mute by default"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:850
+#: assets/src/blocks/godam-gallery-v2/edit.js:1281
 msgid "+ Add Video"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:924
 msgid "Item Size"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:930
 msgid "Size of each gallery item."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:932
 msgid "S"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:933
 msgid "M"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:934
 msgid "L"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:939
+#: assets/src/blocks/godam-gallery-v2/edit.js:941
 msgid "Info Display"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:946
 msgid "Only Image"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:950
 msgid "Show Video Title and Date"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:973
 msgid "Visible videos autoplay one at a time and continue through the full video."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:978
 msgid "Videos will play when hovered over"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:992
 msgid "Show play button"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:997
 msgid "Play button overlay is visible on each tile."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:998
 msgid "Play button overlay is hidden."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:11269
+#: assets/src/blocks/godam-gallery-v2/edit.js:1004
+#: assets/src/blocks/godam-gallery-v2/edit.js:1008
+#: assets/src/blocks/godam-player/edit.js:1036
 #: pages/analytics/PlaybackPerformance.js:343
-#: assets/build/blocks/godam-player/index.js:10730
-#: assets/build/pages/analytics.min.js:10467
-#: assets/build/pages/dashboard.min.js:885
 msgid "Performance"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1030
 msgid "Engagement"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1046
 msgid "Query Settings"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1061
 msgid "Order by"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1097
 msgid "Search and select media folders"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1107
 msgid "Search and select authors"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1153
 msgid "Select Start Date"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1183
 msgid "Select End Date"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1217
 msgid "Load More Button"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1221
 msgid "Infinite Scroll"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1228
 msgid "Carousel layout always uses Infinite Scroll when more items are enabled."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1229
 msgid "Choose how visitors load more videos in query galleries."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1267
 msgid "Upload or select videos to add to your gallery."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/index.js:1
+#: assets/src/blocks/godam-gallery-v2/edit.js:1319
 msgid "Loading matching videos…"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/view.js:1
+#: assets/src/blocks/godam-gallery-v2/view.js:129
+#: assets/src/blocks/godam-gallery-v2/view.js:136
 msgid "Video player"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/view.js:1
+#: assets/src/blocks/godam-gallery-v2/view.js:142
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:85
-#: assets/build/pages/onboarding.min.js:1389
 msgid "Close"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/view.js:1
+#: assets/src/blocks/godam-gallery-v2/view.js:149
 msgid "Previous video"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/view.js:1
+#: assets/src/blocks/godam-gallery-v2/view.js:156
 msgid "Next video"
 msgstr ""
 
-#: assets/build/blocks/godam-image/index.js:1
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:200
-#: pages/video-editor/components/layers/HotspotLayer.js:769
-#: assets/build/pages/video-editor.min.js:23303
-#: assets/build/pages/video-editor.min.js:24717
-msgid "Custom Icon"
-msgstr ""
-
-#. translators: %d: hotspot number
-#. translators: %d is the hotspot index
-#: assets/build/blocks/godam-image/index.js:3
-#: assets/build/blocks/godam-image/index.js:5
-#: pages/video-editor/components/layers/HotspotLayer.js:458
-#: assets/build/pages/video-editor.min.js:24406
-msgid "Hotspot %d"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:84
 msgid "Only image files are allowed in the GoDAM Image block."
 msgstr ""
 
-#: assets/build/blocks/godam-image/index.js:5
-msgid "Customize Image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: pages/video-editor/components/cta/CardCTA.js:399
-#: assets/build/pages/video-editor.min.js:20870
-msgid "Remove image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:165
+#: assets/src/blocks/godam-image/edit.js:264
 msgid "Add Image"
 msgstr ""
 
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:182
+msgid "Customize Image"
+msgstr ""
+
+#: assets/src/blocks/godam-image/edit.js:197
+#: pages/video-editor/components/cta/CardCTA.js:399
+msgid "Remove image"
+msgstr ""
+
+#: assets/src/blocks/godam-image/edit.js:224
 msgid "Add hotspot and product layers to make your image stand out."
 msgstr ""
 
-#: assets/build/blocks/godam-image/index.js:5
+#: assets/src/blocks/godam-image/edit.js:249
 msgid "Upload or select an image from your media library to get started."
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:9304
-#: assets/build/blocks/godam-player/index.js:9310
-#: assets/build/blocks/godam-player/index.js:8764
-#: assets/build/blocks/godam-player/index.js:8770
+#: assets/src/blocks/godam-pdf/caption.js:44
+#: assets/src/blocks/godam-pdf/caption.js:48
+#: assets/src/blocks/godam-player/caption.js:50
+#: assets/src/blocks/godam-player/caption.js:56
 msgid "Add caption"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:9311
-#: assets/build/blocks/godam-player/index.js:8771
+#: assets/src/blocks/godam-pdf/caption.js:49
+#: assets/src/blocks/godam-player/caption.js:57
 msgid "Remove caption"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:220
 msgid "Only PDF files can be attached to this block. Please select a PDF document."
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:334
+#: assets/src/blocks/godam-pdf/edit.js:521
 msgid "Doc Selection"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:336
+#: assets/src/blocks/godam-pdf/edit.js:523
 msgid "Add title, description, and more to make your document stand out."
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:351
 msgid "+ Add Document"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:362
 msgid "Attach a document here"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:365
 msgid "Upload a PDF to embed it or display it as a card with a cover image."
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:379
 msgid "+ Upload Document"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:424
+msgid "Only PDF files are supported. Replace this file with a PDF; it will not be shown on your page."
+msgstr ""
+
+#: assets/src/blocks/godam-pdf/edit.js:456
 msgid "page"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:456
 msgid "pages"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:468
 msgid "Document cover"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:533
 msgid "Remove document"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:555
 msgid "Add document description"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:563
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:286
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:291
-#: assets/build/pages/video-editor.min.js:21743
-#: assets/build/pages/video-editor.min.js:26655
 msgid "Preview"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:587
 msgid "Show cover"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:596
 msgid "Cover"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:118
+#: assets/src/blocks/godam-pdf/edit.js:606
+#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:118
 msgid "Auto-generated cover"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:610
 msgid "Auto-generated"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:643
 msgid "Select cover image"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:103
+#: assets/src/blocks/godam-pdf/edit.js:665
+#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:103
 msgid "Remove cover"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:695
 msgid "+ Add Cover"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
+#: assets/src/blocks/godam-pdf/edit.js:701
 msgid "Recommended aspect ratio: 16:9."
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:11118
-#: assets/build/blocks/godam-player/index.js:10580
+#: assets/src/blocks/godam-pdf/edit.js:711
+#: assets/src/blocks/godam-player/edit.js:886
 msgid "Height"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/view.js:1
+#: assets/src/blocks/godam-pdf/view.js:142
 msgid "<strong>Unable to load PDF.</strong> All sources are unavailable."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9305
-#: assets/build/blocks/godam-player/index.js:8765
+#: assets/src/blocks/godam-player/caption.js:51
 msgid "Caption text"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9557
-#: assets/build/blocks/godam-player/index.js:9621
-#: assets/build/blocks/godam-player/index.js:9012
-#: assets/build/blocks/godam-player/index.js:9085
-#: assets/build/js/media-library.min.js:10064
-#: assets/build/js/media-library.min.js:10065
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:149
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:222
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:317
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:318
 msgid "Upload Custom Thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9565
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:156
 #: pages/video-editor/components/appearance/ThumbnailSelector.jsx:158
-#: assets/build/blocks/godam-player/index.js:9019
-#: assets/build/pages/video-editor.min.js:19264
 msgid "Upload custom thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9578
-#: assets/build/blocks/godam-player/index.js:9035
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:172
 msgid "Custom uploaded thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9582
-#: assets/build/blocks/godam-player/index.js:9037
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:174
 msgid "Select custom thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9586
-#: assets/build/blocks/godam-player/index.js:9040
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:177
 msgid "Custom thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9593
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:183
 #: pages/video-editor/components/appearance/ThumbnailSelector.jsx:139
-#: assets/build/blocks/godam-player/index.js:9046
-#: assets/build/pages/video-editor.min.js:19245
 msgid "Remove custom thumbnail"
 msgstr ""
 
 #. translators: %s: thumbnail URL
-#: assets/build/blocks/godam-player/index.js:9603
-#: assets/build/blocks/godam-player/index.js:9065
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:202
+#, js-format
 msgid "Select thumbnail: %s"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9610
-#: assets/build/blocks/godam-player/index.js:9071
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:208
 msgid "Auto-generated from video"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9641
+#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:245
 #: pages/tools/components/tabs/RetranscodeTab.jsx:553
-#: assets/build/blocks/godam-player/index.js:9108
-#: assets/build/pages/tools.min.js:2985
 msgid "Reset"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9875
-#: assets/build/blocks/godam-player/index.js:9322
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:208
 msgid "Video SEO Schema"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9885
-#: assets/build/blocks/godam-player/index.js:9334
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:220
 msgid "SEO data is customized for this block. Changes to the media library will not affect this block."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9885
-#: assets/build/blocks/godam-player/index.js:9335
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:221
 msgid "SEO data is synced from the media library. Enable to customize SEO for this specific block."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9890
-#: assets/build/blocks/godam-player/index.js:9341
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:227
 msgid "SEO data is automatically synced from the media library. Any changes made to the video in the media library will be reflected here."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9895
-#: assets/build/blocks/godam-player/index.js:9347
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:233
 msgid "You have overridden the default SEO. Changes to this video in the media library will not update the SEO for this block."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9902
-#: assets/build/blocks/godam-player/index.js:9354
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:240
 msgid "Reset to media library defaults"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9914
-#: assets/build/blocks/godam-player/index.js:9370
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:256
 msgid "Headline *"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9924
-#: assets/build/blocks/godam-player/index.js:9382
-#: assets/build/js/godam-elementor-frontend.min.js:468
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:268
+#: assets/src/js/elementor/widgets/godam-video.js:323
 msgid "It is recommended to add a description for better video SEO."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9924
-#: assets/build/blocks/godam-player/index.js:9383
-#: assets/build/js/godam-elementor-frontend.min.js:471
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:269
+#: assets/src/js/elementor/widgets/godam-video.js:326
 msgid "Description of the video"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9929
-#: assets/build/blocks/godam-player/index.js:9390
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:276
 msgid "ISO 8601 datetime format. Example: 2024–01–15T10:30:00+00:00"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9945
-#: assets/build/blocks/godam-player/index.js:9408
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:294
 msgid "URL of the video thumbnail. Example: https://www.example.com/thumbnail.jpg"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9964
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:308
+#: assets/src/js/deactivation-feedback.js:36
+#: assets/src/js/godam-player/engagement.js:744
 #: pages/godam/components/ConfirmModal.jsx:38
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:191
 #: pages/media-library/App.js:178
@@ -4807,441 +4768,756 @@ msgstr ""
 #: pages/video-editor/components/chapters/ChapterForm.js:124
 #: pages/video-editor/components/layers/LayersHeader.js:105
 #: pages/video-editor/components/transcription/Transcription.js:295
-#: assets/build/blocks/godam-player/index.js:9422
-#: assets/build/js/deactivation-feedback.min.js:92
-#: assets/build/pages/godam.min.js:10162
-#: assets/build/pages/godam.min.js:12888
-#: assets/build/pages/media-library.min.js:5829
-#: assets/build/pages/media-library.min.js:7545
-#: assets/build/pages/media-library.min.js:7688
-#: assets/build/pages/media-library.min.js:7803
-#: assets/build/pages/video-editor.min.js:15596
-#: assets/build/pages/video-editor.min.js:19736
-#: assets/build/pages/video-editor.min.js:25024
-#: assets/build/pages/video-editor.min.js:26220
 msgid "Cancel"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:9968
+#: assets/src/blocks/godam-player/components/VideoSEOModal.js:311
+#: assets/src/js/godam-player/engagement.js:1115
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:134
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:140
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:360
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:493
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:130
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:191
-#: assets/build/blocks/godam-player/index.js:9425
-#: assets/build/pages/godam.min.js:11233
-#: assets/build/pages/godam.min.js:11532
-#: assets/build/pages/godam.min.js:12076
-#: assets/build/pages/godam.min.js:12689
-#: assets/build/pages/godam.min.js:13232
-#: assets/build/pages/video-editor.min.js:21648
 msgid "Save"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10070
-#: assets/build/blocks/godam-player/index.js:9499
+#: assets/src/blocks/godam-player/edit-common-settings.js:68
 msgid "Muted because of Autoplay."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10109
-#: assets/build/blocks/godam-player/index.js:9537
+#: assets/src/blocks/godam-player/edit-common-settings.js:105
 msgid "Play on loop"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10135
-#: assets/build/blocks/godam-player/index.js:9563
-msgid "Play on modal"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:10138
-#: assets/build/blocks/godam-player/index.js:9566
-msgid "Play video in a popup modal when clicked."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:10144
-#: assets/build/blocks/godam-player/index.js:9573
+#: assets/src/blocks/godam-player/edit-common-settings.js:132
 msgid "Show share button"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10152
-#: assets/build/blocks/godam-player/index.js:9582
+#: assets/src/blocks/godam-player/edit-common-settings.js:141
 msgid "Show transcription"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10168
-#: assets/build/blocks/godam-player/index.js:9598
+#: assets/src/blocks/godam-player/edit-common-settings.js:157
 msgid "No subtitle/transcript file uploaded."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10172
-#: assets/build/blocks/godam-player/index.js:9601
+#: assets/src/blocks/godam-player/edit-common-settings.js:160
 msgid "Click here to upload subtitles."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10179
-#: assets/build/blocks/godam-player/index.js:9611
+#: assets/src/blocks/godam-player/edit-common-settings.js:170
 msgid "Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it. Best for overall page performance."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10180
-#: assets/build/blocks/godam-player/index.js:9612
+#: assets/src/blocks/godam-player/edit-common-settings.js:171
 msgid "For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly - one or two per page."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10255
-#: assets/build/blocks/godam-player/index.js:9686
+#: assets/src/blocks/godam-player/edit-common-settings.js:245
 msgid "Likes & Comments"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10360
-#: assets/build/blocks/godam-player/index.js:9780
+#: assets/src/blocks/godam-player/edit.js:86
 msgid "Add a heading…"
 msgstr ""
 
 #. translators: %d: Label of the video text track e.g: "French subtitles".
-#: assets/build/blocks/godam-player/index.js:10632
-#: assets/build/blocks/godam-player/index.js:10058
+#: assets/src/blocks/godam-player/edit.js:364
+#, js-format
 msgctxt "video caption"
 msgid "Failed to load video data with id: %d"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:10764
-#: assets/build/blocks/godam-player/index.js:10193
+#: assets/src/blocks/godam-player/edit.js:499
 msgid "Only video files are allowed in the GoDAM Video block."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11032
-#: assets/build/blocks/godam-player/index.js:10484
+#: assets/src/blocks/godam-player/edit.js:790
 msgid "Add subtitles, layers, and more to make your video stand out."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11043
-#: assets/build/blocks/godam-player/index.js:11351
-#: assets/build/blocks/godam-player/index.js:10497
-#: assets/build/blocks/godam-player/index.js:10810
+#: assets/src/blocks/godam-player/edit.js:803
+#: assets/src/blocks/godam-player/edit.js:1116
 msgid "Add Video"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11053
-#: assets/build/blocks/godam-player/index.js:10511
+#: assets/src/blocks/godam-player/edit.js:817
 msgid "Customize Video"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11068
+#: assets/src/blocks/godam-player/edit.js:835
 #: pages/video-editor/components/ads/CustomAdSettings.js:219
-#: assets/build/blocks/godam-player/index.js:10529
-#: assets/build/pages/video-editor.min.js:18791
 msgid "Remove video"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11085
-#: assets/build/blocks/godam-player/index.js:10549
+#: assets/src/blocks/godam-player/edit.js:855
 msgid "Hover option is disabled when autoplay is on."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11088
-#: assets/build/blocks/godam-player/index.js:10552
+#: assets/src/blocks/godam-player/edit.js:858
 msgid "Show player"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11124
-#: assets/build/blocks/godam-player/index.js:10584
+#: assets/src/blocks/godam-player/edit.js:890
 msgid "Set the video height. Width is auto-calculated from the aspect ratio."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11131
-#: assets/build/blocks/godam-player/index.js:10588
+#: assets/src/blocks/godam-player/edit.js:894
 msgid "Show overlay blocks"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11136
-#: assets/build/blocks/godam-player/index.js:10591
+#: assets/src/blocks/godam-player/edit.js:897
 msgid "Display blocks on top of the video player."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11140
-#: assets/build/blocks/godam-player/index.js:10597
+#: assets/src/blocks/godam-player/edit.js:903
 msgid "Vertical alignment"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11144
-#: assets/build/blocks/godam-player/index.js:10601
+#: assets/src/blocks/godam-player/edit.js:907
 msgid "Top"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11147
-#: assets/build/blocks/godam-player/index.js:10602
+#: assets/src/blocks/godam-player/edit.js:908
 msgid "Center"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11150
-#: assets/build/blocks/godam-player/index.js:10603
+#: assets/src/blocks/godam-player/edit.js:909
 msgid "Bottom"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11154
-#: assets/build/blocks/godam-player/index.js:10606
+#: assets/src/blocks/godam-player/edit.js:912
 msgid "Choose where to position the overlay blocks vertically."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11156
-#: assets/build/blocks/godam-player/index.js:10609
+#: assets/src/blocks/godam-player/edit.js:915
 msgid "Time range"
 msgstr ""
 
 #. translators: %s: formatted time
-#: assets/build/blocks/godam-player/index.js:11166
-#: assets/build/blocks/godam-player/index.js:10618
+#: assets/src/blocks/godam-player/edit.js:924
+#, js-format
 msgid "Overlay will be visible for %s from the start of the video."
 msgstr ""
 
 #. translators: %s: formatted time
-#: assets/build/blocks/godam-player/index.js:11174
-#: assets/build/blocks/godam-player/index.js:10626
+#: assets/src/blocks/godam-player/edit.js:932
+#, js-format
 msgid "Video duration: %s"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11192
-#: assets/build/blocks/godam-player/index.js:10656
+#: assets/src/blocks/godam-player/edit.js:962
 msgid "Video SEO"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11195
-#: assets/build/blocks/godam-player/index.js:10660
+#: assets/src/blocks/godam-player/edit.js:966
 msgid "SEO"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11225
-#: assets/build/blocks/godam-player/index.js:10691
+#: assets/src/blocks/godam-player/edit.js:997
 msgid "You don't have an active plan to use this feature. Upgrade now to use unlimited features as part of GoDAM suite."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11233
+#: assets/src/blocks/godam-player/edit.js:1007
 #: pages/godam/components/TrialCountdownBanner.jsx:78
-#: assets/build/blocks/godam-player/index.js:10701
-#: assets/build/pages/analytics.min.js:16610
-#: assets/build/pages/dashboard.min.js:4681
-#: assets/build/pages/godam.min.js:10689
-#: assets/build/pages/help.min.js:957
-#: assets/build/pages/tools.min.js:1043
-#: assets/build/pages/video-editor.min.js:15992
 msgid "Upgrade Now"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11284
-#: assets/build/blocks/godam-player/index.js:10738
+#: assets/src/blocks/godam-player/edit.js:1044
 msgid "Hover Options"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11339
-#: assets/build/blocks/godam-player/index.js:10797
+#: assets/src/blocks/godam-player/edit.js:1103
 msgid "Upload or select a video from your media library to get started."
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:11435
-#: assets/build/blocks/godam-player/index.js:10887
+#: assets/src/blocks/godam-player/edit.js:1193
 msgid "Video caption text"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:12057
-#: pages/godam/components/GoDAMHeader.jsx:102
-#: assets/build/blocks/godam-player/index.js:11422
-#: assets/build/js/media-library.min.js:9504
-#: assets/build/pages/analytics.min.js:16364
-#: assets/build/pages/dashboard.min.js:4435
-#: assets/build/pages/godam.min.js:10421
-#: assets/build/pages/help.min.js:711
-#: assets/build/pages/tools.min.js:797
-#: assets/build/pages/video-editor.min.js:15308
-#: assets/build/pages/video-editor.min.js:15746
-msgid "Manage Media"
+#: assets/src/blocks/godam-player/track-uploader.js:39
+msgid "Video Captions"
 msgstr ""
 
-#: assets/build/blocks/godam-player/index.js:12062
-#: assets/build/blocks/godam-player/index.js:11427
-#: assets/build/js/media-library.min.js:9509
-#: assets/build/pages/video-editor.min.js:15313
-msgid "Premium Feature"
+#. translators: %s: video caption label.
+#: assets/src/blocks/godam-player/track-uploader.js:53
+#, js-format
+msgctxt "video caption"
+msgid "Edit %s"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-player/track-uploader.js:71
+msgid "Edit track"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:73
+msgid "File"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:84
+msgid "Source language"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:104
+msgid "Remove track"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:111
+msgid "English"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:123
+msgid "Apply"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:154
+msgid "Manage Video Captions"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:179
+msgid "No captions added yet"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:181
+msgid "You can upload subtitle or caption files (.vtt) to improve accessibility."
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:194
+msgid "Add new track"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:205
+msgid "Open Media Library"
+msgstr ""
+
+#: assets/src/blocks/godam-player/track-uploader.js:228
+msgctxt "verb"
+msgid "Upload"
+msgstr ""
+
+#: assets/src/blocks/godam-video-duration/edit.js:33
 msgid "Default (HH:MM:SS)"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:34
+#: assets/src/blocks/godam-video-duration/edit.js:63
 msgid "00:00:00"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:38
 msgid "Minutes only (MM:SS)"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:39
 msgid "00:00"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:43
 msgid "Total Seconds"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:44
 msgid "0s"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:51
 msgid "Duration Settings"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/index.js:1
+#: assets/src/blocks/godam-video-duration/edit.js:53
 msgid "Duration Format"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:39
 msgid "Thumbnail Settings"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:42
 msgid "Show play button overlay"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:46
 msgid "Play button will be displayed."
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:47
 msgid "No play button will be displayed."
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:53
 msgid "Link to post"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:57
 msgid "Thumbnail will link to the video page."
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:58
 msgid "Thumbnail will not be linked."
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:65
 msgid "Open in new tab"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:69
 msgid "Link will open in a new tab."
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:70
 msgid "Link will open in the same tab."
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
+#: assets/src/blocks/godam-video-thumbnail/edit.js:82
 msgid "GoDAM Video Thumbnail"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:168
 msgid "Enter label for the field"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:181
 msgid "Enter description"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:184
 msgid "Enter description for the field"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:249
 msgid "100 MB"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:250
 msgid "Maximum file size (in MB)"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:273
 msgid "Is recorder field required?"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:283
 msgid "Enter error message"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:287
 msgid "Enter the required error message"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:303
 msgid "Field settings"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:310
 #: pages/analytics/charts.js:179
-#: assets/build/pages/analytics.min.js:11458
-#: assets/build/pages/dashboard.min.js:1456
 msgid "Untitled"
 msgstr ""
 
 #. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:7
+#: assets/src/blocks/sureforms/blocks/recorder/edit.js:353
+#, js-format
 msgid "Maximum allowed size: %s MB"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:22
+msgid "Select a reason"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:23
+msgid "I found a better plugin"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:24
+msgid "The plugin is not working as expected"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:25
+msgid "I was just testing"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:26
+msgid "Other"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:28
+msgid "Additional details…"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:32
+msgid "Skip & Deactivate"
+msgstr ""
+
+#: assets/src/js/deactivation-feedback.js:37
+msgid "Submit & Deactivate"
+msgstr ""
+
+#. translators: %d: Maximum allowed file size in MB.
+#: assets/src/js/everestforms/index.js:61
+#, js-format
+msgid "File size exceeds the maximum limit of %d MB."
+msgstr ""
+
+#: assets/src/js/everestforms/index.js:231
+#: assets/src/js/fluentforms/index.js:245
+#: assets/src/js/ninja-forms/index.js:216
+msgid "File upload in progress…"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:725
+msgid "Add timestamp"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:731
+msgid "Add emoji"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:739
+#: assets/src/js/godam-player/engagement.js:928
+#: assets/src/js/godam-player/engagement.js:968
+msgid "Reply"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:739
+msgid "Comment"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:915
+msgid "This comment has been deleted"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:938
+#: pages/media-library/components/context-menu/ContextMenu.jsx:464
+#: pages/media-library/components/modal/DeleteModal.jsx:114
+#: pages/video-editor/components/SidebarLayers.js:750
+#: pages/video-editor/components/transcription/Transcription.js:304
+msgid "Delete"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:968
+msgid "Replies"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1020
+msgid "No comments yet. Be the first to comment!"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1081
+msgid "Register"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1081
+msgid "Login"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1081
+msgid "to comment"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1088
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:58
+#: pages/onboarding/components/screens/LoginScreen.jsx:54
+#: pages/onboarding/components/screens/SignupScreen.jsx:77
+msgid "Email"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1092
+msgid "Enter your email"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1105
+msgid "Back"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1115
+msgid "Continue as Guest"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1151
+msgid "GoDAM Video"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1262
+msgid "Comments"
+msgstr ""
+
+#: assets/src/js/godam-player/engagement.js:1267
+msgid "Hide Comments"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/chaptersManager.js:71
+msgid "Chapter"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/controlsManager.js:84
+msgid "Custom Fullscreen"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/controlsManager.js:165
+msgid "Exit Fullscreen"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/controlsManager.js:377
+#: pages/video-editor/VideoJSPlayer.js:195
+msgid "Custom Play Button"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/controlsManager.js:421
+#: assets/src/js/godam-player/managers/controlsManager.js:438
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:429
+msgid "Branding"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:320
+#: pages/video-editor/components/layers/CTALayer.js:265
+msgid "Done"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:324
+msgid "Skip Form"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:325
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:329
+#: pages/godam/components/WooUnlockedNotice.jsx:202
+#: pages/video-editor/components/forms/FormPreview.js:86
+#: pages/video-editor/components/layers/CTALayer.js:265
+msgid "Skip"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:326
+msgid "Skip Poll"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:413
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:416
+#: assets/src/js/godam-player/managers/layers/formLayerManager.js:507
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
+msgid "Continue"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/layers/hotspotLayerManager.js:707
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:200
+#: pages/video-editor/components/layers/HotspotLayer.js:769
+msgid "Custom Icon"
+msgstr ""
+
+#. translators: %d: hotspot number
+#. translators: %d is the hotspot index
+#: assets/src/js/godam-player/managers/layers/hotspotLayerManager.js:749
+#: assets/src/js/godam-player/managers/layers/hotspotLayerManager.js:756
+#: pages/video-editor/components/layers/HotspotLayer.js:458
+#, js-format
+msgid "Hotspot %d"
+msgstr ""
+
+#. translators: %d: number of seconds to seek backward
+#. translators: %d: number of seconds to seek forward
+#: assets/src/js/godam-player/managers/playerManager.js:440
+#: assets/src/js/godam-player/managers/playerManager.js:456
+#, js-format
+msgid "%ds"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:278
+msgid "Check out this video!"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:312
+msgid "Share Media"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:321
+msgid "Page Link"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:322
+#: pages/godam/components/GoDAMHeader.jsx:107
+msgid "GoDAM Central"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:323
+msgid "Embed"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:332
+msgid "Start at"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:336
+msgid "mm:ss"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/shareManager.js:643
+msgid "copy icon"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:280
+msgid "Toggle transcript"
+msgstr ""
+
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:366
+#: assets/src/js/godam-player/managers/transcriptPanelManager.js:368
+msgid "Close transcript"
+msgstr ""
+
+#: assets/src/js/godam-player/masterSettings.js:264
+msgid "Invalid item"
+msgstr ""
+
+#. translators: %d: Maximum allowed duration in seconds
+#: assets/src/js/godam-recorder/index.js:271
+#, js-format
+msgid "Maximum allowed duration is %d seconds. Please upload or record a shorter file."
+msgstr ""
+
+#: assets/src/js/godam-recorder/index.js:370
+#: assets/src/js/godam-recorder/index.js:373
+msgid "Remove recording"
+msgstr ""
+
+#: assets/src/js/media-library/index.js:187
+msgid "Search Media"
+msgstr ""
+
+#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:209
+msgid "Not started"
+msgstr ""
+
+#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:229
+msgid "Media is transcoded"
+msgstr ""
+
+#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:265
+msgid "Transcoding…"
+msgstr ""
+
+#: assets/src/js/media-library/utility.js:79
+#: pages/godam/components/GoDAMHeader.jsx:102
+msgid "Manage Media"
+msgstr ""
+
+#: assets/src/js/media-library/utility.js:84
+msgid "Premium Feature"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:108
+msgid "No thumbnails found"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:265
+msgid "Select Custom Thumbnail"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:266
+msgid "Use this image"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:278
+msgid "Please select a valid image file (JPEG, PNG, GIF, etc.)."
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:314
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:315
+msgid "Only 3 custom thumbnails allowed"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:362
+msgid "Custom Video Thumbnail"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:369
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:373
+msgid "Remove Image"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:588
+#: assets/src/js/media-library/views/attachment-detail-two-column.js:1192
+msgid "Video Thumbnails"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-details.js:145
+msgid "oEmbed Video URL"
+msgstr ""
+
+#: assets/src/js/media-library/views/attachment-details.js:147
+msgid "The oEmbed URL can be used to embed the video in other platforms that support oEmbed."
+msgstr ""
+
+#: assets/src/js/ninja-forms/index.js:280
+msgid "Upload failed. Please try again."
+msgstr ""
+
+#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:122
+msgid "Custom cover"
+msgstr ""
+
+#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:157
+msgid "Select Cover Image"
+msgstr ""
+
+#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:158
+msgid "Use image"
+msgstr ""
+
+#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:32
+msgid "Select or Upload Document"
+msgstr ""
+
+#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:28
+msgid "Select or Upload Image"
+msgstr ""
+
+#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:81
+msgid "Select or Upload Video"
+msgstr ""
+
+#: assets/src/js/wpforms-godam-recorder-editor.js:15
+msgid "Select or Upload Video Of Your Choice"
+msgstr ""
+
+#: assets/src/js/wpforms-godam-recorder-editor.js:20
+msgid "Use this video"
 msgstr ""
 
 #: pages/analytics/Analytics.js:103
 #: pages/analytics/SingleMetrics.js:157
 #: pages/dashboard/Dashboard.js:224
-#: assets/build/pages/analytics.min.js:9267
-#: assets/build/pages/analytics.min.js:10972
-#: assets/build/pages/dashboard.min.js:1240
-#: assets/build/pages/dashboard.min.js:3266
 msgid "All time"
 msgstr ""
 
 #: pages/analytics/Analytics.js:408
-#: assets/build/pages/analytics.min.js:9572
 msgid "Select Video to Perform Performance Comparison Testing"
 msgstr ""
 
 #: pages/analytics/Analytics.js:410
-#: assets/build/pages/analytics.min.js:9574
 msgid "Use this Video"
 msgstr ""
 
 #: pages/analytics/Analytics.js:517
-#: assets/build/pages/analytics.min.js:9681
 msgid "This media doesn't exist."
 msgstr ""
 
 #: pages/analytics/Analytics.js:519
-#: assets/build/pages/analytics.min.js:9683
 msgid "Go to Dashboard"
 msgstr ""
 
 #: pages/analytics/Analytics.js:531
-#: assets/build/pages/analytics.min.js:9695
 msgid "Single Video Analytics"
 msgstr ""
 
 #: pages/analytics/Analytics.js:532
-#: assets/build/pages/analytics.min.js:9696
 msgid "Back to Media Editor"
 msgstr ""
 
 #: pages/analytics/Analytics.js:541
 #: pages/dashboard/Dashboard.js:312
-#: assets/build/pages/analytics.min.js:9705
-#: assets/build/pages/dashboard.min.js:3354
 msgid "Heads up: analytics update periodically, so new activity may take up to 30 minutes to show here."
 msgstr ""
 
 #: pages/analytics/Analytics.js:555
 #: pages/dashboard/components/TopVideosTable.js:302
 #: pages/dashboard/components/TopVideosTable.js:314
-#: assets/build/pages/analytics.min.js:9719
-#: assets/build/pages/dashboard.min.js:3978
-#: assets/build/pages/dashboard.min.js:3990
 msgid "Video thumbnail"
 msgstr ""
 
@@ -5249,8 +5525,7 @@ msgstr ""
 #. translators: %d is the number of layers.
 #: pages/analytics/Analytics.js:575
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:233
-#: assets/build/pages/analytics.min.js:9739
-#: assets/build/pages/video-editor.min.js:21690
+#, js-format
 msgid "%d layer"
 msgid_plural "%d layers"
 msgstr[0] ""
@@ -5258,22 +5533,16 @@ msgstr[1] ""
 
 #: pages/analytics/Analytics.js:591
 #: pages/dashboard/Dashboard.js:354
-#: assets/build/pages/analytics.min.js:9755
-#: assets/build/pages/dashboard.min.js:3396
 msgid "Insights"
 msgstr ""
 
 #: pages/analytics/Analytics.js:601
 #: pages/analytics/Analytics.js:886
 #: pages/dashboard/components/TopVideosTable.js:275
-#: assets/build/pages/analytics.min.js:9765
-#: assets/build/pages/analytics.min.js:10050
-#: assets/build/pages/dashboard.min.js:3951
 msgid "Average Engagement"
 msgstr ""
 
 #: pages/analytics/Analytics.js:602
-#: assets/build/pages/analytics.min.js:9766
 msgid "Video engagement rate is the percentage of video watched. Average Engagement = Total time played / (Total plays x Video length)"
 msgstr ""
 
@@ -5284,100 +5553,71 @@ msgstr ""
 #: pages/analytics/PlaybackPerformance.js:524
 #: pages/dashboard/components/TopVideosTable.js:195
 #: pages/dashboard/components/TopVideosTable.js:272
-#: assets/build/pages/analytics.min.js:9777
-#: assets/build/pages/analytics.min.js:10066
-#: assets/build/pages/analytics.min.js:10549
-#: assets/build/pages/analytics.min.js:10648
-#: assets/build/pages/analytics.min.js:12166
-#: assets/build/pages/dashboard.min.js:967
-#: assets/build/pages/dashboard.min.js:1066
-#: assets/build/pages/dashboard.min.js:3871
-#: assets/build/pages/dashboard.min.js:3948
 msgid "Play Rate"
 msgstr ""
 
 #: pages/analytics/Analytics.js:614
 #: pages/dashboard/Dashboard.js:383
-#: assets/build/pages/analytics.min.js:9778
-#: assets/build/pages/dashboard.min.js:3425
 msgid "Play rate is the percentage of page visitors who clicked play. Play Rate = Total plays / Page loads"
 msgstr ""
 
 #: pages/analytics/Analytics.js:625
 #: pages/dashboard/components/TopVideosTable.js:197
 #: pages/dashboard/Dashboard.js:396
-#: assets/build/pages/analytics.min.js:9789
-#: assets/build/pages/dashboard.min.js:3438
-#: assets/build/pages/dashboard.min.js:3873
 msgid "Watch Time"
 msgstr ""
 
 #: pages/analytics/Analytics.js:626
 #: pages/dashboard/Dashboard.js:397
-#: assets/build/pages/analytics.min.js:9790
-#: assets/build/pages/dashboard.min.js:3439
 msgid "Total time the video has been watched, aggregated across all plays"
 msgstr ""
 
 #: pages/analytics/Analytics.js:652
-#: assets/build/pages/analytics.min.js:9816
 msgid "Viewer Retention Curve"
 msgstr ""
 
 #: pages/analytics/Analytics.js:666
-#: assets/build/pages/analytics.min.js:9830
 msgid "Viewer retention will appear here once this video receives views."
 msgstr ""
 
 #: pages/analytics/Analytics.js:714
-#: assets/build/pages/analytics.min.js:9878
 msgid "Views by Source"
 msgstr ""
 
 #: pages/analytics/Analytics.js:725
-#: assets/build/pages/analytics.min.js:9889
 msgid "Performance Comparison"
 msgstr ""
 
 #: pages/analytics/Analytics.js:736
-#: assets/build/pages/analytics.min.js:9900
 msgid "In Progress"
 msgstr ""
 
 #: pages/analytics/Analytics.js:741
-#: assets/build/pages/analytics.min.js:9905
 msgid "Initiate the test comparison to generate analytical insights."
 msgstr ""
 
 #: pages/analytics/Analytics.js:746
-#: assets/build/pages/analytics.min.js:9910
 msgid "The test is complete! Review results to identify the best-performing video."
 msgstr ""
 
 #: pages/analytics/Analytics.js:758
-#: assets/build/pages/analytics.min.js:9922
 msgid "Start Test"
 msgstr ""
 
 #: pages/analytics/Analytics.js:789
-#: assets/build/pages/analytics.min.js:9953
 msgid "Test this video against others to see which performs better."
 msgstr ""
 
 #: pages/analytics/Analytics.js:798
-#: assets/build/pages/analytics.min.js:9962
 msgid "Upload or Replace CTA Image"
 msgstr ""
 
 #: pages/analytics/Analytics.js:803
-#: assets/build/pages/analytics.min.js:9967
 msgid "Choose"
 msgstr ""
 
 #: pages/analytics/Analytics.js:874
 #: pages/analytics/components/Placements/index.js:228
-#: assets/build/pages/analytics.min.js:10038
-#: assets/build/pages/analytics.min.js:12164
 msgid "Views"
 msgstr ""
 
@@ -5386,251 +5626,171 @@ msgstr ""
 #: pages/dashboard/components/TopVideosTable.js:273
 #: pages/dashboard/components/ViewersGauge.js:95
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:105
-#: assets/build/pages/analytics.min.js:10057
-#: assets/build/pages/dashboard.min.js:3872
-#: assets/build/pages/dashboard.min.js:3949
-#: assets/build/pages/dashboard.min.js:4186
-#: assets/build/pages/video-editor.min.js:21355
 msgid "Total Plays"
 msgstr ""
 
 #: pages/analytics/Analytics.js:914
-#: assets/build/pages/analytics.min.js:10078
 msgid "Page Loads"
 msgstr ""
 
 #: pages/analytics/Analytics.js:928
-#: assets/build/pages/analytics.min.js:10092
 msgid "Play Time"
 msgstr ""
 
 #: pages/analytics/Analytics.js:942
-#: assets/build/pages/analytics.min.js:10106
 msgid "Video Length"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:70
-#: assets/build/pages/analytics.min.js:11626
-#: assets/build/pages/dashboard.min.js:1624
-#: assets/build/pages/shared-components.min.js:126
 msgid "7 Days"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:71
-#: assets/build/pages/analytics.min.js:11627
-#: assets/build/pages/dashboard.min.js:1625
-#: assets/build/pages/shared-components.min.js:127
 msgid "Last 7 days"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:76
-#: assets/build/pages/analytics.min.js:11632
-#: assets/build/pages/dashboard.min.js:1630
-#: assets/build/pages/shared-components.min.js:132
 msgid "15 Days"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:77
-#: assets/build/pages/analytics.min.js:11633
-#: assets/build/pages/dashboard.min.js:1631
-#: assets/build/pages/shared-components.min.js:133
 msgid "Last 15 days"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:82
-#: assets/build/pages/analytics.min.js:11638
-#: assets/build/pages/dashboard.min.js:1636
-#: assets/build/pages/shared-components.min.js:138
 msgid "1 Month"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:83
-#: assets/build/pages/analytics.min.js:11639
-#: assets/build/pages/dashboard.min.js:1637
-#: assets/build/pages/shared-components.min.js:139
 msgid "Last 1 month"
 msgstr ""
 
 #. translators: 1: range start (e.g. "Nov 7"), 2: range end (e.g. "Nov 13").
 #: pages/analytics/components/DateRangePicker/index.js:129
-#: assets/build/pages/analytics.min.js:11685
-#: assets/build/pages/dashboard.min.js:1683
-#: assets/build/pages/shared-components.min.js:185
+#, js-format
 msgid "%1$s - %2$s"
 msgstr ""
 
 #. translators: %s: range start date, e.g. "Nov 7".
 #: pages/analytics/components/DateRangePicker/index.js:137
-#: assets/build/pages/analytics.min.js:11693
-#: assets/build/pages/dashboard.min.js:1691
-#: assets/build/pages/shared-components.min.js:193
+#, js-format
 msgid "From %s"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:168
-#: assets/build/pages/analytics.min.js:11718
-#: assets/build/pages/dashboard.min.js:1716
-#: assets/build/pages/shared-components.min.js:218
 msgid "Su"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:169
-#: assets/build/pages/analytics.min.js:11719
-#: assets/build/pages/dashboard.min.js:1717
-#: assets/build/pages/shared-components.min.js:219
 msgid "Mo"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:170
-#: assets/build/pages/analytics.min.js:11720
-#: assets/build/pages/dashboard.min.js:1718
-#: assets/build/pages/shared-components.min.js:220
 msgid "Tu"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:171
-#: assets/build/pages/analytics.min.js:11721
-#: assets/build/pages/dashboard.min.js:1719
-#: assets/build/pages/shared-components.min.js:221
 msgid "We"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:172
-#: assets/build/pages/analytics.min.js:11722
-#: assets/build/pages/dashboard.min.js:1720
-#: assets/build/pages/shared-components.min.js:222
 msgid "Th"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:173
-#: assets/build/pages/analytics.min.js:11723
-#: assets/build/pages/dashboard.min.js:1721
-#: assets/build/pages/shared-components.min.js:223
 msgid "Fr"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:174
-#: assets/build/pages/analytics.min.js:11724
-#: assets/build/pages/dashboard.min.js:1722
-#: assets/build/pages/shared-components.min.js:224
 msgid "Sa"
 msgstr ""
 
 #. translators: %s: the selected range label.
 #: pages/analytics/components/DateRangePicker/index.js:195
-#: assets/build/pages/analytics.min.js:11742
-#: assets/build/pages/dashboard.min.js:1740
-#: assets/build/pages/shared-components.min.js:242
+#, js-format
 msgid "Date range: %s"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:289
-#: assets/build/pages/analytics.min.js:11836
-#: assets/build/pages/dashboard.min.js:1834
-#: assets/build/pages/shared-components.min.js:336
 msgid "Previous month"
 msgstr ""
 
 #: pages/analytics/components/DateRangePicker/index.js:305
-#: assets/build/pages/analytics.min.js:11852
-#: assets/build/pages/dashboard.min.js:1850
-#: assets/build/pages/shared-components.min.js:352
 msgid "Next month"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:32
-#: assets/build/pages/analytics.min.js:11968
 msgid "Video Block"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:34
-#: assets/build/pages/analytics.min.js:11970
 msgid "Shoppable Video"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:35
-#: assets/build/pages/analytics.min.js:11971
 msgid "WooCommerce Product Gallery"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:36
-#: assets/build/pages/analytics.min.js:11972
 msgid "Product Reels"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:37
-#: assets/build/pages/analytics.min.js:11973
 msgid "Reel Pop"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:174
-#: assets/build/pages/analytics.min.js:12110
 msgid "Unknown page"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:229
 #: pages/analytics/PlaysVsViewers.js:115
-#: assets/build/pages/analytics.min.js:10780
-#: assets/build/pages/analytics.min.js:12165
 msgid "Plays"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:232
-#: assets/build/pages/analytics.min.js:12168
 msgid "Avg Watch Time"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:238
-#: assets/build/pages/analytics.min.js:12174
 msgid "<1s"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:266
-#: assets/build/pages/analytics.min.js:12202
 msgid "Displayed on:"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:287
-#: assets/build/pages/analytics.min.js:12223
 msgid "Edit Page"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:372
 #: pages/dashboard/components/TopVideosTable.js:200
 #: pages/dashboard/components/TopVideosTable.js:277
-#: assets/build/pages/analytics.min.js:12308
-#: assets/build/pages/dashboard.min.js:3876
-#: assets/build/pages/dashboard.min.js:3953
 msgid "Placements"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:384
-#: assets/build/pages/analytics.min.js:12320
 msgid "Unable to load placement analytics. Please try again."
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:396
-#: assets/build/pages/analytics.min.js:12332
 msgid "No placements in this date range"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:399
-#: assets/build/pages/analytics.min.js:12335
 msgid "This video had no placement activity in the selected range."
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:411
-#: assets/build/pages/analytics.min.js:12347
 msgid "View all time"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:416
-#: assets/build/pages/analytics.min.js:12352
 msgid "No placement data for this video yet"
 msgstr ""
 
 #: pages/analytics/components/Placements/index.js:474
-#: assets/build/pages/analytics.min.js:12410
 msgid "Placement breakdown reflects activity since v2.1.0. Totals above include the video's full history."
 msgstr ""
 
@@ -5639,20 +5799,12 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:41
 #: pages/video-editor/components/SidebarLayers.js:462
 #: pages/video-editor/utils/layerTypes.js:71
-#: assets/build/pages/analytics.min.js:12550
-#: assets/build/pages/video-editor.min.js:17842
-#: assets/build/pages/video-editor.min.js:17845
-#: assets/build/pages/video-editor.min.js:18266
-#: assets/build/pages/video-editor.min.js:29952
 msgid "CTA"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:139
 #: pages/video-editor/components/forms/FormFields.js:49
 #: pages/video-editor/components/SidebarLayers.js:481
-#: assets/build/pages/analytics.min.js:12560
-#: assets/build/pages/video-editor.min.js:18285
-#: assets/build/pages/video-editor.min.js:22172
 msgid "Form"
 msgstr ""
 
@@ -5661,11 +5813,6 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:47
 #: pages/video-editor/components/SidebarLayers.js:463
 #: pages/video-editor/utils/layerTypes.js:76
-#: assets/build/pages/analytics.min.js:12568
-#: assets/build/pages/video-editor.min.js:17848
-#: assets/build/pages/video-editor.min.js:17851
-#: assets/build/pages/video-editor.min.js:18267
-#: assets/build/pages/video-editor.min.js:29957
 msgid "Hotspot"
 msgstr ""
 
@@ -5675,107 +5822,80 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:127
 #: pages/video-editor/components/SidebarLayers.js:498
 #: pages/video-editor/utils/layerTypes.js:86
-#: assets/build/pages/analytics.min.js:12578
-#: assets/build/pages/video-editor.min.js:17928
-#: assets/build/pages/video-editor.min.js:17931
-#: assets/build/pages/video-editor.min.js:18302
-#: assets/build/pages/video-editor.min.js:25082
-#: assets/build/pages/video-editor.min.js:29967
 msgid "Poll"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:165
-#: assets/build/pages/analytics.min.js:12586
 msgid "Woo Hotspot"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:228
-#: assets/build/pages/analytics.min.js:12649
 msgid "Viewed"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:229
-#: assets/build/pages/analytics.min.js:12650
 msgid "Clicked"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:230
-#: assets/build/pages/analytics.min.js:12651
 msgid "Submitted"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:231
-#: assets/build/pages/analytics.min.js:12652
 msgid "Hovered"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:232
-#: assets/build/pages/analytics.min.js:12653
 msgid "Skipped"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:233
-#: assets/build/pages/analytics.min.js:12654
 msgid "Voted"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:234
-#: assets/build/pages/analytics.min.js:12655
 msgid "Added to Cart"
 msgstr ""
 
 #: pages/analytics/constants/layerTypes.js:235
-#: assets/build/pages/analytics.min.js:12656
 msgid "No Action"
 msgstr ""
 
 #: pages/analytics/helper.js:141
-#: assets/build/pages/analytics.min.js:13010
-#: assets/build/pages/dashboard.min.js:2235
 msgid "Views by Location"
 msgstr ""
 
 #: pages/analytics/helper.js:152
-#: assets/build/pages/analytics.min.js:13021
-#: assets/build/pages/dashboard.min.js:2246
 msgid "Views by location will show up here"
 msgstr ""
 
 #: pages/analytics/helper.js:726
-#: assets/build/pages/analytics.min.js:13595
-#: assets/build/pages/dashboard.min.js:2820
 msgid "retention"
 msgstr ""
 
 #: pages/analytics/helper.js:729
-#: assets/build/pages/analytics.min.js:13598
-#: assets/build/pages/dashboard.min.js:2823
 msgid "viewers"
 msgstr ""
 
 #: pages/analytics/hooks/useVideoLayerData.js:190
-#: assets/build/pages/analytics.min.js:13863
 msgid "Layer"
 msgstr ""
 
 #. translators: 1: layer type label (e.g. "CTA"), 2: position in the video in seconds.
 #: pages/analytics/hooks/useVideoLayerData.js:197
-#: assets/build/pages/analytics.min.js:13870
+#, js-format
 msgid "%1$s layer at %2$ss"
 msgstr ""
 
 #: pages/analytics/index.js:39
-#: assets/build/pages/analytics.min.js:102310
 msgid "View analytics"
 msgstr ""
 
 #: pages/analytics/index.js:79
-#: assets/build/pages/analytics.min.js:102350
 msgid "No video is selected"
 msgstr ""
 
 #: pages/analytics/index.js:89
-#: assets/build/pages/analytics.min.js:102360
 msgid "Select Video to Edit"
 msgstr ""
 
@@ -5783,149 +5903,116 @@ msgstr ""
 #: pages/analytics/PlaybackPerformance.js:525
 #: pages/dashboard/components/TopVideosTable.js:198
 #: pages/dashboard/Dashboard.js:410
-#: assets/build/pages/analytics.min.js:10542
-#: assets/build/pages/analytics.min.js:10649
-#: assets/build/pages/dashboard.min.js:960
-#: assets/build/pages/dashboard.min.js:1067
-#: assets/build/pages/dashboard.min.js:3452
-#: assets/build/pages/dashboard.min.js:3874
 msgid "Engagement Rate"
 msgstr ""
 
 #: pages/analytics/PlaybackPerformance.js:520
-#: assets/build/pages/analytics.min.js:10644
-#: assets/build/pages/dashboard.min.js:1062
 msgid "Playback Performance"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:91
-#: assets/build/pages/analytics.min.js:10756
 msgid "Plays / Unique viewers"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:116
 #: pages/dashboard/components/ViewersGauge.js:89
-#: assets/build/pages/analytics.min.js:10781
-#: assets/build/pages/dashboard.min.js:4180
 msgid "Unique viewers"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:127
 #: pages/analytics/SingleMetrics.js:127
-#: assets/build/pages/analytics.min.js:10792
-#: assets/build/pages/analytics.min.js:10942
-#: assets/build/pages/dashboard.min.js:1210
 msgid "vs prev 7 days"
 msgstr ""
 
 #: pages/analytics/PlaysVsViewers.js:134
-#: assets/build/pages/analytics.min.js:10799
 msgid "Sessions per user:"
 msgstr ""
 
 #: pages/analytics/SingleMetrics.js:126
-#: assets/build/pages/analytics.min.js:10941
-#: assets/build/pages/dashboard.min.js:1209
 msgid "vs prev period"
 msgstr ""
 
 #. translators: %d is the count of removed layers.
 #: pages/analytics/timeline/HistoricalLayersDrawer.js:55
-#: assets/build/pages/analytics.min.js:14553
+#, js-format
 msgid "Removed layers (%d)"
 msgid_plural "Removed layers (%d)"
 msgstr[0] ""
 msgstr[1] ""
 
 #: pages/analytics/timeline/HistoricalLayersDrawer.js:70
-#: assets/build/pages/analytics.min.js:14568
 msgid "No longer in the video; historical analytics preserved."
 msgstr ""
 
 #: pages/analytics/timeline/InfoTooltip.js:49
-#: assets/build/pages/analytics.min.js:14639
 msgid "Info"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:138
-#: assets/build/pages/analytics.min.js:14788
 msgid "Untitled layer"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:142
-#: assets/build/pages/analytics.min.js:14792
 msgid "Appeared at"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:164
-#: assets/build/pages/analytics.min.js:14814
 msgid "View this poll’s results"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:165
-#: assets/build/pages/analytics.min.js:14815
 msgid "View this form’s entries"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:168
-#: assets/build/pages/analytics.min.js:14818
 msgid "View Poll results"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:169
-#: assets/build/pages/analytics.min.js:14819
 msgid "View Form entries"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:177
-#: assets/build/pages/analytics.min.js:14827
 msgid "Edit this layer in the video editor"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:179
-#: assets/build/pages/analytics.min.js:14829
 msgid "Edit Layer"
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:186
-#: assets/build/pages/analytics.min.js:14836
 msgid "This layer is no longer in the video. Historical analytics preserved."
 msgstr ""
 
 #: pages/analytics/timeline/LayerDetailPanel.js:188
-#: assets/build/pages/analytics.min.js:14838
 msgid "Removed from video"
 msgstr ""
 
 #: pages/analytics/timeline/LayerInteractionFunnel.js:159
-#: assets/build/pages/analytics.min.js:15129
 msgid "Interaction Outcomes"
 msgstr ""
 
 #: pages/analytics/timeline/LayerInteractionFunnel.js:162
-#: assets/build/pages/analytics.min.js:15132
 msgid "Of everyone who saw this layer (Viewed = 100%), the share who took each action. \"No action\" saw the layer but never interacted. A viewer can appear in more than one action, so the bars need not add up to 100%."
 msgstr ""
 
 #: pages/analytics/timeline/LayerInteractionFunnel.js:169
-#: assets/build/pages/analytics.min.js:15139
 msgid "Out of all viewers who saw this layer"
 msgstr ""
 
 #. translators: %1$s value, %2$s percentage
 #: pages/analytics/timeline/LayerInteractionFunnel.js:221
-#: assets/build/pages/analytics.min.js:15191
+#, js-format
 msgid "%1$s viewers (%2$s%%) saw this layer but didn't interact with it."
 msgstr ""
 
 #. translators: %1$s action name, %2$s value, %3$s percentage
 #: pages/analytics/timeline/LayerInteractionFunnel.js:228
-#: assets/build/pages/analytics.min.js:15198
+#, js-format
 msgid "%1$s: %2$s viewers (%3$s%%)."
 msgstr ""
 
 #: pages/analytics/timeline/LayerInteractionFunnel.js:278
-#: assets/build/pages/analytics.min.js:15248
 msgid "of viewers"
 msgstr ""
 
@@ -5933,157 +6020,128 @@ msgstr ""
 #. translators: 1: comma-separated positions, 2: last position.
 #: pages/analytics/timeline/LayerModifiedNotice.js:63
 #: pages/analytics/timeline/LayerModifiedNotice.js:71
-#: assets/build/pages/analytics.min.js:15324
-#: assets/build/pages/analytics.min.js:15332
+#, js-format
 msgid "%1$s and %2$s"
 msgstr ""
 
 #: pages/analytics/timeline/LayerModifiedNotice.js:162
-#: assets/build/pages/analytics.min.js:15423
 msgid "This layer has been modified."
 msgstr ""
 
 #. translators: %s is a comma-separated list of timestamps like "0:01 and 0:03".
 #: pages/analytics/timeline/LayerModifiedNotice.js:166
-#: assets/build/pages/analytics.min.js:15427
+#, js-format
 msgid "It was previously at %s. Analytics shown here are cumulative across all changes."
 msgstr ""
 
 #: pages/analytics/timeline/LayerModifiedNotice.js:174
-#: assets/build/pages/analytics.min.js:15435
 msgid "Dismiss notice"
 msgstr ""
 
 #: pages/analytics/timeline/LayerTimelineMarker.js:137
-#: assets/build/pages/analytics.min.js:15583
 msgid "Conversion rate — share of viewers who saw this layer and interacted with it."
 msgstr ""
 
 #: pages/analytics/timeline/LayerTimelineMarker.js:155
 #: pages/analytics/timeline/SubHotspotRail.js:222
-#: assets/build/pages/analytics.min.js:15601
-#: assets/build/pages/analytics.min.js:16072
 msgid "Removed"
 msgstr ""
 
 #: pages/analytics/timeline/LayerTimelineStrip.js:192
-#: assets/build/pages/analytics.min.js:15801
 msgid "Interactive layers on the video timeline"
 msgstr ""
 
 #: pages/analytics/timeline/LayerTimelineStrip.js:197
-#: assets/build/pages/analytics.min.js:15806
 msgid "Nothing to show yet"
 msgstr ""
 
 #: pages/analytics/timeline/LayerTimelineStrip.js:200
-#: assets/build/pages/analytics.min.js:15809
 msgid "Layer analytics appear after the video is played on the front end and the activity is processed. A layer you just added won't have data until viewers interact with it."
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:60
-#: assets/build/pages/analytics.min.js:15910
 msgid "Products in this layer"
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:61
-#: assets/build/pages/analytics.min.js:15911
 msgid "Hotspots in this layer"
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:66
-#: assets/build/pages/analytics.min.js:15916
 msgid "Each row is one product hotspot inside this layer. Select a row to see its individual funnel; \"All Products (Cumulative)\" counts sessions that converted on any product."
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:70
-#: assets/build/pages/analytics.min.js:15920
 msgid "Each row is one hotspot inside this layer. Select a row to see its individual funnel; \"All Hotspots (Cumulative)\" counts sessions that converted on any hotspot."
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:79
-#: assets/build/pages/analytics.min.js:15929
 msgid "Conversion"
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:85
-#: assets/build/pages/analytics.min.js:15935
 msgid "Share of sessions that saw the product and converted — clicked through to it or added it to the cart. Each session counts once, so this never exceeds 100%."
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:89
-#: assets/build/pages/analytics.min.js:15939
 msgid "Share of sessions that saw the hotspot and clicked it. Each session counts once, so this never exceeds 100%."
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:122
-#: assets/build/pages/analytics.min.js:15972
 msgid "All Products (Cumulative)"
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:123
-#: assets/build/pages/analytics.min.js:15973
 msgid "All Hotspots (Cumulative)"
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:139
-#: assets/build/pages/analytics.min.js:15989
 msgid "A session counts as converted here when it converts on any one product in this layer — clicks it or adds it to the cart. Each session counts once, so this can read higher than every single product's rate."
 msgstr ""
 
 #: pages/analytics/timeline/SubHotspotRail.js:143
-#: assets/build/pages/analytics.min.js:15993
 msgid "A session counts as converted here when it clicks any one hotspot in this layer. Each session counts once, so this can read higher than every single hotspot's rate."
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:35
-#: assets/build/pages/analytics.min.js:11044
 msgid "Add an interactive layer in the video editor to start tracking performance."
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:45
-#: assets/build/pages/analytics.min.js:11054
 msgid "Click on any hotspot on the left to see its performance."
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:50
-#: assets/build/pages/analytics.min.js:11059
 msgid "Click on any layer above to view its performance details."
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:162
-#: assets/build/pages/analytics.min.js:11171
 msgid "Video Layer Timeline"
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:166
-#: assets/build/pages/analytics.min.js:11175
 msgid "Each marker represents an interactive layer in this video. Click a marker to see how viewers interacted with it."
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:173
-#: assets/build/pages/analytics.min.js:11182
 msgid "See when interactive layers appeared in your video and how they performed."
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:189
-#: assets/build/pages/analytics.min.js:11198
 msgid "Video conversion"
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:193
-#: assets/build/pages/analytics.min.js:11202
 msgid "Share of plays where the viewer converted on any layer (clicked a CTA, submitted a form, voted in a poll, or added a product to cart). A play counts once even if the viewer converts on several layers, so this never exceeds 100%."
 msgstr ""
 
 #. translators: 1: converting sessions, 2: total plays.
 #: pages/analytics/VideoLayerTimeline.js:206
-#: assets/build/pages/analytics.min.js:11215
+#, js-format
 msgid "%1$s of %2$s plays"
 msgstr ""
 
 #: pages/analytics/VideoLayerTimeline.js:222
-#: assets/build/pages/analytics.min.js:11231
 msgid "Unable to load layer analytics. Please try again."
 msgstr ""
 
@@ -6096,25 +6154,21 @@ msgid "Feature Screenshot"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:193
-#: assets/build/pages/dashboard.min.js:3869
 msgid "Media ID"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:199
 #: pages/dashboard/components/TopVideosTable.js:276
-#: assets/build/pages/dashboard.min.js:3875
-#: assets/build/pages/dashboard.min.js:3952
 msgid "Conversion Rate"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:225
-#: assets/build/pages/dashboard.min.js:3901
 msgid "Top Videos"
 msgstr ""
 
 #. translators: %s: number of videos (already locale-formatted).
 #: pages/dashboard/components/TopVideosTable.js:230
-#: assets/build/pages/dashboard.min.js:3906
+#, js-format
 msgid "%s video"
 msgid_plural "%s videos"
 msgstr[0] ""
@@ -6122,148 +6176,121 @@ msgstr[1] ""
 
 #: pages/dashboard/components/TopVideosTable.js:243
 #: pages/dashboard/components/TopVideosTable.js:244
-#: assets/build/pages/dashboard.min.js:3919
-#: assets/build/pages/dashboard.min.js:3920
 msgid "Search videos"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:250
-#: assets/build/pages/dashboard.min.js:3926
 msgid "Show deleted videos"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:261
-#: assets/build/pages/dashboard.min.js:3937
 msgid "Exporting…"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:261
-#: assets/build/pages/dashboard.min.js:3937
 msgid "Export"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:270
-#: assets/build/pages/dashboard.min.js:3946
 msgid "Name"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:274
-#: assets/build/pages/dashboard.min.js:3950
 msgid "Total Watch Time"
 msgstr ""
 
 #. translators: 1: converting sessions, 2: total plays.
 #: pages/dashboard/components/TopVideosTable.js:335
-#: assets/build/pages/dashboard.min.js:4011
+#, js-format
 msgid "%1$s of %2$s sessions converted"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:339
-#: assets/build/pages/dashboard.min.js:4015
 msgid "No layer conversions in this period"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:357
-#: assets/build/pages/dashboard.min.js:4033
 msgid "No videos match your search"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:358
-#: assets/build/pages/dashboard.min.js:4034
 msgid "No video plays yet"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:362
-#: assets/build/pages/dashboard.min.js:4038
 msgid "Try a different title, or clear the search to see all videos."
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:363
-#: assets/build/pages/dashboard.min.js:4039
 msgid "Once your videos start getting views, your top performers will show up here."
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:374
-#: assets/build/pages/dashboard.min.js:4050
 msgid "Top videos pagination"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:380
-#: assets/build/pages/dashboard.min.js:4056
 msgid "Previous page"
 msgstr ""
 
 #: pages/dashboard/components/TopVideosTable.js:406
-#: assets/build/pages/dashboard.min.js:4082
 msgid "Next page"
 msgstr ""
 
 #. translators: %s: total plays count.
 #: pages/dashboard/components/ViewersGauge.js:55
-#: assets/build/pages/dashboard.min.js:4146
+#, js-format
 msgid "Unique viewers unavailable for the selected range; %s total plays"
 msgstr ""
 
 #. translators: 1: unique viewers count, 2: total plays count.
 #: pages/dashboard/components/ViewersGauge.js:60
-#: assets/build/pages/dashboard.min.js:4151
+#, js-format
 msgid "%1$s unique viewers of %2$s total plays"
 msgstr ""
 
 #: pages/dashboard/components/ViewersGauge.js:100
-#: assets/build/pages/dashboard.min.js:4191
 msgid "Unique Viewers"
 msgstr ""
 
 #. translators: %d: number of days in the compared previous window.
 #: pages/dashboard/Dashboard.js:221
-#: assets/build/pages/dashboard.min.js:3263
+#, js-format
 msgid "vs prev %d days"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:323
-#: assets/build/pages/dashboard.min.js:3365
 msgid "See Reel Pop Analytics"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:333
-#: assets/build/pages/dashboard.min.js:3375
 msgid "Total Plays / Unique Viewers"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:366
-#: assets/build/pages/dashboard.min.js:3408
 msgid "Active Videos"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:367
-#: assets/build/pages/dashboard.min.js:3409
 msgid "Number of unique videos that received user interactions each day, such as views or plays."
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:382
-#: assets/build/pages/dashboard.min.js:3424
 msgid "Avg. Play Rate"
 msgstr ""
 
 #: pages/dashboard/Dashboard.js:411
-#: assets/build/pages/dashboard.min.js:3453
 msgid "Average share of each video that viewers watched, across all plays."
 msgstr ""
 
 #: pages/godam/App.js:35
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:101
-#: assets/build/pages/godam.min.js:9985
-#: assets/build/pages/godam.min.js:13595
 msgid "API Key"
 msgstr ""
 
 #: pages/godam/App.js:44
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:101
 #: pages/help/App.js:55
-#: assets/build/pages/godam.min.js:9994
-#: assets/build/pages/godam.min.js:11493
-#: assets/build/pages/help.min.js:1692
 msgid "General Settings"
 msgstr ""
 
@@ -6271,190 +6298,95 @@ msgstr ""
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:101
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:110
 #: pages/help/App.js:59
-#: assets/build/pages/godam.min.js:10000
-#: assets/build/pages/godam.min.js:13203
-#: assets/build/pages/godam.min.js:13212
-#: assets/build/pages/help.min.js:1696
 msgid "Video Settings"
 msgstr ""
 
 #: pages/godam/App.js:56
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:408
-#: assets/build/pages/godam.min.js:10006
-#: assets/build/pages/godam.min.js:12604
 msgid "Video Player"
 msgstr ""
 
 #: pages/godam/App.js:65
-#: assets/build/pages/godam.min.js:10015
 msgid "Video Ads"
 msgstr ""
 
 #: pages/godam/App.js:74
-#: assets/build/pages/godam.min.js:10024
 msgid "Integrations Settings"
 msgstr ""
 
 #: pages/godam/components/ConfirmModal.jsx:37
-#: assets/build/pages/godam.min.js:10161
-#: assets/build/pages/video-editor.min.js:15595
 msgid "Confirm"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:19
-#: assets/build/pages/godam.min.js:10229
-#: assets/build/pages/help.min.js:519
-#: assets/build/pages/tools.min.js:605
 msgid "Support"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:23
-#: assets/build/pages/godam.min.js:10233
-#: assets/build/pages/help.min.js:523
-#: assets/build/pages/tools.min.js:609
 msgid "Docs"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:27
-#: assets/build/pages/godam.min.js:10237
-#: assets/build/pages/help.min.js:527
-#: assets/build/pages/tools.min.js:613
 msgid "Newsletter"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:39
-#: assets/build/pages/godam.min.js:10249
-#: assets/build/pages/help.min.js:539
-#: assets/build/pages/tools.min.js:625
 msgid "Twitter X"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:44
-#: assets/build/pages/godam.min.js:10254
-#: assets/build/pages/help.min.js:544
-#: assets/build/pages/tools.min.js:630
 msgid "Facebook"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:49
-#: assets/build/pages/godam.min.js:10259
-#: assets/build/pages/help.min.js:549
-#: assets/build/pages/tools.min.js:635
 msgid "Linkedin"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:54
-#: assets/build/pages/godam.min.js:10264
-#: assets/build/pages/help.min.js:554
-#: assets/build/pages/tools.min.js:640
 msgid "Instagram"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:59
-#: assets/build/pages/godam.min.js:10269
-#: assets/build/pages/help.min.js:559
-#: assets/build/pages/tools.min.js:645
 msgid "Youtube"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:64
-#: assets/build/pages/godam.min.js:10274
-#: assets/build/pages/help.min.js:564
-#: assets/build/pages/tools.min.js:650
 msgid "WordPress.org"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:67
-#: assets/build/pages/godam.min.js:10277
-#: assets/build/pages/help.min.js:567
-#: assets/build/pages/tools.min.js:653
 msgid "Rate us on WordPress.org"
 msgstr ""
 
 #: pages/godam/components/GoDAMFooter.jsx:77
-#: assets/build/pages/godam.min.js:10287
-#: assets/build/pages/help.min.js:577
-#: assets/build/pages/tools.min.js:663
 msgid "Made with ♥ by the GoDAM Team"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:92
-#: assets/build/pages/analytics.min.js:16354
-#: assets/build/pages/dashboard.min.js:4425
-#: assets/build/pages/godam.min.js:10411
-#: assets/build/pages/help.min.js:701
-#: assets/build/pages/tools.min.js:787
-#: assets/build/pages/video-editor.min.js:15736
 msgid "Need help?"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:107
-#: assets/build/pages/analytics.min.js:16369
-#: assets/build/pages/dashboard.min.js:4440
-#: assets/build/pages/godam.min.js:10426
-#: assets/build/pages/help.min.js:716
-#: assets/build/pages/tools.min.js:802
-#: assets/build/pages/video-editor.min.js:15751
 msgid "Premium feature"
 msgstr ""
 
-#: pages/godam/components/GoDAMHeader.jsx:107
-#: assets/build/pages/analytics.min.js:16369
-#: assets/build/pages/dashboard.min.js:4440
-#: assets/build/pages/godam.min.js:10426
-#: assets/build/pages/help.min.js:716
-#: assets/build/pages/tools.min.js:802
-#: assets/build/pages/video-editor.min.js:15751
-msgid "GoDAM Central"
-msgstr ""
-
 #: pages/godam/components/GoDAMHeader.jsx:118
-#: assets/build/pages/analytics.min.js:16380
-#: assets/build/pages/dashboard.min.js:4451
-#: assets/build/pages/godam.min.js:10437
-#: assets/build/pages/help.min.js:727
-#: assets/build/pages/tools.min.js:813
-#: assets/build/pages/video-editor.min.js:15762
 msgid "Upgrade plan"
 msgstr ""
 
 #: pages/godam/components/GoDAMHeader.jsx:130
-#: assets/build/pages/analytics.min.js:16392
-#: assets/build/pages/dashboard.min.js:4463
-#: assets/build/pages/godam.min.js:10449
-#: assets/build/pages/help.min.js:739
-#: assets/build/pages/tools.min.js:825
-#: assets/build/pages/video-editor.min.js:15774
 msgid "Get GoDAM"
 msgstr ""
 
 #: pages/godam/components/ProUpgradeNotice.jsx:111
-#: assets/build/pages/analytics.min.js:16517
-#: assets/build/pages/dashboard.min.js:4588
-#: assets/build/pages/godam.min.js:10574
-#: assets/build/pages/help.min.js:864
-#: assets/build/pages/tools.min.js:950
-#: assets/build/pages/video-editor.min.js:15899
 msgid "You are now a pro member"
 msgstr ""
 
 #: pages/godam/components/ProUpgradeNotice.jsx:113
-#: assets/build/pages/analytics.min.js:16519
-#: assets/build/pages/dashboard.min.js:4590
-#: assets/build/pages/godam.min.js:10576
-#: assets/build/pages/help.min.js:866
-#: assets/build/pages/tools.min.js:952
-#: assets/build/pages/video-editor.min.js:15901
 msgid "With a paid plan, you get fixed storage, bandwidth that resets monthly, and unlimited sites."
 msgstr ""
 
 #: pages/godam/components/ProUpgradeNotice.jsx:117
-#: assets/build/pages/analytics.min.js:16523
-#: assets/build/pages/dashboard.min.js:4594
-#: assets/build/pages/godam.min.js:10580
-#: assets/build/pages/help.min.js:870
-#: assets/build/pages/tools.min.js:956
-#: assets/build/pages/video-editor.min.js:15905
 msgid "Got it"
 msgstr ""
 
@@ -6463,11 +6395,6 @@ msgstr ""
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:182
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:98
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:66
-#: assets/build/pages/godam.min.js:11158
-#: assets/build/pages/godam.min.js:11459
-#: assets/build/pages/godam.min.js:11898
-#: assets/build/pages/godam.min.js:12294
-#: assets/build/pages/godam.min.js:13168
 msgid "Settings saved successfully."
 msgstr ""
 
@@ -6481,16 +6408,6 @@ msgstr ""
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:104
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:69
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:72
-#: assets/build/pages/godam.min.js:11161
-#: assets/build/pages/godam.min.js:11164
-#: assets/build/pages/godam.min.js:11462
-#: assets/build/pages/godam.min.js:11465
-#: assets/build/pages/godam.min.js:11901
-#: assets/build/pages/godam.min.js:11904
-#: assets/build/pages/godam.min.js:12297
-#: assets/build/pages/godam.min.js:12300
-#: assets/build/pages/godam.min.js:13171
-#: assets/build/pages/godam.min.js:13174
 msgid "Failed to save settings."
 msgstr ""
 
@@ -6502,48 +6419,32 @@ msgstr ""
 #: pages/video-editor/App.js:124
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:206
 #: pages/video-editor/VideoEditor.js:137
-#: assets/build/pages/godam.min.js:11173
-#: assets/build/pages/godam.min.js:11474
-#: assets/build/pages/godam.min.js:11913
-#: assets/build/pages/godam.min.js:12583
-#: assets/build/pages/godam.min.js:13183
-#: assets/build/pages/video-editor.min.js:16562
-#: assets/build/pages/video-editor.min.js:16774
-#: assets/build/pages/video-editor.min.js:21663
 msgid "You have unsaved changes. Are you sure you want to leave?"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:94
-#: assets/build/pages/godam.min.js:11193
 msgid "Video Ads Settings"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:99
-#: assets/build/pages/godam.min.js:11198
 msgid "Enable Global Video Ads"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:100
-#: assets/build/pages/godam.min.js:11199
 msgid "Enable or disable video ads on all videos across the site"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:111
 #: pages/video-editor/components/appearance/Appearance.js:224
-#: assets/build/pages/godam.min.js:11210
-#: assets/build/pages/video-editor.min.js:19076
 msgid "Ad Tag URL"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:114
-#: assets/build/pages/godam.min.js:11213
 msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads"
 msgstr ""
 
 #: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:115
 #: pages/video-editor/components/appearance/Appearance.js:233
-#: assets/build/pages/godam.min.js:11214
-#: assets/build/pages/video-editor.min.js:19085
 msgid "Learn more."
 msgstr ""
 
@@ -6554,38 +6455,26 @@ msgstr ""
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:141
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:130
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:302
-#: assets/build/pages/godam.min.js:11233
-#: assets/build/pages/godam.min.js:11532
-#: assets/build/pages/godam.min.js:12076
-#: assets/build/pages/godam.min.js:12689
-#: assets/build/pages/godam.min.js:12838
-#: assets/build/pages/godam.min.js:13232
-#: assets/build/pages/video-editor.min.js:21759
 msgid "Saving…"
 msgstr ""
 
 #: pages/godam/components/tabs/APIKey/APIKey.jsx:40
-#: assets/build/pages/godam.min.js:11075
 msgid "Ensure Smooth Video Playback"
 msgstr ""
 
 #: pages/godam/components/tabs/APIKey/APIKey.jsx:42
-#: assets/build/pages/godam.min.js:11077
 msgid "Start with GoDAM Free for 60 days, or plans starting from $9/mo."
 msgstr ""
 
 #: pages/godam/components/tabs/APIKey/APIKey.jsx:51
-#: assets/build/pages/godam.min.js:11086
 msgid "Choose GoDAM Plan"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:36
-#: assets/build/pages/godam.min.js:11278
 msgid "Select Brand Image"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:38
-#: assets/build/pages/godam.min.js:11280
 msgid "Use this brand image"
 msgstr ""
 
@@ -6593,2144 +6482,1596 @@ msgstr ""
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:59
 #: pages/video-editor/components/cta/CardCTA.js:188
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:100
-#: assets/build/pages/godam.min.js:11295
-#: assets/build/pages/godam.min.js:13367
-#: assets/build/pages/video-editor.min.js:20659
-#: assets/build/pages/video-editor.min.js:23203
 msgid "Only Image files are allowed"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:89
-#: assets/build/pages/godam.min.js:11331
 msgid "Brand Logo"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:96
-#: assets/build/pages/godam.min.js:11338
 msgid "The brand logo will not be applied to the player skin."
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:101
-#: assets/build/pages/godam.min.js:11343
 msgid "Shown beside player controls. Can be overridden per video."
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:131
-#: assets/build/pages/godam.min.js:11373
 msgid "Selected custom brand"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:106
-#: assets/build/pages/godam.min.js:11498
 msgid "Enable folder organization in media library."
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:109
-#: assets/build/pages/godam.min.js:11501
 msgid "This setting is managed by your site administrator and can’t be changed here."
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:110
-#: assets/build/pages/godam.min.js:11502
 msgid "Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization."
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:121
-#: assets/build/pages/godam.min.js:11513
 msgid "Enable GTM Tracking"
 msgstr ""
 
 #: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:122
-#: assets/build/pages/godam.min.js:11514
 msgid "Enable Google Tag Manager video tracking for analytics and conversion tracking."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:22
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:26
-#: assets/build/pages/godam.min.js:12106
-#: assets/build/pages/godam.min.js:12110
 msgid "WooCommerce"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:23
-#: assets/build/pages/godam.min.js:12107
 msgid "GoDAM for Woo"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:28
-#: assets/build/pages/godam.min.js:12112
 msgid "Pro"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:60
-#: assets/build/pages/godam.min.js:11600
 msgid "Installing…"
 msgstr ""
 
 #. translators: %s: Add-on plugin name, e.g. "GoDAM for Woo".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:65
-#: assets/build/pages/godam.min.js:11605
+#, js-format
 msgid "Install %s"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:95
-#: assets/build/pages/godam.min.js:11635
 msgid "Upgrade Plan"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:110
-#: assets/build/pages/godam.min.js:11826
 msgid "Integration status updated successfully."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:119
-#: assets/build/pages/godam.min.js:11835
 msgid "Failed to toggle add-on."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:148
-#: assets/build/pages/godam.min.js:11864
 msgid "Add-on installed successfully! Reloading…"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:156
-#: assets/build/pages/godam.min.js:11872
 msgid "Installation failed."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:223
-#: assets/build/pages/godam.min.js:11939
 msgid "Integration Settings"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:263
-#: assets/build/pages/godam.min.js:11979
 msgid "Installation failed. Please download the ZIP and install it like any other WordPress plugin."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:272
-#: assets/build/pages/godam.min.js:11988
 msgid "Download ZIP"
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:282
-#: assets/build/pages/godam.min.js:11998
 msgid "View Installation Guide"
 msgstr ""
 
 #. translators: %s: Integration name, e.g. "WooCommerce".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:293
-#: assets/build/pages/godam.min.js:12009
+#, js-format
 msgid "The %s add-on plugin is not installed. Please install it to enable this integration."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:302
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:47
-#: assets/build/pages/godam.min.js:11688
-#: assets/build/pages/godam.min.js:12018
 msgid "This is a Pro feature."
 msgstr ""
 
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:314
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:59
-#: assets/build/pages/godam.min.js:11700
-#: assets/build/pages/godam.min.js:12030
 msgid "to use this integration."
 msgstr ""
 
 #. translators: %s: Integration name, e.g. "WooCommerce".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:36
-#: assets/build/pages/godam.min.js:11677
+#, js-format
 msgid "Enable %s Integration"
 msgstr ""
 
 #. translators: %s: Integration name, e.g. "WooCommerce".
 #: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:64
-#: assets/build/pages/godam.min.js:11705
+#, js-format
 msgid "Enable or disable the %s integration."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/CustomVideoPlayerCSS.jsx:50
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:473
-#: assets/build/pages/godam.min.js:12171
-#: assets/build/pages/godam.min.js:12669
 msgid "Custom CSS"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:30
-#: assets/build/pages/godam.min.js:12226
 msgid "Classic"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:31
-#: assets/build/pages/godam.min.js:12227
 msgid "Minimal"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:32
-#: assets/build/pages/godam.min.js:12228
 msgid "Pills"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:33
-#: assets/build/pages/godam.min.js:12229
 msgid "Bubble"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:414
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:420
-#: assets/build/pages/godam.min.js:12610
-#: assets/build/pages/godam.min.js:12616
 msgid "Player Skin"
 msgstr ""
 
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:429
-#: assets/build/pages/godam.min.js:12625
-msgid "Branding"
-msgstr ""
-
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:435
-#: assets/build/pages/godam.min.js:12631
 msgid "Brand color"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:447
-#: assets/build/pages/godam.min.js:12643
 msgid "Clear"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:456
-#: assets/build/pages/godam.min.js:12652
 msgid "The brand color will not be applied to the player skin."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:461
-#: assets/build/pages/godam.min.js:12657
 msgid "Applied to the video block. Can be overridden per video."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:478
-#: assets/build/pages/godam.min.js:12674
 msgid "Any custom CSS you add will be applied to all player skins. It's global and not tied to a specific skin style."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:39
-#: assets/build/pages/godam.min.js:12736
 msgid "Please enter a valid API key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:50
-#: assets/build/pages/godam.min.js:12747
 msgid "The API key you’ve entered is incorrect. Please enter a valid key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:60
-#: assets/build/pages/godam.min.js:12757
 msgid "API key deactivated successfully!"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:69
-#: assets/build/pages/godam.min.js:12766
 msgid "Failed to deactivate API key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:84
-#: assets/build/pages/godam.min.js:12781
 msgid "API key status refreshed!"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:94
-#: assets/build/pages/godam.min.js:12791
 msgid "Failed to refresh API key status"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:104
-#: assets/build/pages/godam.min.js:12801
 msgid "API Settings"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:125
-#: assets/build/pages/godam.min.js:12822
 msgid "Remove API key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:141
-#: assets/build/pages/godam.min.js:12838
 msgid "Save API Key"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
-#: assets/build/pages/godam.min.js:12848
 msgid "Refreshing…"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:161
-#: assets/build/pages/godam.min.js:12858
 msgid "Access your active API key from"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:168
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:42
-#: assets/build/pages/godam.min.js:12865
-#: assets/build/pages/godam.min.js:13536
 msgid "Account"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:173
-#: assets/build/pages/godam.min.js:12870
 msgid "Having any issue?"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:180
-#: assets/build/pages/godam.min.js:12877
 msgid "Contact Support"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:189
-#: assets/build/pages/godam.min.js:12886
 msgid "Remove API Key?"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:190
-#: assets/build/pages/godam.min.js:12887
 msgid "Yes, Remove"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/APISettings.jsx:198
-#: assets/build/pages/godam.min.js:12895
 msgid "If you remove the API key, your account will be deactivated and you’ll lose access to the platform."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:60
-#: assets/build/pages/godam.min.js:13554
 msgid "Your API key is required to access the features. You can get your active API key from"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:70
-#: assets/build/pages/godam.min.js:13564
 msgid "API key verified"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:80
-#: assets/build/pages/godam.min.js:13574
 msgid "Your API Key has expired. You can renew it from your"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:91
-#: assets/build/pages/godam.min.js:13585
 msgid "Unable to verify API key. Please click \"Refresh Status\" to try again."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:105
-#: assets/build/pages/godam.min.js:13599
 msgid "Enter your API key here"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:63
-#: assets/build/pages/godam.min.js:12965
 msgctxt "gigabyte"
 msgid "GB"
 msgstr ""
 
 #. translators: %s: total plan size in gigabytes
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:68
-#: assets/build/pages/godam.min.js:12970
+#, js-format
 msgid "of %s GB available"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:90
-#: assets/build/pages/godam.min.js:12992
 msgid "Plan Usage"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:93
 #: pages/onboarding/components/SidePanel.jsx:22
-#: assets/build/pages/godam.min.js:12995
-#: assets/build/pages/onboarding.min.js:657
 msgid "Bandwidth"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/UsageData.jsx:98
 #: pages/onboarding/components/SidePanel.jsx:25
-#: assets/build/pages/godam.min.js:13000
-#: assets/build/pages/onboarding.min.js:660
 msgid "Storage"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:13
-#: assets/build/pages/godam.min.js:13023
 msgid "Highest quality (100%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:14
-#: assets/build/pages/godam.min.js:13024
 msgid "Higher quality (80%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:15
-#: assets/build/pages/godam.min.js:13025
 msgid "Medium quality (60%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:16
-#: assets/build/pages/godam.min.js:13026
 msgid "Lower quality (40%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:17
-#: assets/build/pages/godam.min.js:13027
 msgid "Lowest quality (20%)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:28
-#: assets/build/pages/godam.min.js:13038
 msgid "Video Quality"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:34
-#: assets/build/pages/godam.min.js:13044
 msgid "Select the video quality."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:28
-#: assets/build/pages/godam.min.js:13079
 msgid "Enable video engagement globally"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:32
-#: assets/build/pages/godam.min.js:13083
 msgid "If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:39
-#: assets/build/pages/godam.min.js:13090
 msgid "Enable video share globally"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:43
-#: assets/build/pages/godam.min.js:13094
 msgid "If disabled, sharing options (such as social sharing buttons) will not be available for GoDAM videos. If enabled, it can be overridden in the block settings panel."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:104
-#: assets/build/pages/godam.min.js:13206
 msgid "Connect your GoDAM API key from the API Key tab to configure video settings."
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:48
-#: assets/build/pages/godam.min.js:13290
 msgid "Number of video thumbnails generated"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:59
-#: assets/build/pages/godam.min.js:13301
 msgid "This field specifies the number of video thumbnails that will be generated by the GoDAM. To choose from the generated thumbnails for a video, go to Media > Edit > Video Thumbnails. Thumbnails are only generated when the video is first uploaded. Please enter a value between 1 and 10"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:45
-#: assets/build/pages/godam.min.js:13353
 msgid "Select a Watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:47
-#: assets/build/pages/godam.min.js:13355
 msgid "Use this watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:86
-#: assets/build/pages/godam.min.js:13394
 msgid "Enable video watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:93
-#: assets/build/pages/godam.min.js:13401
 msgid "If enabled, GoDAM will add a watermark to the transcoded video"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:100
-#: assets/build/pages/godam.min.js:13408
 msgid "Use image watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:108
-#: assets/build/pages/godam.min.js:13416
 msgid "If enabled, Transcoder will use an image instead of text as the watermark for the transcoded video"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:110
-#: assets/build/pages/godam.min.js:13418
 msgid "(Recommended dimensions: 200 px width × 70 px height)"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:125
-#: assets/build/pages/godam.min.js:13433
 msgid "Change Watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:126
-#: assets/build/pages/godam.min.js:13434
 msgid "Select Watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:138
-#: assets/build/pages/godam.min.js:13446
 msgid "Remove Watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:146
-#: assets/build/pages/godam.min.js:13454
 msgid "Selected watermark"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:166
-#: assets/build/pages/godam.min.js:13474
 msgid "Watermark Text"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:174
-#: assets/build/pages/godam.min.js:13482
 msgid "Enter watermark text"
 msgstr ""
 
 #: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:175
-#: assets/build/pages/godam.min.js:13483
 msgid "Specify the watermark text that will be added to transcoded videos"
 msgstr ""
 
 #. translators: %s: trial end date.
 #: pages/godam/components/TrialCountdownBanner.jsx:68
-#: assets/build/pages/analytics.min.js:16600
-#: assets/build/pages/dashboard.min.js:4671
-#: assets/build/pages/godam.min.js:10679
-#: assets/build/pages/help.min.js:947
-#: assets/build/pages/tools.min.js:1033
-#: assets/build/pages/video-editor.min.js:15982
+#, js-format
 msgid "Free trial ends on %s"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:69
-#: assets/build/pages/analytics.min.js:16687
-#: assets/build/pages/dashboard.min.js:4758
-#: assets/build/pages/godam.min.js:10858
-#: assets/build/pages/help.min.js:1126
-#: assets/build/pages/tools.min.js:1120
-#: assets/build/pages/video-editor.min.js:16069
 msgid "Interactive product hotspots"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:70
-#: assets/build/pages/analytics.min.js:16688
-#: assets/build/pages/dashboard.min.js:4759
-#: assets/build/pages/godam.min.js:10859
-#: assets/build/pages/help.min.js:1127
-#: assets/build/pages/tools.min.js:1121
-#: assets/build/pages/video-editor.min.js:16070
 msgid "Tag products directly on your videos so viewers can buy in a click."
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:75
-#: assets/build/pages/analytics.min.js:16693
-#: assets/build/pages/dashboard.min.js:4764
-#: assets/build/pages/godam.min.js:10864
-#: assets/build/pages/help.min.js:1132
-#: assets/build/pages/tools.min.js:1126
-#: assets/build/pages/video-editor.min.js:16075
 msgid "Shoppable video"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:76
-#: assets/build/pages/analytics.min.js:16694
-#: assets/build/pages/dashboard.min.js:4765
-#: assets/build/pages/godam.min.js:10865
-#: assets/build/pages/help.min.js:1133
-#: assets/build/pages/tools.min.js:1127
-#: assets/build/pages/video-editor.min.js:16076
 msgid "Turn any product video into a storefront that drives conversions."
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:81
-#: assets/build/pages/analytics.min.js:16699
-#: assets/build/pages/dashboard.min.js:4770
-#: assets/build/pages/godam.min.js:10870
-#: assets/build/pages/help.min.js:1138
-#: assets/build/pages/tools.min.js:1132
-#: assets/build/pages/video-editor.min.js:16081
 msgid "Reel Pops"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:82
-#: assets/build/pages/analytics.min.js:16700
-#: assets/build/pages/dashboard.min.js:4771
-#: assets/build/pages/godam.min.js:10871
-#: assets/build/pages/help.min.js:1139
-#: assets/build/pages/tools.min.js:1133
-#: assets/build/pages/video-editor.min.js:16082
 msgid "Surface short, shoppable product reels across your store."
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:87
-#: assets/build/pages/analytics.min.js:16705
-#: assets/build/pages/dashboard.min.js:4776
-#: assets/build/pages/godam.min.js:10876
-#: assets/build/pages/help.min.js:1144
-#: assets/build/pages/tools.min.js:1138
-#: assets/build/pages/video-editor.min.js:16087
 msgid "Enhanced product page"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:88
-#: assets/build/pages/analytics.min.js:16706
-#: assets/build/pages/dashboard.min.js:4777
-#: assets/build/pages/godam.min.js:10877
-#: assets/build/pages/help.min.js:1145
-#: assets/build/pages/tools.min.js:1139
-#: assets/build/pages/video-editor.min.js:16088
 msgid "Showcase your videos right on the WooCommerce product page."
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:179
-#: assets/build/pages/analytics.min.js:16797
-#: assets/build/pages/dashboard.min.js:4868
-#: assets/build/pages/godam.min.js:10968
-#: assets/build/pages/help.min.js:1236
-#: assets/build/pages/tools.min.js:1230
-#: assets/build/pages/video-editor.min.js:16179
 msgid "You have unlocked Woo features"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:183
-#: assets/build/pages/analytics.min.js:16801
-#: assets/build/pages/dashboard.min.js:4872
-#: assets/build/pages/godam.min.js:10972
-#: assets/build/pages/help.min.js:1240
-#: assets/build/pages/tools.min.js:1234
-#: assets/build/pages/video-editor.min.js:16183
 msgid "You've Unlocked Woo Features"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:185
 #: pages/onboarding/components/screens/EntryScreen.jsx:38
-#: assets/build/pages/analytics.min.js:16803
-#: assets/build/pages/dashboard.min.js:4874
-#: assets/build/pages/godam.min.js:10974
-#: assets/build/pages/help.min.js:1242
-#: assets/build/pages/onboarding.min.js:847
-#: assets/build/pages/tools.min.js:1236
-#: assets/build/pages/video-editor.min.js:16185
 msgid "Turn your product videos into interactive shopping experiences, focused video content for WooCommerce."
-msgstr ""
-
-#: pages/godam/components/WooUnlockedNotice.jsx:202
-#: pages/video-editor/components/forms/FormPreview.js:86
-#: pages/video-editor/components/layers/CTALayer.js:265
-#: assets/build/pages/analytics.min.js:16820
-#: assets/build/pages/dashboard.min.js:4891
-#: assets/build/pages/godam.min.js:10991
-#: assets/build/pages/help.min.js:1259
-#: assets/build/pages/tools.min.js:1253
-#: assets/build/pages/video-editor.min.js:16202
-#: assets/build/pages/video-editor.min.js:22310
-#: assets/build/pages/video-editor.min.js:23778
-msgid "Skip"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:205
 #: pages/video-editor/onboarding/WelcomeIntroModal.jsx:66
-#: assets/build/pages/analytics.min.js:16823
-#: assets/build/pages/dashboard.min.js:4894
-#: assets/build/pages/godam.min.js:10994
-#: assets/build/pages/help.min.js:1262
-#: assets/build/pages/tools.min.js:1256
-#: assets/build/pages/video-editor.min.js:16205
-#: assets/build/pages/video-editor.min.js:27753
 msgid "Get Started"
 msgstr ""
 
 #: pages/godam/components/WooUnlockedNotice.jsx:226
-#: assets/build/pages/analytics.min.js:16844
-#: assets/build/pages/dashboard.min.js:4915
-#: assets/build/pages/godam.min.js:11015
-#: assets/build/pages/help.min.js:1283
-#: assets/build/pages/tools.min.js:1277
-#: assets/build/pages/video-editor.min.js:16226
 msgid "Feature preview slides"
 msgstr ""
 
 #: pages/godam/utils/index.js:77
-#: assets/build/js/godam-lifterlms-embed.min.js:77
-#: assets/build/js/lifterLMSEmbed.min.js:77
-#: assets/build/pages/analytics.min.js:16941
-#: assets/build/pages/dashboard.min.js:5012
-#: assets/build/pages/godam.min.js:13935
-#: assets/build/pages/help.min.js:1595
-#: assets/build/pages/tools.min.js:1374
-#: assets/build/pages/video-editor.min.js:16323
 msgid "Your API key has expired."
 msgstr ""
 
 #: pages/godam/utils/index.js:78
-#: assets/build/js/godam-lifterlms-embed.min.js:78
-#: assets/build/js/lifterLMSEmbed.min.js:78
-#: assets/build/pages/analytics.min.js:16942
-#: assets/build/pages/dashboard.min.js:5013
-#: assets/build/pages/godam.min.js:13936
-#: assets/build/pages/help.min.js:1596
-#: assets/build/pages/tools.min.js:1375
-#: assets/build/pages/video-editor.min.js:16324
 msgid "Please renew your subscription from your Account to continue."
 msgstr ""
 
 #: pages/godam/utils/index.js:86
-#: assets/build/js/godam-lifterlms-embed.min.js:86
-#: assets/build/js/lifterLMSEmbed.min.js:86
-#: assets/build/pages/analytics.min.js:16950
-#: assets/build/pages/dashboard.min.js:5021
-#: assets/build/pages/godam.min.js:13944
-#: assets/build/pages/help.min.js:1604
-#: assets/build/pages/tools.min.js:1383
-#: assets/build/pages/video-editor.min.js:16332
 msgid "Unable to verify API key."
 msgstr ""
 
 #: pages/godam/utils/index.js:87
-#: assets/build/js/godam-lifterlms-embed.min.js:87
-#: assets/build/js/lifterLMSEmbed.min.js:87
-#: assets/build/pages/analytics.min.js:16951
-#: assets/build/pages/dashboard.min.js:5022
-#: assets/build/pages/godam.min.js:13945
-#: assets/build/pages/help.min.js:1605
-#: assets/build/pages/tools.min.js:1384
-#: assets/build/pages/video-editor.min.js:16333
 msgid "This may be a temporary issue. Please try again later."
 msgstr ""
 
 #: pages/godam/utils/index.js:95
-#: assets/build/js/godam-lifterlms-embed.min.js:95
-#: assets/build/js/lifterLMSEmbed.min.js:95
-#: assets/build/pages/analytics.min.js:16959
-#: assets/build/pages/dashboard.min.js:5030
-#: assets/build/pages/godam.min.js:13953
-#: assets/build/pages/help.min.js:1613
-#: assets/build/pages/tools.min.js:1392
-#: assets/build/pages/video-editor.min.js:16341
 msgid "API key issue detected."
 msgstr ""
 
 #: pages/godam/utils/index.js:96
-#: assets/build/js/godam-lifterlms-embed.min.js:96
-#: assets/build/js/lifterLMSEmbed.min.js:96
-#: assets/build/pages/analytics.min.js:16960
-#: assets/build/pages/dashboard.min.js:5031
-#: assets/build/pages/godam.min.js:13954
-#: assets/build/pages/help.min.js:1614
-#: assets/build/pages/tools.min.js:1393
-#: assets/build/pages/video-editor.min.js:16342
 msgid "Please check your API key settings."
 msgstr ""
 
 #: pages/help/App.js:63
-#: assets/build/pages/help.min.js:1700
 msgid "Configuring the Video Block"
 msgstr ""
 
 #: pages/help/App.js:73
-#: assets/build/pages/help.min.js:1710
 msgid "Appearance Customisation"
 msgstr ""
 
 #: pages/help/App.js:77
-#: assets/build/pages/help.min.js:1714
 msgid "Call To Actions"
 msgstr ""
 
 #: pages/help/App.js:81
-#: assets/build/pages/help.min.js:1718
 msgid "Hotspots"
 msgstr ""
 
 #: pages/help/App.js:85
 #: pages/video-editor/components/SidebarLayers.js:50
-#: assets/build/pages/help.min.js:1722
-#: assets/build/pages/video-editor.min.js:17854
 msgid "Forms"
 msgstr ""
 
 #: pages/help/App.js:89
-#: assets/build/pages/help.min.js:1726
 msgid "ADs"
 msgstr ""
 
 #: pages/help/App.js:99
-#: assets/build/pages/help.min.js:1736
 msgid "Interface"
 msgstr ""
 
 #: pages/help/App.js:103
-#: assets/build/pages/help.min.js:1740
 msgid "How Tos"
 msgstr ""
 
 #: pages/help/App.js:131
-#: assets/build/pages/help.min.js:1768
 msgid "Hi, How can we help?"
 msgstr ""
 
 #: pages/help/App.js:132
-#: assets/build/pages/help.min.js:1769
 msgid "Welcome to the GoDAM Help Center!"
 msgstr ""
 
 #: pages/help/App.js:134
-#: assets/build/pages/help.min.js:1771
 msgid "Click on the documentation links below to find step-by-step guides, FAQs, and troubleshooting tips for the features you need help with."
 msgstr ""
 
 #: pages/help/App.js:148
 #: pages/help/App.js:150
-#: assets/build/pages/help.min.js:1785
-#: assets/build/pages/help.min.js:1787
 msgid "Search using keywords"
 msgstr ""
 
 #: pages/help/App.js:214
-#: assets/build/pages/help.min.js:1851
 msgid "Help us improve GoDAM"
 msgstr ""
 
 #: pages/help/App.js:217
-#: assets/build/pages/help.min.js:1854
 msgid "Allows the GoDAM plugin to track anonymous events for analytics purposes. This helps us improve the product experience."
 msgstr ""
 
 #: pages/media-library/App.js:167
-#: assets/build/pages/media-library.min.js:5818
 msgid "New Folder"
 msgstr ""
 
 #: pages/media-library/App.js:178
-#: assets/build/pages/media-library.min.js:5829
 msgid "Bulk Select"
 msgstr ""
 
 #: pages/media-library/App.js:186
-#: assets/build/pages/media-library.min.js:5837
 msgid "By Name (A-Z)"
 msgstr ""
 
 #: pages/media-library/App.js:187
-#: assets/build/pages/media-library.min.js:5838
 msgid "By Name (Z-A)"
 msgstr ""
 
 #: pages/media-library/App.js:202
-#: assets/build/pages/media-library.min.js:5853
 msgid "All Media"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:201
-#: assets/build/pages/media-library.min.js:6097
 msgid "Folder ID is missing for download."
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:210
-#: assets/build/pages/media-library.min.js:6106
 msgid "Preparing ZIP file…"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:218
-#: assets/build/pages/media-library.min.js:6114
 msgid "Failed to create ZIP file"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:224
-#: assets/build/pages/media-library.min.js:6120
 msgid "Invalid response: missing ZIP URL"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:242
-#: assets/build/pages/media-library.min.js:6138
 msgid "Failed to download folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:267
-#: assets/build/pages/media-library.min.js:6163
 msgid "Invalid folder for bookmark."
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:290
-#: assets/build/pages/media-library.min.js:6186
 msgid "Bookmark removed successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:291
-#: assets/build/pages/media-library.min.js:6187
 msgid "Bookmark added successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:301
-#: assets/build/pages/media-library.min.js:6197
 msgid "Bookmarks added successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:307
-#: assets/build/pages/media-library.min.js:6203
 msgid "Failed to update bookmark status"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:323
-#: assets/build/pages/media-library.min.js:6219
 msgid "Invalid folder to lock."
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:339
-#: assets/build/pages/media-library.min.js:6235
 msgid "Folder unlocked successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:340
-#: assets/build/pages/media-library.min.js:6236
 msgid "Folder locked successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:362
-#: assets/build/pages/media-library.min.js:6258
 msgid "Folders locked successfully"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:369
-#: assets/build/pages/media-library.min.js:6265
 msgid "Failed to update folder lock status"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:421
-#: assets/build/pages/media-library.min.js:6317
 msgid "New Sub-folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:429
 #: pages/media-library/components/modal/RenameModal.jsx:98
-#: assets/build/pages/media-library.min.js:6325
-#: assets/build/pages/media-library.min.js:7797
 msgid "Rename"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:437
-#: assets/build/pages/media-library.min.js:6333
 msgid "Lock Folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:437
-#: assets/build/pages/media-library.min.js:6333
 msgid "Unlock Folder"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:445
-#: assets/build/pages/media-library.min.js:6341
 msgid "Add Bookmark"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:445
-#: assets/build/pages/media-library.min.js:6341
 msgid "Remove Bookmark"
 msgstr ""
 
 #: pages/media-library/components/context-menu/ContextMenu.jsx:455
-#: assets/build/pages/media-library.min.js:6351
 msgid "Download Zip"
-msgstr ""
-
-#: pages/media-library/components/context-menu/ContextMenu.jsx:464
-#: pages/media-library/components/modal/DeleteModal.jsx:114
-#: pages/video-editor/components/SidebarLayers.js:750
-#: pages/video-editor/components/transcription/Transcription.js:304
-#: assets/build/pages/media-library.min.js:6360
-#: assets/build/pages/media-library.min.js:7538
-#: assets/build/pages/video-editor.min.js:18554
-#: assets/build/pages/video-editor.min.js:26229
-msgid "Delete"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/BookmarkTab.jsx:56
 #: pages/media-library/components/folder-tree/BookmarkTab.jsx:76
-#: assets/build/pages/media-library.min.js:6424
-#: assets/build/pages/media-library.min.js:6444
 msgid "Bookmarks"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/BookmarkTab.jsx:64
-#: assets/build/pages/media-library.min.js:6432
 msgid "No bookmarks yet"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:125
-#: assets/build/pages/media-library.min.js:6591
 msgid "The parent folder is locked, so this folder cannot be moved."
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:155
-#: assets/build/pages/media-library.min.js:6621
 msgid "The destination folder is locked and cannot be modified"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:260
-#: assets/build/pages/media-library.min.js:6726
 msgid "Currently opened folder is locked and cannot be modified"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:271
-#: assets/build/pages/media-library.min.js:6737
 msgid "This folder is locked and cannot be modified"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:285
-#: assets/build/pages/media-library.min.js:6751
 msgid "Items assigned successfully"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/FolderTree.jsx:305
-#: assets/build/pages/media-library.min.js:6771
 msgid "Failed to assign items"
 msgstr ""
 
 #. translators: %s is the error message
 #: pages/media-library/components/folder-tree/FolderTree.jsx:392
-#: assets/build/pages/media-library.min.js:6858
+#, js-format
 msgid "Error: %s"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/LockedTab.jsx:65
 #: pages/media-library/components/folder-tree/LockedTab.jsx:85
-#: assets/build/pages/media-library.min.js:6984
-#: assets/build/pages/media-library.min.js:7004
 msgid "Locked"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/LockedTab.jsx:73
-#: assets/build/pages/media-library.min.js:6992
 msgid "No locked folders yet"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/TreeItem.jsx:97
-#: assets/build/pages/media-library.min.js:7228
 msgid "Collapse folder"
 msgstr ""
 
 #: pages/media-library/components/folder-tree/TreeItem.jsx:97
-#: assets/build/pages/media-library.min.js:7228
 msgid "Expand folder"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:63
-#: assets/build/pages/media-library.min.js:7487
 msgid "Folders deleted successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:63
-#: assets/build/pages/media-library.min.js:7487
 msgid "Folder deleted successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:72
-#: assets/build/pages/media-library.min.js:7496
 msgid "Failed to delete folder"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:91
-#: assets/build/pages/media-library.min.js:7515
 msgid "Confirm Delete"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7522
 msgid "Deleting"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7522
 msgid "these"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7522
 msgid "folders"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7522
 msgid "will remove them and all its subfolders, but"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:98
-#: assets/build/pages/media-library.min.js:7522
 msgid "media associated with them will not be deleted"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:102
-#: assets/build/pages/media-library.min.js:7526
 msgid "Deleting the folder"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:102
-#: assets/build/pages/media-library.min.js:7526
 msgid "will remove it and all its subfolders, but"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:102
-#: assets/build/pages/media-library.min.js:7526
 msgid "media associated with it will not be deleted"
 msgstr ""
 
 #: pages/media-library/components/modal/DeleteModal.jsx:107
-#: assets/build/pages/media-library.min.js:7531
 msgid "Are you sure you want to proceed? This action cannot be undone."
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:71
-#: assets/build/pages/media-library.min.js:7627
 msgid "Folder created successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:83
-#: assets/build/pages/media-library.min.js:7639
 msgid "Folder with that name already exists."
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:90
-#: assets/build/pages/media-library.min.js:7646
 msgid "Failed to create folder"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:110
-#: assets/build/pages/media-library.min.js:7666
 msgid "Create a new folder"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:118
 #: pages/media-library/components/modal/RenameModal.jsx:88
-#: assets/build/pages/media-library.min.js:7674
-#: assets/build/pages/media-library.min.js:7787
 msgid "Folder Name"
 msgstr ""
 
 #: pages/media-library/components/modal/FolderCreationModal.jsx:126
-#: assets/build/pages/media-library.min.js:7682
 msgid "Create"
 msgstr ""
 
 #: pages/media-library/components/modal/RenameModal.jsx:57
-#: assets/build/pages/media-library.min.js:7756
 msgid "Folder renamed successfully"
 msgstr ""
 
 #: pages/media-library/components/modal/RenameModal.jsx:64
-#: assets/build/pages/media-library.min.js:7763
 msgid "Failed to rename folder"
 msgstr ""
 
 #: pages/media-library/components/modal/RenameModal.jsx:83
-#: assets/build/pages/media-library.min.js:7782
 msgid "Rename folder"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:173
-#: assets/build/pages/media-library.min.js:7991
 msgid "Search folder"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:190
-#: assets/build/pages/media-library.min.js:8008
 msgid "No folders found."
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:220
-#: assets/build/pages/media-library.min.js:8038
 msgid "Searching…"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:220
-#: assets/build/pages/media-library.min.js:8038
 msgid "Loading more results…"
 msgstr ""
 
 #: pages/media-library/components/search-bar/SearchBar.jsx:221
-#: assets/build/pages/media-library.min.js:8039
 msgid "Error fetching results."
 msgstr ""
 
 #: pages/onboarding/components/BackButton.jsx:19
-#: assets/build/pages/onboarding.min.js:520
 msgid "BACK"
 msgstr ""
 
 #: pages/onboarding/components/OnboardingModal.jsx:71
-#: assets/build/pages/onboarding.min.js:615
 msgid "GoDAM onboarding"
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:34
-#: assets/build/pages/onboarding.min.js:843
 msgid "You have unlocked GoDAM for Woo"
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:34
 #: pages/onboarding/components/screens/WelcomeScreen.jsx:19
-#: assets/build/pages/onboarding.min.js:843
-#: assets/build/pages/onboarding.min.js:1289
 msgid "Welcome to GoDAM Pro!"
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:39
-#: assets/build/pages/onboarding.min.js:848
 msgid "A scalable digital asset management platform for WordPress, optimized for conversion-driven video content."
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:43
-#: assets/build/pages/onboarding.min.js:852
 msgid "New here? Start your 60-day free trial now."
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:46
-#: assets/build/pages/onboarding.min.js:855
 msgid "Enjoy a 60-day free trial. After that, continue for $9/month or cancel anytime. No credit card or payment required today."
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:49
 #: pages/onboarding/components/screens/SignupScreen.jsx:70
 #: pages/video-editor/components/transcription/Transcription.js:254
-#: assets/build/pages/onboarding.min.js:858
-#: assets/build/pages/onboarding.min.js:1185
-#: assets/build/pages/video-editor.min.js:26179
 msgid "OR"
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:52
-#: assets/build/pages/onboarding.min.js:861
 msgid "Login with Email"
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:55
 #: pages/onboarding/components/screens/SignupScreen.jsx:67
-#: assets/build/pages/onboarding.min.js:864
-#: assets/build/pages/onboarding.min.js:1182
 msgid "Continue with Google"
 msgstr ""
 
 #: pages/onboarding/components/screens/EntryScreen.jsx:58
-#: assets/build/pages/onboarding.min.js:867
 msgid "Already have a License key?"
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:34
 #: pages/onboarding/utils/validators.js:61
-#: assets/build/pages/onboarding.min.js:908
-#: assets/build/pages/onboarding.min.js:1865
 msgid "Enter a valid email address."
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:41
-#: assets/build/pages/onboarding.min.js:915
 msgid "Could not send the reset link."
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:48
-#: assets/build/pages/onboarding.min.js:922
 msgid "Reset your password"
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:52
-#: assets/build/pages/onboarding.min.js:926
 msgid "If that account exists, we've emailed a link to set a new password. Open it to finish resetting, then come back and sign in."
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:56
-#: assets/build/pages/onboarding.min.js:930
 msgid "Confirm your email and we'll send you a link to set up a new password."
 msgstr ""
 
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:58
-#: pages/onboarding/components/screens/LoginScreen.jsx:54
-#: pages/onboarding/components/screens/SignupScreen.jsx:77
-#: assets/build/pages/onboarding.min.js:932
-#: assets/build/pages/onboarding.min.js:1091
-#: assets/build/pages/onboarding.min.js:1192
-msgid "Email"
-msgstr ""
-
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:61
-#: assets/build/pages/onboarding.min.js:935
 msgid "Sending…"
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:61
-#: assets/build/pages/onboarding.min.js:935
 msgid "Reset Password"
 msgstr ""
 
 #: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:67
-#: assets/build/pages/onboarding.min.js:941
 msgid "Go back to sign in"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:36
-#: assets/build/pages/onboarding.min.js:984
 msgid "Please enter your license key."
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:43
-#: assets/build/pages/onboarding.min.js:991
 msgid "That license key could not be verified."
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:50
-#: assets/build/pages/onboarding.min.js:998
 msgid "Sign in with license key"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:57
-#: assets/build/pages/onboarding.min.js:1005
 msgid "License key"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:58
-#: assets/build/pages/onboarding.min.js:1006
 msgid "Enter your license key"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:67
-#: assets/build/pages/onboarding.min.js:1015
 msgid "Hide license key"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:67
-#: assets/build/pages/onboarding.min.js:1015
 msgid "Show license key"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:74
-#: assets/build/pages/onboarding.min.js:1022
 msgid "Verifying…"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:74
-#: assets/build/pages/onboarding.min.js:1022
 msgid "Verify to Sign in"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:78
-#: assets/build/pages/onboarding.min.js:1026
 msgid "Lost your key? Find it on your GoDAM app"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:81
-#: assets/build/pages/onboarding.min.js:1029
 msgid "Login with email instead?"
 msgstr ""
 
 #: pages/onboarding/components/screens/LicenseKeyScreen.jsx:82
 #: pages/onboarding/components/screens/LoginScreen.jsx:62
 #: pages/onboarding/components/screens/SignupScreen.jsx:91
-#: assets/build/pages/onboarding.min.js:1030
-#: assets/build/pages/onboarding.min.js:1099
-#: assets/build/pages/onboarding.min.js:1206
 msgid "Sign in"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:36
-#: assets/build/pages/onboarding.min.js:1073
 msgid "Enter a valid email and password."
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:44
-#: assets/build/pages/onboarding.min.js:1081
 msgid "Invalid email or password."
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:51
-#: assets/build/pages/onboarding.min.js:1088
 msgid "Sign in to your account"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:55
 #: pages/onboarding/components/screens/SignupScreen.jsx:78
-#: assets/build/pages/onboarding.min.js:1092
-#: assets/build/pages/onboarding.min.js:1193
 msgid "Password"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:55
 #: pages/onboarding/components/screens/SignupScreen.jsx:79
-#: assets/build/pages/onboarding.min.js:1092
-#: assets/build/pages/onboarding.min.js:1194
 msgid "Enter Password"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:57
-#: assets/build/pages/onboarding.min.js:1094
 msgid "Forgot Password?"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:62
-#: assets/build/pages/onboarding.min.js:1099
 msgid "Signing in…"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:66
-#: assets/build/pages/onboarding.min.js:1103
 msgid "Don't have an account?"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:67
-#: assets/build/pages/onboarding.min.js:1104
 msgid "Sign up"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:70
-#: assets/build/pages/onboarding.min.js:1107
 msgid "Got a licence key?"
 msgstr ""
 
 #: pages/onboarding/components/screens/LoginScreen.jsx:71
-#: assets/build/pages/onboarding.min.js:1108
 msgid "Login with key"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:57
-#: assets/build/pages/onboarding.min.js:1172
 msgid "Could not create your account. Please try again."
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:64
-#: assets/build/pages/onboarding.min.js:1179
 msgid "Create your account"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:74
-#: assets/build/pages/onboarding.min.js:1189
 msgid "First Name"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:75
-#: assets/build/pages/onboarding.min.js:1190
 msgid "Last Name"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:78
-#: assets/build/pages/onboarding.min.js:1193
 msgid "Enter password"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:79
-#: assets/build/pages/onboarding.min.js:1194
 msgid "Confirm Password"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:82
-#: assets/build/pages/onboarding.min.js:1197
 msgid "I agree to"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:82
-#: assets/build/pages/onboarding.min.js:1197
 msgid "Terms and Conditions, Privacy Policy, Refund Policy"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:83
-#: assets/build/pages/onboarding.min.js:1198
 msgid "Email me product updates and release news."
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:87
-#: assets/build/pages/onboarding.min.js:1202
 msgid "Creating…"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:87
-#: assets/build/pages/onboarding.min.js:1202
 msgid "Sign Up"
 msgstr ""
 
 #: pages/onboarding/components/screens/SignupScreen.jsx:90
-#: assets/build/pages/onboarding.min.js:1205
 msgid "Already have an account?"
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:31
-#: assets/build/pages/onboarding.min.js:1244
 msgid "Verification email re-sent."
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:33
-#: assets/build/pages/onboarding.min.js:1246
 msgid "Could not resend the email."
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:39
-#: assets/build/pages/onboarding.min.js:1252
 msgid "Verify your email"
 msgstr ""
 
 #. translators: %s: user email address.
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:42
-#: assets/build/pages/onboarding.min.js:1255
+#, js-format
 msgid "We sent a verification link to %s. Click it to activate your account, then sign in."
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:43
-#: assets/build/pages/onboarding.min.js:1256
 msgid "We sent you a verification link. Click it to activate your account, then sign in."
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:47
-#: assets/build/pages/onboarding.min.js:1260
 msgid "I've verified, sign in"
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:50
-#: assets/build/pages/onboarding.min.js:1263
 msgid "Resending…"
 msgstr ""
 
 #: pages/onboarding/components/screens/VerifyEmailScreen.jsx:50
-#: assets/build/pages/onboarding.min.js:1263
 msgid "Resend email"
 msgstr ""
 
 #: pages/onboarding/components/screens/WelcomeScreen.jsx:20
-#: assets/build/pages/onboarding.min.js:1290
 msgid "You're all set. Upload videos to your WordPress Media Library and GoDAM auto-syncs them here."
 msgstr ""
 
 #: pages/onboarding/components/screens/WelcomeScreen.jsx:28
-#: assets/build/pages/onboarding.min.js:1298
 msgid "Go to dashboard"
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:54
-#: assets/build/pages/onboarding.min.js:1358
 msgid "Could not get the workspace key."
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:64
-#: assets/build/pages/onboarding.min.js:1368
 msgid "No workspaces yet"
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:67
-#: assets/build/pages/onboarding.min.js:1371
 msgid "This account has no workspaces. <a>Create one in the GoDAM app</a>, then come back."
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:82
-#: assets/build/pages/onboarding.min.js:1386
 msgid "Select a workspace"
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:83
-#: assets/build/pages/onboarding.min.js:1387
 msgid "Choose a workspace to start working!"
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:89
-#: assets/build/pages/onboarding.min.js:1393
 msgid "Select a Workspace"
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:118
-#: assets/build/pages/onboarding.min.js:1422
 msgid "Please note that you won't be able to switch to another workspace after logging in."
 msgstr ""
 
 #: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
-#: assets/build/pages/onboarding.min.js:1427
 msgid "Connecting…"
 msgstr ""
 
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
-#: assets/build/pages/onboarding.min.js:1427
-msgid "Continue"
-msgstr ""
-
 #: pages/onboarding/components/SidePanel.jsx:21
-#: assets/build/pages/onboarding.min.js:656
 msgid "Sites"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:21
-#: assets/build/pages/onboarding.min.js:656
 msgid "Use GoDAM on unlimited WordPress sites."
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:22
-#: assets/build/pages/onboarding.min.js:657
 msgid "Generous bandwidth that resets every month."
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:23
-#: assets/build/pages/onboarding.min.js:658
 msgid "Teams"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:23
-#: assets/build/pages/onboarding.min.js:658
 msgid "Invite unlimited editors and contributors."
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:24
-#: assets/build/pages/onboarding.min.js:659
 msgid "Security"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:24
-#: assets/build/pages/onboarding.min.js:659
 msgid "Enterprise-grade encryption."
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:25
-#: assets/build/pages/onboarding.min.js:660
 msgid "A one-time storage allocation that stays yours."
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:26
-#: assets/build/pages/onboarding.min.js:661
 msgid "Global CDN"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:26
-#: assets/build/pages/onboarding.min.js:661
 msgid "Media served from 100+ locations."
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:30
-#: assets/build/pages/onboarding.min.js:665
 msgid "No credit card required"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:31
-#: assets/build/pages/onboarding.min.js:666
 msgid "Drive conversions with AI-powered tools"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:32
-#: assets/build/pages/onboarding.min.js:667
 msgid "Set up in minutes on your existing site"
 msgstr ""
 
 #: pages/onboarding/components/SidePanel.jsx:39
-#: assets/build/pages/onboarding.min.js:674
 msgid "Used by forward thinking teams"
 msgstr ""
 
 #: pages/onboarding/utils/use-connect.js:37
-#: assets/build/pages/onboarding.min.js:1655
 msgid "Could not load your workspaces. Please try again."
 msgstr ""
 
 #: pages/onboarding/utils/use-google-signin.js:50
 #: pages/onboarding/utils/use-google-signin.js:114
-#: assets/build/pages/onboarding.min.js:1710
-#: assets/build/pages/onboarding.min.js:1774
 msgid "Google sign-in failed."
 msgstr ""
 
 #: pages/onboarding/utils/use-google-signin.js:61
-#: assets/build/pages/onboarding.min.js:1721
 msgid "Google sign-in is unavailable right now. Please use another sign-in method."
 msgstr ""
 
 #: pages/onboarding/utils/use-google-signin.js:67
-#: assets/build/pages/onboarding.min.js:1727
 msgid "Popup blocked. Allow popups for this site and try again."
 msgstr ""
 
 #: pages/onboarding/utils/use-google-signin.js:125
-#: assets/build/pages/onboarding.min.js:1785
 msgid "Google sign-in was cancelled."
 msgstr ""
 
 #: pages/onboarding/utils/use-google-signin.js:138
-#: assets/build/pages/onboarding.min.js:1798
 msgid "Could not start Google sign-in."
 msgstr ""
 
 #: pages/onboarding/utils/validators.js:58
-#: assets/build/pages/onboarding.min.js:1862
 msgid "First name is required."
 msgstr ""
 
 #: pages/onboarding/utils/validators.js:64
-#: assets/build/pages/onboarding.min.js:1868
 msgid "Password must be at least 8 characters."
 msgstr ""
 
 #: pages/onboarding/utils/validators.js:67
-#: assets/build/pages/onboarding.min.js:1871
 msgid "Passwords do not match."
 msgstr ""
 
 #: pages/onboarding/utils/validators.js:70
-#: assets/build/pages/onboarding.min.js:1874
 msgid "Please accept the Terms to continue."
 msgstr ""
 
 #: pages/shared/AnalyticsUnavailableNotice.jsx:24
-#: assets/build/pages/analytics.min.js:17007
-#: assets/build/pages/dashboard.min.js:5078
 msgid "Analytics is temporarily unavailable."
 msgstr ""
 
 #: pages/shared/AnalyticsUnavailableNotice.jsx:25
-#: assets/build/pages/analytics.min.js:17008
-#: assets/build/pages/dashboard.min.js:5079
 msgid "We couldn’t reach the GoDAM analytics service. This is usually temporary. Please refresh in a few minutes."
 msgstr ""
 
 #: pages/tools/App.js:28
-#: assets/build/pages/tools.min.js:1476
 msgid "Video Migration"
 msgstr ""
 
 #: pages/tools/App.js:34
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:201
-#: assets/build/pages/tools.min.js:1482
-#: assets/build/pages/tools.min.js:1810
 msgid "Media Usage Sync"
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:70
-#: assets/build/pages/tools.min.js:1679
 msgid "Media usage sync completed successfully."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:102
-#: assets/build/pages/tools.min.js:1711
 msgid "All posts are already synced — nothing to do."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:110
-#: assets/build/pages/tools.min.js:1719
 msgid "Failed to start the sync. Please try again."
 msgstr ""
 
 #. translators: 1: posts synced so far, 2: total posts to sync.
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:129
-#: assets/build/pages/tools.min.js:1738
+#, js-format
 msgid "Sync stopped. %1$d of %2$d posts were synced. You can resume at any time."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:139
-#: assets/build/pages/tools.min.js:1748
 msgid "Failed to stop the sync. Please try again."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:150
-#: assets/build/pages/tools.min.js:1759
 msgid "Syncing…"
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:153
-#: assets/build/pages/tools.min.js:1762
 msgid "Resume Sync"
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:156
-#: assets/build/pages/tools.min.js:1765
 msgid "Sync Completed"
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:158
-#: assets/build/pages/tools.min.js:1767
 msgid "Start Sync"
 msgstr ""
 
 #. translators: 1: posts synced so far, 2: total posts to sync.
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:167
-#: assets/build/pages/tools.min.js:1776
+#, js-format
 msgid "%1$d of %2$d posts synced…"
 msgstr ""
 
 #. translators: 1: posts synced so far, 2: total posts to sync.
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:175
-#: assets/build/pages/tools.min.js:1784
+#, js-format
 msgid "%1$d of %2$d posts synced (stopped)."
 msgstr ""
 
 #. translators: %d: total number of posts synced.
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:182
-#: assets/build/pages/tools.min.js:1791
+#, js-format
 msgid "%d posts synced."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:204
-#: assets/build/pages/tools.min.js:1813
 msgid "Scans all existing posts and pages to record which media files are used where. GoDAM starts this scan automatically in the background — use this page to monitor progress or trigger it manually if needed."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:210
-#: assets/build/pages/tools.min.js:1819
 msgid "This sync is completely non-destructive."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:212
-#: assets/build/pages/tools.min.js:1821
 msgid "It will not alter, move, or delete any of your existing media files."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:216
-#: assets/build/pages/tools.min.js:1825
 msgid "Processing runs in small background batches so your site stays fully responsive throughout."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:232
-#: assets/build/pages/tools.min.js:1841
 msgid "Only administrators can start or stop the media usage sync."
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:255
-#: assets/build/pages/tools.min.js:1864
 msgid "Stopping…"
 msgstr ""
 
 #: pages/tools/components/tabs/MediaUsageSyncTab.jsx:256
-#: assets/build/pages/tools.min.js:1865
 msgid "Stop Sync"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:36
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:40
-#: assets/build/pages/tools.min.js:1913
-#: assets/build/pages/tools.min.js:2231
 msgid "Starting…"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:54
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:69
-#: assets/build/pages/tools.min.js:1931
-#: assets/build/pages/tools.min.js:2260
 msgid "Something went wrong while starting migration."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:130
-#: assets/build/pages/tools.min.js:2007
 msgid "WordPress core video migration completed successfully 🎉"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:133
-#: assets/build/pages/tools.min.js:2010
 msgid "WordPress core video migration failed. Please try again."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:165
-#: assets/build/pages/tools.min.js:2042
 msgid "Core video Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:167
-#: assets/build/pages/tools.min.js:2044
 msgid "This tool replaces WordPress core video blocks with GoDAM video blocks. It does not replace videos added in the WordPress Classic Editor."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:186
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:222
-#: assets/build/pages/tools.min.js:2063
-#: assets/build/pages/tools.min.js:2413
 msgid "Abort"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
-#: assets/build/pages/tools.min.js:2072
-#: assets/build/pages/tools.min.js:2422
 msgid "Restart Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
-#: assets/build/pages/tools.min.js:2072
-#: assets/build/pages/tools.min.js:2422
 msgid "Start Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:141
-#: assets/build/pages/tools.min.js:2332
 msgid "Vimeo Video Migration has been successfully completed for all posts and pages 🎉"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:144
-#: assets/build/pages/tools.min.js:2335
 msgid "Vimeo Video Migration failed. Please try again."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:176
-#: assets/build/pages/tools.min.js:2367
 msgid "Vimeo video Migration"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:178
-#: assets/build/pages/tools.min.js:2369
 msgid "This tool replaces WordPress Vimeo Embed blocks with GoDAM Video blocks. It does not replace Vimeo videos added in the WordPress Classic Editor."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:183
-#: assets/build/pages/tools.min.js:2374
 msgid "This migrator will only migrate Vimeo videos that are already fetched on GoDAM Central."
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:184
-#: assets/build/pages/tools.min.js:2375
 msgid "Open"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:199
-#: assets/build/pages/tools.min.js:2390
 msgid "Vimeo video migration in WordPress can only begin after all Vimeo videos have been successfully migrated to GoDAM Central,"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:201
-#: assets/build/pages/tools.min.js:2392
 msgid "Check here!"
 msgstr ""
 
 #: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:210
-#: assets/build/pages/tools.min.js:2401
 msgid "Migration is in progress. Please wait…"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:65
-#: assets/build/pages/tools.min.js:2497
 msgid "The requested operation is not allowed. The nonce provided in the URL is invalid or expired."
 msgstr ""
 
 #. translators: %d is the number of selected media files to be transcoded.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:95
 #: pages/tools/components/tabs/RetranscodeTab.jsx:120
-#: assets/build/pages/tools.min.js:2527
-#: assets/build/pages/tools.min.js:2552
+#, js-format
 msgid "%d selected media file(s) will be transcoded."
 msgstr ""
 
 #. translators: %d is the number of selected media files to be retranscoded.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:105
-#: assets/build/pages/tools.min.js:2537
+#, js-format
 msgid "%d selected media file(s) will be retranscoded."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:153
-#: assets/build/pages/tools.min.js:2585
 msgid "No media files found for retranscoding. Please ensure you have media files that require retranscoding."
 msgstr ""
 
 #. translators: %s is the error message.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:160
-#: assets/build/pages/tools.min.js:2592
+#, js-format
 msgid "Failed to fetch media for retranscoding: %s"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:177
-#: assets/build/pages/tools.min.js:2609
 msgid "Aborting operation to send media for retranscoding."
 msgstr ""
 
 #. translators: %d is the number of virtual media files found.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:286
-#: assets/build/pages/tools.min.js:2718
+#, js-format
 msgid "%d virtual media file(s) found, which need to be retranscoded on GoDAM Central."
 msgstr ""
 
 #. translators: %d is the number of media files retranscoded.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:295
-#: assets/build/pages/tools.min.js:2727
+#, js-format
 msgid "Successfully sent %d media file(s) for retranscoding."
 msgstr ""
 
 #. translators: %d is the number of media files that failed to retranscode.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:310
-#: assets/build/pages/tools.min.js:2742
+#, js-format
 msgid "Failed to send %d media file(s) for retranscoding."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:323
-#: assets/build/pages/tools.min.js:2755
 msgid "Operation completed without any media files to retranscode."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:356
-#: assets/build/pages/tools.min.js:2788
 msgid "This tool allows you to retranscode your media files. You can either retranscode specific files selected from the Media Library, or those that are not yet transcoded."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:363
-#: assets/build/pages/tools.min.js:2795
 msgid "Checking the \"Force retranscode\" option will retranscode all media files regardless of their current state."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:368
-#: assets/build/pages/tools.min.js:2800
 msgid "Note: Transcoding and retranscoding will use your bandwidth allowance. Use the force retranscode option carefully."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:379
-#: assets/build/pages/tools.min.js:2811
 msgid "Storage Limit Exceeded:"
 msgstr ""
 
 #. translators: %s is the storage usage percentage.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:382
-#: assets/build/pages/tools.min.js:2814
+#, js-format
 msgid "Your storage usage has exceeded your plan limit (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:403
-#: assets/build/pages/tools.min.js:2835
 msgid "Force retranscode (even if already transcoded)"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:419
-#: assets/build/pages/tools.min.js:2851
 msgid "Fetching media that require retranscoding…"
 msgstr ""
 
 #. translators: %d is the number of untranscoded media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:438
-#: assets/build/pages/tools.min.js:2870
+#, js-format
 msgid "%d untranscoded media file(s) selected"
 msgstr ""
 
 #. translators: %d is the number of transcoded media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:447
-#: assets/build/pages/tools.min.js:2879
+#, js-format
 msgid "%d transcoded media file(s) selected"
 msgstr ""
 
 #. translators: 1: number of media files that require retranscoding, 2: total number of media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:460
-#: assets/build/pages/tools.min.js:2892
+#, js-format
 msgid "%1$d/%2$d media file(s) require retranscoding."
 msgstr ""
 
 #. translators: 1: number of media files that will be retranscoded regardless of their current state, 2: total number of media files.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:466
-#: assets/build/pages/tools.min.js:2898
+#, js-format
 msgid "%1$d/%2$d media file(s) will be retranscoded regardless of their current state."
 msgstr ""
 
 #. translators: 1: number of media files sent for retranscoding, 2: total number of media files selected.
 #: pages/tools/components/tabs/RetranscodeTab.jsx:479
-#: assets/build/pages/tools.min.js:2911
+#, js-format
 msgid "%1$d/%2$d media files sent for retranscoding…"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:517
-#: assets/build/pages/tools.min.js:2949
 msgid "Fetch Media"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:521
-#: assets/build/pages/tools.min.js:2953
 msgid "Start Transcoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:523
-#: assets/build/pages/tools.min.js:2955
 msgid "Start Retranscoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:527
-#: assets/build/pages/tools.min.js:2959
 msgid "Restart Transcoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:529
-#: assets/build/pages/tools.min.js:2961
 msgid "Restart Retranscoding"
 msgstr ""
 
 #: pages/tools/components/tabs/RetranscodeTab.jsx:542
-#: assets/build/pages/tools.min.js:2974
 msgid "Abort Operation"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:96
-#: assets/build/pages/video-editor.min.js:18668
 msgid "Select / Upload Ad video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:98
-#: assets/build/pages/video-editor.min.js:18670
 msgid "Add video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:160
-#: assets/build/pages/video-editor.min.js:18732
 msgid "Ad video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:169
-#: assets/build/pages/video-editor.min.js:18741
 msgid "This ad will be overridden by the Ad server's ads."
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:175
-#: assets/build/pages/video-editor.min.js:18747
 msgid "Ad Video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:186
-#: assets/build/pages/video-editor.min.js:18758
 msgid "Select Ad Video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:189
-#: assets/build/pages/video-editor.min.js:18761
 msgid "Upload or choose a self-hosted video (MP4 recommended)."
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:196
-#: assets/build/pages/video-editor.min.js:18768
 msgid "Click to replace video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:201
-#: assets/build/pages/video-editor.min.js:18773
 msgid "Replace ad video"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:234
-#: assets/build/pages/video-editor.min.js:18806
 msgid "Playback"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:237
-#: assets/build/pages/video-editor.min.js:18809
 msgid "Skippable"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:238
-#: assets/build/pages/video-editor.min.js:18810
 msgid "Allow viewers to skip the ad"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:249
-#: assets/build/pages/video-editor.min.js:18821
 msgid "Skip after (seconds)"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:250
-#: assets/build/pages/video-editor.min.js:18822
 msgid "Time in seconds before the skip button appears"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:262
-#: assets/build/pages/video-editor.min.js:18834
 msgid "Click-through"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:264
-#: assets/build/pages/video-editor.min.js:18836
 msgid "Click link"
 msgstr ""
 
 #: pages/video-editor/components/ads/CustomAdSettings.js:267
-#: assets/build/pages/video-editor.min.js:18839
 msgid "URL to open when the ad is clicked"
 msgstr ""
 
@@ -8738,142 +8079,111 @@ msgstr ""
 #: pages/video-editor/components/cta/CardCTA.js:274
 #: pages/video-editor/components/cta/CardCTA.js:284
 #: pages/video-editor/components/layers/HotspotLayer.js:486
-#: assets/build/pages/video-editor.min.js:18840
-#: assets/build/pages/video-editor.min.js:20745
-#: assets/build/pages/video-editor.min.js:20755
-#: assets/build/pages/video-editor.min.js:24434
 msgid "Please enter a valid URL (e.g., https://example.com)"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:84
-#: assets/build/pages/video-editor.min.js:18936
 msgid "Select Custom Logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:85
-#: assets/build/pages/video-editor.min.js:18937
 msgid "Use this logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:93
-#: assets/build/pages/video-editor.min.js:18945
 msgid "Only image files are allowed"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:132
-#: assets/build/pages/video-editor.min.js:18984
 msgid "Show volume slider"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:138
-#: assets/build/pages/video-editor.min.js:18990
 msgid "Display captions"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:144
-#: assets/build/pages/video-editor.min.js:18996
 msgid "Adjust Skip Duration"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:145
-#: assets/build/pages/video-editor.min.js:18997
 msgid "Number of seconds the skip-forward / skip-backward buttons jump."
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:149
-#: assets/build/pages/video-editor.min.js:19001
 msgid "5 seconds"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:150
-#: assets/build/pages/video-editor.min.js:19002
 msgid "10 seconds"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:151
-#: assets/build/pages/video-editor.min.js:19003
 msgid "30 seconds"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:156
-#: assets/build/pages/video-editor.min.js:19008
 msgid "Customisation Settings"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:165
-#: assets/build/pages/video-editor.min.js:19017
 msgid "Add Custom logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:174
-#: assets/build/pages/video-editor.min.js:19026
 msgid "Replace logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:176
 #: pages/video-editor/components/appearance/Appearance.js:178
-#: assets/build/pages/video-editor.min.js:19028
-#: assets/build/pages/video-editor.min.js:19030
 msgid "Custom logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:179
-#: assets/build/pages/video-editor.min.js:19031
 msgid "Click to replace"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:182
-#: assets/build/pages/video-editor.min.js:19034
 msgid "Remove logo"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:194
-#: assets/build/pages/video-editor.min.js:19046
 msgid "Player Theme"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:199
-#: assets/build/pages/video-editor.min.js:19051
 msgid "Player Appearance"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:206
-#: assets/build/pages/video-editor.min.js:19058
 msgid "Icons hover colour"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:213
-#: assets/build/pages/video-editor.min.js:19065
 msgid "Ad Server"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:216
-#: assets/build/pages/video-editor.min.js:19068
 msgid "Use ad server's ad"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:217
-#: assets/build/pages/video-editor.min.js:19069
 msgid "Enable this option to use ads from the ad server. This option will disable the ads layer"
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:231
-#: assets/build/pages/video-editor.min.js:19083
 msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads."
 msgstr ""
 
 #: pages/video-editor/components/appearance/Appearance.js:243
-#: assets/build/pages/video-editor.min.js:19095
 msgid "Select a default thumbnail for this video. You can also override the default thumbnail for different video placements."
 msgstr ""
 
 #: pages/video-editor/components/appearance/ThumbnailSelector.jsx:67
-#: assets/build/pages/video-editor.min.js:19173
 msgid "Select Video Thumbnail"
 msgstr ""
 
 #: pages/video-editor/components/appearance/ThumbnailSelector.jsx:68
-#: assets/build/pages/video-editor.min.js:19174
 msgid "Use this thumbnail"
 msgstr ""
 
@@ -8881,236 +8191,190 @@ msgstr ""
 #. translators: %d is the chapter position in the list.
 #: pages/video-editor/components/audio/AudioCardPreview.js:285
 #: pages/video-editor/components/chapters/Chapters.js:129
-#: assets/build/pages/video-editor.min.js:19562
-#: assets/build/pages/video-editor.min.js:19924
+#, js-format
 msgid "Chapter %d"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:63
-#: assets/build/pages/video-editor.min.js:19675
 msgid "Invalid start time format"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:65
-#: assets/build/pages/video-editor.min.js:19677
 msgid "Start time cannot be negative"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:67
-#: assets/build/pages/video-editor.min.js:19679
 msgid "Start time exceeds the video duration"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:72
-#: assets/build/pages/video-editor.min.js:19684
 msgid "Invalid end time format"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:74
-#: assets/build/pages/video-editor.min.js:19686
 msgid "End time must be after the start time"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:76
-#: assets/build/pages/video-editor.min.js:19688
 msgid "End time exceeds the video duration"
 msgstr ""
 
 #. translators: %s is the title of the overlapping chapter.
 #: pages/video-editor/components/chapters/ChapterForm.js:87
-#: assets/build/pages/video-editor.min.js:19699
+#, js-format
 msgid "Overlaps with “%s”"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:90
-#: assets/build/pages/video-editor.min.js:19702
 msgid "Overlaps with another chapter"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:116
 #: pages/video-editor/components/chapters/Chapters.js:142
-#: assets/build/pages/video-editor.min.js:19728
-#: assets/build/pages/video-editor.min.js:19937
 msgid "Edit chapter"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:116
 #: pages/video-editor/components/chapters/ChapterForm.js:165
-#: assets/build/pages/video-editor.min.js:19728
-#: assets/build/pages/video-editor.min.js:19777
 msgid "Add chapter"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:131
-#: assets/build/pages/video-editor.min.js:19743
 msgid "Chapter title"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:132
-#: assets/build/pages/video-editor.min.js:19744
 msgid "e.g. Introduction"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:140
-#: assets/build/pages/video-editor.min.js:19752
 msgid "Start time"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:148
-#: assets/build/pages/video-editor.min.js:19760
 msgid "End time"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:165
-#: assets/build/pages/video-editor.min.js:19777
 msgid "Save chapter"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:169
-#: assets/build/pages/video-editor.min.js:19781
 msgid "Read more about timestamp format"
 msgstr ""
 
 #: pages/video-editor/components/chapters/ChapterForm.js:175
-#: assets/build/pages/video-editor.min.js:19787
 msgid "here"
 msgstr ""
 
 #. translators: %d is the number of chapters.
 #: pages/video-editor/components/chapters/Chapters.js:80
-#: assets/build/pages/video-editor.min.js:19875
+#, js-format
 msgid "Chapters (%d)"
 msgstr ""
 
 #: pages/video-editor/components/chapters/Chapters.js:150
-#: assets/build/pages/video-editor.min.js:19945
 msgid "Delete chapter"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:174
-#: assets/build/pages/video-editor.min.js:20645
 msgid "Select Custom Background Image"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:176
-#: assets/build/pages/video-editor.min.js:20647
 msgid "Use this Background Image"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:310
-#: assets/build/pages/video-editor.min.js:20781
 msgid "Image Left, Text Right (Full Height)"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:311
-#: assets/build/pages/video-editor.min.js:20782
 msgid "Text Left, Image Right (Full Height)"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:312
-#: assets/build/pages/video-editor.min.js:20783
 msgid "Image Left, Text Right"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:313
-#: assets/build/pages/video-editor.min.js:20784
 msgid "Text Left, Image Right"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:314
-#: assets/build/pages/video-editor.min.js:20785
 msgid "Image Top, Text Bottom"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:315
-#: assets/build/pages/video-editor.min.js:20786
 msgid "Text Top, Image Bottom"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:316
-#: assets/build/pages/video-editor.min.js:20787
 msgid "Image Background"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:317
-#: assets/build/pages/video-editor.min.js:20788
 msgid "Text Only (No Image)"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:338
-#: assets/build/pages/video-editor.min.js:20809
 msgid "Card Layout"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:360
-#: assets/build/pages/video-editor.min.js:20831
 msgid "Recommended size: 100KB"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:376
-#: assets/build/pages/video-editor.min.js:20847
 msgid "Click to replace image"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:381
-#: assets/build/pages/video-editor.min.js:20852
 msgid "Replace image"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:386
-#: assets/build/pages/video-editor.min.js:20857
 msgid "Selected CTA image"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:423
-#: assets/build/pages/video-editor.min.js:20894
 msgid "Width"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:436
 #: pages/video-editor/components/cta/CardCTA.js:438
-#: assets/build/pages/video-editor.min.js:20907
-#: assets/build/pages/video-editor.min.js:20909
 msgid "Card Title"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:441
-#: assets/build/pages/video-editor.min.js:20912
 msgid "Add title here"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:446
-#: assets/build/pages/video-editor.min.js:20917
 msgid "Character limit"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:449
-#: assets/build/pages/video-editor.min.js:20920
 msgid "Your description"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:455
-#: assets/build/pages/video-editor.min.js:20926
 msgid "Button Settings"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:457
-#: assets/build/pages/video-editor.min.js:20928
 msgid "Button Title"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:464
-#: assets/build/pages/video-editor.min.js:20935
 msgid "Button Link"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:472
-#: assets/build/pages/video-editor.min.js:20943
 msgid "Button Colour"
 msgstr ""
 
 #: pages/video-editor/components/cta/CardCTA.js:477
-#: assets/build/pages/video-editor.min.js:20948
 msgid "Text"
 msgstr ""
 
@@ -9118,187 +8382,144 @@ msgstr ""
 #: pages/video-editor/components/layers/FormLayer.js:147
 #: pages/video-editor/components/layers/HotspotLayer.js:580
 #: pages/video-editor/components/layers/PollLayer.js:72
-#: assets/build/pages/video-editor.min.js:20955
-#: assets/build/pages/video-editor.min.js:23935
-#: assets/build/pages/video-editor.min.js:24528
-#: assets/build/pages/video-editor.min.js:25115
 msgid "Background"
 msgstr ""
 
 #: pages/video-editor/components/cta/HtmlCTA.js:25
-#: assets/build/pages/video-editor.min.js:20993
 msgid "Custom HTML"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/ConfigurationPanel.js:48
-#: assets/build/pages/video-editor.min.js:21060
 msgid "Configuration Panel"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/ConfigurationPanel.js:49
-#: assets/build/pages/video-editor.min.js:21061
 msgid "Selected layer will be displayed here"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/ConfigurationPanel.js:52
-#: assets/build/pages/video-editor.min.js:21064
 msgid "No layers selected"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/ConfigurationPanel.js:53
-#: assets/build/pages/video-editor.min.js:21065
 msgid "Select a layer from the left panel to edit its properties"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorSkeleton.js:57
 #: pages/video-editor/components/editor-shell/EditorSkeleton.js:59
-#: assets/build/pages/video-editor.min.js:21138
-#: assets/build/pages/video-editor.min.js:21140
 msgid "Loading video editor…"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:107
-#: assets/build/pages/video-editor.min.js:21357
 msgid "The total number of times this video has been played."
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:110
-#: assets/build/pages/video-editor.min.js:21360
 msgid "Layer CTR"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:112
-#: assets/build/pages/video-editor.min.js:21362
 msgid "Click-through rate of interactive layers: the share of plays where a viewer interacted with a layer. Layer CTR = Converting sessions / Total plays."
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:115
-#: assets/build/pages/video-editor.min.js:21365
 msgid "Avg. Watch Time"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:117
-#: assets/build/pages/video-editor.min.js:21367
 msgid "Average time watched per play. Avg. Watch Time = Total watch time / Total plays."
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:120
-#: assets/build/pages/video-editor.min.js:21370
 msgid "Total Impressions"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorStatsRow.js:122
-#: assets/build/pages/video-editor.min.js:21372
 msgid "How many times the video player loaded on a page, whether or not it was played."
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTabRail.js:18
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:601
-#: assets/build/pages/video-editor.min.js:21412
-#: assets/build/pages/video-editor.min.js:26965
 msgid "Layers"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTabRail.js:45
-#: assets/build/pages/video-editor.min.js:21439
 msgid "Editor sections"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:130
-#: assets/build/pages/video-editor.min.js:21587
 msgid "Click to edit title"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:192
-#: assets/build/pages/video-editor.min.js:21649
 msgid "Save Video"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:222
-#: assets/build/pages/video-editor.min.js:21679
 msgid "Back to media library"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:253
-#: assets/build/pages/video-editor.min.js:21710
 msgid "You can copy the block into one of the two options:"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:255
-#: assets/build/pages/video-editor.min.js:21712
 msgid "1. Insert as a block in the Block editor."
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:257
-#: assets/build/pages/video-editor.min.js:21714
 msgid "2. Insert as HTML content in the Block editor."
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:272
-#: assets/build/pages/video-editor.min.js:21729
 msgid "Copy"
 msgstr ""
 
 #: pages/video-editor/components/editor-shell/EditorTopBar.js:308
-#: assets/build/pages/video-editor.min.js:21765
 msgid "More options"
 msgstr ""
 
 #: pages/video-editor/components/forms/AjaxWarning.js:19
-#: assets/build/pages/video-editor.min.js:21896
 msgid "AJAX submission is required to prevent the form from reloading the video page on submit."
 msgstr ""
 
 #: pages/video-editor/components/forms/AjaxWarning.js:20
-#: assets/build/pages/video-editor.min.js:21897
 msgid "Make sure it's enabled in your"
 msgstr ""
 
 #: pages/video-editor/components/forms/AjaxWarning.js:28
-#: assets/build/pages/video-editor.min.js:21905
 msgid "form settings"
 msgstr ""
 
 #: pages/video-editor/components/forms/CF7.js:57
 #: pages/video-editor/components/SidebarLayers.js:67
 #: pages/video-editor/utils/layerTypes.js:40
-#: assets/build/pages/video-editor.min.js:17871
-#: assets/build/pages/video-editor.min.js:21970
-#: assets/build/pages/video-editor.min.js:29921
 msgid "Contact Form 7"
 msgstr ""
 
 #: pages/video-editor/components/forms/FluentForm.js:44
 #: pages/video-editor/components/SidebarLayers.js:91
 #: pages/video-editor/utils/layerTypes.js:44
-#: assets/build/pages/video-editor.min.js:17895
-#: assets/build/pages/video-editor.min.js:22103
-#: assets/build/pages/video-editor.min.js:29925
 msgid "Fluent Forms"
 msgstr ""
 
 #. translators: %s is the form plugin name, e.g. "Gravity Forms".
 #: pages/video-editor/components/forms/FormFields.js:58
-#: assets/build/pages/video-editor.min.js:22181
+#, js-format
 msgid "Please activate the %s plugin to use this feature."
 msgstr ""
 
 #: pages/video-editor/components/forms/FormFields.js:74
-#: assets/build/pages/video-editor.min.js:22197
 msgid "Select Theme"
 msgstr ""
 
 #: pages/video-editor/components/forms/FormFields.js:90
-#: assets/build/pages/video-editor.min.js:22213
 msgid "Edit Form"
 msgstr ""
 
 #: pages/video-editor/components/forms/forminatorForms.js:42
 #: pages/video-editor/components/SidebarLayers.js:85
 #: pages/video-editor/utils/layerTypes.js:43
-#: assets/build/pages/video-editor.min.js:17889
-#: assets/build/pages/video-editor.min.js:23083
-#: assets/build/pages/video-editor.min.js:29924
 msgid "Forminator Forms"
 msgstr ""
 
@@ -9306,25 +8527,18 @@ msgstr ""
 #: pages/video-editor/components/forms/JetpackForm.js:190
 #: pages/video-editor/components/forms/MetForm.js:67
 #: pages/video-editor/components/forms/NinjaForm.js:67
-#: assets/build/pages/video-editor.min.js:22273
-#: assets/build/pages/video-editor.min.js:22644
-#: assets/build/pages/video-editor.min.js:22757
-#: assets/build/pages/video-editor.min.js:22833
 msgid "Loading form…"
 msgstr ""
 
 #: pages/video-editor/components/forms/FormSelector.js:34
-#: assets/build/pages/video-editor.min.js:22353
 msgid "Select Form"
 msgstr ""
 
 #: pages/video-editor/components/forms/GravityForm.js:22
-#: assets/build/pages/video-editor.min.js:22396
 msgid "Orbital"
 msgstr ""
 
 #: pages/video-editor/components/forms/GravityForm.js:26
-#: assets/build/pages/video-editor.min.js:22400
 msgid "Gravity"
 msgstr ""
 
@@ -9332,441 +8546,339 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:55
 #: pages/video-editor/utils/layerTypes.js:38
 #: pages/video-editor/utils/layerTypes.js:66
-#: assets/build/pages/video-editor.min.js:17859
-#: assets/build/pages/video-editor.min.js:22429
-#: assets/build/pages/video-editor.min.js:29919
-#: assets/build/pages/video-editor.min.js:29947
 msgid "Gravity Forms"
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:164
-#: assets/build/pages/video-editor.min.js:22618
 msgid "Jetpack"
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:197
-#: assets/build/pages/video-editor.min.js:22651
 msgid "Error loading form. Please check if the form exists."
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:204
-#: assets/build/pages/video-editor.min.js:22658
 msgid "No form selected or form not found."
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:216
-#: assets/build/pages/video-editor.min.js:22670
 msgid "No Jetpack forms found. Please"
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:223
-#: assets/build/pages/video-editor.min.js:22677
 msgid "create a Jetpack contact form"
 msgstr ""
 
 #: pages/video-editor/components/forms/JetpackForm.js:225
-#: assets/build/pages/video-editor.min.js:22679
 msgid "first."
 msgstr ""
 
 #: pages/video-editor/components/forms/MetForm.js:43
 #: pages/video-editor/components/SidebarLayers.js:109
 #: pages/video-editor/utils/layerTypes.js:47
-#: assets/build/pages/video-editor.min.js:17913
-#: assets/build/pages/video-editor.min.js:22733
-#: assets/build/pages/video-editor.min.js:29928
 msgid "MetForm"
 msgstr ""
 
 #: pages/video-editor/components/forms/Sureform.js:42
 #: pages/video-editor/components/SidebarLayers.js:79
 #: pages/video-editor/utils/layerTypes.js:42
-#: assets/build/pages/video-editor.min.js:17883
-#: assets/build/pages/video-editor.min.js:22884
-#: assets/build/pages/video-editor.min.js:29923
 msgid "SureForms"
 msgstr ""
 
 #: pages/video-editor/components/forms/WPForm.js:42
 #: pages/video-editor/components/SidebarLayers.js:61
 #: pages/video-editor/utils/layerTypes.js:39
-#: assets/build/pages/video-editor.min.js:17865
-#: assets/build/pages/video-editor.min.js:22946
-#: assets/build/pages/video-editor.min.js:29920
 msgid "WPForms"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:85
-#: assets/build/pages/video-editor.min.js:23188
 msgid "Select or Upload Custom Icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:87
-#: assets/build/pages/video-editor.min.js:23190
 msgid "Use this icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:147
-#: assets/build/pages/video-editor.min.js:23250
 msgid "Search icons…"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:192
-#: assets/build/pages/video-editor.min.js:23295
 msgid "Add Icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:216
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:224
-#: assets/build/pages/video-editor.min.js:23319
-#: assets/build/pages/video-editor.min.js:23327
 msgid "Replace icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:232
-#: assets/build/pages/video-editor.min.js:23335
 msgid "Remove icon"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:250
-#: assets/build/pages/video-editor.min.js:23353
 msgid "Select from library"
 msgstr ""
 
 #: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:261
-#: assets/build/pages/video-editor.min.js:23364
 msgid "Add custom"
 msgstr ""
 
 #: pages/video-editor/components/layers/AdsLayer.js:51
-#: assets/build/pages/video-editor.min.js:23504
 msgid "Self hosted video Ad"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:56
-#: assets/build/pages/video-editor.min.js:23569
 msgid "Card Style"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:56
-#: assets/build/pages/video-editor.min.js:23569
 msgid "Perfect for everyone"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:57
-#: assets/build/pages/video-editor.min.js:23570
 msgid "HTML"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:57
-#: assets/build/pages/video-editor.min.js:23570
 msgid "Great for developers"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:206
-#: assets/build/pages/video-editor.min.js:23719
 msgid "Call To Action"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:226
-#: assets/build/pages/video-editor.min.js:23739
 msgid "Advanced"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:227
-#: assets/build/pages/video-editor.min.js:23740
 msgid "Layer Background Colour"
 msgstr ""
 
 #: pages/video-editor/components/layers/CTALayer.js:230
-#: assets/build/pages/video-editor.min.js:23743
 msgid "Layer background color"
-msgstr ""
-
-#: pages/video-editor/components/layers/CTALayer.js:265
-#: assets/build/pages/video-editor.min.js:23778
-msgid "Done"
 msgstr ""
 
 #: pages/video-editor/components/layers/FormLayer.js:128
 #: pages/video-editor/components/layers/HotspotLayer.js:590
 #: pages/video-editor/components/layers/PollLayer.js:54
-#: assets/build/pages/video-editor.min.js:23916
-#: assets/build/pages/video-editor.min.js:24538
-#: assets/build/pages/video-editor.min.js:25097
 msgid "Behaviour"
 msgstr ""
 
 #: pages/video-editor/components/layers/FormLayer.js:131
 #: pages/video-editor/components/layers/PollLayer.js:57
-#: assets/build/pages/video-editor.min.js:23919
-#: assets/build/pages/video-editor.min.js:25100
 msgid "Allow user to skip"
 msgstr ""
 
 #: pages/video-editor/components/layers/FormLayer.js:136
-#: assets/build/pages/video-editor.min.js:23924
 msgid "If enabled, the user will be able to skip the form submission."
 msgstr ""
 
 #: pages/video-editor/components/layers/FormLayer.js:142
 #: pages/video-editor/components/layers/PollLayer.js:67
-#: assets/build/pages/video-editor.min.js:23930
-#: assets/build/pages/video-editor.min.js:25110
 msgid "Background Colour"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:63
-#: assets/build/pages/video-editor.min.js:24011
 msgid "Pulse"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:64
 #: pages/video-editor/components/layers/HotspotLayer.js:573
-#: assets/build/pages/video-editor.min.js:24012
-#: assets/build/pages/video-editor.min.js:24521
 msgid "Icon"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:176
-#: assets/build/pages/video-editor.min.js:24124
 msgid "Layer duration exceeds the remaining video length. Please reduce the duration."
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:224
-#: assets/build/pages/video-editor.min.js:24172
 msgid "New Hotspot"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:438
-#: assets/build/pages/video-editor.min.js:24386
 msgid "Add Hotspots"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:442
-#: assets/build/pages/video-editor.min.js:24390
 msgid "Drag the hotspot in video to reposition it."
 msgstr ""
 
 #. translators: %d is the hotspot index
 #: pages/video-editor/components/layers/HotspotLayer.js:466
-#: assets/build/pages/video-editor.min.js:24414
+#, js-format
 msgid "Delete Hotspot %d"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:476
-#: assets/build/pages/video-editor.min.js:24424
 msgid "Tooltip Text"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:477
-#: assets/build/pages/video-editor.min.js:24425
 msgid "Click Me!"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:483
-#: assets/build/pages/video-editor.min.js:24431
 msgid "Link"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:502
-#: assets/build/pages/video-editor.min.js:24450
 msgid "Add Hotspot"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:511
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:107
-#: assets/build/pages/video-editor.min.js:24459
-#: assets/build/pages/video-editor.min.js:25238
 msgid "Start Time"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:518
-#: assets/build/pages/video-editor.min.js:24466
 msgid "Layer Duration (seconds)"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:525
-#: assets/build/pages/video-editor.min.js:24473
 msgid "Duration (in seconds) this layer will stay visible. Maximum: 10 hours (36000 seconds)"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:531
-#: assets/build/pages/video-editor.min.js:24479
 msgid "Style"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:555
-#: assets/build/pages/video-editor.min.js:24503
 msgid "Pulse colour"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:593
-#: assets/build/pages/video-editor.min.js:24541
 msgid "Pause video when hotspot is hovered"
 msgstr ""
 
 #: pages/video-editor/components/layers/HotspotLayer.js:596
-#: assets/build/pages/video-editor.min.js:24544
 msgid "Player will pause the video while the layer is displayed and users hover over the hotspots."
 msgstr ""
 
 #: pages/video-editor/components/layers/Layer.js:86
-#: assets/build/pages/video-editor.min.js:24839
 msgid "Loading layer…"
 msgstr ""
 
 #: pages/video-editor/components/layers/Layer.js:90
-#: assets/build/pages/video-editor.min.js:24843
 msgid "Error: No layer components registered"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayerErrorBoundary.js:46
-#: assets/build/pages/video-editor.min.js:24900
 msgid "This layer could not be opened. It may be provided by an add-on that needs updating to work with this version of GoDAM."
 msgstr ""
 
 #: pages/video-editor/components/layers/LayerErrorBoundary.js:53
-#: assets/build/pages/video-editor.min.js:24907
 msgid "Back to layers"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayersHeader.js:65
 #: pages/video-editor/components/layers/LayersHeader.js:66
-#: assets/build/pages/video-editor.min.js:24984
-#: assets/build/pages/video-editor.min.js:24985
 msgid "Layer name"
 msgstr ""
 
 #. translators: %s is the layer display time in seconds.
 #: pages/video-editor/components/layers/LayersHeader.js:77
-#: assets/build/pages/video-editor.min.js:24996
+#, js-format
 msgid "%ss"
 msgstr ""
 
 #: pages/video-editor/components/layers/LayersHeader.js:90
 #: pages/video-editor/components/layers/LayersHeader.js:96
 #: pages/video-editor/components/layers/LayersHeader.js:113
-#: assets/build/pages/video-editor.min.js:25009
-#: assets/build/pages/video-editor.min.js:25015
-#: assets/build/pages/video-editor.min.js:25032
 msgid "Delete layer"
 msgstr ""
 
 #: pages/video-editor/components/layers/PollLayer.js:45
-#: assets/build/pages/video-editor.min.js:25088
 msgid "Select Poll"
 msgstr ""
 
 #: pages/video-editor/components/layers/PollLayer.js:62
-#: assets/build/pages/video-editor.min.js:25105
 msgid "If enabled, the user will be able to skip the poll."
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:27
-#: assets/build/pages/video-editor.min.js:25158
 msgid "Fixed Timestamp"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:28
-#: assets/build/pages/video-editor.min.js:25159
 msgid "Appears at a set second"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:32
-#: assets/build/pages/video-editor.min.js:25163
 msgid "Watch Depth"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:33
-#: assets/build/pages/video-editor.min.js:25164
 msgid "Fires after the user crosses a watch %"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:37
-#: assets/build/pages/video-editor.min.js:25168
 msgid "On Pause"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:38
-#: assets/build/pages/video-editor.min.js:25169
 msgid "Shows when the viewer pauses (single CTA only)"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:42
-#: assets/build/pages/video-editor.min.js:25173
 msgid "End of Video"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:43
-#: assets/build/pages/video-editor.min.js:25174
 msgid "Overlays on the final frame when playback ends"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:60
-#: assets/build/pages/video-editor.min.js:25191
 msgid "CTA Trigger"
 msgstr ""
 
 #: pages/video-editor/components/layers/shared/TriggerSection.jsx:98
-#: assets/build/pages/video-editor.min.js:25229
 msgid "Another CTA already uses On Pause — only one CTA per video can."
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:58
-#: assets/build/pages/video-editor.min.js:17862
 msgid "Gravity Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:64
-#: assets/build/pages/video-editor.min.js:17868
 msgid "WPForms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:70
-#: assets/build/pages/video-editor.min.js:17874
 msgid "Contact Form 7 plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:73
 #: pages/video-editor/utils/layerTypes.js:41
-#: assets/build/pages/video-editor.min.js:17877
-#: assets/build/pages/video-editor.min.js:29922
 msgid "Jetpack Forms"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:76
-#: assets/build/pages/video-editor.min.js:17880
 msgid "Jetpack plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:82
-#: assets/build/pages/video-editor.min.js:17886
 msgid "SureForms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:88
-#: assets/build/pages/video-editor.min.js:17892
 msgid "Forminator Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:94
-#: assets/build/pages/video-editor.min.js:17898
 msgid "Fluent Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:100
-#: assets/build/pages/video-editor.min.js:17904
 msgid "Everest Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:106
-#: assets/build/pages/video-editor.min.js:17910
 msgid "Ninja Forms plugin is not active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:112
-#: assets/build/pages/video-editor.min.js:17916
 msgid "MetForm plugin is not active"
 msgstr ""
 
@@ -9774,20 +8886,14 @@ msgstr ""
 #: pages/video-editor/components/SidebarLayers.js:120
 #: pages/video-editor/components/SidebarLayers.js:510
 #: pages/video-editor/utils/layerTypes.js:81
-#: assets/build/pages/video-editor.min.js:17921
-#: assets/build/pages/video-editor.min.js:17924
-#: assets/build/pages/video-editor.min.js:18314
-#: assets/build/pages/video-editor.min.js:29962
 msgid "Ad"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:121
-#: assets/build/pages/video-editor.min.js:17925
 msgid "This ad will be overridden by Ad server's ads"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:129
-#: assets/build/pages/video-editor.min.js:17933
 msgid "Poll plugin is not active"
 msgstr ""
 
@@ -9795,926 +8901,666 @@ msgstr ""
 #. translators: %s is the layer type label; e.g. "CTA Layer".
 #: pages/video-editor/components/SidebarLayers.js:159
 #: pages/video-editor/components/SidebarLayers.js:713
-#: assets/build/pages/video-editor.min.js:17963
-#: assets/build/pages/video-editor.min.js:18517
+#, js-format
 msgid "%s Layer"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:462
-#: assets/build/pages/video-editor.min.js:18266
 msgid "Add a clickable button"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:463
-#: assets/build/pages/video-editor.min.js:18267
 msgid "Add an info hotspot"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:482
-#: assets/build/pages/video-editor.min.js:18286
 msgid "Embed a lead form"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:486
-#: assets/build/pages/video-editor.min.js:18290
 msgid "No form plugin is active"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:499
-#: assets/build/pages/video-editor.min.js:18303
 msgid "Create an interactive poll"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:511
-#: assets/build/pages/video-editor.min.js:18315
 msgid "Insert an advertisement"
 msgstr ""
 
 #. translators: %d is the number of layers.
 #: pages/video-editor/components/SidebarLayers.js:544
-#: assets/build/pages/video-editor.min.js:18348
+#, js-format
 msgid "Layers (%d)"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:575
 #: pages/video-editor/components/timeline/Timeline.js:428
-#: assets/build/pages/video-editor.min.js:18379
-#: assets/build/pages/video-editor.min.js:25768
 msgid "Add layer"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:632
-#: assets/build/pages/video-editor.min.js:18436
 msgid "To add a layer, pick a spot on the timeline where you want the layer."
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:653
-#: assets/build/pages/video-editor.min.js:18457
 msgid "No layers yet"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:655
-#: assets/build/pages/video-editor.min.js:18459
 msgid "Add interactive elements like CTAs, polls, and forms to your video"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:728
-#: assets/build/pages/video-editor.min.js:18532
 msgid "Layer options"
 msgstr ""
 
 #: pages/video-editor/components/SidebarLayers.js:740
-#: assets/build/pages/video-editor.min.js:18544
 msgid "Duplicate"
 msgstr ""
 
 #: pages/video-editor/components/timeline/Timeline.js:399
-#: assets/build/pages/video-editor.min.js:25739
 msgid "Click to add layer"
 msgstr ""
 
 #: pages/video-editor/components/timeline/Timeline.js:424
-#: assets/build/pages/video-editor.min.js:25764
 msgid "Add layer at this time"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:74
-#: assets/build/pages/video-editor.min.js:25999
 msgid "Transcription failed. Please try again."
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:124
-#: assets/build/pages/video-editor.min.js:26049
 msgid "Could not start transcription. Please try again."
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:134
-#: assets/build/pages/video-editor.min.js:26059
 msgid "Select a caption file"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:135
-#: assets/build/pages/video-editor.min.js:26060
 msgid "Use this file"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:144
-#: assets/build/pages/video-editor.min.js:26069
 msgid "Please choose a .vtt or .srt caption file."
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:150
-#: assets/build/pages/video-editor.min.js:26075
 msgid "Could not attach the caption file."
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:164
-#: assets/build/pages/video-editor.min.js:26089
 msgid "Could not remove the transcript."
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:199
-#: assets/build/pages/video-editor.min.js:26124
 msgid "Replace transcription file"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:206
 #: pages/video-editor/components/transcription/Transcription.js:285
-#: assets/build/pages/video-editor.min.js:26131
-#: assets/build/pages/video-editor.min.js:26210
 msgid "Delete transcription"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:230
-#: assets/build/pages/video-editor.min.js:26155
 msgid "No cues found in this caption file."
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:240
-#: assets/build/pages/video-editor.min.js:26165
 msgid "Automatically transcribe the audio using GoDAM's AI engine"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:250
-#: assets/build/pages/video-editor.min.js:26175
 msgid "Generate Transcription"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:261
-#: assets/build/pages/video-editor.min.js:26186
 msgid "Generating transcription…"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:264
-#: assets/build/pages/video-editor.min.js:26189
 msgid "This usually takes 10–15 minutes. We'll notify you once it's ready"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:276
-#: assets/build/pages/video-editor.min.js:26201
 msgid "Upload File"
 msgstr ""
 
 #: pages/video-editor/components/transcription/Transcription.js:288
-#: assets/build/pages/video-editor.min.js:26213
 msgid "Delete this transcription? This cannot be undone."
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:72
-#: assets/build/pages/video-editor.min.js:26436
 msgid "Images"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:87
-#: assets/build/pages/video-editor.min.js:26451
 msgid "All Videos"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:88
-#: assets/build/pages/video-editor.min.js:26452
 msgid "All Images"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:89
-#: assets/build/pages/video-editor.min.js:26453
 msgid "All Audio"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:90
-#: assets/build/pages/video-editor.min.js:26454
 msgid "All"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:96
-#: assets/build/pages/video-editor.min.js:26460
 msgid "Edited"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:97
-#: assets/build/pages/video-editor.min.js:26461
 msgid "Unedited"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:103
-#: assets/build/pages/video-editor.min.js:26467
 msgid "Transcoded"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:104
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:610
-#: assets/build/pages/video-editor.min.js:26468
-#: assets/build/pages/video-editor.min.js:26974
 msgid "Non Transcoded"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:115
-#: assets/build/pages/video-editor.min.js:26479
 msgid "Newest Uploaded"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:116
-#: assets/build/pages/video-editor.min.js:26480
 msgid "Oldest Uploaded"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:117
-#: assets/build/pages/video-editor.min.js:26481
 msgid "Recently Edited"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:118
-#: assets/build/pages/video-editor.min.js:26482
 msgid "Name A-Z"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:119
-#: assets/build/pages/video-editor.min.js:26483
 msgid "Name Z-A"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:272
-#: assets/build/pages/video-editor.min.js:26636
 msgid "Quick actions"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:301
-#: assets/build/pages/video-editor.min.js:26665
 msgid "Copy block"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:313
-#: assets/build/pages/video-editor.min.js:26677
 msgid "View Analytics"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:487
 #: pages/video-editor/VideoEditor.js:546
-#: assets/build/pages/video-editor.min.js:17183
-#: assets/build/pages/video-editor.min.js:26851
 msgid "GoDAM block copied to clipboard"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:488
 #: pages/video-editor/VideoEditor.js:549
-#: assets/build/pages/video-editor.min.js:17186
-#: assets/build/pages/video-editor.min.js:26852
 msgid "Failed to copy GoDAM block"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:560
-#: assets/build/pages/video-editor.min.js:26924
 msgid "Sourced from GoDAM Central"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:572
-#: assets/build/pages/video-editor.min.js:26936
 msgid "Media name"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:581
-#: assets/build/pages/video-editor.min.js:26945
 msgid "Details"
 msgstr ""
 
 #. translators: %s: human-readable date the video was last edited.
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:594
-#: assets/build/pages/video-editor.min.js:26958
+#, js-format
 msgid "Last edited %s"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:650
-#: assets/build/pages/video-editor.min.js:27014
 msgid "Upload media to the WordPress Media Library, GoDAM auto-syncs it here."
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:659
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:138
-#: assets/build/pages/video-editor.min.js:27023
-#: assets/build/pages/video-editor.min.js:27679
 msgid "See how it works"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:670
-#: assets/build/pages/video-editor.min.js:27034
 msgid "Search"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:672
-#: assets/build/pages/video-editor.min.js:27036
 msgid "Search media"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:678
-#: assets/build/pages/video-editor.min.js:27042
 msgid "Filter by media type"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:686
-#: assets/build/pages/video-editor.min.js:27050
 msgid "Filter media"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:694
-#: assets/build/pages/video-editor.min.js:27058
 msgid "Sort media"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:707
-#: assets/build/pages/video-editor.min.js:27071
 msgid "You have no media yet!"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:709
-#: assets/build/pages/video-editor.min.js:27073
 msgid "Upload media to the"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:715
-#: assets/build/pages/video-editor.min.js:27079
 msgid "WordPress Media Library"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:717
-#: assets/build/pages/video-editor.min.js:27081
 msgid "and GoDAM will sync them here."
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:720
-#: assets/build/pages/video-editor.min.js:27084
 msgid "You can start selling as soon as you add a product."
 msgstr ""
 
 #. translators: 1: number of loaded media items, 2: total media items.
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:751
-#: assets/build/pages/video-editor.min.js:27115
+#, js-format
 msgid "Showing %1$d of %2$d media items"
 msgstr ""
 
 #: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:765
-#: assets/build/pages/video-editor.min.js:27129
 msgid "Load more"
 msgstr ""
 
 #: pages/video-editor/onboarding/productGuide.js:197
-#: assets/build/pages/video-editor.min.js:27958
 msgid "Next"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:187
-#: assets/build/pages/video-editor.min.js:27478
 msgid "GoDAM video"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:223
-#: assets/build/pages/video-editor.min.js:27514
 msgid "Do you want to end the product guide?"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:224
-#: assets/build/pages/video-editor.min.js:27515
 msgid "End guide"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:225
-#: assets/build/pages/video-editor.min.js:27516
 msgid "Keep going"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:230
-#: assets/build/pages/video-editor.min.js:27521
 msgid "You can start it anytime using the “See how it works” button on the Media Editor."
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:235
-#: assets/build/pages/video-editor.min.js:27526
 msgid "Do you want to add it to a page?"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:236
-#: assets/build/pages/video-editor.min.js:27527
 msgid "Yes, Continue"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:237
-#: assets/build/pages/video-editor.min.js:27528
 msgid "Not now"
 msgstr ""
 
 #: pages/video-editor/onboarding/ProductGuide.jsx:243
-#: assets/build/pages/video-editor.min.js:27534
 msgid "We’ll open a new draft page and drop the video right in."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:37
 #: pages/video-editor/onboarding/steps.js:38
-#: assets/build/pages/video-editor.min.js:28225
-#: assets/build/pages/video-editor.min.js:28226
 msgid "Start by adding layers to this video to make it interactive."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:37
-#: assets/build/pages/video-editor.min.js:28225
 msgid "Downloaded a demo video."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:59
-#: assets/build/pages/video-editor.min.js:28247
 msgid "Select a spot on the timeline where you want to add your layer."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:67
-#: assets/build/pages/video-editor.min.js:28255
 msgid "Start by selecting a layer from the dropdown to add it here."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:78
-#: assets/build/pages/video-editor.min.js:28266
 msgid "Start with a CTA — it’s the quickest way to make your video interactive."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:86
-#: assets/build/pages/video-editor.min.js:28274
 msgid "Use this panel to customize and configure your layer settings."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:95
-#: assets/build/pages/video-editor.min.js:28283
 msgid "Save the video to use it anywhere on your WordPress site."
 msgstr ""
 
 #: pages/video-editor/onboarding/steps.js:103
-#: assets/build/pages/video-editor.min.js:28291
 msgid "Now copy the video to use it in a page."
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:28
-#: assets/build/pages/video-editor.min.js:27569
 msgid "Woo"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:29
-#: assets/build/pages/video-editor.min.js:27570
 msgid "Turn product videos into sales"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:30
-#: assets/build/pages/video-editor.min.js:27571
 msgid "Add shoppable galleries and product blocks."
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:35
-#: assets/build/pages/video-editor.min.js:27576
 msgid "Make your videos interactive"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:36
-#: assets/build/pages/video-editor.min.js:27577
 msgid "Add CTAs or hotspots directly on top of any video."
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:79
-#: assets/build/pages/video-editor.min.js:27620
 msgid "Welcome to GoDAM"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:87
-#: assets/build/pages/video-editor.min.js:27628
 msgid "Choose what you’d like to explore first."
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:90
-#: assets/build/pages/video-editor.min.js:27631
 msgid "Welcome options"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeChooserModal.jsx:129
 #: pages/video-editor/onboarding/WelcomeIntroModal.jsx:57
-#: assets/build/pages/video-editor.min.js:27670
-#: assets/build/pages/video-editor.min.js:27744
 msgid "Skip for now"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeIntroModal.jsx:37
-#: assets/build/pages/video-editor.min.js:27724
 msgid "Get Started with GoDAM"
 msgstr ""
 
 #: pages/video-editor/onboarding/WelcomeIntroModal.jsx:45
-#: assets/build/pages/video-editor.min.js:27732
 msgid "Get started by adding interactive layers to your video"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:496
-#: assets/build/pages/video-editor.min.js:17133
 msgid "Please select a form for the layer at timestamp:"
 msgid_plural "Please select a form for the layers at timestamps:"
 msgstr[0] ""
 msgstr[1] ""
 
 #: pages/video-editor/VideoEditor.js:592
-#: assets/build/pages/video-editor.min.js:17229
 msgid "Edit video metadata"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:594
-#: assets/build/pages/video-editor.min.js:17231
 msgid "Edit image metadata"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:596
-#: assets/build/pages/video-editor.min.js:17233
 msgid "Edit audio metadata"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:598
-#: assets/build/pages/video-editor.min.js:17235
 msgid "Edit metadata"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:624
-#: assets/build/pages/video-editor.min.js:17261
 msgid "Title updated"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:628
-#: assets/build/pages/video-editor.min.js:17265
 msgid "Failed to update title"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:650
-#: assets/build/pages/video-editor.min.js:17287
 msgid "Untitled image"
 msgstr ""
 
 #: pages/video-editor/VideoEditor.js:711
-#: assets/build/pages/video-editor.min.js:17348
 msgid "Changes saved successfully"
 msgstr ""
 
-#: pages/video-editor/VideoJSPlayer.js:195
-#: assets/build/pages/video-editor.min.js:17643
-msgid "Custom Play Button"
-msgstr ""
-
 #: pages/whats-new/components/Header.js:25
-#: assets/build/pages/whats-new.min.js:757
 msgid "What's New in GoDAM"
 msgstr ""
 
-#: assets/build/js/deactivation-feedback.min.js:78
-msgid "Select a reason"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:79
-msgid "I found a better plugin"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:80
-msgid "The plugin is not working as expected"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:81
-msgid "I was just testing"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:82
-msgid "Other"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:84
-msgid "Additional details…"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:88
-msgid "Skip & Deactivate"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:93
-msgid "Submit & Deactivate"
-msgstr ""
-
-#. translators: %d: Maximum allowed file size in MB.
-#: assets/build/js/everestforms.min.js:117
-msgid "File size exceeds the maximum limit of %d MB."
-msgstr ""
-
-#: assets/build/js/everestforms.min.js:287
-#: assets/build/js/fluentforms.min.js:301
-#: assets/build/js/ninja-forms.min.js:272
-msgid "File upload in progress…"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9220
-msgid "Not started"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9240
-msgid "Media is transcoded"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9276
-msgid "Transcoding…"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:9855
-msgid "No thumbnails found"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10012
-msgid "Select Custom Thumbnail"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10013
-msgid "Use this image"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10025
-msgid "Please select a valid image file (JPEG, PNG, GIF, etc.)."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10061
-#: assets/build/js/media-library.min.js:10062
-msgid "Only 3 custom thumbnails allowed"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10109
-msgid "Custom Video Thumbnail"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10116
-#: assets/build/js/media-library.min.js:10120
-msgid "Remove Image"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:10335
-#: assets/build/js/media-library.min.js:10950
-msgid "Video Thumbnails"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:11105
-msgid "oEmbed Video URL"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:11107
-msgid "The oEmbed URL can be used to embed the video in other platforms that support oEmbed."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:78420
-msgid "Search Media"
-msgstr ""
-
-#: assets/build/js/ninja-forms.min.js:336
-msgid "Upload failed. Please try again."
-msgstr ""
-
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:122
-msgid "Custom cover"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:157
-msgid "Select Cover Image"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:158
-msgid "Use image"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-selector-param.min.js:32
-msgid "Select or Upload Document"
-msgstr ""
-
-#: assets/build/js/wpbakery-image-selector-param.min.js:28
-msgid "Select or Upload Image"
-msgstr ""
-
-#: assets/build/js/wpbakery-video-selector-param.min.js:250
-msgid "Select or Upload Video"
-msgstr ""
-
-#: assets/build/js/wpforms-godam-recorder-editor.min.js:69932
-msgid "Select or Upload Video Of Your Choice"
-msgstr ""
-
-#: assets/build/js/wpforms-godam-recorder-editor.min.js:69937
-msgid "Use this video"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:9780
-msgid "Invalid item"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-audio/block.json
 msgctxt "block title"
 msgid "Audio"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-audio/block.json
 msgctxt "block description"
 msgid "Embed a GoDAM audio player."
 msgstr ""
 
-#: assets/build/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-audio/block.json
 msgctxt "block keyword"
 msgid "music"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-audio/block.json
 msgctxt "block keyword"
 msgid "sound"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-audio/block.json
 msgctxt "block keyword"
 msgid "podcast"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-audio/block.json
 msgctxt "block keyword"
 msgid "recording"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/block.json
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-image/block.json
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/build/blocks/godam-player/block.json
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
+#: assets/src/blocks/godam-audio/block.json
+#: assets/src/blocks/godam-gallery-v2-item/block.json
+#: assets/src/blocks/godam-gallery-v2/block.json
+#: assets/src/blocks/godam-image/block.json
+#: assets/src/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-player/block.json
+#: assets/src/blocks/sureforms/blocks/recorder/block.json
 msgctxt "block keyword"
 msgid "godam"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/block.json
+#: assets/src/blocks/godam-gallery-v2-item/block.json
 msgctxt "block title"
 msgid "Gallery V2 Item"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/block.json
+#: assets/src/blocks/godam-gallery-v2-item/block.json
 msgctxt "block description"
 msgid "A single video item for the GoDAM Gallery V2 block."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-player/block.json
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-gallery-v2-item/block.json
+#: assets/src/blocks/godam-gallery-v2/block.json
+#: assets/src/blocks/godam-player/block.json
+#: assets/src/blocks/godam-video-duration/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block keyword"
 msgid "video"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-gallery-v2-item/block.json
+#: assets/src/blocks/godam-gallery-v2/block.json
+#: assets/src/blocks/godam-video-duration/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block keyword"
 msgid "gallery"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2-item/block.json
+#: assets/src/blocks/godam-gallery-v2-item/block.json
 msgctxt "block keyword"
 msgid "item"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/block.json
+#: assets/src/blocks/godam-gallery-v2/block.json
 msgctxt "block title"
 msgid "Video Gallery"
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/block.json
+#: assets/src/blocks/godam-gallery-v2/block.json
 msgctxt "block description"
 msgid "Create a handpicked or query-based GoDAM video gallery."
 msgstr ""
 
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-gallery-v2/block.json
+#: assets/src/blocks/godam-video-duration/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block keyword"
 msgid "grid"
 msgstr ""
 
-#: assets/build/blocks/godam-image/block.json
+#: assets/src/blocks/godam-image/block.json
 msgctxt "block title"
-msgid "GoDAM Image"
+msgid "Image"
 msgstr ""
 
-#: assets/build/blocks/godam-image/block.json
+#: assets/src/blocks/godam-image/block.json
 msgctxt "block description"
 msgid "Display an image with interactive GoDAM hotspot and product layers."
 msgstr ""
 
-#: assets/build/blocks/godam-image/block.json
+#: assets/src/blocks/godam-image/block.json
 msgctxt "block keyword"
 msgid "image"
 msgstr ""
 
-#: assets/build/blocks/godam-image/block.json
+#: assets/src/blocks/godam-image/block.json
 msgctxt "block keyword"
 msgid "hotspot"
 msgstr ""
 
-#: assets/build/blocks/godam-image/block.json
+#: assets/src/blocks/godam-image/block.json
 msgctxt "block keyword"
 msgid "shoppable"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-pdf/block.json
 msgctxt "block title"
 msgid "Document"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-pdf/block.json
 msgctxt "block description"
 msgid "Embed a PDF file with preview."
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-pdf/block.json
 msgctxt "block keyword"
 msgid "document"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-pdf/block.json
 msgctxt "block keyword"
 msgid "pdf"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-pdf/block.json
 msgctxt "block keyword"
 msgid "file"
 msgstr ""
 
-#: assets/build/blocks/godam-pdf/block.json
+#: assets/src/blocks/godam-pdf/block.json
 msgctxt "block keyword"
 msgid "preview"
 msgstr ""
 
-#: assets/build/blocks/godam-player/block.json
+#: assets/src/blocks/godam-player/block.json
 msgctxt "block title"
 msgid "Video"
 msgstr ""
 
-#: assets/build/blocks/godam-player/block.json
+#: assets/src/blocks/godam-player/block.json
 msgctxt "block description"
 msgid "Embed a video from your media library or upload a new one."
 msgstr ""
 
-#: assets/build/blocks/godam-player/block.json
+#: assets/src/blocks/godam-player/block.json
 msgctxt "block keyword"
 msgid "movie"
 msgstr ""
 
-#: assets/build/blocks/godam-player/block.json
+#: assets/src/blocks/godam-player/block.json
 msgctxt "block keyword"
 msgid "player"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/block.json
+#: assets/src/blocks/godam-video-duration/block.json
 msgctxt "block title"
 msgid "GoDAM Video Duration"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/block.json
+#: assets/src/blocks/godam-video-duration/block.json
 msgctxt "block description"
 msgid "Display GoDAM video's duration"
 msgstr ""
 
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-video-duration/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block keyword"
 msgid "videos"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block title"
 msgid "GoDAM Video Thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block description"
 msgid "Display GoDAM video thumbnail"
 msgstr ""
 
-#: assets/build/blocks/godam-video-thumbnail/block.json
+#: assets/src/blocks/godam-video-thumbnail/block.json
 msgctxt "block keyword"
 msgid "thumbnail"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
+#: assets/src/blocks/sureforms/blocks/recorder/block.json
 msgctxt "block title"
 msgid "GoDAM Recorder"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
+#: assets/src/blocks/sureforms/blocks/recorder/block.json
 msgctxt "block description"
 msgid "Enable audio/video submissions inside forms using the GoDAM Recorder field that supports webcam, screencast, and audio recording"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
+#: assets/src/blocks/sureforms/blocks/recorder/block.json
 msgctxt "block keyword"
 msgid "sureforms"
 msgstr ""
 
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
+#: assets/src/blocks/sureforms/blocks/recorder/block.json
 msgctxt "block keyword"
 msgid "recorder"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -223,6 +223,13 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 27. Likes and Comments
 
 == Changelog ==
+
+= v2.1.1 (August 5, 2026) =
+
+- Fix: Removed every GoDAM translation call that ran before the `init` action, so WordPress 6.7+ no longer reports `Function _load_textdomain_just_in_time was called incorrectly` for the `godam` text domain. Covers the WPForms and Fluent Forms field registrations, the add-on compatibility and dependency notices, and the media library transcode status column.
+- Tweak: The media library transcode status column no longer re-verifies the API key over HTTP on front-end, REST and cron requests.
+- Fix: The translation template is now built from source instead of compiled assets, adding 47 strings that could not previously be translated and dropping stale ones that no longer exist in the plugin.
+- Chore: PHP unit tests now run on every pull request.
 
 = v2.1.0 (July 30, 2026) =
 

--- a/tests/php/AddonDependencyMessagesTest.php
+++ b/tests/php/AddonDependencyMessagesTest.php
@@ -119,6 +119,17 @@ class AddonDependencyMessagesTest extends TestCase {
 	}
 
 	/**
+	 * A message string is returned as-is even when a function of that name
+	 * exists, so `is_callable()` on a string can never turn a message into a
+	 * function call.
+	 */
+	public function test_string_message_matching_a_function_name_is_not_invoked() {
+		$addon = $this->make_addon( $this->dependency( false, 'phpversion' ) );
+
+		$this->assertSame( array( 'phpversion' ), $addon->get_missing_dependency_messages() );
+	}
+
+	/**
 	 * The dependency check itself must never build the message. This is the
 	 * actual #465 regression: `dependencies_met()` runs on every request, so a
 	 * message built there translates on every request.

--- a/tests/php/AddonDependencyMessagesTest.php
+++ b/tests/php/AddonDependencyMessagesTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Unit tests for add-on dependency notice messages.
+ *
+ * Regression cover for #465: GoDAM asks add-ons for their dependencies during
+ * `plugins_loaded`, so an add-on that builds a translated message there triggers
+ * `_load_textdomain_just_in_time was called incorrectly` on every request. A
+ * 'message' may therefore be a callback, resolved only when the notice renders.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RTGODAM\Inc\Addons\Abstract_Addon;
+
+require_once __DIR__ . '/../../inc/classes/addons/class-abstract-addon.php';
+
+/**
+ * @covers \RTGODAM\Inc\Addons\Abstract_Addon::get_missing_dependency_messages
+ * @covers \RTGODAM\Inc\Addons\Abstract_Addon::dependencies_met
+ */
+class AddonDependencyMessagesTest extends TestCase {
+
+	/**
+	 * Build a minimal add-on reporting the given dependencies.
+	 *
+	 * @param array $dependencies Dependency definitions.
+	 *
+	 * @return Abstract_Addon
+	 */
+	private function make_addon( array $dependencies ) {
+		return new class( $dependencies ) extends Abstract_Addon {
+
+			/**
+			 * Dependencies to report.
+			 *
+			 * @var array
+			 */
+			private $dependencies;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array $dependencies Dependency definitions.
+			 */
+			public function __construct( array $dependencies ) {
+				$this->dependencies = $dependencies;
+			}
+
+			public function get_slug() {
+				return 'stub-addon';
+			}
+
+			public function get_name() {
+				return 'Stub Add-on';
+			}
+
+			public function get_version() {
+				return '1.0.0';
+			}
+
+			public function get_path() {
+				return __DIR__;
+			}
+
+			public function get_url() {
+				return 'https://example.org/';
+			}
+
+			public function boot() {}
+
+			public function get_dependencies() {
+				return $this->dependencies;
+			}
+		};
+	}
+
+	/**
+	 * Dependency definition with a message supplied in the requested style.
+	 *
+	 * @param bool            $satisfied Whether the dependency check passes.
+	 * @param string|callable $message   Notice text, or a callback returning it.
+	 *
+	 * @return array
+	 */
+	private function dependency( $satisfied, $message ) {
+		return array(
+			array(
+				'name'    => 'WooCommerce',
+				'check'   => static function () use ( $satisfied ) {
+					return $satisfied;
+				},
+				'message' => $message,
+			),
+		);
+	}
+
+	/** A callback message is resolved when the messages are requested. */
+	public function test_callable_message_is_resolved() {
+		$addon = $this->make_addon(
+			$this->dependency(
+				false,
+				static function () {
+					return 'WooCommerce is required.';
+				}
+			)
+		);
+
+		$this->assertSame( array( 'WooCommerce is required.' ), $addon->get_missing_dependency_messages() );
+	}
+
+	/** A plain string message keeps working, so existing add-ons are unaffected. */
+	public function test_string_message_still_works() {
+		$addon = $this->make_addon( $this->dependency( false, 'WooCommerce is required.' ) );
+
+		$this->assertSame( array( 'WooCommerce is required.' ), $addon->get_missing_dependency_messages() );
+	}
+
+	/**
+	 * The dependency check itself must never build the message. This is the
+	 * actual #465 regression: `dependencies_met()` runs on every request, so a
+	 * message built there translates on every request.
+	 */
+	public function test_dependency_check_does_not_build_the_message() {
+		$built = 0;
+		$addon = $this->make_addon(
+			$this->dependency(
+				false,
+				static function () use ( &$built ) {
+					++$built;
+					return 'WooCommerce is required.';
+				}
+			)
+		);
+
+		$addon->dependencies_met();
+
+		$this->assertSame( 0, $built, 'The message callback ran during the dependency check.' );
+
+		$addon->get_missing_dependency_messages();
+
+		$this->assertSame( 1, $built, 'The message callback did not run when the notice was built.' );
+	}
+
+	/** Satisfied dependencies produce no message at all. */
+	public function test_satisfied_dependency_produces_no_message() {
+		$addon = $this->make_addon(
+			$this->dependency(
+				true,
+				static function () {
+					return 'WooCommerce is required.';
+				}
+			)
+		);
+
+		$this->assertTrue( $addon->dependencies_met() );
+		$this->assertSame( array(), $addon->get_missing_dependency_messages() );
+	}
+}

--- a/tests/php/EarlyTranslationHooksTest.php
+++ b/tests/php/EarlyTranslationHooksTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Guard against reintroducing #465.
+ *
+ * Three GoDAM call sites used to translate during `plugins_loaded`, which makes
+ * WordPress 6.7+ log `_load_textdomain_just_in_time was called incorrectly` and,
+ * with WP_DEBUG_DISPLAY on, print that notice into the page. Core reports only
+ * the first such call per text domain per request, so a regression in any one of
+ * these is easy to miss by eye. These assertions read the source directly.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class EarlyTranslationHooksTest extends TestCase {
+
+	/**
+	 * Read a plugin source file.
+	 *
+	 * @param string $relative_path Path relative to the plugin root.
+	 *
+	 * @return string
+	 */
+	private function source( $relative_path ) {
+		$path = dirname( __DIR__, 2 ) . '/' . $relative_path;
+
+		$this->assertFileExists( $path );
+
+		return (string) file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
+	 * The WPForms field translates its labels in the constructor, so it must not
+	 * be built on `wpforms_loaded` (which fires during `plugins_loaded`).
+	 */
+	public function test_wpforms_field_is_registered_on_init() {
+		$source = $this->source( 'inc/classes/wpforms/class-wpforms-integration.php' );
+
+		$this->assertStringNotContainsString( "add_action( 'wpforms_loaded'", $source );
+		$this->assertStringContainsString( "add_action( 'init', array( \$this, 'init_godam_video_field' ) )", $source );
+	}
+
+	/**
+	 * Same for the Fluent Forms recorder field, previously built on
+	 * `fluentform/loaded`.
+	 */
+	public function test_fluentforms_field_is_registered_on_init() {
+		$source = $this->source( 'inc/classes/fluentforms/class-init.php' );
+
+		$this->assertStringNotContainsString( "add_action( 'fluentform/loaded'", $source );
+		$this->assertStringContainsString( "add_action( 'init', array( \$this, 'on_fluentforms_loaded' ) )", $source );
+	}
+
+	/**
+	 * The add-on compatibility warning builds translated notice text, so it runs
+	 * on `admin_init` rather than inline during `plugins_loaded`.
+	 */
+	public function test_addon_compatibility_warning_runs_on_admin_init() {
+		$source = $this->source( 'inc/classes/addons/class-addon-registry.php' );
+
+		$this->assertStringNotContainsString( '$this->warn_incompatible_addons();', $source );
+		$this->assertStringContainsString( "add_action( 'admin_init', array( \$this, 'warn_incompatible_addons' ) )", $source );
+	}
+
+	/**
+	 * Add-on boot notices are built by a callback at render time, so nothing in
+	 * `boot_addons()` translates during `plugins_loaded`.
+	 */
+	public function test_addon_boot_notices_are_deferred() {
+		$source = $this->source( 'inc/classes/addons/class-addon-registry.php' );
+
+		$this->assertStringContainsString( 'private function show_admin_notice( callable $message_callback )', $source );
+	}
+}

--- a/tests/php/EarlyTranslationHooksTest.php
+++ b/tests/php/EarlyTranslationHooksTest.php
@@ -36,14 +36,39 @@ class EarlyTranslationHooksTest extends TestCase {
 	}
 
 	/**
+	 * Pattern matching `add_action( '<hook>', … '<callback>' … )`, tolerating
+	 * whitespace, short array syntax and extra arguments, so that a harmless
+	 * reformat does not fail the guard.
+	 *
+	 * @param string $hook     Hook name.
+	 * @param string $callback Method name.
+	 *
+	 * @return string
+	 */
+	private function registration_pattern( $hook, $callback ) {
+		return '/add_action\(\s*[\'"]' . preg_quote( $hook, '/' ) . '[\'"][^)]*[\'"]' . preg_quote( $callback, '/' ) . '[\'"]/';
+	}
+
+	/**
+	 * Pattern matching any registration on the given hook, whatever the callback.
+	 *
+	 * @param string $hook Hook name.
+	 *
+	 * @return string
+	 */
+	private function hook_pattern( $hook ) {
+		return '/add_action\(\s*[\'"]' . preg_quote( $hook, '/' ) . '[\'"]/';
+	}
+
+	/**
 	 * The WPForms field translates its labels in the constructor, so it must not
 	 * be built on `wpforms_loaded` (which fires during `plugins_loaded`).
 	 */
 	public function test_wpforms_field_is_registered_on_init() {
 		$source = $this->source( 'inc/classes/wpforms/class-wpforms-integration.php' );
 
-		$this->assertStringNotContainsString( "add_action( 'wpforms_loaded'", $source );
-		$this->assertStringContainsString( "add_action( 'init', array( \$this, 'init_godam_video_field' ) )", $source );
+		$this->assertDoesNotMatchRegularExpression( $this->hook_pattern( 'wpforms_loaded' ), $source );
+		$this->assertMatchesRegularExpression( $this->registration_pattern( 'init', 'init_godam_video_field' ), $source );
 	}
 
 	/**
@@ -53,8 +78,8 @@ class EarlyTranslationHooksTest extends TestCase {
 	public function test_fluentforms_field_is_registered_on_init() {
 		$source = $this->source( 'inc/classes/fluentforms/class-init.php' );
 
-		$this->assertStringNotContainsString( "add_action( 'fluentform/loaded'", $source );
-		$this->assertStringContainsString( "add_action( 'init', array( \$this, 'on_fluentforms_loaded' ) )", $source );
+		$this->assertDoesNotMatchRegularExpression( $this->hook_pattern( 'fluentform/loaded' ), $source );
+		$this->assertMatchesRegularExpression( $this->registration_pattern( 'init', 'on_fluentforms_loaded' ), $source );
 	}
 
 	/**
@@ -64,8 +89,8 @@ class EarlyTranslationHooksTest extends TestCase {
 	public function test_addon_compatibility_warning_runs_on_admin_init() {
 		$source = $this->source( 'inc/classes/addons/class-addon-registry.php' );
 
-		$this->assertStringNotContainsString( '$this->warn_incompatible_addons();', $source );
-		$this->assertStringContainsString( "add_action( 'admin_init', array( \$this, 'warn_incompatible_addons' ) )", $source );
+		$this->assertDoesNotMatchRegularExpression( '/\$this->warn_incompatible_addons\(\s*\)\s*;/', $source );
+		$this->assertMatchesRegularExpression( $this->registration_pattern( 'admin_init', 'warn_incompatible_addons' ), $source );
 	}
 
 	/**
@@ -75,6 +100,9 @@ class EarlyTranslationHooksTest extends TestCase {
 	public function test_addon_boot_notices_are_deferred() {
 		$source = $this->source( 'inc/classes/addons/class-addon-registry.php' );
 
-		$this->assertStringContainsString( 'private function show_admin_notice( callable $message_callback )', $source );
+		$this->assertMatchesRegularExpression(
+			'/function\s+show_admin_notice\(\s*callable\s+\$\w+\s*\)/',
+			$source
+		);
 	}
 }

--- a/tests/php/EarlyTranslationHooksTest.php
+++ b/tests/php/EarlyTranslationHooksTest.php
@@ -2,11 +2,16 @@
 /**
  * Guard against reintroducing #465.
  *
- * Three GoDAM call sites used to translate during `plugins_loaded`, which makes
- * WordPress 6.7+ log `_load_textdomain_just_in_time was called incorrectly` and,
- * with WP_DEBUG_DISPLAY on, print that notice into the page. Core reports only
- * the first such call per text domain per request, so a regression in any one of
- * these is easy to miss by eye. These assertions read the source directly.
+ * Four GoDAM call sites used to translate before `init` — three during
+ * `plugins_loaded`, one at plugin file load — which makes WordPress 6.7+ log
+ * `_load_textdomain_just_in_time was called incorrectly` and, with
+ * WP_DEBUG_DISPLAY on, print that notice into the page.
+ *
+ * Core reports only the first such call per text domain per request, so a
+ * regression in any one of these is easy to miss by eye. The media-column site
+ * is worse still: it only translates once the cached API key data is over an
+ * hour old, so it reads as clean on almost every request even with a `gettext`
+ * filter attached. These assertions read the source directly instead.
  *
  * @package GoDAM
  */
@@ -102,6 +107,27 @@ class EarlyTranslationHooksTest extends TestCase {
 
 		$this->assertMatchesRegularExpression(
 			'/function\s+show_admin_notice\(\s*callable\s+\$\w+\s*\)/',
+			$source
+		);
+	}
+
+	/**
+	 * The media list table column is registered on `admin_init`, not at file
+	 * load. Deciding whether to register it resolves the API key, which can call
+	 * `rtgodam_verify_api_key()` and translate, so a file-scope call translated
+	 * before `init`.
+	 */
+	public function test_media_status_columns_are_registered_on_admin_init() {
+		$source = $this->source( 'admin/godam-transcoder-functions.php' );
+
+		// File scope, not a call inside a function: those are always indented.
+		$this->assertDoesNotMatchRegularExpression(
+			'/^\$\w+\s*=\s*rtgodam_get_user_data\(/m',
+			$source
+		);
+
+		$this->assertMatchesRegularExpression(
+			$this->registration_pattern( 'admin_init', 'rtgodam_register_media_status_columns' ),
 			$source
 		);
 	}


### PR DESCRIPTION
## What?

Fixes every GoDAM call site that translated during `plugins_loaded`, which WordPress 6.7+ reports as `_load_textdomain_just_in_time was called incorrectly`.

Closes #465.

## Why it kept coming back

Core reports this **at most once per text domain per request**: `get_translations_for_domain()` parks a `NOOP_Translations` object in `$l10n[$domain]` after the first attempt, so every later early call short-circuits and never reaches `_load_textdomain_just_in_time()`. Fixing the reported call site just uncovers the next one, which is why the issue has looked "already fixed" more than once since June 2025.

So instead of following the notice, I traced **every** early translation call with a temporary `gettext` filter. Four call sites, all reachable on a default install:

| Call site | Ran on | Fix |
|---|---|---|
| `WPForms_Integration::init_godam_video_field()` → field constructor translates labels | `wpforms_loaded` | moved to `init`, where WPForms registers its own fields |
| `FluentForms\Init::on_fluentforms_loaded()` → `Recorder_Field::__construct()` | `fluentform/loaded` | moved to `init` |
| `Addon_Registry::warn_incompatible_addons()` | `plugins_loaded` (15) | moved to `admin_init`: admin-only anyway, and late enough to translate |
| `Addon_Registry::boot_addons()`, both notice branches | `plugins_loaded` (15) | notice text is now a callback, built when the notice renders |

The first two are the change from #915 by @mi5t4n, which this PR supersedes (that PR is correct, it just could not close the issue on its own; the `Addon_Registry` code did not exist yet when it was opened).

`Abstract_Addon::get_dependencies()` is asked for during `plugins_loaded`, so a `'message'` may now be a callback and is resolved in `get_missing_dependency_messages()`. Plain strings still work, so no add-on breaks.

Add-on side: rtCamp/godam-for-woo#188 uses the callback for the `godam-for-woo` domain, which had the same problem.

## Testing instructions

Site: WP 7.0.2, `WP_DEBUG` + `WP_DEBUG_DISPLAY` on, Query Monitor active, with Fluent Forms, WPForms Lite, Everest Forms, Gravity Forms, WooCommerce and GoDAM for WooCommerce active.

1. Load the front page, Dashboard, Plugins, GoDAM settings, Media, the block editor and `/wp-json/`. No `Translation loading for the godam domain` notice on any of them (before this PR it appears on all of them).
2. WPForms: the GoDAM video field still appears in the form builder and saves. `wpforms_builder_fields_buttons` and `wpforms_field_properties` still carry the GoDAM callbacks after `init`.
3. Fluent Forms: the recorder field still appears in the builder and renders on the front end. `fluentform/editor_components`, `fluentform/form_input_types`, `fluentform/render_item_godam-recorder-field` and both `wp_ajax*_ff_godam_recorder_upload` handlers are all still registered.
4. Add-on notices, all three still render with unchanged text:
   - deactivate WooCommerce → "GoDAM for Woo requires WooCommerce…"
   - register an add-on with a minimum GoDAM version higher than installed → "… requires GoDAM x.y.z or higher"
   - filter `godam_addon_minimum_compatible_versions` so GoDAM for WooCommerce looks out of date → the update notice on Dashboard and Plugins

Note: the notice only fires when WordPress can resolve a translation path for the domain, so on a site with no language files for `godam` you may see nothing either way. Verified in both `en_US` and `de_DE`.

## Tests

- `AddonDependencyMessagesTest` covers callable and string messages, and asserts the dependency check itself never builds the message (the actual regression).
- `EarlyTranslationHooksTest` asserts the four hook timings directly, so a regression fails CI instead of hiding behind another domain's notice.

`vendor/bin/phpunit`: 53 tests, 121 assertions, green. `npm run lint:php`: clean.

## Automation impact

No UI or markup changes, no new or changed selectors. Existing E2E flows for the WPForms and Fluent Forms recorder fields are unaffected, though they now exercise fields registered on `init`.

## Review follow-up (3014bf7)

Copilot's four points, all addressed:

- `show_admin_notice()` returns early when `! is_admin()`, so front-end, REST and cron requests no longer queue an `admin_notices` callback that can never run.
- The callback result is cast to string before the empty check, so `null`/`false` is a no-op rather than a `wp_kses_post()` warning.
- Dependency callbacks are invoked directly instead of via `call_user_func()`. Related hazard found while doing it: `is_callable()` is true for a string matching a function name, so a message like `'phpversion'` would have been executed. The message is now only invoked when it is a non-string callable, covered by a test.
- The hook-timing guard tests are regex-based, so reformatting no longer fails them while a renamed hook or callback still does.

## Cross-version check with the add-on

Released GoDAM 2.1.0 paired with rtCamp/godam-for-woo#188 fatals wp-admin when WooCommerce is inactive, because 2.1.0 passes the callback straight to `wp_kses_post()`. That is a constraint on the add-on release, not on this PR: this PR must ship first, and the add-on bumps `GODAM_WOO_MIN_GODAM_VERSION` to this release in its own version bump. Details and the verified matrix are in rtCamp/godam-for-woo#188.
