### PR TITLE
feat(analytics): Viewer Reach, KPI tiles and per-type metrics on the layer panels (W7–W11)

### DIFF
--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -1013,6 +1013,14 @@ class Pages {
 						$entry['entries_url'] = $entries_url;
 					}
 
+					// Poll layers additionally carry the wp-polls id so the
+					// analytics panel can fetch that poll's answer distribution.
+					// The votes live in wp-polls' own tables, so this id is the
+					// only handle the React side has on them.
+					if ( 'poll' === $saved_layer['type'] && ! empty( $saved_layer['poll_id'] ) ) {
+						$entry['pollId'] = absint( $saved_layer['poll_id'] );
+					}
+
 					$active_layer_config[] = $entry;
 				}
 			}

--- a/inc/classes/rest-api/class-polls.php
+++ b/inc/classes/rest-api/class-polls.php
@@ -48,6 +48,32 @@ class Polls extends Base {
 					),
 				),
 			),
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/poll/(?P<id>\d+)/results',
+				'args'      => array(
+					array(
+						'methods'             => \WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_poll_results' ),
+						// Analytics read, so it is gated to users who can open the
+						// analytics dashboard (authors and above, matching the menu's
+						// `upload_files` capability). Vote tallies are aggregate
+						// reporting data, not public page content.
+						'permission_callback' => function () {
+							return current_user_can( 'upload_files' );
+						},
+						'args'                =>
+							array(
+								'id' => array(
+									'description'       => __( 'The ID of the Poll.', 'godam' ),
+									'type'              => 'integer',
+									'required'          => true,
+									'sanitize_callback' => 'absint',
+								),
+							),
+					),
+				),
+			),
 		);
 	}
 
@@ -105,6 +131,135 @@ class Polls extends Base {
 		);
 
 		return rest_ensure_response( $return_object );
+	}
+
+	/**
+	 * Get one poll's answer distribution, for the Poll layer analytics panel.
+	 *
+	 * The tallies belong to the WP Polls plugin, which stores them per poll in
+	 * its own tables. They are therefore poll-wide: every vote on this poll from
+	 * anywhere on the site, with no way to attribute a vote to a video or a date
+	 * range. GoDAM's own `voted` analytics event records that a vote happened but
+	 * not which answer was chosen, so this is the only source available. The UI
+	 * states the limitation next to the chart.
+	 *
+	 * Answers are returned in the plugin's own display order (`polla_aid`), so
+	 * the chart matches what a visitor sees in the poll itself.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_poll_results( $request ) {
+		global $wpdb;
+
+		if ( ! $this->is_poll_plugin_active() ) {
+			return new \WP_Error( 'poll_plugin_not_active', __( 'Poll plugin is not active.', 'godam' ), array( 'status' => 404 ) );
+		}
+
+		$poll_id = absint( $request->get_param( 'id' ) );
+
+		if ( empty( $poll_id ) ) {
+			return new \WP_Error( 'invalid_poll_id', __( 'Invalid poll ID.', 'godam' ), array( 'status' => 404 ) );
+		}
+
+		$cache_key   = 'poll_results_' . $poll_id;
+		$cache_group = 'godam_polls';
+
+		$results = wp_cache_get( $cache_key, $cache_group );
+
+		if ( false === $results ) {
+			// Direct query: wp-polls keeps answers in its own custom tables, so
+			// there is no WP API for this. `$wpdb->pollsa` is registered by the
+			// plugin; guard on it in case a future version drops the alias.
+			$answers_table  = isset( $wpdb->pollsa ) ? $wpdb->pollsa : '';
+			$question_table = isset( $wpdb->pollsq ) ? $wpdb->pollsq : '';
+
+			if ( empty( $answers_table ) ) {
+				return new \WP_Error( 'poll_tables_missing', __( 'Poll data is unavailable.', 'godam' ), array( 'status' => 404 ) );
+			}
+
+			$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery -- direct query is needed because custom table.
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name comes from $wpdb, not from input.
+					"SELECT polla_aid, polla_answers, polla_votes FROM {$answers_table} WHERE polla_qid = %d ORDER BY polla_aid ASC",
+					$poll_id
+				)
+			);
+
+			$question = '';
+			if ( ! empty( $question_table ) ) {
+				$question = (string) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery -- direct query is needed because custom table.
+					$wpdb->prepare(
+						// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name comes from $wpdb, not from input.
+						"SELECT pollq_question FROM {$question_table} WHERE pollq_id = %d",
+						$poll_id
+					)
+				);
+			}
+
+			$shaped = self::shape_poll_answers( $rows );
+
+			$results = array(
+				'id'          => $poll_id,
+				'question'    => wp_strip_all_tags( $question ),
+				'answers'     => $shaped['answers'],
+				'total_votes' => $shaped['total_votes'],
+			);
+
+			wp_cache_set( $cache_key, $results, $cache_group, 5 * MINUTE_IN_SECONDS );
+		}
+
+		return rest_ensure_response( $results );
+	}
+
+	/**
+	 * Shape raw wp-polls answer rows into the API's answer list plus a total.
+	 *
+	 * Split out from the route so the tallying is unit-testable without a
+	 * WordPress install. Every field is coerced rather than trusted: wp-polls
+	 * stores answers as the poll author entered them, including any markup, and
+	 * a third-party table can hold anything at all.
+	 *
+	 * Rows with no usable answer text are dropped, since a nameless bar is not
+	 * renderable, but their votes still count toward the total so the caption
+	 * does not under-report the poll.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $rows Rows from the wp-polls answers table.
+	 * @return array{answers:array,total_votes:int} Shaped answers and their total.
+	 */
+	public static function shape_poll_answers( $rows ) {
+		$answers     = array();
+		$total_votes = 0;
+
+		foreach ( (array) $rows as $row ) {
+			$row = is_array( $row ) ? (object) $row : $row;
+			if ( ! is_object( $row ) ) {
+				continue;
+			}
+
+			$votes        = isset( $row->polla_votes ) ? absint( $row->polla_votes ) : 0;
+			$total_votes += $votes;
+
+			$answer = isset( $row->polla_answers ) ? wp_strip_all_tags( (string) $row->polla_answers ) : '';
+			if ( '' === $answer ) {
+				continue;
+			}
+
+			$answers[] = array(
+				'id'     => isset( $row->polla_aid ) ? absint( $row->polla_aid ) : 0,
+				'answer' => $answer,
+				'votes'  => $votes,
+			);
+		}
+
+		return array(
+			'answers'     => $answers,
+			'total_votes' => $total_votes,
+		);
 	}
 
 	/**

--- a/pages/analytics/VideoLayerTimeline.js
+++ b/pages/analytics/VideoLayerTimeline.js
@@ -103,13 +103,19 @@ const VideoLayerTimeline = ( { attachmentID, videoDuration } ) => {
 	const [ range, setRange ] = useState( () => spanDays( 7 ) );
 	const siteUrl = window.location.origin;
 
-	const { parents, isLoading, errorType, errorMessage, videoConversion } =
-		useVideoLayerData( {
-			videoId: attachmentID,
-			siteUrl,
-			startDate: range.startDate,
-			endDate: range.endDate,
-		} );
+	const {
+		parents,
+		isLoading,
+		errorType,
+		errorMessage,
+		videoConversion,
+		retentionArray,
+	} = useVideoLayerData( {
+		videoId: attachmentID,
+		siteUrl,
+		startDate: range.startDate,
+		endDate: range.endDate,
+	} );
 
 	// Cumulative video conversion — same metric as the Dashboard's per-video
 	// column, scoped to this video and the selected range. Hidden when there
@@ -239,6 +245,9 @@ const VideoLayerTimeline = ( { attachmentID, videoDuration } ) => {
 							<LayerDetailPanel
 								parent={ selectedParent }
 								attachmentID={ attachmentID }
+								retentionArray={ retentionArray }
+								range={ range }
+								siteUrl={ siteUrl }
 							/>
 						</div>
 					) }

--- a/pages/analytics/hooks/useLayerKpiComparison.js
+++ b/pages/analytics/hooks/useLayerKpiComparison.js
@@ -1,0 +1,150 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useFetchAnalyticsDataQuery,
+	useFetchProcessedLayerAnalyticsQuery,
+} from '../redux/api/analyticsApi';
+import { groupRows, indexActiveConfig, readActiveLayerConfig } from './useVideoLayerData';
+import { buildLayerKpis } from '../timeline/layerKpis';
+import {
+	parseRetentionArray,
+	percentDelta,
+	previousRange,
+	spanLengthInDays,
+} from '../timeline/reach';
+
+/**
+ * Period-over-period deltas for the layer panel that is currently open.
+ *
+ * The layer endpoint has no `%change` field of its own (godam-analytics #234
+ * added period-over-period only to the dashboard KPIs), so the comparison is
+ * computed here from a second read of the previous equal-length window.
+ *
+ * Scoped to the **selected** layer on purpose. `useVideoLayerData` already fires
+ * one request per layer type; fetching a previous window for all five would
+ * double a five-request fan-out behind a proxy with a bounded timeout, to
+ * produce numbers that are only ever visible inside one open panel. So this
+ * fetches exactly two things, and only while a panel is open: the previous
+ * window for that layer's type, and the previous window's retention array for
+ * the reach delta.
+ *
+ * Returns nulls (which hide the badges) rather than zeros whenever a comparison
+ * is not available: an All Time range has no previous window, and a layer that
+ * did not exist in the previous window has no previous row.
+ *
+ * @param {Object}        params
+ * @param {number|string} params.videoId     WP attachment ID.
+ * @param {string}        params.siteUrl     site_url query param.
+ * @param {Object|null}   params.layer       Selected parent layer entry from useVideoLayerData.
+ * @param {Object}        params.range       Current range: { startDate, endDate }.
+ * @param {Object|null}   params.currentKpis buildLayerKpis() result for the current range.
+ * @return {{reachDelta:number|null, primaryDelta:number|null, spanDays:number|null, isLoading:boolean}} Deltas.
+ */
+export function useLayerKpiComparison( {
+	videoId,
+	siteUrl,
+	layer,
+	range,
+	currentKpis,
+} ) {
+	const previous = useMemo( () => previousRange( range || {} ), [ range ] );
+	const layerType = layer?.layer_type || null;
+	const layerId = layer?.id || null;
+
+	// One extra layer-type read, and one extra payload read for the reach
+	// baseline. Both skipped entirely at All Time (no previous window) and
+	// whenever no panel is open.
+	const skip = ! videoId || ! previous || ! layerType;
+
+	const previousLayers = useFetchProcessedLayerAnalyticsQuery(
+		{
+			layerType,
+			startDate: previous?.startDate,
+			endDate: previous?.endDate,
+			siteUrl,
+			videoId,
+		},
+		{ skip },
+	);
+
+	const previousAnalytics = useFetchAnalyticsDataQuery(
+		{
+			videoId,
+			siteUrl,
+			startDate: previous?.startDate,
+			endDate: previous?.endDate,
+		},
+		{ skip },
+	);
+
+	const spanDays = useMemo( () => {
+		if ( ! previous ) {
+			return null;
+		}
+		const [ y, m, d ] = previous.startDate.split( '-' ).map( Number );
+		const [ ey, em, ed ] = previous.endDate.split( '-' ).map( Number );
+		return spanLengthInDays(
+			new Date( y, m - 1, d ),
+			new Date( ey, em - 1, ed ),
+		);
+	}, [ previous ] );
+
+	const previousKpis = useMemo( () => {
+		if ( skip || ! layerId ) {
+			return null;
+		}
+		const rows = previousLayers.data?.layer_analytics?.individual_layers;
+		if ( ! Array.isArray( rows ) || rows.length === 0 ) {
+			return null;
+		}
+
+		// Reuse the same grouping the current window goes through, so the
+		// previous counts are derived identically (parent aggregation,
+		// sub-hotspot folding, no_action) and the delta compares like with like.
+		const configIndex = indexActiveConfig( readActiveLayerConfig() );
+		const grouped = groupRows( rows, layerType, configIndex );
+		const match = grouped.find( ( entry ) => entry.id === layerId );
+		if ( ! match ) {
+			return null;
+		}
+
+		return buildLayerKpis( {
+			layerType,
+			counts: match.counts,
+			noAction: match.no_action,
+			retentionArray: parseRetentionArray(
+				previousAnalytics.data?.all_time_heatmap,
+			),
+			// The layer's position in the previous window, not today's: a layer
+			// that was moved should be compared where it actually sat then.
+			timestamp: match.timestamp,
+		} );
+	}, [
+		skip,
+		layerId,
+		layerType,
+		previousLayers.data,
+		previousAnalytics.data,
+	] );
+
+	return {
+		reachDelta: percentDelta(
+			currentKpis?.donut?.reach,
+			previousKpis?.donut?.reach,
+		),
+		primaryDelta: percentDelta(
+			currentKpis?.primary?.value,
+			previousKpis?.primary?.value,
+		),
+		spanDays,
+		isLoading: ! skip && ( previousLayers.isFetching || previousAnalytics.isFetching ),
+	};
+}
+
+export default useLayerKpiComparison;

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -12,10 +12,12 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
+	useFetchAnalyticsDataQuery,
 	useFetchProcessedLayerAnalyticsQuery,
 	useFetchProcessedAnalyticsHistoryQuery,
 } from '../redux/api/analyticsApi';
 import { LAYER_TYPE_BY_ID, FORM_TYPE_LABELS } from '../constants/layerTypes';
+import { parseRetentionArray } from '../timeline/reach';
 
 /**
  * Parse layer_metadata which the microservice returns as a JSON string
@@ -210,7 +212,7 @@ function resolveLayerName( rawName, meta, timestamp, formType ) {
  *
  * @return {Array<{id:string,type:string,subIds?:string[]}>|null} Layer config or null.
  */
-function readActiveLayerConfig() {
+export function readActiveLayerConfig() {
 	if (
 		typeof window === 'undefined' ||
 		! window.godamAnalyticsConfig ||
@@ -227,12 +229,13 @@ function readActiveLayerConfig() {
  * @param {Array|null} config readActiveLayerConfig() result.
  * @return {{activeParentIds:Set<string>|null, activeSubIdsByParent:Map<string,Set<string>>}} Lookup helpers.
  */
-function indexActiveConfig( config ) {
+export function indexActiveConfig( config ) {
 	if ( ! config ) {
 		return {
 			activeParentIds: null,
 			activeSubIdsByParent: new Map(),
 			entriesUrlByParent: new Map(),
+			pollIdByParent: new Map(),
 		};
 	}
 	const activeParentIds = new Set();
@@ -241,6 +244,10 @@ function indexActiveConfig( config ) {
 	// PHP builds the URL (admin_url + the saved integration id); we just carry
 	// it through to the detail panel.
 	const entriesUrlByParent = new Map();
+	// parent layer id -> wp-polls poll id (poll layers only). The answer
+	// distribution lives in the wp-polls tables, so this id is the panel's only
+	// handle on it.
+	const pollIdByParent = new Map();
 	config.forEach( ( entry ) => {
 		if ( ! entry?.id ) {
 			return;
@@ -252,8 +259,11 @@ function indexActiveConfig( config ) {
 		if ( entry.entries_url ) {
 			entriesUrlByParent.set( entry.id, entry.entries_url );
 		}
+		if ( entry.pollId ) {
+			pollIdByParent.set( entry.id, Number( entry.pollId ) );
+		}
 	} );
-	return { activeParentIds, activeSubIdsByParent, entriesUrlByParent };
+	return { activeParentIds, activeSubIdsByParent, entriesUrlByParent, pollIdByParent };
 }
 
 /**
@@ -511,6 +521,7 @@ export function groupRows( rows, layerType, configIndex ) {
 			// wp-admin link to this form's entries / poll's results, when the
 			// integration has one (empty string otherwise → link hidden).
 			entries_url: configIndex.entriesUrlByParent?.get( parentId ) || '',
+			poll_id: configIndex.pollIdByParent?.get( parentId ) || null,
 		} );
 	} );
 
@@ -532,7 +543,7 @@ export function groupRows( rows, layerType, configIndex ) {
  * @param {string}        params.siteUrl   site_url query param.
  * @param {?string}       params.startDate ISO start date (null = All Time).
  * @param {?string}       params.endDate   ISO end date (null = All Time).
- * @return {Object} { parents, isLoading, errorType, errorMessage }.
+ * @return {Object} { parents, isLoading, errorType, errorMessage, videoConversion, retentionArray }.
  */
 export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 	// One RTK Query hook per layer type. React's rules-of-hooks forbid
@@ -568,6 +579,30 @@ export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 	const history = useFetchProcessedAnalyticsHistoryQuery(
 		{ startDate, endDate, videoId, siteUrl },
 		{ skip: ! videoId },
+	);
+
+	// Per-second retention for the SAME range as the layer data above, which is
+	// where Viewer Reach comes from (see timeline/reach.js). The microservice
+	// sums the per-day heatmaps server-side in range mode (godam-analytics #235),
+	// so this is the identical array the Viewer Retention Curve draws and the
+	// reach tile can never disagree with the chart on the same page.
+	//
+	// At All Time the date args are omitted, so RTK shares Analytics.js's
+	// all-time cache key and this costs no extra request; a bounded range forks
+	// into one request of its own per range change.
+	const rangedAnalytics = useFetchAnalyticsDataQuery(
+		{
+			videoId,
+			siteUrl,
+			...( startDate ? { startDate } : {} ),
+			...( endDate ? { endDate } : {} ),
+		},
+		{ skip: ! videoId },
+	);
+
+	const retentionArray = useMemo(
+		() => parseRetentionArray( rangedAnalytics.data?.all_time_heatmap ),
+		[ rangedAnalytics.data ],
 	);
 
 	const videoConversion = useMemo( () => {
@@ -673,5 +708,6 @@ export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 		errorType: allErrored ? firstErrorPayload?.errorType : null,
 		errorMessage: allErrored ? firstErrorPayload?.message : null,
 		videoConversion,
+		retentionArray,
 	};
 }

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -581,6 +581,13 @@ export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 		{ skip: ! videoId },
 	);
 
+	const isLoading =
+		cta.isLoading || cta.isFetching ||
+		form.isLoading || form.isFetching ||
+		hotspot.isLoading || hotspot.isFetching ||
+		poll.isLoading || poll.isFetching ||
+		woo.isLoading || woo.isFetching;
+
 	// Per-second retention for the SAME range as the layer data above, which is
 	// where Viewer Reach comes from (see timeline/reach.js). The microservice
 	// sums the per-day heatmaps server-side in range mode (godam-analytics #235),
@@ -590,6 +597,16 @@ export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 	// At All Time the date args are omitted, so RTK shares Analytics.js's
 	// all-time cache key and this costs no extra request; a bounded range forks
 	// into one request of its own per range change.
+	//
+	// Deliberately queued BEHIND the layer reads rather than fired alongside
+	// them. Each of these REST calls occupies a PHP worker for the whole
+	// microservice round-trip, and this page already fires five layer reads plus
+	// history plus the all-time payload on mount. Adding a further concurrent
+	// request tips a small FPM pool (a stock Local install, or a modest shared
+	// host) into queueing, and then nothing on the page resolves at all.
+	//
+	// Nothing is lost by waiting: reach is only rendered inside the detail
+	// panel, which itself cannot appear until the layer reads have landed.
 	const rangedAnalytics = useFetchAnalyticsDataQuery(
 		{
 			videoId,
@@ -597,7 +614,7 @@ export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 			...( startDate ? { startDate } : {} ),
 			...( endDate ? { endDate } : {} ),
 		},
-		{ skip: ! videoId },
+		{ skip: ! videoId || isLoading },
 	);
 
 	const retentionArray = useMemo(
@@ -625,13 +642,6 @@ export function useVideoLayerData( { videoId, siteUrl, startDate, endDate } ) {
 			converting: totals.converting,
 		};
 	}, [ history.data ] );
-
-	const isLoading =
-		cta.isLoading || cta.isFetching ||
-		form.isLoading || form.isFetching ||
-		hotspot.isLoading || hotspot.isFetching ||
-		poll.isLoading || poll.isFetching ||
-		woo.isLoading || woo.isFetching;
 
 	// Soft errors come back as { errorType, message } from the proxy
 	// transformResponse. Per layer type — if all five are errored we

--- a/pages/analytics/redux/api/analyticsApi.js
+++ b/pages/analytics/redux/api/analyticsApi.js
@@ -114,6 +114,20 @@ export const analyticsApi = createApi( {
 				};
 			},
 		} ),
+		fetchPollResults: builder.query( {
+			query: ( { pollId } ) => ( {
+				url: `godam/v1/poll/${ encodeURIComponent( pollId ) }/results`,
+			} ),
+			transformResponse: ( response ) => ( {
+				answers: Array.isArray( response?.answers ) ? response.answers : [],
+				totalVotes: Number( response?.total_votes ) || 0,
+				question: response?.question || '',
+			} ),
+			// wp-polls being inactive, or the poll having been deleted, is a
+			// normal state rather than a failure: the panel just hides the
+			// distribution. Swallow the 404 so it never surfaces as an error.
+			transformErrorResponse: () => ( { answers: [], totalVotes: 0, question: '' } ),
+		} ),
 	} ),
 } );
 
@@ -121,4 +135,5 @@ export const {
 	useFetchAnalyticsDataQuery,
 	useFetchProcessedAnalyticsHistoryQuery,
 	useFetchProcessedLayerAnalyticsQuery,
+	useFetchPollResultsQuery,
 } = analyticsApi;

--- a/pages/analytics/timeline/LayerDetailPanel.js
+++ b/pages/analytics/timeline/LayerDetailPanel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 /**
  * WordPress dependencies
@@ -17,8 +17,15 @@ import {
 	LAYER_TYPE_BY_ID,
 	withAlpha,
 } from '../constants/layerTypes';
+import { useFetchPollResultsQuery } from '../redux/api/analyticsApi';
+import { useLayerKpiComparison } from '../hooks/useLayerKpiComparison';
+import { buildLayerKpis } from './layerKpis';
 import LayerIcon from './LayerIcon';
 import LayerInteractionFunnel from './LayerInteractionFunnel';
+import LayerKpiTiles from './LayerKpiTiles';
+import LayerReachDonut from './LayerReachDonut';
+import LinkedProducts from './LinkedProducts';
+import PollAnswerDistribution from './PollAnswerDistribution';
 import SubHotspotRail from './SubHotspotRail';
 import LayerModifiedNotice from './LayerModifiedNotice';
 
@@ -71,13 +78,58 @@ function formatTimestamp( seconds ) {
  * Sub-hotspot selection state is owned here — selecting a sub from the
  * rail swaps the funnel data but leaves the rest of the panel intact.
  *
+ * The Viewer Reach donut and the KPI tiles stay at PARENT level even while a
+ * sub-hotspot is selected: reach is a property of the layer's position in the
+ * video, which every sub of a layer shares, and the Figma panels show one set of
+ * headline numbers per layer rather than per sub.
+ *
  * @param {Object}        props
- * @param {Object|null}   props.parent       Currently selected parent layer entry, or null.
- * @param {number|string} props.attachmentID WP attachment ID for the Edit Layer link.
+ * @param {Object|null}   props.parent           Currently selected parent layer entry, or null.
+ * @param {number|string} props.attachmentID     WP attachment ID for the Edit Layer link.
+ * @param {number[]}      [props.retentionArray] Per-second view counts for the selected range.
+ * @param {Object}        [props.range]          Selected range: { startDate, endDate }.
+ * @param {string}        [props.siteUrl]        site_url query param, for the comparison fetch.
  * @return {JSX.Element|null} The detail card, or null when no layer is selected.
  */
-const LayerDetailPanel = ( { parent, attachmentID } ) => {
+const LayerDetailPanel = ( {
+	parent,
+	attachmentID,
+	retentionArray = [],
+	range = {},
+	siteUrl = '',
+} ) => {
 	const [ selectedSubId, setSelectedSubId ] = useState( null );
+
+	// Headline KPIs for the parent layer. Computed before the early returns
+	// below so the hook order stays stable across renders.
+	const kpis = useMemo(
+		() =>
+			parent
+				? buildLayerKpis( {
+					layerType: parent.layer_type,
+					counts: parent.counts,
+					noAction: parent.no_action,
+					retentionArray,
+					timestamp: parent.timestamp,
+				} )
+				: null,
+		[ parent, retentionArray ],
+	);
+
+	const { reachDelta, primaryDelta, spanDays } = useLayerKpiComparison( {
+		videoId: attachmentID,
+		siteUrl,
+		layer: parent,
+		range,
+		currentKpis: kpis,
+	} );
+
+	// Poll answer distribution comes from wp-polls, not from analytics. Skipped
+	// for every other layer type and for poll layers with no saved poll id.
+	const pollResults = useFetchPollResultsQuery(
+		{ pollId: parent?.poll_id },
+		{ skip: parent?.layer_type !== 'poll' || ! parent?.poll_id },
+	);
 
 	// Whenever the selected parent changes, reset to the aggregate view.
 	useEffect( () => {
@@ -202,6 +254,33 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 				/>
 			) }
 
+			{ /* Linked Products (Woo only) — the products this layer points at,
+			    named and thumbnailed from the event metadata the Woo player
+			    already emits. Sits above the metrics, matching Figma W11. */ }
+			{ parent.layer_type === 'woo' && (
+				<LinkedProducts subHotspots={ parent.sub_hotspots } />
+			) }
+
+			{ /* Headline metrics: Viewer Reach donut beside the KPI tiles.
+			    Both are parent-level even when a sub-hotspot is selected. */ }
+			{ kpis && (
+				<div className="grid gap-4 px-6 pt-5 grid-cols-1 md:grid-cols-[minmax(200px,260px)_minmax(0,1fr)] md:items-center">
+					<LayerReachDonut
+						reach={ kpis.donut.reach }
+						arcAction={ kpis.donut.arcAction }
+						arcValue={ kpis.donut.arcValue }
+						arcShare={ kpis.donut.arcShare }
+						delta={ reachDelta }
+						spanDays={ spanDays }
+					/>
+					<LayerKpiTiles
+						kpis={ kpis }
+						primaryDelta={ primaryDelta }
+						spanDays={ spanDays }
+					/>
+				</div>
+			) }
+
 			{ /* Body. Single column on mobile (the sub-hotspot rail stacks
 			    above the funnel); two columns from md up. Avoids the rail +
 			    funnel overflowing on narrow screens. */ }
@@ -226,6 +305,17 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 					noAction={ funnelNoAction }
 				/>
 			</div>
+
+			{ /* Poll answer distribution, from the wp-polls tables. */ }
+			{ parent.layer_type === 'poll' && !! parent.poll_id && (
+				<div className="px-6 pb-6">
+					<PollAnswerDistribution
+						answers={ pollResults.data?.answers }
+						totalVotes={ pollResults.data?.totalVotes }
+						isLoading={ pollResults.isLoading }
+					/>
+				</div>
+			) }
 		</section>
 	);
 };

--- a/pages/analytics/timeline/LayerDetailPanel.js
+++ b/pages/analytics/timeline/LayerDetailPanel.js
@@ -267,7 +267,7 @@ const LayerDetailPanel = ( {
 				<div className="grid gap-4 px-6 pt-5 grid-cols-1 md:grid-cols-[minmax(200px,260px)_minmax(0,1fr)] md:items-center">
 					<LayerReachDonut
 						reach={ kpis.donut.reach }
-						arcAction={ kpis.donut.arcAction }
+						arcLabel={ kpis.donut.arcLabel }
 						arcValue={ kpis.donut.arcValue }
 						arcShare={ kpis.donut.arcShare }
 						delta={ reachDelta }

--- a/pages/analytics/timeline/LayerKpiTiles.js
+++ b/pages/analytics/timeline/LayerKpiTiles.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import InfoTooltip from './InfoTooltip';
+import TrendBadge from './TrendBadge';
+
+/**
+ * Format a resolved KPI value for display.
+ *
+ * Rates get one decimal and a % sign; counts get full numbers with thousands
+ * separators (no 1.2K abbreviation and no hover-to-reveal, per the 2.0 number
+ * treatment). A null value means "not knowable for this range" and renders an
+ * em-less dash rather than 0, so an unknown never reads as a measured zero.
+ *
+ * @param {Object}      tile       Resolved tile.
+ * @param {string}      tile.kind  'rate' | 'count' | 'reachRate'.
+ * @param {number|null} tile.value Resolved value.
+ * @return {string} Display string.
+ */
+export function formatKpiValue( { kind, value } ) {
+	if ( value === null || value === undefined || ! Number.isFinite( Number( value ) ) ) {
+		return '-';
+	}
+	const num = Number( value );
+	if ( kind === 'count' ) {
+		return num.toLocaleString();
+	}
+	return `${ +num.toFixed( 1 ) }%`;
+}
+
+/**
+ * One tile. The primary variant spans the full width and carries the trend
+ * badge; secondary tiles sit side by side beneath it.
+ *
+ * @param {Object}      props
+ * @param {Object}      props.tile       Resolved tile from buildLayerKpis.
+ * @param {boolean}     [props.primary]  Render as the wide primary tile.
+ * @param {number|null} [props.delta]    Percentage change, primary only.
+ * @param {number|null} [props.spanDays] Length of the compared window.
+ * @return {JSX.Element} The tile.
+ */
+const KpiTile = ( { tile, primary = false, delta = null, spanDays = null } ) => (
+	<div
+		className={ `rounded-lg border border-zinc-200 bg-white px-4 py-3 ${
+			primary ? 'w-full' : ''
+		}` }
+		data-test-id={ `godam-layer-kpi-${ tile.id }` }
+	>
+		<div className="flex items-center gap-1">
+			<span className="text-xs text-zinc-500">{ tile.label }</span>
+			{ tile.tooltip && <InfoTooltip size={ 13 } text={ tile.tooltip } /> }
+		</div>
+		<div
+			className={ `mt-0.5 font-semibold text-zinc-900 tabular-nums ${
+				primary ? 'text-2xl' : 'text-lg'
+			}` }
+		>
+			{ formatKpiValue( tile ) }
+		</div>
+		{ primary && (
+			<TrendBadge
+				delta={ delta }
+				spanDays={ spanDays }
+				testId={ `godam-layer-kpi-${ tile.id }-trend` }
+			/>
+		) }
+	</div>
+);
+
+/**
+ * KPI tiles for the layer detail panel (Figma W7–W11): one wide headline tile
+ * with a period-over-period badge, and two supporting tiles below it.
+ *
+ * Composition per layer type comes from LAYER_KPI_SPEC, so this component never
+ * branches on `layer_type`.
+ *
+ * @param {Object}      props
+ * @param {Object}      props.kpis           Result of buildLayerKpis().
+ * @param {number|null} [props.primaryDelta] Change in the primary metric vs the previous window.
+ * @param {number|null} [props.spanDays]     Length of the compared window.
+ * @return {JSX.Element|null} The tile grid, or null without KPIs.
+ */
+const LayerKpiTiles = ( { kpis, primaryDelta = null, spanDays = null } ) => {
+	if ( ! kpis ) {
+		return null;
+	}
+
+	return (
+		<div className="flex flex-col gap-3" data-test-id="godam-layer-kpi-tiles">
+			<KpiTile
+				tile={ kpis.primary }
+				primary
+				delta={ primaryDelta }
+				spanDays={ spanDays }
+			/>
+			<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				{ kpis.secondary.map( ( tile ) => (
+					<KpiTile key={ tile.id } tile={ tile } />
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default LayerKpiTiles;
+export { KpiTile };

--- a/pages/analytics/timeline/LayerKpiTiles.test.js
+++ b/pages/analytics/timeline/LayerKpiTiles.test.js
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import { formatKpiValue } from './LayerKpiTiles';
+import { barShade } from './PollAnswerDistribution';
+
+describe( 'formatKpiValue', () => {
+	it( 'renders a rate with one decimal and a percent sign', () => {
+		expect( formatKpiValue( { kind: 'rate', value: 24 } ) ).toBe( '24%' );
+		expect( formatKpiValue( { kind: 'rate', value: 14.23 } ) ).toBe( '14.2%' );
+		expect( formatKpiValue( { kind: 'reachRate', value: 91.96 } ) ).toBe( '92%' );
+	} );
+
+	it( 'renders counts in full, with separators and no abbreviation', () => {
+		// The 2.0 treatment is full numbers: no "1.2K", no hover-to-reveal.
+		expect( formatKpiValue( { kind: 'count', value: 1200 } ) ).toBe(
+			( 1200 ).toLocaleString(),
+		);
+		expect( formatKpiValue( { kind: 'count', value: 0 } ) ).toBe( '0' );
+	} );
+
+	it( 'renders a dash for an unknown value rather than a measured zero', () => {
+		expect( formatKpiValue( { kind: 'rate', value: null } ) ).toBe( '-' );
+		expect( formatKpiValue( { kind: 'count', value: null } ) ).toBe( '-' );
+		expect( formatKpiValue( { kind: 'reachRate', value: undefined } ) ).toBe( '-' );
+		expect( formatKpiValue( { kind: 'rate', value: NaN } ) ).toBe( '-' );
+		expect( formatKpiValue( { kind: 'rate', value: Infinity } ) ).toBe( '-' );
+	} );
+
+	it( 'shows a rate above 100% as measured, without clamping', () => {
+		expect( formatKpiValue( { kind: 'rate', value: 120 } ) ).toBe( '120%' );
+	} );
+} );
+
+describe( 'barShade', () => {
+	it( 'starts at the full admin accent and steps lighter', () => {
+		const first = barShade( 0, 3 );
+		const last = barShade( 2, 3 );
+		expect( first ).toContain( '100%' );
+		expect( first ).toContain( 'var(--wp-admin-theme-color' );
+		expect( last ).toContain( '30%' );
+	} );
+
+	it( 'keeps a single bar at the full accent', () => {
+		expect( barShade( 0, 1 ) ).toContain( '100%' );
+	} );
+
+	it( 'never drops below the legibility floor', () => {
+		for ( let count = 1; count <= 8; count++ ) {
+			for ( let idx = 0; idx < count; idx++ ) {
+				const mix = Number( /(\d+)%/.exec( barShade( idx, count ) )[ 1 ] );
+				expect( mix ).toBeGreaterThanOrEqual( 30 );
+				expect( mix ).toBeLessThanOrEqual( 100 );
+			}
+		}
+	} );
+} );

--- a/pages/analytics/timeline/LayerReachDonut.js
+++ b/pages/analytics/timeline/LayerReachDonut.js
@@ -11,7 +11,6 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { actionLabel } from '../constants/layerTypes';
 import InfoTooltip from './InfoTooltip';
 import TrendBadge from './TrendBadge';
 
@@ -40,7 +39,7 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
  *
  * @param {Object}      props
  * @param {number|null} props.reach      Viewers at the layer's second, or null.
- * @param {string}      props.arcAction  Action filling the ring, e.g. 'clicked'.
+ * @param {string}      props.arcLabel   Display label for the ring's action.
  * @param {number}      props.arcValue   That action's count.
  * @param {number|null} props.arcShare   That action as a percentage of impressions.
  * @param {number|null} [props.delta]    Reach change vs the previous equal window.
@@ -49,7 +48,7 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
  */
 const LayerReachDonut = ( {
 	reach,
-	arcAction,
+	arcLabel,
 	arcValue,
 	arcShare,
 	delta = null,
@@ -81,7 +80,7 @@ const LayerReachDonut = ( {
 						/* translators: 1: viewer reach count, 2: action label, 3: action count. */
 						__( 'Viewer reach %1$s, %2$s %3$s', 'godam' ),
 						Number( reach ).toLocaleString(),
-						actionLabel( arcAction ),
+						arcLabel,
 						Number( arcValue || 0 ).toLocaleString(),
 					) }
 				>
@@ -140,7 +139,7 @@ const LayerReachDonut = ( {
 						background: 'var(--wp-admin-theme-color, #ab3a6c)',
 					} }
 				/>
-				<span>{ actionLabel( arcAction ) }</span>
+				<span>{ arcLabel }</span>
 				<span className="font-medium text-zinc-900 tabular-nums">
 					{ Number( arcValue || 0 ).toLocaleString() }
 				</span>

--- a/pages/analytics/timeline/LayerReachDonut.js
+++ b/pages/analytics/timeline/LayerReachDonut.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { actionLabel } from '../constants/layerTypes';
+import InfoTooltip from './InfoTooltip';
+import TrendBadge from './TrendBadge';
+
+// Geometry. A plain SVG ring drawn with stroke-dasharray, deliberately not d3:
+// one arc needs no scales, no axes and no layout, and this keeps the layer panel
+// free of a charting dependency it would otherwise only use here.
+const SIZE = 168;
+const STROKE = 18;
+const RADIUS = ( SIZE - STROKE ) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+/**
+ * Viewer Reach donut for the layer detail panel (Figma W7–W11).
+ *
+ * The centre is Viewer Reach: how many viewers were still watching when this
+ * layer appeared, read from the retention array. The ring is the layer's
+ * headline action as a share of its own impressions.
+ *
+ * Those two numbers count different populations on purpose, so the ring is
+ * never drawn as a fraction of the centre value. The tooltip spells the
+ * distinction out, and the arc legend shows the action's own tally.
+ *
+ * Renders nothing when reach is unknown (no retention data for the range, or the
+ * layer sits past the length recorded with these events). Hiding beats drawing
+ * an empty ring, which reads as "no viewers reached this layer".
+ *
+ * @param {Object}      props
+ * @param {number|null} props.reach      Viewers at the layer's second, or null.
+ * @param {string}      props.arcAction  Action filling the ring, e.g. 'clicked'.
+ * @param {number}      props.arcValue   That action's count.
+ * @param {number|null} props.arcShare   That action as a percentage of impressions.
+ * @param {number|null} [props.delta]    Reach change vs the previous equal window.
+ * @param {number|null} [props.spanDays] Length of the compared window.
+ * @return {JSX.Element|null} The donut, or null when reach is unknown.
+ */
+const LayerReachDonut = ( {
+	reach,
+	arcAction,
+	arcValue,
+	arcShare,
+	delta = null,
+	spanDays = null,
+} ) => {
+	if ( reach === null || reach === undefined ) {
+		return null;
+	}
+
+	// The ring length is the action's share of impressions, bounded to the
+	// circle for drawing only. A share above 100% (counts that genuinely
+	// disagree) still shows its true value in the legend and the tile.
+	const share = Number.isFinite( Number( arcShare ) ) ? Number( arcShare ) : 0;
+	const drawn = Math.max( 0, Math.min( 100, share ) );
+	const dash = ( drawn / 100 ) * CIRCUMFERENCE;
+
+	return (
+		<div
+			className="flex flex-col items-center gap-2 py-2"
+			data-test-id="godam-layer-reach-donut"
+		>
+			<div className="relative" style={ { width: SIZE, height: SIZE } }>
+				<svg
+					width={ SIZE }
+					height={ SIZE }
+					viewBox={ `0 0 ${ SIZE } ${ SIZE }` }
+					role="img"
+					aria-label={ sprintf(
+						/* translators: 1: viewer reach count, 2: action label, 3: action count. */
+						__( 'Viewer reach %1$s, %2$s %3$s', 'godam' ),
+						Number( reach ).toLocaleString(),
+						actionLabel( arcAction ),
+						Number( arcValue || 0 ).toLocaleString(),
+					) }
+				>
+					{ /* Track. */ }
+					<circle
+						cx={ SIZE / 2 }
+						cy={ SIZE / 2 }
+						r={ RADIUS }
+						fill="none"
+						stroke="color-mix(in srgb, var(--wp-admin-theme-color, #ab3a6c) 18%, white)"
+						strokeWidth={ STROKE }
+					/>
+					{ /* Arc, starting at 12 o'clock. */ }
+					{ dash > 0 && (
+						<circle
+							cx={ SIZE / 2 }
+							cy={ SIZE / 2 }
+							r={ RADIUS }
+							fill="none"
+							stroke="var(--wp-admin-theme-color, #ab3a6c)"
+							strokeWidth={ STROKE }
+							strokeLinecap="round"
+							strokeDasharray={ `${ dash } ${ CIRCUMFERENCE - dash }` }
+							transform={ `rotate(-90 ${ SIZE / 2 } ${ SIZE / 2 })` }
+						/>
+					) }
+				</svg>
+
+				{ /* Centre label. Absolutely positioned rather than an SVG
+				    <text> so it inherits the panel's font stack and the
+				    tooltip button can be a real focusable element. */ }
+				<div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+					<span className="text-2xl font-semibold text-zinc-900 tabular-nums">
+						{ Number( reach ).toLocaleString() }
+					</span>
+					<span className="flex items-center gap-1 text-xs text-zinc-500 pointer-events-auto">
+						{ __( 'Viewer Reach', 'godam' ) }
+						<InfoTooltip
+							size={ 13 }
+							text={ __(
+								'Viewers still watching when this layer appeared, from the same retention data as the Viewer Retention Curve. It counts viewers, while the ring counts this layer\'s own interactions, so the two are not a fraction of one another.',
+								'godam',
+							) }
+						/>
+					</span>
+				</div>
+			</div>
+
+			{ /* Arc legend: which action the ring represents, and its tally. */ }
+			<div className="flex items-center gap-1.5 text-xs text-zinc-600">
+				<span
+					className="inline-block rounded-sm"
+					style={ {
+						width: 9,
+						height: 9,
+						background: 'var(--wp-admin-theme-color, #ab3a6c)',
+					} }
+				/>
+				<span>{ actionLabel( arcAction ) }</span>
+				<span className="font-medium text-zinc-900 tabular-nums">
+					{ Number( arcValue || 0 ).toLocaleString() }
+				</span>
+			</div>
+
+			<TrendBadge
+				delta={ delta }
+				spanDays={ spanDays }
+				testId="godam-layer-reach-trend"
+			/>
+		</div>
+	);
+};
+
+export default LayerReachDonut;

--- a/pages/analytics/timeline/LinkedProducts.js
+++ b/pages/analytics/timeline/LinkedProducts.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Linked Products chips for a Woo layer (Figma W11).
+ *
+ * Lists the products a Woo hotspot layer points at, so the panel names its
+ * subjects before showing the metrics. Name and thumbnail come from the
+ * `layer_metadata` the Woo player already emits with each event
+ * (`product_name`, `product_image`), which is a snapshot from when the event
+ * fired; no extra lookup is made against WooCommerce here.
+ *
+ * Chips carry no per-product metric on purpose. The sub-hotspot rail below is
+ * where per-product performance lives, and the rail's per-sub conversion rate
+ * is still subject to godam-analytics#196 (a sub inherits its parent's
+ * full-range impressions), so duplicating a rate up here would spread a known
+ * caveat across two places.
+ *
+ * Order follows the rail (best-performing first), and renders nothing when the
+ * layer has no sub-hotspot rows for the range.
+ *
+ * @param {Object}   props
+ * @param {Object[]} props.subHotspots Sub-hotspot entries from useVideoLayerData.
+ * @return {JSX.Element|null} The chip row, or null when there are no products.
+ */
+const LinkedProducts = ( { subHotspots } ) => {
+	const products = Array.isArray( subHotspots ) ? subHotspots : [];
+	if ( products.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="px-6 pt-5" data-test-id="godam-layer-linked-products">
+			<h4 className="text-sm font-semibold text-zinc-900 m-0">
+				{ __( 'Linked Products', 'godam' ) }
+			</h4>
+			<ul className="m-0 mt-2 p-0 list-none flex flex-wrap gap-2">
+				{ products.map( ( product ) => (
+					<li
+						key={ product.id }
+						className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 min-w-0"
+						style={ { opacity: product.isActive === false ? 0.55 : 1 } }
+					>
+						{ product.product_image ? (
+							<img
+								src={ product.product_image }
+								alt=""
+								width={ 24 }
+								height={ 24 }
+								className="rounded object-cover shrink-0"
+								style={ { width: 24, height: 24 } }
+							/>
+						) : (
+							<span
+								className="rounded bg-zinc-100 shrink-0"
+								style={ { width: 24, height: 24 } }
+							/>
+						) }
+						<span
+							className="text-xs text-zinc-700 truncate"
+							style={ { maxWidth: 180 } }
+							title={ product.name }
+						>
+							{ product.name }
+						</span>
+						{ product.isActive === false && (
+							<span className="text-[10px] uppercase tracking-wide text-zinc-400 shrink-0">
+								{ __( 'Removed', 'godam' ) }
+							</span>
+						) }
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+};
+
+export default LinkedProducts;

--- a/pages/analytics/timeline/PollAnswerDistribution.js
+++ b/pages/analytics/timeline/PollAnswerDistribution.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InfoTooltip from './InfoTooltip';
+
+/**
+ * Shade for the bar at position `idx` of `count` bars. Same monochrome
+ * admin-theme ramp the interaction funnel uses, so the two charts in one panel
+ * read as one system.
+ *
+ * @param {number} idx   Bar position (0-based).
+ * @param {number} count Total bars.
+ * @return {string} A `color-mix()` value usable as a CSS background.
+ */
+function barShade( idx, count ) {
+	const t = count > 1 ? idx / ( count - 1 ) : 0;
+	const mix = Math.round( 100 - ( t * 70 ) );
+	return `color-mix(in srgb, var(--wp-admin-theme-color, #ab3a6c) ${ mix }%, white)`;
+}
+
+/**
+ * Answer Distribution for a Poll layer (Figma W10).
+ *
+ * The votes belong to the WP Polls plugin, which owns the answers and their
+ * tallies. GoDAM's own `voted` event records that a vote happened but not which
+ * answer was chosen, so this distribution is necessarily **poll-wide**: it
+ * covers every vote on that poll from anywhere on the site, and it cannot be
+ * scoped to this video or to the panel's date range. The caption says so
+ * rather than letting the placement imply otherwise.
+ *
+ * Renders nothing when the poll has no answers, when wp-polls is inactive (the
+ * REST route 404s and the caller passes no answers), or when the layer carries
+ * no poll id. Scoping this properly would need the player to emit the chosen
+ * answer, which is new ingestion and forward-only.
+ *
+ * @param {Object}   props
+ * @param {Object[]} props.answers      `[{ answer, votes }]` from the poll results route.
+ * @param {number}   [props.totalVotes] Total votes across answers.
+ * @param {boolean}  [props.isLoading]  Request in flight.
+ * @return {JSX.Element|null} The distribution, or null when there is nothing to show.
+ */
+const PollAnswerDistribution = ( { answers, totalVotes = 0, isLoading = false } ) => {
+	if ( isLoading ) {
+		return (
+			<div className="mt-4" data-test-id="godam-layer-poll-distribution-loading">
+				<div className="h-4 w-40 rounded bg-zinc-100" />
+				<div className="mt-3 flex flex-col gap-2">
+					<div className="h-7 rounded bg-zinc-100" />
+					<div className="h-7 rounded bg-zinc-100" />
+				</div>
+			</div>
+		);
+	}
+
+	const rows = Array.isArray( answers ) ? answers : [];
+	if ( rows.length === 0 ) {
+		return null;
+	}
+
+	// Bars are scaled to the most-voted answer so the shape of the distribution
+	// stays readable when every option polls low.
+	const max = rows.reduce( ( acc, row ) => Math.max( acc, Number( row.votes ) || 0 ), 0 );
+
+	return (
+		<div className="mt-4" data-test-id="godam-layer-poll-distribution">
+			<div className="flex items-center gap-1">
+				<h4 className="text-sm font-semibold text-zinc-900 m-0">
+					{ __( 'Answer Distribution', 'godam' ) }
+				</h4>
+				<InfoTooltip
+					size={ 13 }
+					text={ __(
+						'Vote tallies come from the WP Polls plugin, which stores them per poll. They cover every vote on this poll across your site, so they are not limited to this video or to the selected date range.',
+						'godam',
+					) }
+				/>
+			</div>
+
+			<ul className="m-0 mt-2 p-0 list-none rounded-lg border border-zinc-200 divide-y divide-zinc-100">
+				{ rows.map( ( row, idx ) => {
+					const votes = Number( row.votes ) || 0;
+					const width = max > 0 ? ( votes / max ) * 100 : 0;
+					return (
+						<li
+							key={ row.id ?? `${ row.answer }-${ idx }` }
+							className="flex items-center gap-3 px-3 py-2"
+						>
+							<span
+								className="text-xs text-zinc-600 shrink-0 truncate"
+								style={ { maxWidth: 140 } }
+								title={ row.answer }
+							>
+								{ row.answer }
+							</span>
+							<span className="flex-1 h-6 rounded bg-zinc-50 overflow-hidden">
+								<span
+									className="block h-full rounded"
+									style={ {
+										width: `${ width }%`,
+										background: barShade( idx, rows.length ),
+										transition: 'width 160ms ease-out',
+									} }
+								/>
+							</span>
+							<span className="text-xs font-medium text-zinc-900 tabular-nums shrink-0">
+								{ votes.toLocaleString() }
+							</span>
+						</li>
+					);
+				} ) }
+			</ul>
+
+			<p className="text-[11px] text-zinc-400 m-0 mt-1.5">
+				{ __( 'Poll-wide totals from WP Polls, all videos and all dates.', 'godam' ) }
+				{ totalVotes > 0 && ` ${ totalVotes.toLocaleString() } ${ __( 'votes', 'godam' ) }.` }
+			</p>
+		</div>
+	);
+};
+
+export default PollAnswerDistribution;
+export { barShade };

--- a/pages/analytics/timeline/PollAnswerDistribution.js
+++ b/pages/analytics/timeline/PollAnswerDistribution.js
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -122,7 +122,11 @@ const PollAnswerDistribution = ( { answers, totalVotes = 0, isLoading = false } 
 
 			<p className="text-[11px] text-zinc-400 m-0 mt-1.5">
 				{ __( 'Poll-wide totals from WP Polls, all videos and all dates.', 'godam' ) }
-				{ totalVotes > 0 && ` ${ totalVotes.toLocaleString() } ${ __( 'votes', 'godam' ) }.` }
+				{ totalVotes > 0 && ` ${ sprintf(
+					/* translators: %s: formatted total number of votes. */
+					_n( '%s vote.', '%s votes.', totalVotes, 'godam' ),
+					totalVotes.toLocaleString(),
+				) }` }
 			</p>
 		</div>
 	);

--- a/pages/analytics/timeline/TrendBadge.js
+++ b/pages/analytics/timeline/TrendBadge.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { arrowDown, arrowUp } from '@wordpress/icons';
+
+/**
+ * Period-over-period trend badge for a layer KPI.
+ *
+ * Renders as an arrow + coloured percentage + muted "vs prev N days" label,
+ * matching the treatment on the dashboard and per-video KPI cards. Renders
+ * nothing when `delta` is null, which is how "no comparable previous window"
+ * is expressed (an All Time range, or a layer with no data before this range).
+ *
+ * A rising number is green and a falling one red. That reads correctly for
+ * every metric this panel shows, because all of them are metrics you want to
+ * go up: reach, CTR, submission rate. The two exceptions, Abandon Rate and
+ * Skip Rate, do not get a badge (only the primary tile and the donut do).
+ *
+ * @param {Object}      props
+ * @param {number|null} props.delta      Percentage change, or null to render nothing.
+ * @param {number|null} [props.spanDays] Length of the compared window, for the label.
+ * @param {string}      [props.testId]   data-test-id hook.
+ * @return {JSX.Element|null} The badge, or null.
+ */
+const TrendBadge = ( { delta, spanDays = null, testId } ) => {
+	if ( delta === null || delta === undefined || ! Number.isFinite( Number( delta ) ) ) {
+		return null;
+	}
+
+	const value = Number( delta );
+	const rising = value > 0;
+	const flat = value === 0;
+	// Rising is green, falling red, unchanged muted. Every metric that carries a
+	// badge here is one you want to go up (reach, CTR, submission rate); the two
+	// "lower is better" rates, Abandon and Skip, are secondary tiles and get no
+	// badge at all.
+	let toneClass = 'text-emerald-600';
+	if ( flat ) {
+		toneClass = 'text-zinc-500';
+	} else if ( ! rising ) {
+		toneClass = 'text-red-600';
+	}
+	const label = spanDays
+		? sprintf(
+			/* translators: %d: number of days in the comparison window. */
+			__( 'vs prev %d days', 'godam' ),
+			spanDays,
+		)
+		: __( 'vs prev period', 'godam' );
+
+	return (
+		<span
+			className="inline-flex items-center gap-1 text-[11px]"
+			data-test-id={ testId }
+		>
+			{ ! flat && (
+				<span className={ rising ? 'text-emerald-600' : 'text-red-600' }>
+					<Icon icon={ rising ? arrowUp : arrowDown } size={ 12 } />
+				</span>
+			) }
+			<span className={ `font-medium ${ toneClass }` }>
+				{ /* One decimal, and the sign carried by the arrow rather than
+				    repeated in the text. */ }
+				{ `${ Math.abs( +value.toFixed( 1 ) ) }%` }
+			</span>
+			<span className="text-zinc-400 whitespace-nowrap">{ label }</span>
+		</span>
+	);
+};
+
+export default TrendBadge;

--- a/pages/analytics/timeline/layerKpis.js
+++ b/pages/analytics/timeline/layerKpis.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { actionLabel } from '../constants/layerTypes';
 import { reachAt, reachRateAt } from './reach';
 
 /**
@@ -50,6 +51,7 @@ const REACH_RATE_TOOLTIP = __(
  * KPI descriptor per layer type.
  *
  * - `donutArc` — which action fills the ring around the Viewer Reach centre.
+ * - `donutArcLabel` — optional override for that action's display label.
  * - `primary` — the wide tile, the one that carries a trend badge.
  * - `secondary` — the two tiles below it.
  *
@@ -88,6 +90,10 @@ export const LAYER_KPI_SPEC = {
 	},
 	form: {
 		donutArc: 'no_action',
+		// The generic action label for this bucket is "No Action", but on a form
+		// the panel already calls it Abandon Rate, so the ring says the same
+		// thing (and matches the Figma segment label).
+		donutArcLabel: __( 'Abandoned', 'godam' ),
 		primary: {
 			id: 'submission-rate',
 			kind: 'rate',
@@ -311,6 +317,7 @@ export function buildLayerKpis( {
 			// than drawing an empty ring that reads as zero viewers.
 			reach,
 			arcAction: spec.donutArc,
+			arcLabel: spec.donutArcLabel || actionLabel( spec.donutArc ),
 			arcValue,
 			// The ring is the arc action as a share of impressions, which keeps
 			// it in one unit. Reach is the centre label, not the denominator:

--- a/pages/analytics/timeline/layerKpis.js
+++ b/pages/analytics/timeline/layerKpis.js
@@ -1,0 +1,326 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { reachAt, reachRateAt } from './reach';
+
+/**
+ * Per-layer-type KPI composition for the layer detail panel (W7–W11).
+ *
+ * One descriptor per layer type, next to `funnel` in constants/layerTypes.js in
+ * spirit: adding a KPI means editing a descriptor, not adding a branch in JSX.
+ *
+ * ## The one rule for rates
+ *
+ * Every rate here is `action / viewed` **taken from the same microservice row**.
+ * That matters because `viewed` is not one unit across layer types: atomic
+ * layers (CTA / Form / Poll) and sub-hotspot rows are aggregated with
+ * `COUNT(*)` (raw events) while hotspot / Woo parent rows use
+ * `uniqExact(page_load_session_id)` (distinct sessions). Within a single row
+ * every action shares its row's unit, so a ratio of two actions from that row
+ * is always internally consistent and always matches the funnel bars rendered
+ * directly beneath the tiles.
+ *
+ * The one exception is Viewer Reach, which comes off the retention array
+ * instead (see reach.js) and therefore counts a different population. It is
+ * labelled "Viewer Reach", never "Impressions", and carries a tooltip saying
+ * so.
+ *
+ * The panel deliberately does NOT reuse the server's `conversion_rate` for
+ * these tiles. That value's numerator is distinct converting *sessions* over
+ * `viewed`, which for atomic layers mixes sessions with events. It stays where
+ * it already ships (the sub-hotspot rail header), untouched.
+ */
+
+const IMPRESSIONS_TOOLTIP = __(
+	'How many times this layer was shown to a viewer. Counted from the layer\'s own impression events, so it can exceed the number of plays when a viewer rewatches.',
+	'godam',
+);
+
+const REACH_RATE_TOOLTIP = __(
+	'Share of the viewers who started this video that were still watching when this layer appeared. Read from the same retention data as the Viewer Retention Curve, so it counts viewers rather than layer impressions.',
+	'godam',
+);
+
+/**
+ * KPI descriptor per layer type.
+ *
+ * - `donutArc` — which action fills the ring around the Viewer Reach centre.
+ * - `primary` — the wide tile, the one that carries a trend badge.
+ * - `secondary` — the two tiles below it.
+ *
+ * Tile shapes: `{ kind: 'rate', numerator }` divides that action by `viewed`;
+ * `{ kind: 'count', key }` shows a raw tally; `{ kind: 'reachRate' }` is the
+ * retention-derived percentage.
+ */
+export const LAYER_KPI_SPEC = {
+	cta: {
+		donutArc: 'clicked',
+		primary: {
+			id: 'ctr',
+			kind: 'rate',
+			numerator: 'clicked',
+			label: __( 'CTR', 'godam' ),
+			tooltip: __(
+				'Share of this layer\'s impressions that resulted in a click.',
+				'godam',
+			),
+		},
+		secondary: [
+			{
+				id: 'reach-rate',
+				kind: 'reachRate',
+				label: __( 'Viewer Reach rate', 'godam' ),
+				tooltip: REACH_RATE_TOOLTIP,
+			},
+			{
+				id: 'impressions',
+				kind: 'count',
+				key: 'viewed',
+				label: __( 'Impressions', 'godam' ),
+				tooltip: IMPRESSIONS_TOOLTIP,
+			},
+		],
+	},
+	form: {
+		donutArc: 'no_action',
+		primary: {
+			id: 'submission-rate',
+			kind: 'rate',
+			numerator: 'submitted',
+			label: __( 'Submission Rate', 'godam' ),
+			tooltip: __(
+				'Share of this layer\'s impressions that ended in a submitted form.',
+				'godam',
+			),
+		},
+		secondary: [
+			{
+				id: 'abandon-rate',
+				kind: 'rate',
+				numerator: 'no_action',
+				label: __( 'Abandon Rate', 'godam' ),
+				// The definition is stated outright because it is the honest
+				// limit of what the current events can tell us: there is no
+				// "started filling in the form" event, so this counts viewers
+				// who ignored the form the same as viewers who began and left.
+				tooltip: __(
+					'Share of impressions where the viewer neither submitted the form nor dismissed it. Submission, Skip and Abandon together account for every impression.',
+					'godam',
+				),
+			},
+			{
+				id: 'skip-rate',
+				kind: 'rate',
+				numerator: 'skipped',
+				label: __( 'Skip Rate', 'godam' ),
+				tooltip: __(
+					'Share of this layer\'s impressions where the viewer dismissed the form.',
+					'godam',
+				),
+			},
+		],
+	},
+	hotspot: {
+		donutArc: 'clicked',
+		primary: {
+			id: 'conversion-rate',
+			kind: 'rate',
+			numerator: 'clicked',
+			label: __( 'Conversion Rate', 'godam' ),
+			tooltip: __(
+				'Share of this layer\'s impressions where a hotspot was clicked.',
+				'godam',
+			),
+		},
+		secondary: [
+			{
+				id: 'impressions',
+				kind: 'count',
+				key: 'viewed',
+				label: __( 'Impressions', 'godam' ),
+				tooltip: IMPRESSIONS_TOOLTIP,
+			},
+			{
+				id: 'hover-rate',
+				kind: 'rate',
+				numerator: 'hovered',
+				label: __( 'Hover Rate', 'godam' ),
+				tooltip: __(
+					'Share of this layer\'s impressions where the viewer hovered a hotspot to reveal its tooltip.',
+					'godam',
+				),
+			},
+		],
+	},
+	poll: {
+		donutArc: 'voted',
+		primary: {
+			id: 'conversion-rate',
+			kind: 'rate',
+			numerator: 'voted',
+			label: __( 'Conversion Rate', 'godam' ),
+			tooltip: __(
+				'Share of this layer\'s impressions that ended in a vote.',
+				'godam',
+			),
+		},
+		secondary: [
+			{
+				id: 'impressions',
+				kind: 'count',
+				key: 'viewed',
+				label: __( 'Impressions', 'godam' ),
+				tooltip: IMPRESSIONS_TOOLTIP,
+			},
+			{
+				id: 'skip-rate',
+				kind: 'rate',
+				numerator: 'skipped',
+				label: __( 'Skip Rate', 'godam' ),
+				tooltip: __(
+					'Share of this layer\'s impressions where the viewer dismissed the poll.',
+					'godam',
+				),
+			},
+		],
+	},
+	woo: {
+		donutArc: 'added_to_cart',
+		primary: {
+			id: 'add-to-cart-rate',
+			kind: 'rate',
+			numerator: 'added_to_cart',
+			label: __( 'Add to Cart Rate', 'godam' ),
+			tooltip: __(
+				'Share of this layer\'s impressions where a product was added to the cart from the hotspot.',
+				'godam',
+			),
+		},
+		secondary: [
+			{
+				id: 'product-click-rate',
+				kind: 'rate',
+				numerator: 'clicked',
+				label: __( 'Product Click Rate', 'godam' ),
+				tooltip: __(
+					'Share of this layer\'s impressions where the viewer clicked through to a product page.',
+					'godam',
+				),
+			},
+			{
+				id: 'reach-rate',
+				kind: 'reachRate',
+				label: __( 'Viewer Reach rate', 'godam' ),
+				tooltip: REACH_RATE_TOOLTIP,
+			},
+		],
+	},
+};
+
+/**
+ * One action count as a percentage of the row's impressions.
+ *
+ * Returns null when there are no impressions, so the tile renders a dash
+ * instead of a misleading 0%. Unclamped on purpose: a value above 100% means
+ * the counts genuinely disagree and should be visible, not hidden (the ticket's
+ * "correctness at source, no clamp" rule).
+ *
+ * @param {Object} counts       Action counts for one layer row, including `no_action`.
+ * @param {string} numeratorKey Which action forms the numerator.
+ * @return {number|null} Percentage, or null when there are no impressions.
+ */
+export function actionRate( counts, numeratorKey ) {
+	const impressions = Number( counts?.viewed ) || 0;
+	if ( impressions <= 0 ) {
+		return null;
+	}
+	const numerator = Number( counts?.[ numeratorKey ] ) || 0;
+	return ( numerator / impressions ) * 100;
+}
+
+/**
+ * Resolve one tile descriptor into a value.
+ *
+ * @param {Object}        tile           Tile descriptor from LAYER_KPI_SPEC.
+ * @param {Object}        counts         Action counts including `no_action`.
+ * @param {number[]}      retentionArray Per-second view counts.
+ * @param {number|string} timestamp      Layer position in seconds.
+ * @return {{id:string,kind:string,label:string,tooltip:string,value:number|null}} Resolved tile.
+ */
+function resolveTile( tile, counts, retentionArray, timestamp ) {
+	let value = null;
+	if ( tile.kind === 'rate' ) {
+		value = actionRate( counts, tile.numerator );
+	} else if ( tile.kind === 'count' ) {
+		value = Number( counts?.[ tile.key ] ) || 0;
+	} else if ( tile.kind === 'reachRate' ) {
+		value = reachRateAt( retentionArray, timestamp );
+	}
+	return {
+		id: tile.id,
+		kind: tile.kind,
+		label: tile.label,
+		tooltip: tile.tooltip,
+		value,
+	};
+}
+
+/**
+ * Build the donut + tile values for one layer.
+ *
+ * Pure: the same inputs always give the same output, so the panel calls it
+ * twice (selected range and previous equal range) and diffs the two to get the
+ * trend badges. No fetching, no formatting.
+ *
+ * @param {Object}        props
+ * @param {string}        props.layerType        'cta' | 'form' | 'hotspot' | 'poll' | 'woo'.
+ * @param {Object}        props.counts           Action counts for the layer row.
+ * @param {number}        [props.noAction]       Viewers who saw the layer and did nothing.
+ * @param {number[]}      [props.retentionArray] Per-second view counts for the range.
+ * @param {number|string} [props.timestamp]      Layer position in seconds.
+ * @return {{donut:Object,primary:Object,secondary:Object[]}|null} Resolved KPIs, or null for an unknown type.
+ */
+export function buildLayerKpis( {
+	layerType,
+	counts,
+	noAction = 0,
+	retentionArray = [],
+	timestamp = 0,
+} ) {
+	const spec = LAYER_KPI_SPEC[ layerType ];
+	if ( ! spec ) {
+		return null;
+	}
+
+	// `no_action` is derived in the data hook rather than returned by the
+	// microservice, so fold it in here to make it addressable like any other
+	// action (the Form panel's Abandon Rate needs it as a numerator).
+	const withNoAction = { ...( counts || {} ), no_action: Number( noAction ) || 0 };
+
+	const reach = reachAt( retentionArray, timestamp );
+	const arcValue = Number( withNoAction[ spec.donutArc ] ) || 0;
+
+	return {
+		donut: {
+			// Null reach means "unknown", and the panel hides the donut rather
+			// than drawing an empty ring that reads as zero viewers.
+			reach,
+			arcAction: spec.donutArc,
+			arcValue,
+			// The ring is the arc action as a share of impressions, which keeps
+			// it in one unit. Reach is the centre label, not the denominator:
+			// mixing the two populations into one ratio is exactly what the
+			// tooltips warn against.
+			arcShare: actionRate( withNoAction, spec.donutArc ),
+		},
+		primary: resolveTile( spec.primary, withNoAction, retentionArray, timestamp ),
+		secondary: spec.secondary.map( ( tile ) =>
+			resolveTile( tile, withNoAction, retentionArray, timestamp ),
+		),
+	};
+}

--- a/pages/analytics/timeline/layerKpis.test.js
+++ b/pages/analytics/timeline/layerKpis.test.js
@@ -1,0 +1,188 @@
+/**
+ * Internal dependencies
+ */
+import { LAYER_KPI_SPEC, actionRate, buildLayerKpis } from './layerKpis';
+import { LAYER_TYPES } from '../constants/layerTypes';
+
+describe( 'actionRate', () => {
+	it( 'divides the action by the row\'s impressions', () => {
+		expect( actionRate( { viewed: 200, clicked: 50 }, 'clicked' ) ).toBe( 25 );
+	} );
+
+	it( 'treats a missing action as zero', () => {
+		expect( actionRate( { viewed: 10 }, 'added_to_cart' ) ).toBe( 0 );
+	} );
+
+	it( 'returns null with no impressions, so the tile shows a dash not 0%', () => {
+		expect( actionRate( { viewed: 0, clicked: 3 }, 'clicked' ) ).toBeNull();
+		expect( actionRate( {}, 'clicked' ) ).toBeNull();
+		expect( actionRate( undefined, 'clicked' ) ).toBeNull();
+	} );
+
+	it( 'does not clamp above 100%, so disagreeing counts stay visible', () => {
+		expect( actionRate( { viewed: 10, clicked: 12 }, 'clicked' ) ).toBe( 120 );
+	} );
+} );
+
+describe( 'LAYER_KPI_SPEC', () => {
+	it( 'covers every registered layer type', () => {
+		const registered = LAYER_TYPES.map( ( t ) => t.id ).sort();
+		expect( Object.keys( LAYER_KPI_SPEC ).sort() ).toEqual( registered );
+	} );
+
+	it( 'gives every type a primary tile and exactly two secondary tiles', () => {
+		Object.values( LAYER_KPI_SPEC ).forEach( ( spec ) => {
+			expect( spec.primary ).toBeTruthy();
+			expect( spec.primary.label ).toBeTruthy();
+			expect( spec.primary.tooltip ).toBeTruthy();
+			expect( spec.secondary ).toHaveLength( 2 );
+		} );
+	} );
+
+	it( 'only fills the donut arc with an action the type\'s funnel tracks', () => {
+		Object.entries( LAYER_KPI_SPEC ).forEach( ( [ id, spec ] ) => {
+			const funnel = LAYER_TYPES.find( ( t ) => t.id === id ).funnel;
+			expect( funnel ).toContain( spec.donutArc );
+		} );
+	} );
+
+	it( 'labels the retention-derived tile "Viewer Reach", never "Impressions"', () => {
+		// Reach and Impressions count different populations, so the two must
+		// never borrow each other's wording.
+		const allTiles = Object.values( LAYER_KPI_SPEC ).flatMap( ( spec ) => [
+			spec.primary,
+			...spec.secondary,
+		] );
+		const reachLabels = allTiles
+			.filter( ( tile ) => tile.kind === 'reachRate' )
+			.map( ( tile ) => tile.label );
+		const countLabels = allTiles
+			.filter( ( tile ) => tile.kind === 'count' )
+			.map( ( tile ) => tile.label );
+
+		expect( reachLabels.length ).toBeGreaterThan( 0 );
+		expect( reachLabels.every( ( label ) => /Reach/.test( label ) ) ).toBe( true );
+		expect( countLabels.some( ( label ) => /Reach/.test( label ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'buildLayerKpis', () => {
+	const retention = [ 100, 90, 80, 70, 60 ];
+
+	it( 'returns null for an unknown layer type', () => {
+		expect( buildLayerKpis( { layerType: 'audio', counts: {} } ) ).toBeNull();
+	} );
+
+	it( 'builds the CTA panel: CTR primary, reach rate + impressions', () => {
+		const kpis = buildLayerKpis( {
+			layerType: 'cta',
+			counts: { viewed: 200, clicked: 50, skipped: 20 },
+			noAction: 130,
+			retentionArray: retention,
+			timestamp: 2,
+		} );
+
+		expect( kpis.primary.id ).toBe( 'ctr' );
+		expect( kpis.primary.value ).toBe( 25 );
+		expect( kpis.secondary.map( ( t ) => t.id ) ).toEqual( [
+			'reach-rate',
+			'impressions',
+		] );
+		// 80 viewers at second 2 out of 100 starters.
+		expect( kpis.secondary[ 0 ].value ).toBe( 80 );
+		expect( kpis.secondary[ 1 ].value ).toBe( 200 );
+	} );
+
+	it( 'puts reach in the donut centre and the arc action as a share of impressions', () => {
+		const kpis = buildLayerKpis( {
+			layerType: 'cta',
+			counts: { viewed: 200, clicked: 50 },
+			retentionArray: retention,
+			timestamp: 4,
+		} );
+
+		expect( kpis.donut.reach ).toBe( 60 );
+		expect( kpis.donut.arcAction ).toBe( 'clicked' );
+		expect( kpis.donut.arcValue ).toBe( 50 );
+		expect( kpis.donut.arcShare ).toBe( 25 );
+	} );
+
+	it( 'exposes no_action as an addressable numerator for the Form abandon tile', () => {
+		const kpis = buildLayerKpis( {
+			layerType: 'form',
+			counts: { viewed: 100, submitted: 24, skipped: 16 },
+			noAction: 60,
+			retentionArray: retention,
+			timestamp: 1,
+		} );
+
+		const byId = Object.fromEntries(
+			[ kpis.primary, ...kpis.secondary ].map( ( t ) => [ t.id, t.value ] ),
+		);
+		expect( byId[ 'submission-rate' ] ).toBe( 24 );
+		expect( byId[ 'abandon-rate' ] ).toBe( 60 );
+		expect( byId[ 'skip-rate' ] ).toBe( 16 );
+		// The decision behind the definition: the three account for everything.
+		expect(
+			byId[ 'submission-rate' ] + byId[ 'abandon-rate' ] + byId[ 'skip-rate' ],
+		).toBe( 100 );
+		// The Form donut ring is the abandoned share, per the Figma tooltip.
+		expect( kpis.donut.arcAction ).toBe( 'no_action' );
+		expect( kpis.donut.arcValue ).toBe( 60 );
+	} );
+
+	it( 'reports unknown reach as null so the donut can hide instead of showing 0', () => {
+		const kpis = buildLayerKpis( {
+			layerType: 'cta',
+			counts: { viewed: 10, clicked: 1 },
+			retentionArray: [],
+			timestamp: 2,
+		} );
+		expect( kpis.donut.reach ).toBeNull();
+		expect( kpis.secondary[ 0 ].value ).toBeNull();
+		// Impression-based tiles still work without retention data.
+		expect( kpis.primary.value ).toBe( 10 );
+	} );
+
+	it( 'reports unknown reach for a layer positioned past the recorded length', () => {
+		const kpis = buildLayerKpis( {
+			layerType: 'hotspot',
+			counts: { viewed: 40, clicked: 10, hovered: 20 },
+			retentionArray: retention,
+			timestamp: 99,
+		} );
+		expect( kpis.donut.reach ).toBeNull();
+		expect( kpis.primary.value ).toBe( 25 );
+	} );
+
+	it( 'builds Woo from add-to-cart, not from clicks', () => {
+		const kpis = buildLayerKpis( {
+			layerType: 'woo',
+			counts: { viewed: 50, clicked: 10, added_to_cart: 5, hovered: 30 },
+			retentionArray: retention,
+			timestamp: 0,
+		} );
+		expect( kpis.primary.id ).toBe( 'add-to-cart-rate' );
+		expect( kpis.primary.value ).toBe( 10 );
+		expect( kpis.secondary[ 0 ].id ).toBe( 'product-click-rate' );
+		expect( kpis.secondary[ 0 ].value ).toBe( 20 );
+		expect( kpis.donut.arcAction ).toBe( 'added_to_cart' );
+	} );
+
+	it( 'is pure, so the same inputs give an equal result twice over', () => {
+		const args = {
+			layerType: 'poll',
+			counts: { viewed: 80, voted: 20, skipped: 10 },
+			noAction: 50,
+			retentionArray: retention,
+			timestamp: 3,
+		};
+		expect( buildLayerKpis( args ) ).toEqual( buildLayerKpis( args ) );
+	} );
+
+	it( 'tolerates a missing counts object', () => {
+		const kpis = buildLayerKpis( { layerType: 'cta', retentionArray: retention } );
+		expect( kpis.primary.value ).toBeNull();
+		expect( kpis.donut.arcValue ).toBe( 0 );
+	} );
+} );

--- a/pages/analytics/timeline/layerKpis.test.js
+++ b/pages/analytics/timeline/layerKpis.test.js
@@ -39,6 +39,14 @@ describe( 'LAYER_KPI_SPEC', () => {
 		} );
 	} );
 
+	it( 'gives every donut arc a display label', () => {
+		Object.keys( LAYER_KPI_SPEC ).forEach( ( id ) => {
+			const kpis = buildLayerKpis( { layerType: id, counts: { viewed: 10 } } );
+			expect( kpis.donut.arcLabel ).toBeTruthy();
+			expect( kpis.donut.arcLabel ).not.toBe( kpis.donut.arcAction );
+		} );
+	} );
+
 	it( 'only fills the donut arc with an action the type\'s funnel tracks', () => {
 		Object.entries( LAYER_KPI_SPEC ).forEach( ( [ id, spec ] ) => {
 			const funnel = LAYER_TYPES.find( ( t ) => t.id === id ).funnel;
@@ -103,6 +111,7 @@ describe( 'buildLayerKpis', () => {
 
 		expect( kpis.donut.reach ).toBe( 60 );
 		expect( kpis.donut.arcAction ).toBe( 'clicked' );
+		expect( kpis.donut.arcLabel ).toBe( 'Clicked' );
 		expect( kpis.donut.arcValue ).toBe( 50 );
 		expect( kpis.donut.arcShare ).toBe( 25 );
 	} );
@@ -126,9 +135,12 @@ describe( 'buildLayerKpis', () => {
 		expect(
 			byId[ 'submission-rate' ] + byId[ 'abandon-rate' ] + byId[ 'skip-rate' ],
 		).toBe( 100 );
-		// The Form donut ring is the abandoned share, per the Figma tooltip.
+		// The Form donut ring is the abandoned share, per the Figma tooltip, and
+		// it says "Abandoned" rather than the generic "No Action" so the ring and
+		// the Abandon Rate tile use one word for one thing.
 		expect( kpis.donut.arcAction ).toBe( 'no_action' );
 		expect( kpis.donut.arcValue ).toBe( 60 );
+		expect( kpis.donut.arcLabel ).toBe( 'Abandoned' );
 	} );
 
 	it( 'reports unknown reach as null so the donut can hide instead of showing 0', () => {

--- a/pages/analytics/timeline/reach.js
+++ b/pages/analytics/timeline/reach.js
@@ -1,0 +1,248 @@
+/**
+ * Viewer Reach maths for the per-video layer panels.
+ *
+ * "Viewer Reach" answers "how many viewers were still watching when this layer
+ * appeared?". It is read off the same per-second retention array the Viewer
+ * Retention Curve draws (`all_time_heatmap`, summed per-day server-side for the
+ * selected range), indexed at the layer's timestamp. Reusing that array means
+ * the tile always agrees with the curve the user is looking at on the same page.
+ *
+ * Why not the layer's own `viewed` count: `viewed` is not one unit across layer
+ * types. The microservice aggregates atomic layers (CTA / Form / Poll) and
+ * sub-hotspot rows with `COUNT(*)` (raw events, so a looping viewer contributes
+ * more than one) but hotspot / Woo parent rows with
+ * `uniqExact(page_load_session_id)` (distinct sessions). So `viewed / plays`
+ * would exceed 100% legitimately on atomic layers, and no clamp can fix that
+ * honestly. `viewed` stays in the UI as "Impressions", a deliberately different
+ * metric from Reach.
+ *
+ * Reach and Impressions therefore count different populations: the retention
+ * array includes sessions with no `type=1` page_load (same convention as the
+ * shipped curve), while layer events are gated on one. Both carry tooltips
+ * saying so.
+ */
+
+/**
+ * Parse the per-second retention array out of an analytics payload field.
+ *
+ * The microservice returns it as a JSON string in both range and all-time mode.
+ * Anything unparseable or non-array yields `[]`, which every consumer below
+ * treats as "no reach data" rather than zero reach.
+ *
+ * @param {string|Array|null|undefined} raw `all_time_heatmap` as returned by the REST proxy.
+ * @return {number[]} Per-second view counts, or [] when unavailable.
+ */
+export function parseRetentionArray( raw ) {
+	if ( Array.isArray( raw ) ) {
+		return raw.map( ( v ) => Number( v ) || 0 );
+	}
+	if ( typeof raw !== 'string' || raw.trim() === '' ) {
+		return [];
+	}
+	try {
+		const parsed = JSON.parse( raw );
+		return Array.isArray( parsed ) ? parsed.map( ( v ) => Number( v ) || 0 ) : [];
+	} catch ( e ) {
+		return [];
+	}
+}
+
+/**
+ * The denominator for a reach rate: how many viewers the video started with.
+ *
+ * Mirrors `generateRetentionCurve` in helper.js (`data[0] || max(data)`) so the
+ * tile and the curve normalise against the identical baseline. The `max`
+ * fallback covers the case where second 0 recorded nothing but later seconds
+ * did, which happens when every session's first beacon lands mid-video.
+ *
+ * @param {number[]} array Per-second view counts.
+ * @return {number} Starting viewers, or 0 when there is no data.
+ */
+export function reachBase( array ) {
+	if ( ! Array.isArray( array ) || array.length === 0 ) {
+		return 0;
+	}
+	const first = Number( array[ 0 ] ) || 0;
+	if ( first > 0 ) {
+		return first;
+	}
+	return array.reduce( ( max, v ) => Math.max( max, Number( v ) || 0 ), 0 );
+}
+
+/**
+ * Viewers still watching at `timestamp`.
+ *
+ * Returns null (not 0) whenever the answer is unknown, so callers hide the
+ * tile instead of reporting a confident zero:
+ * no retention array at all, or the layer sits past the end of the array. The
+ * latter happens when a layer was positioned beyond the `video_length` recorded
+ * with these events, e.g. the video was re-encoded shorter after the layer was
+ * placed.
+ *
+ * @param {number[]}      array     Per-second view counts.
+ * @param {number|string} timestamp Layer position in seconds.
+ * @return {number|null} Viewers at that second, or null when unknown.
+ */
+export function reachAt( array, timestamp ) {
+	if ( ! Array.isArray( array ) || array.length === 0 ) {
+		return null;
+	}
+	const seconds = Math.floor( Number( timestamp ) || 0 );
+	if ( seconds < 0 || seconds >= array.length ) {
+		return null;
+	}
+	return Number( array[ seconds ] ) || 0;
+}
+
+/**
+ * Reach as a percentage of the video's starting viewers.
+ *
+ * Deliberately unclamped: a rewatched second can legitimately exceed 100%,
+ * exactly as the retention curve documents and renders. Clamping here would
+ * make the tile disagree with the chart directly above it.
+ *
+ * @param {number[]}      array     Per-second view counts.
+ * @param {number|string} timestamp Layer position in seconds.
+ * @return {number|null} Percentage, or null when reach or the baseline is unknown.
+ */
+export function reachRateAt( array, timestamp ) {
+	const reach = reachAt( array, timestamp );
+	if ( reach === null ) {
+		return null;
+	}
+	const base = reachBase( array );
+	if ( base <= 0 ) {
+		return null;
+	}
+	return ( reach / base ) * 100;
+}
+
+/**
+ * The equal-length window immediately before `range`, for period-over-period
+ * deltas. A 7-day range ending today returns the 7 days before it.
+ *
+ * Returns null for an open-ended ("All Time") range, which has no previous
+ * window to compare against.
+ *
+ * Uses calendar arithmetic through the Date constructor rather than fixed-ms
+ * subtraction, matching `spanDays` in the DateRangePicker: a DST shift inside
+ * the window must not move the boundary onto the wrong calendar day.
+ *
+ * @param {Object}      range           Current range.
+ * @param {string|null} range.startDate ISO YYYY-MM-DD.
+ * @param {string|null} range.endDate   ISO YYYY-MM-DD.
+ * @return {{startDate:string,endDate:string}|null} Previous window, or null.
+ */
+export function previousRange( { startDate, endDate } = {} ) {
+	if ( ! startDate || ! endDate ) {
+		return null;
+	}
+	const start = parseISO( startDate );
+	const end = parseISO( endDate );
+	if ( ! start || ! end || end < start ) {
+		return null;
+	}
+
+	const days = spanLengthInDays( start, end );
+	const prevEnd = new Date(
+		start.getFullYear(),
+		start.getMonth(),
+		start.getDate() - 1,
+	);
+	const prevStart = new Date(
+		prevEnd.getFullYear(),
+		prevEnd.getMonth(),
+		prevEnd.getDate() - ( days - 1 ),
+	);
+	return { startDate: formatISO( prevStart ), endDate: formatISO( prevEnd ) };
+}
+
+/**
+ * Inclusive length of a range in whole days. Rounded because a DST transition
+ * makes the raw millisecond difference 23 or 25 hours for one of the days.
+ *
+ * @param {Date} start Range start at local midnight.
+ * @param {Date} end   Range end at local midnight.
+ * @return {number} Day count, at least 1.
+ */
+export function spanLengthInDays( start, end ) {
+	const msPerDay = 24 * 60 * 60 * 1000;
+	return Math.max( 1, Math.round( ( end - start ) / msPerDay ) + 1 );
+}
+
+/**
+ * Percentage change between two values.
+ *
+ * Matches the convention used by both the microservice (`compute_percent_change`
+ * in app/utils/helpers.py) and the dashboard cards (`calculateTrendPercentage`
+ * in helper.js): a zero baseline reports ±100 rather than infinity, so the layer
+ * badges read the same way as the KPI badges elsewhere on the page.
+ *
+ * Returns null when there is no comparable previous value at all, which hides
+ * the badge rather than implying a flat 0% change.
+ *
+ * @param {number|null|undefined} current  Value for the selected range.
+ * @param {number|null|undefined} previous Value for the previous equal range.
+ * @return {number|null} Percentage change, or null when incomparable.
+ */
+export function percentDelta( current, previous ) {
+	// Guard null/'' explicitly: Number(null) and Number('') are both 0, which
+	// would turn "no previous window" into a confident +100%.
+	if (
+		current === null ||
+		current === undefined ||
+		current === '' ||
+		previous === null ||
+		previous === undefined ||
+		previous === ''
+	) {
+		return null;
+	}
+	const now = Number( current );
+	const before = Number( previous );
+	if ( ! Number.isFinite( now ) || ! Number.isFinite( before ) ) {
+		return null;
+	}
+	if ( before === 0 ) {
+		if ( now > 0 ) {
+			return 100;
+		}
+		return now < 0 ? -100 : 0;
+	}
+	return ( ( now - before ) / before ) * 100;
+}
+
+/**
+ * 'YYYY-MM-DD' to a local-midnight Date. Null for anything malformed, so a
+ * garbled range degrades to "no previous window" instead of NaN dates.
+ *
+ * @param {string} iso ISO date string.
+ * @return {Date|null} Parsed date or null.
+ */
+function parseISO( iso ) {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec( String( iso || '' ) );
+	if ( ! match ) {
+		return null;
+	}
+	const [ , y, m, d ] = match.map( Number );
+	const date = new Date( y, m - 1, d );
+	// Reject impossible dates that the constructor silently rolls over
+	// (2026-02-30 becomes March 2).
+	if ( date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d ) {
+		return null;
+	}
+	return date;
+}
+
+/**
+ * Local-midnight Date to 'YYYY-MM-DD'.
+ *
+ * @param {Date} date Date to format.
+ * @return {string} ISO date string.
+ */
+function formatISO( date ) {
+	const y = date.getFullYear();
+	const m = String( date.getMonth() + 1 ).padStart( 2, '0' );
+	const d = String( date.getDate() ).padStart( 2, '0' );
+	return `${ y }-${ m }-${ d }`;
+}

--- a/pages/analytics/timeline/reach.test.js
+++ b/pages/analytics/timeline/reach.test.js
@@ -1,0 +1,188 @@
+/**
+ * Internal dependencies
+ */
+import {
+	parseRetentionArray,
+	percentDelta,
+	previousRange,
+	reachAt,
+	reachBase,
+	reachRateAt,
+	spanLengthInDays,
+} from './reach';
+
+describe( 'parseRetentionArray', () => {
+	it( 'parses the JSON string the microservice returns', () => {
+		expect( parseRetentionArray( '[5,4,3]' ) ).toEqual( [ 5, 4, 3 ] );
+	} );
+
+	it( 'passes an already-parsed array through, coercing values', () => {
+		expect( parseRetentionArray( [ '5', 4, null ] ) ).toEqual( [ 5, 4, 0 ] );
+	} );
+
+	it( 'returns [] for every unusable input rather than throwing', () => {
+		expect( parseRetentionArray( undefined ) ).toEqual( [] );
+		expect( parseRetentionArray( null ) ).toEqual( [] );
+		expect( parseRetentionArray( '' ) ).toEqual( [] );
+		expect( parseRetentionArray( '   ' ) ).toEqual( [] );
+		expect( parseRetentionArray( 'not json' ) ).toEqual( [] );
+		// Valid JSON, wrong shape — the endpoint nulls the field in some modes.
+		expect( parseRetentionArray( '{"a":1}' ) ).toEqual( [] );
+		expect( parseRetentionArray( 'null' ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'reachBase', () => {
+	it( 'uses second 0 as the starting-viewers baseline', () => {
+		expect( reachBase( [ 10, 8, 6 ] ) ).toBe( 10 );
+	} );
+
+	it( 'falls back to the array max when second 0 recorded nothing', () => {
+		// Every session\'s first beacon landed mid-video.
+		expect( reachBase( [ 0, 0, 7, 4 ] ) ).toBe( 7 );
+	} );
+
+	it( 'is 0 for an empty or all-zero array', () => {
+		expect( reachBase( [] ) ).toBe( 0 );
+		expect( reachBase( [ 0, 0 ] ) ).toBe( 0 );
+		expect( reachBase( null ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'reachAt', () => {
+	const array = [ 10, 9, 8, 7 ];
+
+	it( 'floors a fractional layer timestamp to the containing second', () => {
+		expect( reachAt( array, 2 ) ).toBe( 8 );
+		expect( reachAt( array, 2.9 ) ).toBe( 8 );
+	} );
+
+	it( 'reads second 0 for a layer at the very start', () => {
+		expect( reachAt( array, 0 ) ).toBe( 10 );
+	} );
+
+	it( 'returns null past the end of the array, not the last value', () => {
+		// A layer positioned beyond the video_length these events recorded.
+		expect( reachAt( array, 4 ) ).toBeNull();
+		expect( reachAt( array, 900 ) ).toBeNull();
+	} );
+
+	it( 'returns null when there is no retention data', () => {
+		expect( reachAt( [], 1 ) ).toBeNull();
+		expect( reachAt( null, 1 ) ).toBeNull();
+	} );
+
+	it( 'returns null for a negative timestamp', () => {
+		expect( reachAt( array, -1 ) ).toBeNull();
+	} );
+
+	it( 'reports a real zero inside the array as 0, not null', () => {
+		expect( reachAt( [ 10, 0, 5 ], 1 ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'reachRateAt', () => {
+	it( 'is reach over starting viewers, as a percentage', () => {
+		expect( reachRateAt( [ 200, 150, 100 ], 2 ) ).toBe( 50 );
+	} );
+
+	it( 'does not clamp a rewatched second above 100%', () => {
+		// Matches generateRetentionCurve, which leaves headroom for these bumps.
+		expect( reachRateAt( [ 100, 250 ], 1 ) ).toBe( 250 );
+	} );
+
+	it( 'returns null when the baseline is zero', () => {
+		expect( reachRateAt( [ 0, 0, 0 ], 1 ) ).toBeNull();
+	} );
+
+	it( 'returns null when reach itself is unknown', () => {
+		expect( reachRateAt( [ 10, 5 ], 9 ) ).toBeNull();
+		expect( reachRateAt( [], 0 ) ).toBeNull();
+	} );
+} );
+
+describe( 'spanLengthInDays', () => {
+	it( 'counts both endpoints', () => {
+		expect(
+			spanLengthInDays( new Date( 2026, 7, 1 ), new Date( 2026, 7, 7 ) ),
+		).toBe( 7 );
+	} );
+
+	it( 'is 1 for a single day', () => {
+		expect(
+			spanLengthInDays( new Date( 2026, 7, 3 ), new Date( 2026, 7, 3 ) ),
+		).toBe( 1 );
+	} );
+
+	it( 'rounds through a DST transition', () => {
+		// US spring-forward 2026-03-08 makes one day 23h long.
+		expect(
+			spanLengthInDays( new Date( 2026, 2, 5 ), new Date( 2026, 2, 11 ) ),
+		).toBe( 7 );
+	} );
+} );
+
+describe( 'previousRange', () => {
+	it( 'returns the equal-length window ending the day before', () => {
+		expect(
+			previousRange( { startDate: '2026-08-01', endDate: '2026-08-07' } ),
+		).toEqual( { startDate: '2026-07-25', endDate: '2026-07-31' } );
+	} );
+
+	it( 'handles a single-day range', () => {
+		expect(
+			previousRange( { startDate: '2026-08-03', endDate: '2026-08-03' } ),
+		).toEqual( { startDate: '2026-08-02', endDate: '2026-08-02' } );
+	} );
+
+	it( 'crosses a month and a year boundary', () => {
+		// 31 days ending 2025-12-31 starts 2025-12-01, since December has 31 days.
+		expect(
+			previousRange( { startDate: '2026-01-01', endDate: '2026-01-31' } ),
+		).toEqual( { startDate: '2025-12-01', endDate: '2025-12-31' } );
+	} );
+
+	it( 'returns null for an open-ended All Time range', () => {
+		expect( previousRange( { startDate: null, endDate: null } ) ).toBeNull();
+		expect( previousRange( { startDate: '2026-08-01', endDate: null } ) ).toBeNull();
+		expect( previousRange( {} ) ).toBeNull();
+		expect( previousRange() ).toBeNull();
+	} );
+
+	it( 'returns null for malformed or impossible dates', () => {
+		expect( previousRange( { startDate: 'yesterday', endDate: 'today' } ) ).toBeNull();
+		expect( previousRange( { startDate: '2026-02-30', endDate: '2026-03-05' } ) ).toBeNull();
+	} );
+
+	it( 'returns null when the range is inverted', () => {
+		expect(
+			previousRange( { startDate: '2026-08-07', endDate: '2026-08-01' } ),
+		).toBeNull();
+	} );
+} );
+
+describe( 'percentDelta', () => {
+	it( 'computes an ordinary change', () => {
+		expect( percentDelta( 120, 100 ) ).toBe( 20 );
+		expect( percentDelta( 80, 100 ) ).toBe( -20 );
+	} );
+
+	it( 'reports +100 against a zero baseline, matching the server convention', () => {
+		expect( percentDelta( 5, 0 ) ).toBe( 100 );
+	} );
+
+	it( 'reports 0 when both windows are zero', () => {
+		expect( percentDelta( 0, 0 ) ).toBe( 0 );
+	} );
+
+	it( 'returns null when either side is missing, so the badge hides', () => {
+		expect( percentDelta( 10, null ) ).toBeNull();
+		expect( percentDelta( 10, undefined ) ).toBeNull();
+		expect( percentDelta( null, 10 ) ).toBeNull();
+	} );
+
+	it( 'returns null for non-numeric input', () => {
+		expect( percentDelta( 'abc', 10 ) ).toBeNull();
+		expect( percentDelta( 10, 'abc' ) ).toBeNull();
+	} );
+} );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -161,6 +161,9 @@ require_once dirname( __DIR__ ) . '/inc/traits/trait-singleton.php';
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-base.php';
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-video-editor.php';
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-gf.php';
+// Polls::shape_poll_answers is static and pure; loading the class needs only the
+// REST base above plus the wp_strip_all_tags / absint stubs.
+require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-polls.php';
 
 require_once dirname( __DIR__ ) . '/inc/classes/rest-api/class-onboarding-response.php';
 

--- a/tests/php/PollAnswerShapingTest.php
+++ b/tests/php/PollAnswerShapingTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Unit tests for the Poll layer's answer-distribution shaping.
+ *
+ * The vote tallies rendered on the Poll layer analytics panel come out of the
+ * wp-polls plugin's own tables, which GoDAM does not own. These cover the
+ * coercion boundary: whatever shape those rows arrive in, the REST response has
+ * to be a list of `{ id, answer, votes }` with a matching total, and no markup
+ * may reach the React chart.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RTGODAM\Inc\REST_API\Polls;
+
+/**
+ * @covers \RTGODAM\Inc\REST_API\Polls::shape_poll_answers
+ */
+class PollAnswerShapingTest extends TestCase {
+
+	/** A normal poll shapes into ordered answers plus their sum. */
+	public function test_shapes_answers_and_total() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				(object) array(
+					'polla_aid'     => 1,
+					'polla_answers' => 'Yes',
+					'polla_votes'   => 20,
+				),
+				(object) array(
+					'polla_aid'     => 2,
+					'polla_answers' => 'Maybe',
+					'polla_votes'   => 47,
+				),
+				(object) array(
+					'polla_aid'     => 3,
+					'polla_answers' => 'No',
+					'polla_votes'   => 32,
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'id'     => 1,
+					'answer' => 'Yes',
+					'votes'  => 20,
+				),
+				array(
+					'id'     => 2,
+					'answer' => 'Maybe',
+					'votes'  => 47,
+				),
+				array(
+					'id'     => 3,
+					'answer' => 'No',
+					'votes'  => 32,
+				),
+			),
+			$shaped['answers']
+		);
+		$this->assertSame( 99, $shaped['total_votes'] );
+	}
+
+	/** A poll with no votes yet is a valid, empty-looking distribution. */
+	public function test_zero_votes_are_kept() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				(object) array(
+					'polla_aid'     => 1,
+					'polla_answers' => 'Yes',
+					'polla_votes'   => 0,
+				),
+			)
+		);
+
+		$this->assertCount( 1, $shaped['answers'] );
+		$this->assertSame( 0, $shaped['answers'][0]['votes'] );
+		$this->assertSame( 0, $shaped['total_votes'] );
+	}
+
+	/** Markup in a poll answer must never reach the chart. */
+	public function test_markup_is_stripped_from_answers() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				(object) array(
+					'polla_aid'     => 4,
+					'polla_answers' => '<script>alert(1)</script>Yes please',
+					'polla_votes'   => 3,
+				),
+			)
+		);
+
+		$this->assertSame( 'alert(1)Yes please', $shaped['answers'][0]['answer'] );
+	}
+
+	/** A nameless answer is not renderable, but its votes still count. */
+	public function test_blank_answer_is_dropped_but_its_votes_still_total() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				(object) array(
+					'polla_aid'     => 1,
+					'polla_answers' => 'Yes',
+					'polla_votes'   => 10,
+				),
+				(object) array(
+					'polla_aid'     => 2,
+					'polla_answers' => '   ',
+					'polla_votes'   => 5,
+				),
+			)
+		);
+
+		$this->assertCount( 1, $shaped['answers'] );
+		$this->assertSame( 'Yes', $shaped['answers'][0]['answer'] );
+		$this->assertSame( 15, $shaped['total_votes'] );
+	}
+
+	/** Negative or non-numeric vote counts coerce to a non-negative integer. */
+	public function test_vote_counts_are_coerced() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				(object) array(
+					'polla_aid'     => 1,
+					'polla_answers' => 'A',
+					'polla_votes'   => -4,
+				),
+				(object) array(
+					'polla_aid'     => 2,
+					'polla_answers' => 'B',
+					'polla_votes'   => '12',
+				),
+				(object) array(
+					'polla_aid'     => 3,
+					'polla_answers' => 'C',
+					'polla_votes'   => 'not a number',
+				),
+			)
+		);
+
+		$this->assertSame( 4, $shaped['answers'][0]['votes'] );
+		$this->assertSame( 12, $shaped['answers'][1]['votes'] );
+		$this->assertSame( 0, $shaped['answers'][2]['votes'] );
+		$this->assertSame( 16, $shaped['total_votes'] );
+	}
+
+	/** Missing columns must not warn or fatal; they fall back to defaults. */
+	public function test_missing_columns_fall_back() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				(object) array( 'polla_answers' => 'Only an answer' ),
+			)
+		);
+
+		$this->assertSame( 0, $shaped['answers'][0]['id'] );
+		$this->assertSame( 0, $shaped['answers'][0]['votes'] );
+		$this->assertSame( 'Only an answer', $shaped['answers'][0]['answer'] );
+	}
+
+	/** `$wpdb` can be asked for arrays; both row shapes are accepted. */
+	public function test_array_rows_are_accepted() {
+		$shaped = Polls::shape_poll_answers(
+			array(
+				array(
+					'polla_aid'     => 7,
+					'polla_answers' => 'Yes',
+					'polla_votes'   => 2,
+				),
+			)
+		);
+
+		$this->assertSame( 7, $shaped['answers'][0]['id'] );
+		$this->assertSame( 2, $shaped['total_votes'] );
+	}
+
+	/** No rows at all is an empty distribution, not an error. */
+	public function test_empty_input() {
+		$shaped = Polls::shape_poll_answers( array() );
+
+		$this->assertSame( array(), $shaped['answers'] );
+		$this->assertSame( 0, $shaped['total_votes'] );
+	}
+
+	/** A null result set (failed query) degrades the same way. */
+	public function test_null_input() {
+		$shaped = Polls::shape_poll_answers( null );
+
+		$this->assertSame( array(), $shaped['answers'] );
+		$this->assertSame( 0, $shaped['total_votes'] );
+	}
+
+	/** Scalars inside the result set are skipped rather than fataling. */
+	public function test_scalar_rows_are_skipped() {
+		$shaped = Polls::shape_poll_answers( array( 'nonsense', 42, null ) );
+
+		$this->assertSame( array(), $shaped['answers'] );
+		$this->assertSame( 0, $shaped['total_votes'] );
+	}
+}


### PR DESCRIPTION
Fills the per-layer data gap the P1 reskin deliberately left open: the W7–W11 layer panels get a Viewer Reach donut, per-type KPI tiles with a period-over-period badge, the Form submission/abandon/skip rates, the Poll answer distribution, and the Woo Linked Products row.

Part of [rtCamp/godam-plugin-wp#2](https://github.com/rtCamp/godam-plugin-wp/issues/2) (P3, the "per-layer" split).

**No microservice or ingestion change.** Every metric is derived on read from data already stored, so this works retroactively on existing accounts with no release ordering and no waiting for data to accrue.

## What each panel gains

| Layer | Donut centre / ring | Primary tile | Secondary tiles | Extra |
|---|---|---|---|---|
| CTA | Viewer Reach / Clicked | CTR | Viewer Reach rate · Impressions | |
| Form | Viewer Reach / Abandoned | Submission Rate | Abandon Rate · Skip Rate | |
| Hotspot | Viewer Reach / Clicked | Conversion Rate | Impressions · Hover Rate | |
| Poll | Viewer Reach / Voted | Conversion Rate | Impressions · Skip Rate | Answer Distribution |
| Woo | Viewer Reach / Added to Cart | Add to Cart Rate | Product Click Rate · Viewer Reach rate | Linked Products |

The donut and the tiles stay at parent level even while a sub-hotspot is selected: reach is a property of the layer's position, which every sub of a layer shares, and the Figma panels show one set of headline numbers per layer. The existing funnel, sub-hotspot rail, "layer moved" notice and removed-layers drawer are untouched.

## Three decisions worth reviewing

**1. Viewer Reach is read off the retention array, not derived from `viewed`.**

`viewed` is not one unit across layer types. `app/tasks/processing.py` aggregates atomic layers (CTA / Form / Poll) and sub-hotspot rows with `COUNT(*)` (raw events, so a looping viewer contributes more than one) but hotspot / Woo parent rows with `uniqExact(page_load_session_id)` (distinct sessions). So `viewed / plays` exceeds 100% legitimately on atomic layers, and no clamp fixes that honestly; fixing it at source means a new per-entity viewing-sessions map plus a reprocess, which is out of proportion here.

Instead reach is `retentionArray[floor(timestamp)]` and the rate is `array[t] / array[0]` — the exact formula `generateRetentionCurve` uses, off the same range-scoped `all_time_heatmap` (summed server-side by godam-analytics#235). The tile therefore always agrees with the curve on the same page and needs no clamp.

The cost: reach and impressions count different populations (the retention array includes sessions with no `type=1` page_load, matching the shipped curve). They are never divided by one another, the retention-derived tile is always labelled "Viewer Reach", `viewed` is always labelled "Impressions", and both carry tooltips saying which is which.

**2. Every rate tile is `action / viewed` from the same microservice row.** Within one row all actions share that row's unit, so each ratio is internally consistent and matches the funnel bars directly beneath it. The server's `conversion_rate` is deliberately not reused for these tiles (its numerator is distinct converting *sessions* over `viewed`, which for atomic layers mixes sessions with events); it stays where it already ships, in the sub-hotspot rail header.

**3. Form abandon rate = No Action / Impressions.** Submission + Skip + Abandon then account for every impression. This closes the ticket's "abandon-rate formula TBD" open question. The tooltip states the definition outright, because it counts "ignored the form" the same as "started and left" — a truthful abandon needs a `form_start` player event that does not exist yet, and would be forward-only.

## Poll answer distribution

wp-polls owns the votes (`$wpdb->pollsa`), and GoDAM's `voted` event does not record which answer was chosen, so the distribution is necessarily **poll-wide**: every vote on that poll across the site, not scoped to this video or the selected range. The chart says so in a caption and a tooltip rather than letting its placement imply otherwise.

New route `GET /godam/v1/poll/<id>/results`, **gated on `upload_files`** (the same capability as `/analytics/top-videos`) since vote tallies are aggregate reporting data. Note the two pre-existing poll routes (`/polls`, `/poll/<id>`) are still `permission_callback => '__return_true'`; same class as the Gravity Forms restriction in #2049, worth a separate look.

## Woo Linked Products

Chips read `product_name` / `product_image` straight from the `layer_metadata` the Woo player already emits, so there is no extra WooCommerce lookup and no new proxy enrichment. The chips carry no per-product rate on purpose: per-product performance lives in the rail below, and the rail's per-sub conversion is still subject to godam-analytics#196, so duplicating a rate up here would spread a known caveat across two places.

## Explicitly out of scope

- **Avg hover time** (Figma W9) — hover is a count, not a duration. Needs a new player timing event, an ingest whitelist entry and microservice work, and is forward-only.
- **Insight banners** ("Strong placement", "Move to 1:30 for +20% reach") — prescriptive recommendations, deferred to v2.1 on the ticket. The reach data added here is the input they need.
- **Per-layer History with dates** — `layer_positions` is stored per day but `/processed-layer-analytics/` merges it into a cross-day set, so the dates are gone before the frontend sees them. Needs a microservice response change. The existing "layer moved" notice already covers the reposition case.
- **godam-analytics#196** (a deleted sub-hotspot inheriting its parent's full-range impressions) — a correctness fix, not a panel feature. Its WP companion #1956 was closed unmerged, so it is still live; nothing this PR adds displays a per-sub rate.

## This does NOT match the Figma layout, only its metrics

Worth being blunt about, because it is the main review question. The Figma frames contain **none** of the structure this PR adds to: searching the analytics frame finds 0 occurrences of "Layer Timeline", "Video Layer", "Interaction Outcomes", "Hotspots in this layer", "Products in this layer", "All Products" or "No Action".

The design's model is different:

| Figma | Shipped today, and what this PR extends |
|---|---|
| Layer markers pinned **on the Viewer Retention Curve**, with a layer-name legend and a marker tooltip ("CTA • 0:18 / Viewer Retention 45% / Click to see more") | A separate `Video Layer Timeline` section with its own marker strip |
| "Click on the layer from graph" opens a **narrow floating modal** with an X close | An inline, full-width detail card below the strip |
| Its own "Last 7 days" pill **inside the modal** | One date picker for the whole section |
| Donut + arc tooltip chip + **two equal tiles** | Donut + one wide primary tile + two secondary tiles |
| Full-width **"Edit Layer" footer button** | Small "Edit Layer" link in the card header |
| **History** list with dates | Not present (needs per-day `layer_positions`, see above) |
| Insight banner | Not present (v2.1) |
| **"Layer CTR"** as a fourth top-level Insights KPI | Not present |
| **"Drop-off segments"** pie card | Not present |
| No funnel, no sub-hotspot rail | Both shipped and data-backed since v1.12 |

So what this PR contains is the design's **metrics**, implemented faithfully, inside the **existing** panel. It does not restructure the panel toward the Figma's curve-marker + modal interaction.

That restructure is a product decision rather than a purely visual one, which is why it is not attempted here: the Figma layout has no funnel and no sub-hotspot rail, so adopting it as drawn would remove working, data-backed UI that users have today. The P1 reskin spec drew the same line ("a restyle of working, data-backed UI, not a rebuild toward the Figma's richer layout"), deferring the richer layout to P3 — this is P3, so the call is now due. It also depends on work deferred from the retention-curve PR (#2033 shipped curve-only; markers were explicitly left out).

Options, for whoever reviews this:
1. **Merge as-is** and treat the layout rebuild as its own ticket. The metrics land now and nothing regresses.
2. **Rebuild to the Figma**: markers on the retention curve, layer detail as a modal, two-tile layout, History, and retire the separate Timeline section. Highest fidelity; needs a decision on whether the funnel and rail move into the modal or go away.
3. **Middle**: keep the Timeline section as the entry point, restyle the detail card to the Figma card shape (two equal tiles, footer Edit Layer button), and add curve markers separately.

## Verification

Verified live on `godam-dev.local` against a controlled fixture set, with the numbers chosen so every value on screen can be checked by arithmetic (retention `[0]=200`, `[5]=184`, `[20]=150`, `[30]=115`, `[40]=100`, `[50]=80`; previous window at half the baseline):

| Panel | Rendered | Checks |
|---|---|---|
| CTA | Reach 184, Clicked 50, +100% · CTR 25% +25% · Reach rate 92% · Impressions 200 | 184 = retention[5]; 92% = 184/200; 25% = 50/200; +25% = (25−20)/20; +100% = (184−92)/92 |
| Form | Reach 150, Abandoned 60, +100% · Submission 24% +20% · Abandon 60% · Skip 16% | 24+60+16 = 100% of impressions |
| Hotspot | Reach 115, Clicked 14, +101.8% · Conversion 25% +25% · Impressions 56 · Hover 53.6% | 25% = 14/56; 53.6% = 30/56 |
| Poll | Reach 100, Voted 20, +100% · Conversion 25% · Impressions 80 · Skip 12.5% · Answer Distribution from wp-polls | 25% = 20/80; 12.5% = 10/80 |
| Woo | Reach 80, Added to Cart 5, +100% · ATC 10% +25% · Product Click 20% · Reach rate 40% | 10% = 5/50; 20% = 10/50; 40% = 80/200 |

Also covered: the reach tiles hide (dash, no donut) rather than showing a confident zero when there is no retention data for the range or the layer sits past the recorded `video_length`; the capability gate 401s an unauthenticated call to the poll route; an unknown poll id returns an empty distribution and the chart hides.

`npm run lint:js`, `npm run lint:php` and PHPCS clean. 151 jest tests and 55 PHPUnit tests green, of which new here: 30 for the reach maths, 18 for the KPI descriptors, 11 for value formatting, 10 for the poll answer shaping.

## Manual QA steps

1. Open a per-video Analytics page for a video with layers and confirm each layer type's panel shows a Viewer Reach donut whose centre matches the Viewer Retention Curve at that layer's timestamp.
2. Switch the layer card's date range and confirm the reach number, the rates and the "vs prev N days" badges all move together; at **All Time** the badges disappear (no previous window to compare against).
3. On a Poll layer, confirm the Answer Distribution matches the WP Polls admin screen for that poll, and that the caption says the totals are poll-wide.
4. Deactivate WP-Polls and confirm the Poll panel simply drops the distribution with no error.
5. As a Subscriber (or logged out), confirm `/wp-json/godam/v1/poll/1/results` returns 401.
6. On a Woo layer, confirm Linked Products lists the layer's products with thumbnails, and that a product removed from the layer renders muted with a "Removed" tag.
7. Check a video whose layer sits beyond the video length: the reach tiles show a dash instead of 0.

## Automation impact

New `data-test-id` hooks: `godam-layer-reach-donut`, `godam-layer-reach-trend`, `godam-layer-kpi-tiles`, `godam-layer-kpi-<metric>` (`ctr`, `submission-rate`, `abandon-rate`, `skip-rate`, `conversion-rate`, `add-to-cart-rate`, `product-click-rate`, `reach-rate`, `impressions`), `godam-layer-kpi-<metric>-trend`, `godam-layer-linked-products`, `godam-layer-poll-distribution`, `godam-layer-poll-distribution-loading`.

## One thing to be aware of

While verifying I hit a page-bootstrap flake on this Local box: on an initial load the analytics REST calls all return 200 and the RTK store holds fulfilled entries, yet the consuming hooks keep reporting the pre-resolution state, so the layer card stays on its skeleton until any range change nudges it. It reproduces on unmodified `develop` code (checked by rebuilding without this branch's changes), so it is not introduced here, but it is worth a look on its own. A contributing factor is that a stock Local install ships `pm.max_children = 2` while this page fires seven concurrent analytics REST calls that each hold a PHP worker for a full microservice round-trip; that is also why the reach read is queued behind the layer reads in this PR rather than fired alongside them.
