### PR TITLE
Fix/godam media library issues

### DIFF
--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -92,6 +92,10 @@ function initializeMediaLibrarySidebar( frame ) {
 				menu.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( el ) => el.remove() );
 				const div = document.createElement( 'div' );
 				div.id = 'rt-transcoder-media-library-root';
+				// Keep a per-frame reference to the wp.media frame on its own root,
+				// so the React sidebar can filter THIS frame's collection directly
+				// (via Backbone props) instead of poking shared grid-only DOM.
+				div._godamFrame = frame;
 				// Append into the menu's first element child (the .media-menu
 				// container). firstChild could be a whitespace text node, which
 				// cannot take children and would throw a HierarchyRequestError.
@@ -137,6 +141,10 @@ function initializeMediaLibrarySidebar( frame ) {
 			} );
 			const div = document.createElement( 'div' );
 			div.id = 'rt-transcoder-media-library-root';
+			// Keep a per-frame reference to the wp.media frame on its own root, so
+			// the React sidebar can filter THIS frame's collection directly (via
+			// Backbone props) instead of poking shared grid-only DOM.
+			div._godamFrame = frame;
 			menu.appendChild( div );
 			// Pass the exact root so the React app renders into THIS frame's sidebar
 			// instead of guessing which frame is active.

--- a/assets/src/js/media-library/index.js
+++ b/assets/src/js/media-library/index.js
@@ -4,13 +4,9 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * External dependencies
- */
-import videojs from 'video.js';
-
-/**
  * Internal dependencies
  */
+import { getLoadedVideoJs } from './videojs-loader.js';
 import '../../libs/jquery-ui-1.14.2.draggable/jquery-ui';
 import './transcoding-status';
 
@@ -36,6 +32,10 @@ import { isFolderOrgDisabled, isUploadPage, addManageMediaButton } from './utili
  * @param {HTMLElement} container - The DOM element to search for Video.js players.
  */
 function destroyVideoJSPlayersInContainer( container ) {
+	// Only relevant if Video.js was actually loaded (i.e. a player was created this
+	// session). If it was never loaded there are no Video.js players to dispose.
+	const videojs = getLoadedVideoJs();
+
 	if ( ! container || ! videojs ) {
 		return;
 	}

--- a/assets/src/js/media-library/videojs-loader.js
+++ b/assets/src/js/media-library/videojs-loader.js
@@ -1,0 +1,46 @@
+/**
+ * Lazy loader for Video.js in the media library.
+ *
+ * Video.js is a large dependency but is only needed inside the media library when a
+ * (virtual/GoDAM proxy) video attachment's detail panel is opened — which most sessions
+ * never do. Statically importing it pulled the whole library into the always-loaded
+ * media-library bundle. Loading it through a dynamic `import()` splits it into its own
+ * async chunk (webpackChunkName "videojs") that is fetched on demand and then cached, so
+ * the base bundle stays small.
+ */
+
+let cachedVideojs = null;
+let loadingPromise = null;
+
+/**
+ * Dynamically load (and cache) Video.js.
+ *
+ * @return {Promise<Function>} Resolves with the videojs factory function.
+ */
+export function loadVideoJs() {
+	if ( cachedVideojs ) {
+		return Promise.resolve( cachedVideojs );
+	}
+
+	if ( ! loadingPromise ) {
+		loadingPromise = import( /* webpackChunkName: "videojs" */ 'video.js' ).then( ( mod ) => {
+			cachedVideojs = mod.default || mod;
+			return cachedVideojs;
+		} );
+	}
+
+	return loadingPromise;
+}
+
+/**
+ * Synchronously return the already-loaded Video.js, or null if it hasn't been loaded yet.
+ *
+ * Use this where Video.js is only relevant if a player already exists (e.g. cleanup, or
+ * updating a poster on a player that must have been created earlier): if it was never
+ * loaded, there is nothing to act on and the caller can safely skip.
+ *
+ * @return {Function|null} The videojs factory, or null when not yet loaded.
+ */
+export function getLoadedVideoJs() {
+	return cachedVideojs;
+}

--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import DOMPurify from 'isomorphic-dompurify';
-import videojs from 'video.js';
 /**
  * WordPress dependencies
  */
@@ -15,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { addIcon, trashIcon, editIcon, barChartIcon } from '../media-library-icons';
 import { canManageAttachment } from '../utility';
+import { loadVideoJs, getLoadedVideoJs } from '../videojs-loader.js';
 
 const AttachmentDetailsTwoColumn = wp?.media?.view?.Attachment?.Details?.TwoColumn;
 
@@ -536,8 +536,10 @@ export default AttachmentDetailsTwoColumn?.extend( {
 		const virtual = this.model.get( 'virtual' );
 
 		// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
-		if ( undefined !== virtual && virtual ) {
-			const videoPlayer = videojs( 'videojs-player-' + this.model.get( 'id' ) );
+		// The player was created earlier, so Video.js is already loaded and cached here.
+		const posterVideojs = getLoadedVideoJs();
+		if ( undefined !== virtual && virtual && posterVideojs ) {
+			const videoPlayer = posterVideojs( 'videojs-player-' + this.model.get( 'id' ) );
 			videoPlayer.poster( selected );
 		}
 
@@ -709,8 +711,10 @@ export default AttachmentDetailsTwoColumn?.extend( {
 				const virtual = model.get( 'virtual' );
 
 				// If the attachment is virtual (e.g. a GoDAM proxy video), override default preview.
-				if ( undefined !== virtual && virtual ) {
-					const videoPlayer = videojs( 'videojs-player-' + model.get( 'id' ) );
+				// The player was created earlier, so Video.js is already loaded and cached here.
+				const posterVideojs = getLoadedVideoJs();
+				if ( undefined !== virtual && virtual && posterVideojs ) {
+					const videoPlayer = posterVideojs( 'videojs-player-' + model.get( 'id' ) );
 					videoPlayer.poster( thumbnailURL );
 				}
 
@@ -1002,9 +1006,11 @@ export default AttachmentDetailsTwoColumn?.extend( {
 				` );
 
 				// Wait for DOM to fully render the core preview container.
-				setTimeout( () => {
+				setTimeout( async () => {
 					const videoElement = document.getElementById( videoId );
-					if ( videoElement && typeof videojs !== 'undefined' ) {
+					// Lazy-load Video.js only now that a video player is actually needed.
+					const videojs = videoElement ? await loadVideoJs() : null;
+					if ( videoElement && videojs ) {
 						// Calculate initial dimensions using 16:9 aspect ratio as default
 						const viewContainer = this.$el.closest( '.media-modal-content' ).find( '.attachment-media-view' );
 						const availableWidth = viewContainer.length ? viewContainer.width() : window.innerWidth * 0.65;

--- a/assets/src/js/media-library/views/attachment-detail-two-column.js
+++ b/assets/src/js/media-library/views/attachment-detail-two-column.js
@@ -1008,9 +1008,23 @@ export default AttachmentDetailsTwoColumn?.extend( {
 				// Wait for DOM to fully render the core preview container.
 				setTimeout( async () => {
 					const videoElement = document.getElementById( videoId );
+					if ( ! videoElement ) {
+						return;
+					}
+
 					// Lazy-load Video.js only now that a video player is actually needed.
-					const videojs = videoElement ? await loadVideoJs() : null;
-					if ( videoElement && videojs ) {
+					// Guard the async import: if the chunk fails to load (stale cache after an
+					// update, network hiccup) don't leave an unhandled rejection.
+					let videojs = null;
+					try {
+						videojs = await loadVideoJs();
+					} catch ( e ) {
+						return;
+					}
+
+					// The modal may have closed while the chunk was loading — re-check the
+					// element is still attached before initialising a player on it.
+					if ( videojs && videoElement.isConnected ) {
 						// Calculate initial dimensions using 16:9 aspect ratio as default
 						const viewContainer = this.$el.closest( '.media-modal-content' ).find( '.attachment-media-view' );
 						const availableWidth = viewContainer.length ? viewContainer.width() : window.innerWidth * 0.65;

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -318,7 +318,14 @@ class Assets {
 		}
 
 		wp_set_script_translations( 'easydam-media-library', 'godam', RTGODAM_PATH . 'languages' );
-		wp_enqueue_script( 'easydam-media-library' );
+
+		// Only load the heavy media-library bundle (~2.65 MB, bundles video.js) where the
+		// media library / wp.media modal is actually used. It was previously enqueued on
+		// every admin screen. Registration + localization above stay unconditional (cheap,
+		// and inert unless the handle is enqueued).
+		if ( godam_should_load_media_library_assets( $screen ) ) {
+			wp_enqueue_script( 'easydam-media-library' );
+		}
 
 		/**
 		 * Dependency library for the date range picker. Its only consumers (the media-library

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -1227,6 +1227,13 @@ class Pages {
 
 		wp_enqueue_style( 'wp-components' );
 
+		// The media-library React sidebar bundle (~1.1 MB) is the remaining work in this
+		// method; skip it on screens that never open the media library / wp.media modal.
+		// It was previously enqueued on every admin screen.
+		if ( ! godam_should_load_media_library_assets( $screen ) ) {
+			return;
+		}
+
 		// The bundle externalizes several @wordpress packages to wp.* globals
 		// (see the `pages` externals in webpack.config.js). On WP admin / the
 		// block editor these globals are already present, but in other contexts

--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -1243,9 +1243,13 @@ class Pages {
 		// only the handles actually registered in the current context: a handle
 		// missing on older WP / non-standard admin screens would otherwise block
 		// the enqueue entirely.
+		// `media-views` is included so the bundle's modal-close hook (which patches
+		// wp.media.view.Modal in pages/media-library/index.js) has wp.media defined by the
+		// time it runs — otherwise the ordering is incidental and the hook can silently
+		// no-op, leaving React roots unmounted and UI state un-reset.
 		$media_library_deps = array_values(
 			array_filter(
-				array( 'wp-element', 'wp-i18n', 'wp-components', 'wp-api-fetch', 'wp-primitives', 'wp-data', 'wp-notices' ),
+				array( 'wp-element', 'wp-i18n', 'wp-components', 'wp-api-fetch', 'wp-primitives', 'wp-data', 'wp-notices', 'media-views' ),
 				static function ( $handle ) {
 					return wp_script_is( $handle, 'registered' );
 				}

--- a/inc/classes/media-library/class-media-folder-create-zip.php
+++ b/inc/classes/media-library/class-media-folder-create-zip.php
@@ -161,6 +161,9 @@ class Media_Folder_Create_Zip {
 			}
 		}
 
+		// Harden the directory: prevent listing/enumeration of the generated archives.
+		$this->protect_godam_dir( $godam_dir );
+
 		// Full path to the ZIP file.
 		$zip_path = $godam_dir . '/' . $zip_name;
 
@@ -359,8 +362,45 @@ class Media_Folder_Create_Zip {
 	}
 
 	/**
+	 * Harden the uploads/godam directory against enumeration.
+	 *
+	 * The generated ZIPs are static files served from this directory. Writing an
+	 * index.php (blank) and an .htaccess that disables auto-indexing prevents a
+	 * visitor from listing the directory to discover archive filenames. Combined
+	 * with the random token in each ZIP name, direct guessing becomes infeasible.
+	 * Both files are only written when missing, so this is cheap to call repeatedly.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $dir Absolute path to the godam upload directory.
+	 * @return void
+	 */
+	private function protect_godam_dir( $dir ) {
+		global $wp_filesystem;
+
+		if ( empty( $wp_filesystem ) || ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+
+		if ( empty( $wp_filesystem ) ) {
+			return;
+		}
+
+		$index = trailingslashit( $dir ) . 'index.php';
+		if ( ! $wp_filesystem->exists( $index ) ) {
+			$wp_filesystem->put_contents( $index, "<?php\n// Silence is golden.\n", FS_CHMOD_FILE );
+		}
+
+		$htaccess = trailingslashit( $dir ) . '.htaccess';
+		if ( ! $wp_filesystem->exists( $htaccess ) ) {
+			$wp_filesystem->put_contents( $htaccess, "Options -Indexes\n", FS_CHMOD_FILE );
+		}
+	}
+
+	/**
 	 * Cleanup the ZIP file after a scheduled time.
-	 * 
+	 *
 	 * @since 1.3.0
 	 *
 	 * @param string $zip_path The path to the ZIP file to be cleaned up.

--- a/inc/classes/media-library/class-media-folder-create-zip.php
+++ b/inc/classes/media-library/class-media-folder-create-zip.php
@@ -356,8 +356,14 @@ class Media_Folder_Create_Zip {
 			gc_collect_cycles();
 		}
 
-		if ( function_exists( 'wp_cache_flush' ) ) {
-			wp_cache_flush();
+		// Free only the in-memory (runtime) object cache that accumulates while iterating
+		// attachments — NOT the entire persistent site cache. The previous wp_cache_flush()
+		// flushed every group in the object cache (hurting every other request on the site)
+		// just to reclaim memory for one download. wp_cache_flush_runtime() (WP 6.0+) drops
+		// the runtime cache without touching the persistent backend; on older WP we rely on
+		// gc_collect_cycles() plus the memory-threshold guard in the batch loop.
+		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+			wp_cache_flush_runtime();
 		}
 	}
 

--- a/inc/classes/media-library/class-media-folder-create-zip.php
+++ b/inc/classes/media-library/class-media-folder-create-zip.php
@@ -370,11 +370,13 @@ class Media_Folder_Create_Zip {
 	/**
 	 * Harden the uploads/godam directory against enumeration.
 	 *
-	 * The generated ZIPs are static files served from this directory. Writing an
-	 * index.php (blank) and an .htaccess that disables auto-indexing prevents a
-	 * visitor from listing the directory to discover archive filenames. Combined
-	 * with the random token in each ZIP name, direct guessing becomes infeasible.
-	 * Both files are only written when missing, so this is cheap to call repeatedly.
+	 * The generated ZIPs are static files served from this directory. A blank index.php
+	 * stops a visitor from listing the directory to discover archive filenames on both
+	 * Apache and nginx; combined with the random token in each ZIP name, direct guessing
+	 * becomes infeasible. (We deliberately do NOT write an `.htaccess` with
+	 * `Options -Indexes`: it's a no-op on nginx and, on Apache configs where AllowOverride
+	 * excludes Options, it 500s the whole directory — breaking the very downloads it would
+	 * protect. The index.php alone is enough.) The file is only written when missing.
 	 *
 	 * @since 1.3.0
 	 *
@@ -386,21 +388,22 @@ class Media_Folder_Create_Zip {
 
 		if ( empty( $wp_filesystem ) || ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
-			WP_Filesystem();
+
+			// WP_Filesystem() returns false when a non-direct transport needs credentials —
+			// but can still leave a non-connected object in $wp_filesystem, so gate on its
+			// return value rather than on emptiness of the global.
+			if ( ! WP_Filesystem() ) {
+				return;
+			}
 		}
 
-		if ( empty( $wp_filesystem ) ) {
+		if ( empty( $wp_filesystem ) || ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
 			return;
 		}
 
 		$index = trailingslashit( $dir ) . 'index.php';
 		if ( ! $wp_filesystem->exists( $index ) ) {
 			$wp_filesystem->put_contents( $index, "<?php\n// Silence is golden.\n", FS_CHMOD_FILE );
-		}
-
-		$htaccess = trailingslashit( $dir ) . '.htaccess';
-		if ( ! $wp_filesystem->exists( $htaccess ) ) {
-			$wp_filesystem->put_contents( $htaccess, "Options -Indexes\n", FS_CHMOD_FILE );
 		}
 	}
 

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -79,8 +79,10 @@ class Media_Library extends Base {
 
 		$term_id = isset( $matches[1] ) ? (int) $matches[1] : 0;
 
-		// Renaming / re-parenting / deleting a locked folder (or a child of one).
-		if ( $term_id > 0 && $this->is_folder_locked( $term_id ) ) {
+		// Renaming / re-parenting / deleting a locked folder (or a child of one). A
+		// bookmark toggle is a personal flag rather than a modification of the folder's
+		// protected content, so it is still allowed on a locked folder.
+		if ( $term_id > 0 && $this->is_folder_locked( $term_id ) && ! $this->is_bookmark_only_folder_update( $request, $term_id ) ) {
 			return new \WP_Error(
 				'godam_folder_locked',
 				__( 'This folder is locked and cannot be modified.', 'godam' ),
@@ -102,6 +104,67 @@ class Media_Library extends Base {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Whether a native media-folder update request only toggles the `bookmark` meta and
+	 * changes nothing else (name, slug, description, parent, or the `locked` meta itself).
+	 *
+	 * Bookmarking is a per-user convenience flag, not a modification of the folder's
+	 * protected content, so it stays allowed on a locked folder — but this must NOT become
+	 * a hole through which a locked folder is renamed, re-parented, or unlocked.
+	 *
+	 * @param \WP_REST_Request $request The request being dispatched.
+	 * @param int              $term_id The media-folder term id.
+	 * @return bool True if the request only changes the bookmark meta.
+	 */
+	private function is_bookmark_only_folder_update( $request, $term_id ) {
+		if ( 'DELETE' === $request->get_method() ) {
+			return false;
+		}
+
+		$term = get_term( $term_id, 'media-folder' );
+
+		if ( ! $term || is_wp_error( $term ) ) {
+			return false;
+		}
+
+		// Any change to the folder's own fields disqualifies it.
+		$name = $request->get_param( 'name' );
+		if ( ! is_null( $name ) && (string) $name !== (string) $term->name ) {
+			return false;
+		}
+
+		$slug = $request->get_param( 'slug' );
+		if ( ! is_null( $slug ) && (string) $slug !== (string) $term->slug ) {
+			return false;
+		}
+
+		$description = $request->get_param( 'description' );
+		if ( ! is_null( $description ) && (string) $description !== (string) $term->description ) {
+			return false;
+		}
+
+		$parent = $request->get_param( 'parent' );
+		if ( ! is_null( $parent ) && (int) $parent !== (int) $term->parent ) {
+			return false;
+		}
+
+		// The lock state itself must not change through this path (unlocking is a
+		// capability-gated operation handled by the bulk-lock endpoint).
+		$meta = $request->get_param( 'meta' );
+		if ( is_array( $meta ) && array_key_exists( 'locked', $meta ) ) {
+			$current_locked = get_term_meta( $term_id, 'locked', true );
+			$current_bool   = ( '1' === (string) $current_locked || 1 === $current_locked || true === $current_locked || 'true' === $current_locked );
+			$requested      = $meta['locked'];
+			$requested_bool = ( true === $requested || 1 === $requested || '1' === (string) $requested || 'true' === $requested );
+
+			if ( $current_bool !== $requested_bool ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -708,6 +771,11 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_attachment', __( 'No attachment IDs provided.', 'godam' ), array( 'status' => 400 ) );
 		}
 
+		// Prime the post + object-term caches once so the per-id checks below don't each
+		// hit the database (a large drag-move otherwise fired hundreds of queries).
+		_prime_post_caches( $attachment_ids );
+		update_object_term_cache( $attachment_ids, 'attachment' );
+
 		foreach ( $attachment_ids as $attachment_id ) {
 			if ( 'attachment' !== get_post_type( $attachment_id ) ) {
 				return new \WP_Error( 'invalid_attachment', __( 'Invalid attachment ID.', 'godam' ), array( 'status' => 400 ) );
@@ -722,26 +790,28 @@ class Media_Library extends Base {
 			}
 		}
 
-		// if folder id is 0, remove the folder from the attachments.
-		if ( 0 === $folder_term_id ) {
-			// Removing an attachment out of a locked folder mutates that folder's
-			// contents — reject if any attachment currently sits in a locked folder.
-			foreach ( $attachment_ids as $attachment_id ) {
-				$current_folders = wp_get_object_terms( $attachment_id, 'media-folder', array( 'fields' => 'ids' ) );
+		// Moving an attachment OUT of a locked folder empties that (protected) folder —
+		// whether by removing it (folder 0) or by re-assigning it to a different folder,
+		// since wp_set_object_terms() replaces the assignment. Reject if any attachment
+		// currently lives in a locked folder other than the destination.
+		foreach ( $attachment_ids as $attachment_id ) {
+			$current_folders = wp_get_object_terms( $attachment_id, 'media-folder', array( 'fields' => 'ids' ) );
 
-				if ( is_array( $current_folders ) ) {
-					foreach ( $current_folders as $current_folder_id ) {
-						if ( $this->is_folder_locked( $current_folder_id ) ) {
-							return new \WP_Error(
-								'godam_folder_locked',
-								__( 'One or more attachments belong to a locked folder and cannot be moved.', 'godam' ),
-								array( 'status' => 403 )
-							);
-						}
+			if ( is_array( $current_folders ) ) {
+				foreach ( $current_folders as $current_folder_id ) {
+					if ( (int) $current_folder_id !== (int) $folder_term_id && $this->is_folder_locked( $current_folder_id ) ) {
+						return new \WP_Error(
+							'godam_folder_locked',
+							__( 'One or more attachments belong to a locked folder and cannot be moved.', 'godam' ),
+							array( 'status' => 403 )
+						);
 					}
 				}
 			}
+		}
 
+		// if folder id is 0, remove the folder from the attachments.
+		if ( 0 === $folder_term_id ) {
 			foreach ( $attachment_ids as $attachment_id ) {
 
 				$return = $this->remove_all_terms_from_id( $attachment_id, 'media-folder' );
@@ -775,10 +845,6 @@ class Media_Library extends Base {
 		}
 
 		foreach ( $attachment_ids as $attachment_id ) {
-			if ( get_post_type( $attachment_id ) !== 'attachment' ) {
-				return new \WP_Error( 'invalid_attachment', __( 'Invalid attachment ID.', 'godam' ), array( 'status' => 400 ) );
-			}
-
 			$return = wp_set_object_terms( $attachment_id, $folder_term_id, 'media-folder' );
 
 			if ( is_wp_error( $return ) ) {

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1587,10 +1587,23 @@ class Media_Library extends Base {
 				continue;
 			}
 
+			// update_term_meta() returns false BOTH on a genuine failure and when the value
+			// is already what we're setting. Treat "already at the desired value" as success
+			// (a no-op), so re-locking an already-locked folder isn't a "failure"; only a real
+			// write failure (value differs but the update returned false) is recorded.
+			$current = get_term_meta( $folder_id, $meta_key, true );
+
+			if ( (string) $current === (string) $value ) {
+				++$updated_count;
+				continue;
+			}
+
 			$result = update_term_meta( $folder_id, $meta_key, $value );
 
 			if ( false === $result ) {
-				++$updated_count;
+				$failed_ids[] = $folder_id;
+				// translators: %s is the folder ID whose meta update failed.
+				$errors[] = sprintf( __( 'Failed to update folder %s.', 'godam' ), $folder_id );
 			} else {
 				++$updated_count;
 			}

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -676,6 +676,30 @@ class Media_Library extends Base {
 		$attachment_ids = $request->get_param( 'attachment_ids' );
 		$folder_term_id = $request->get_param( 'folder_term_id' );
 
+		// IDOR guard: this route is gated only by the broad `edit_posts` capability, which
+		// does NOT prove the caller may edit these specific objects. Before touching any
+		// terms — in either the assign or the remove-from-folder path — verify every ID is
+		// genuinely an attachment and that the current user can edit that object. Without
+		// this, a user could move (or strip folders from) media they do not own, and the
+		// remove path would act on raw IDs of arbitrary post types.
+		if ( empty( $attachment_ids ) || ! is_array( $attachment_ids ) ) {
+			return new \WP_Error( 'invalid_attachment', __( 'No attachment IDs provided.', 'godam' ), array( 'status' => 400 ) );
+		}
+
+		foreach ( $attachment_ids as $attachment_id ) {
+			if ( 'attachment' !== get_post_type( $attachment_id ) ) {
+				return new \WP_Error( 'invalid_attachment', __( 'Invalid attachment ID.', 'godam' ), array( 'status' => 400 ) );
+			}
+
+			if ( ! current_user_can( 'edit_post', $attachment_id ) ) {
+				return new \WP_Error(
+					'rest_forbidden',
+					__( 'You are not allowed to modify one or more of these attachments.', 'godam' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
 		// if folder id is 0, remove the folder from the attachments.
 		if ( 0 === $folder_term_id ) {
 			// Removing an attachment out of a locked folder mutates that folder's

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -27,6 +27,80 @@ class Media_Library extends Base {
 	protected $rest_base = 'media-library';
 
 	/**
+	 * Setup hooks.
+	 *
+	 * Adds the base REST-route registration plus a server-side guard that enforces
+	 * folder "locked" state on the NATIVE wp/v2/media-folder term endpoints (rename,
+	 * delete, re-parent, create-under). Locking was previously enforced only in React,
+	 * so a direct REST call could still mutate a locked folder.
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks() {
+		parent::setup_hooks();
+
+		add_filter( 'rest_pre_dispatch', array( $this, 'enforce_locked_media_folder' ), 10, 3 );
+	}
+
+	/**
+	 * Reject mutating REST requests against locked media-folder terms.
+	 *
+	 * Runs before dispatch on the native taxonomy routes:
+	 *   - POST/PUT/PATCH /wp/v2/media-folder/{id}  → rename / re-parent an existing folder
+	 *   - DELETE         /wp/v2/media-folder/{id}  → delete an existing folder
+	 *   - POST           /wp/v2/media-folder       → create a folder (blocked only when the
+	 *                                                target parent is locked, i.e. populating it)
+	 * Reads (GET) are always allowed — locking protects against modification, not viewing.
+	 *
+	 * @param mixed            $result  Pre-dispatch result (non-null short-circuits the request).
+	 * @param \WP_REST_Server  $server  Server instance (unused).
+	 * @param \WP_REST_Request $request The request being dispatched.
+	 * @return mixed Original $result, or a 403 WP_Error when the target folder is locked.
+	 */
+	public function enforce_locked_media_folder( $result, $server, $request ) {
+		// Let an already short-circuited result (e.g. another plugin's error) stand.
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		// Only guard the native media-folder collection or a single term.
+		if ( ! preg_match( '#^/wp/v2/media-folder(?:/(\d+))?$#', $request->get_route(), $matches ) ) {
+			return $result;
+		}
+
+		// Only mutating verbs.
+		if ( ! in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true ) ) {
+			return $result;
+		}
+
+		$term_id = isset( $matches[1] ) ? (int) $matches[1] : 0;
+
+		// Renaming / re-parenting / deleting a locked folder (or a child of one).
+		if ( $term_id > 0 && $this->is_folder_locked( $term_id ) ) {
+			return new \WP_Error(
+				'godam_folder_locked',
+				__( 'This folder is locked and cannot be modified.', 'godam' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Creating or moving a folder INTO a locked destination (populating it).
+		if ( 'DELETE' !== $request->get_method() ) {
+			$new_parent = $request->get_param( 'parent' );
+
+			if ( ! is_null( $new_parent ) && (int) $new_parent > 0 && $this->is_folder_locked( (int) $new_parent ) ) {
+				return new \WP_Error(
+					'godam_folder_locked',
+					__( 'The destination folder is locked and cannot be modified.', 'godam' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Register custom REST API routes for Settings Pages.
 	 *
 	 * @return array Array of registered REST API routes
@@ -601,6 +675,24 @@ class Media_Library extends Base {
 
 		// if folder id is 0, remove the folder from the attachments.
 		if ( 0 === $folder_term_id ) {
+			// Removing an attachment out of a locked folder mutates that folder's
+			// contents — reject if any attachment currently sits in a locked folder.
+			foreach ( $attachment_ids as $attachment_id ) {
+				$current_folders = wp_get_object_terms( $attachment_id, 'media-folder', array( 'fields' => 'ids' ) );
+
+				if ( is_array( $current_folders ) ) {
+					foreach ( $current_folders as $current_folder_id ) {
+						if ( $this->is_folder_locked( $current_folder_id ) ) {
+							return new \WP_Error(
+								'godam_folder_locked',
+								__( 'One or more attachments belong to a locked folder and cannot be moved.', 'godam' ),
+								array( 'status' => 403 )
+							);
+						}
+					}
+				}
+			}
+
 			foreach ( $attachment_ids as $attachment_id ) {
 
 				$return = $this->remove_all_terms_from_id( $attachment_id, 'media-folder' );
@@ -622,6 +714,15 @@ class Media_Library extends Base {
 
 		if ( ! $term || is_wp_error( $term ) ) {
 			return new \WP_Error( 'invalid_term', __( 'Invalid folder term ID.', 'godam' ), array( 'status' => 400 ) );
+		}
+
+		// Assigning attachments into a locked folder (or a child of one) populates it — reject.
+		if ( $this->is_folder_locked( $folder_term_id ) ) {
+			return new \WP_Error(
+				'godam_folder_locked',
+				__( 'This folder is locked and cannot be modified.', 'godam' ),
+				array( 'status' => 403 )
+			);
 		}
 
 		foreach ( $attachment_ids as $attachment_id ) {
@@ -1179,6 +1280,18 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_ids', __( 'No folder IDs provided or invalid format.', 'godam' ), array( 'status' => 400 ) );
 		}
 
+		// Reject the whole request if any target is locked (or a child of a locked folder),
+		// so a direct API call can't delete a protected folder — and we never partially delete.
+		foreach ( $folder_ids as $folder_id ) {
+			if ( is_numeric( $folder_id ) && (int) $folder_id > 0 && $this->is_folder_locked( $folder_id ) ) {
+				return new \WP_Error(
+					'godam_folder_locked',
+					__( 'One or more selected folders are locked and cannot be deleted.', 'godam' ),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
 		$deleted_count = 0;
 		$errors        = array();
 
@@ -1235,6 +1348,43 @@ class Media_Library extends Base {
 		} else {
 			return new \WP_Error( 'bulk_delete_failed', __( 'No folders were deleted.', 'godam' ) . ' Errors: ' . implode( ', ', $errors ), array( 'status' => 500 ) );
 		}
+	}
+
+	/**
+	 * Whether a media-folder term is locked, directly or through an ancestor.
+	 *
+	 * Folder locking is protective: a locked folder shields itself AND all of its
+	 * descendants from mutation. So a folder counts as locked if its own `locked`
+	 * term-meta is truthy or if any of its ancestors' is. Client-side gating (React)
+	 * is UX only; this is the authoritative server-side check.
+	 *
+	 * @param int $term_id Media-folder term ID.
+	 * @return bool True if the folder or one of its ancestors is locked.
+	 */
+	private function is_folder_locked( $term_id ) {
+		$term_id = (int) $term_id;
+
+		if ( $term_id <= 0 ) {
+			return false;
+		}
+
+		// The term itself plus every ancestor — a locked ancestor locks the branch.
+		$ids       = array( $term_id );
+		$ancestors = get_ancestors( $term_id, 'media-folder', 'taxonomy' );
+
+		if ( is_array( $ancestors ) ) {
+			$ids = array_merge( $ids, $ancestors );
+		}
+
+		foreach ( $ids as $id ) {
+			$locked_raw = get_term_meta( $id, 'locked', true );
+
+			if ( '1' === $locked_raw || 1 === $locked_raw || true === $locked_raw || 'true' === $locked_raw ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -247,8 +247,11 @@ class Media_Library extends Base {
 				'args'      => array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'download_folder' ),
+					// Requires upload_files (Author+): generating a ZIP aggregates an entire
+					// folder's media into a downloadable archive, so Contributors (edit_posts
+					// only) must not be able to trigger it.
 					'permission_callback' => function () {
-						return current_user_can( 'edit_posts' );
+						return current_user_can( 'upload_files' );
 					},
 					'args'                => array(
 						'folder_id' => array(
@@ -1242,7 +1245,12 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_folder', __( 'Invalid folder term ID.', 'godam' ), array( 'status' => 404 ) );
 		}
 
-		$result = Media_Folder_Create_Zip::get_instance()->create_zip( $folder_id, 'media-folder-' . $term->slug . '.zip' );
+		// Append an unguessable token so the resulting file lives at an unpredictable
+		// URL. The ZIP is a world-readable static file under uploads/godam/ for 24h, so
+		// a predictable name (slug only) let anyone who knew the slug fetch it directly.
+		$zip_name = 'media-folder-' . $term->slug . '-' . wp_generate_password( 20, false ) . '.zip';
+
+		$result = Media_Folder_Create_Zip::get_instance()->create_zip( $folder_id, $zip_name );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -40,6 +40,10 @@ class Media_Library extends Base {
 		parent::setup_hooks();
 
 		add_filter( 'rest_pre_dispatch', array( $this, 'enforce_locked_media_folder' ), 10, 3 );
+
+		// Background builder for folder-ZIP downloads (see download_folder()). Runs via
+		// Action Scheduler when available, otherwise WP-Cron — both invoke this hook.
+		add_action( 'godam_build_folder_zip', array( $this, 'run_folder_zip_job' ), 10, 1 );
 	}
 
 	/**
@@ -258,6 +262,24 @@ class Media_Library extends Base {
 							'required'    => true,
 							'type'        => 'integer',
 							'description' => __( 'ID of the folder to create a ZIP file for.', 'godam' ),
+						),
+					),
+				),
+			),
+			array(
+				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/download-folder-status/(?P<job_id>[A-Za-z0-9]+)',
+				'args'      => array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_folder_zip_status' ),
+					'permission_callback' => function () {
+						return current_user_can( 'upload_files' );
+					},
+					'args'                => array(
+						'job_id' => array(
+							'required'    => true,
+							'type'        => 'string',
+							'description' => __( 'ID of the ZIP build job to poll.', 'godam' ),
 						),
 					),
 				),
@@ -1269,22 +1291,139 @@ class Media_Library extends Base {
 			return new \WP_Error( 'invalid_folder', __( 'Invalid folder term ID.', 'godam' ), array( 'status' => 404 ) );
 		}
 
-		// Append an unguessable token so the resulting file lives at an unpredictable
-		// URL. The ZIP is a world-readable static file under uploads/godam/ for 24h, so
-		// a predictable name (slug only) let anyone who knew the slug fetch it directly.
-		$zip_name = 'media-folder-' . $term->slug . '-' . wp_generate_password( 20, false ) . '.zip';
+		// The archive is built asynchronously. Building it in-request meant a folder with
+		// many/large files (batches of 50, files up to 500 MB) could exceed the PHP/web
+		// server time limit and fail the request. Instead we register a job, kick off a
+		// background build, and hand the client a job id to poll (get_folder_zip_status()).
+		$job_id = wp_generate_password( 32, false );
 
-		$result = Media_Folder_Create_Zip::get_instance()->create_zip( $folder_id, $zip_name );
+		$job = array(
+			'status'    => 'queued',
+			'folder_id' => (int) $folder_id,
+			'user_id'   => get_current_user_id(),
+			'zip_url'   => '',
+			'zip_name'  => '',
+			'message'   => '',
+			'created'   => time(),
+			'updated'   => time(),
+		);
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
+		set_transient( $this->zip_job_transient_key( $job_id ), $job, HOUR_IN_SECONDS );
+
+		// Prefer Action Scheduler (bundled with WooCommerce and many plugins) for reliable
+		// async execution; fall back to WP-Cron nudged with spawn_cron(). Both paths invoke
+		// the `godam_build_folder_zip` hook with the job id (see setup_hooks()).
+		if ( function_exists( 'as_enqueue_async_action' ) ) {
+			as_enqueue_async_action( 'godam_build_folder_zip', array( $job_id ), 'godam' );
+		} else {
+			wp_schedule_single_event( time(), 'godam_build_folder_zip', array( $job_id ) );
+
+			if ( function_exists( 'spawn_cron' ) ) {
+				spawn_cron();
+			}
 		}
 
 		return rest_ensure_response(
 			array(
 				'success' => true,
-				'message' => __( 'ZIP file created successfully.', 'godam' ),
-				'data'    => $result,
+				'message' => __( 'Preparing ZIP file…', 'godam' ),
+				'data'    => array(
+					'job_id' => $job_id,
+					'status' => 'queued',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Transient key for a folder-ZIP build job.
+	 *
+	 * @param string $job_id Job identifier.
+	 * @return string Transient key.
+	 */
+	private function zip_job_transient_key( $job_id ) {
+		return 'godam_zip_job_' . $job_id;
+	}
+
+	/**
+	 * Background handler that builds a folder's ZIP and records the outcome on the job.
+	 *
+	 * Invoked via `godam_build_folder_zip` (Action Scheduler or WP-Cron). The client
+	 * discovers success/failure by polling get_folder_zip_status().
+	 *
+	 * @param string $job_id Job identifier.
+	 * @return void
+	 */
+	public function run_folder_zip_job( $job_id ) {
+		$key = $this->zip_job_transient_key( $job_id );
+		$job = get_transient( $key );
+
+		if ( ! is_array( $job ) ) {
+			return; // Unknown or expired job.
+		}
+
+		$job['status']  = 'processing';
+		$job['updated'] = time();
+		set_transient( $key, $job, HOUR_IN_SECONDS );
+
+		$folder_id = isset( $job['folder_id'] ) ? (int) $job['folder_id'] : 0;
+		$term      = $folder_id ? get_term( $folder_id, 'media-folder' ) : null;
+
+		if ( ! $term || is_wp_error( $term ) ) {
+			$job['status']  = 'failed';
+			$job['message'] = __( 'Invalid folder term ID.', 'godam' );
+			$job['updated'] = time();
+			set_transient( $key, $job, HOUR_IN_SECONDS );
+			return;
+		}
+
+		// Unguessable filename (see the ZIP hardening in Media_Folder_Create_Zip).
+		$zip_name = 'media-folder-' . $term->slug . '-' . wp_generate_password( 20, false ) . '.zip';
+		$result   = Media_Folder_Create_Zip::get_instance()->create_zip( $folder_id, $zip_name );
+
+		if ( is_wp_error( $result ) ) {
+			$job['status']  = 'failed';
+			$job['message'] = $result->get_error_message();
+		} else {
+			$job['status']   = 'completed';
+			$job['zip_url']  = isset( $result['zip_url'] ) ? $result['zip_url'] : '';
+			$job['zip_name'] = isset( $result['zip_name'] ) ? $result['zip_name'] : $zip_name;
+			$job['message']  = isset( $result['message'] ) ? $result['message'] : __( 'ZIP file created successfully.', 'godam' );
+		}
+
+		$job['updated'] = time();
+		set_transient( $key, $job, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Poll the status of a folder-ZIP build job.
+	 *
+	 * @param \WP_REST_Request $request REST API request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_folder_zip_status( $request ) {
+		$job_id = (string) $request->get_param( 'job_id' );
+		$job    = get_transient( $this->zip_job_transient_key( $job_id ) );
+
+		if ( ! is_array( $job ) ) {
+			return new \WP_Error( 'invalid_job', __( 'Unknown or expired download job.', 'godam' ), array( 'status' => 404 ) );
+		}
+
+		// A job may only be polled by the user who started it (admins excepted), so one
+		// user cannot read another's generated ZIP URL.
+		if ( isset( $job['user_id'] ) && get_current_user_id() !== (int) $job['user_id'] && ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'rest_forbidden', __( 'You are not allowed to access this download job.', 'godam' ), array( 'status' => 403 ) );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'data'    => array(
+					'status'   => isset( $job['status'] ) ? $job['status'] : 'queued',
+					'zip_url'  => isset( $job['zip_url'] ) ? $job['zip_url'] : '',
+					'zip_name' => isset( $job['zip_name'] ) ? $job['zip_name'] : '',
+					'message'  => isset( $job['message'] ) ? $job['message'] : '',
+				),
 			)
 		);
 	}

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1448,6 +1448,52 @@ function rtgodam_convert_to_https_url( $urls ) {
 }
 
 /**
+ * Whether the current admin screen hosts the WordPress media library / a wp.media modal
+ * and therefore needs GoDAM's media-library integration.
+ *
+ * Single source of truth for the enqueue gates below. Covers the core screens that host
+ * the media grid or open a wp.media modal, plus every GoDAM admin page (all of them call
+ * wp_enqueue_media() and may open the modal — dashboard, media editor, analytics,
+ * settings, tools, help, what's-new).
+ *
+ * @param WP_Screen|null $screen Current screen object.
+ * @return bool True if the screen uses the media library / wp.media.
+ */
+function godam_is_media_library_screen( $screen ) {
+	if ( ! $screen ) {
+		return false;
+	}
+
+	// Core screens that host the media grid or a wp.media modal. `post`/`page` (as bases)
+	// also cover the Elementor and WPBakery editors, which run on post.php.
+	$media_bases = array(
+		'upload',      // Media Library (grid & list views).
+		'post',        // Add/Edit any post type.
+		'page',        // Add/Edit Page.
+		'attachment',  // Edit Media.
+		'widgets',     // Classic widgets (image widget uses wp.media).
+		'site-editor', // FSE.
+	);
+
+	if ( in_array( $screen->base, $media_bases, true ) || in_array( $screen->id, $media_bases, true ) ) {
+		return true;
+	}
+
+	// GoDAM's own admin pages (screen ids derive from the `rtgodam` menu slug).
+	$godam_pages = array(
+		'toplevel_page_rtgodam',
+		'godam_page_rtgodam_media_editor',
+		'godam_page_rtgodam_analytics',
+		'godam_page_rtgodam_settings',
+		'godam_page_rtgodam_tools',
+		'godam_page_rtgodam_help',
+		'godam_page_rtgodam_whats_new',
+	);
+
+	return in_array( $screen->id, $godam_pages, true );
+}
+
+/**
  * Check if auth detector scripts should be loaded on current screen.
  *
  * @param WP_Screen|null $screen Current screen object.
@@ -1455,87 +1501,32 @@ function rtgodam_convert_to_https_url( $urls ) {
  * @return bool True if auth detector scripts should load.
  */
 function godam_should_load_auth_detector_script( $screen ) {
-	if ( ! $screen ) {
-		return false;
-	}
-
-	// Pages where media library/modal is directly accessible.
-	$media_screens = array(
-		'upload',     // Media Library page (grid & list views).
-		'post',       // Add/Edit Post.
-		'page',       // Add/Edit Page.
-		'attachment', // Edit Media page.
-	);
-
-	// Check if current screen is in the list.
-	if ( in_array( $screen->base, $media_screens, true ) || in_array( $screen->id, $media_screens, true ) ) {
-		return true;
-	}
-
-	// Check if on GoDAM admin pages (where media library/modal can be opened).
-	$godam_pages = array(
-		'toplevel_page_godam',             // Dashboard page.
-		'godam_page_rtgodam_media_editor', // Media Editor page.
-	);
-
-	if ( in_array( $screen->id, $godam_pages, true ) ) {
-		return true;
-	}
-
-	return false;
+	return godam_is_media_library_screen( $screen );
 }
 
 /**
  * Whether the (heavy) GoDAM media-library JS bundles should load on the current screen.
  *
- * The media-library.min.js (~2.6 MB, bundles video.js) and pages/media-library.min.js
- * (React/Redux folder sidebar, ~1.1 MB) were enqueued on EVERY admin screen via a global
- * admin_enqueue_scripts hook. They are only needed where the WordPress media library /
- * wp.media modal is actually used: the Media grid, the post/page/attachment editors
- * (which also covers the Elementor and WPBakery editors, both post.php screens), and
- * GoDAM's own admin pages. Everywhere else the payload is pure overhead. Integrations
- * that open wp.media on other screens can opt in via the filter below.
+ * The media-library.min.js (bundles video.js) and pages/media-library.min.js (React/Redux
+ * folder sidebar) were enqueued on EVERY admin screen via a global admin_enqueue_scripts
+ * hook. They are only needed where the media library / wp.media modal is actually used
+ * (see godam_is_media_library_screen()). Everywhere else the payload is pure overhead.
+ * Integrations that open wp.media on other screens can opt in via the filter below.
  *
  * @param WP_Screen|null $screen Current screen object.
  * @return bool True if the media-library bundles should be enqueued.
  */
 function godam_should_load_media_library_assets( $screen ) {
-	$should_load = false;
-
-	if ( $screen ) {
-		// Core screens where the media library / wp.media modal is available.
-		$media_screens = array(
-			'upload',     // Media Library (grid & list views).
-			'post',       // Add/Edit Post (any post type; also Elementor/WPBakery editors).
-			'page',       // Add/Edit Page.
-			'attachment', // Edit Media.
-		);
-
-		if ( in_array( $screen->base, $media_screens, true ) || in_array( $screen->id, $media_screens, true ) ) {
-			$should_load = true;
-		}
-
-		// GoDAM's own admin pages, which can open the media library / modal.
-		$godam_pages = array(
-			'toplevel_page_godam',
-			'godam_page_rtgodam_media_editor',
-		);
-
-		if ( in_array( $screen->id, $godam_pages, true ) ) {
-			$should_load = true;
-		}
-	}
-
 	/**
 	 * Filters whether the GoDAM media-library JS bundles load on the current screen.
 	 *
 	 * Use this to force-load the bundles on custom screens that open wp.media (e.g.
-	 * classic widgets, term-edit screens with media fields).
+	 * term-edit screens with media fields).
 	 *
 	 * @param bool           $should_load Whether to enqueue the media-library bundles.
 	 * @param WP_Screen|null $screen      Current screen object.
 	 */
-	return (bool) apply_filters( 'godam_should_load_media_library_assets', $should_load, $screen );
+	return (bool) apply_filters( 'godam_should_load_media_library_assets', godam_is_media_library_screen( $screen ), $screen );
 }
 
 // ---------------------------------------------------------------------------

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1485,6 +1485,59 @@ function godam_should_load_auth_detector_script( $screen ) {
 	return false;
 }
 
+/**
+ * Whether the (heavy) GoDAM media-library JS bundles should load on the current screen.
+ *
+ * The media-library.min.js (~2.6 MB, bundles video.js) and pages/media-library.min.js
+ * (React/Redux folder sidebar, ~1.1 MB) were enqueued on EVERY admin screen via a global
+ * admin_enqueue_scripts hook. They are only needed where the WordPress media library /
+ * wp.media modal is actually used: the Media grid, the post/page/attachment editors
+ * (which also covers the Elementor and WPBakery editors, both post.php screens), and
+ * GoDAM's own admin pages. Everywhere else the payload is pure overhead. Integrations
+ * that open wp.media on other screens can opt in via the filter below.
+ *
+ * @param WP_Screen|null $screen Current screen object.
+ * @return bool True if the media-library bundles should be enqueued.
+ */
+function godam_should_load_media_library_assets( $screen ) {
+	$should_load = false;
+
+	if ( $screen ) {
+		// Core screens where the media library / wp.media modal is available.
+		$media_screens = array(
+			'upload',     // Media Library (grid & list views).
+			'post',       // Add/Edit Post (any post type; also Elementor/WPBakery editors).
+			'page',       // Add/Edit Page.
+			'attachment', // Edit Media.
+		);
+
+		if ( in_array( $screen->base, $media_screens, true ) || in_array( $screen->id, $media_screens, true ) ) {
+			$should_load = true;
+		}
+
+		// GoDAM's own admin pages, which can open the media library / modal.
+		$godam_pages = array(
+			'toplevel_page_godam',
+			'godam_page_rtgodam_media_editor',
+		);
+
+		if ( in_array( $screen->id, $godam_pages, true ) ) {
+			$should_load = true;
+		}
+	}
+
+	/**
+	 * Filters whether the GoDAM media-library JS bundles load on the current screen.
+	 *
+	 * Use this to force-load the bundles on custom screens that open wp.media (e.g.
+	 * classic widgets, term-edit screens with media fields).
+	 *
+	 * @param bool           $should_load Whether to enqueue the media-library bundles.
+	 * @param WP_Screen|null $screen      Current screen object.
+	 */
+	return (bool) apply_filters( 'godam_should_load_media_library_assets', $should_load, $screen );
+}
+
 // ---------------------------------------------------------------------------
 // Work-cache helpers
 // ---------------------------------------------------------------------------

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useState, useMemo, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
@@ -33,16 +33,10 @@ import SearchBar from './components/search-bar/SearchBar.jsx';
 const App = () => {
 	const dispatch = useDispatch();
 	const selectedFolder = useSelector( ( state ) => state.FolderReducer.selectedFolder );
-	const contextSelectedFolder = useSelector( ( state ) => state.FolderReducer.currentContextMenuFolder );
 	const isMultiSelecting = useSelector( ( state ) => state.FolderReducer.isMultiSelecting );
 	const currentSortOrder = useSelector( ( state ) => state.FolderReducer.sortOrder );
 	const { data: allMediaCount, refetch: refetchAllMediaCount } = useGetAllMediaCountQuery();
 	const { data: uncategorizedCount, refetch: refetchUncategorizedCount } = useGetCategoryMediaCountQuery( { folderId: 0 } );
-
-	const allFolders = useSelector( ( state ) => state.FolderReducer.folders );
-	const currentFolder = useMemo( () => {
-		return allFolders.find( ( folder ) => folder.id === selectedFolder?.id );
-	}, [ allFolders, selectedFolder ] );
 
 	const [ contextMenu, setContextMenu ] = useState( {
 		visible: false,
@@ -174,7 +168,6 @@ const App = () => {
 							dispatch( setCurrentContextMenuFolder( null ) );
 							dispatch( openModal( 'folderCreation' ) );
 						} }
-						disabled={ selectedFolder?.meta?.locked || currentFolder?.meta?.locked || contextSelectedFolder?.meta?.locked }
 					/>
 				</div>
 				<div className="button-group mb-spacing">

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -166,7 +166,14 @@ const App = () => {
 						variant="primary"
 						text={ __( 'New Folder', 'godam' ) }
 						className="button--full mb-spacing new-folder-button"
-						onClick={ () => dispatch( openModal( 'folderCreation' ) ) }
+						onClick={ () => {
+							// Create at the ROOT from the top-level button. FolderCreationModal
+							// derives the new folder's parent from currentContextMenuFolder, which
+							// a prior right-click leaves set — without this clear, the top button
+							// would nest the folder under the last right-clicked folder.
+							dispatch( setCurrentContextMenuFolder( null ) );
+							dispatch( openModal( 'folderCreation' ) );
+						} }
 						disabled={ selectedFolder?.meta?.locked || currentFolder?.meta?.locked || contextSelectedFolder?.meta?.locked }
 					/>
 				</div>

--- a/pages/media-library/components/context-menu/ContextMenu.jsx
+++ b/pages/media-library/components/context-menu/ContextMenu.jsx
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { openModal, updateSnackbar, updateBookmarks, lockFolder } from '../../redux/slice/folders';
-import { useDownloadZipMutation, useUpdateFolderMutation, useBulkLockFoldersMutation, useBulkBookmarkFoldersMutation } from '../../redux/api/folders';
+import { useDownloadZipMutation, useUpdateFolderMutation, useBulkLockFoldersMutation, useBulkBookmarkFoldersMutation, pollZipJobStatus } from '../../redux/api/folders';
 import {
 	BookmarkStarIcon,
 	DeleteIcon,
@@ -212,29 +212,29 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 				} ),
 			);
 
+			// The archive is now built in the background: start the job, then poll until
+			// it is ready (large folders no longer time out the request).
 			const response = await downloadZipMutation( { folderId: id } ).unwrap();
 
-			if ( ! response?.success ) {
-				throw new Error( response?.message || __( 'Failed to create ZIP file', 'godam' ) );
+			if ( ! response?.success || ! response?.data?.job_id ) {
+				throw new Error( response?.message || __( 'Failed to start ZIP creation', 'godam' ) );
 			}
 
-			const { data } = response;
+			const result = await pollZipJobStatus( response.data.job_id );
 
-			if ( ! data?.zip_url ) {
-				throw new Error( __( 'Invalid response: missing ZIP URL', 'godam' ) );
+			if ( result.status !== 'completed' || ! result.zip_url ) {
+				throw new Error( result.message || __( 'Failed to create ZIP file', 'godam' ) );
 			}
 
 			downloadFile(
-				data.zip_url,
-				data.zip_name || `${ currentFolder?.name || 'folder' }.zip`,
+				result.zip_url,
+				result.zip_name || `${ currentFolder?.name || 'folder' }.zip`,
 				true,
 			);
 
-			const successMessage = data?.message;
-
 			dispatch(
 				updateSnackbar( {
-					message: successMessage,
+					message: result.message || __( 'ZIP file created successfully.', 'godam' ),
 					type: 'success',
 				} ),
 			);

--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -167,7 +167,19 @@ const FolderTree = ( { handleContextMenu } ) => {
 			const activeIndex = clonedItems.findIndex( ( { id } ) => id === active.id );
 			const activeTreeItem = clonedItems[ activeIndex ];
 
-			await updateFolderMutation( { ...activeTreeItem, parent } );
+			// Persist the move first and only commit it to the local tree on success.
+			// Without .unwrap() a server rejection (e.g. locked destination, permission)
+			// resolved silently and the tree kept the optimistic move even though the
+			// server never applied it.
+			try {
+				await updateFolderMutation( { ...activeTreeItem, parent } ).unwrap();
+			} catch ( moveError ) {
+				dispatch( updateSnackbar( {
+					message: moveError?.data?.message || __( 'Failed to move folder', 'godam' ),
+					type: 'fail',
+				} ) );
+				return;
+			}
 
 			clonedItems[ activeIndex ] = { ...activeTreeItem, depth, parent };
 

--- a/pages/media-library/components/modal/DeleteModal.jsx
+++ b/pages/media-library/components/modal/DeleteModal.jsx
@@ -59,7 +59,15 @@ const DeleteModal = () => {
 			if ( ! isMultiSelecting ) {
 				await deleteFolderMutation( selectedFolder.id ).unwrap();
 			} else if ( multiSelectedFolderIds && multiSelectedFolderIds.length ) {
-				await bulkDeleteFoldersMutation( multiSelectedFolderIds ).unwrap();
+				// The bulk endpoint returns HTTP 200 with `errors` on *partial* failure, so
+				// .unwrap() alone won't throw — inspect the payload and surface it as a
+				// failure rather than reporting "deleted successfully" and dropping every
+				// selected folder from the tree.
+				const bulkResult = await bulkDeleteFoldersMutation( multiSelectedFolderIds ).unwrap();
+
+				if ( bulkResult?.errors?.length ) {
+					throw new Error( bulkResult.message || __( 'Some folders could not be deleted', 'godam' ) );
+				}
 			}
 
 			dispatch( deleteFolder() );
@@ -75,7 +83,7 @@ const DeleteModal = () => {
 		} catch ( error ) {
 			dispatch( updateSnackbar(
 				{
-					message: __( 'Failed to delete folder', 'godam' ),
+					message: error?.message || error?.data?.message || __( 'Failed to delete folder', 'godam' ),
 					type: 'fail',
 				},
 			) );

--- a/pages/media-library/components/modal/DeleteModal.jsx
+++ b/pages/media-library/components/modal/DeleteModal.jsx
@@ -50,10 +50,16 @@ const DeleteModal = () => {
 		setIsLoading( true );
 
 		try {
+			// `.unwrap()` is required: RTK Query mutations RESOLVE (do not throw) on
+			// HTTP 4xx/5xx, so without it a server rejection would fall through to the
+			// success path below — showing "deleted successfully" and dropping the
+			// folder from the tree even though it still exists on the server. unwrap()
+			// re-throws the error payload so failures reach the catch (matching how
+			// Rename/Create already handle their mutations).
 			if ( ! isMultiSelecting ) {
-				await deleteFolderMutation( selectedFolder.id );
+				await deleteFolderMutation( selectedFolder.id ).unwrap();
 			} else if ( multiSelectedFolderIds && multiSelectedFolderIds.length ) {
-				await bulkDeleteFoldersMutation( multiSelectedFolderIds );
+				await bulkDeleteFoldersMutation( multiSelectedFolderIds ).unwrap();
 			}
 
 			dispatch( deleteFolder() );

--- a/pages/media-library/components/search-bar/SearchBar.jsx
+++ b/pages/media-library/components/search-bar/SearchBar.jsx
@@ -144,11 +144,14 @@ const SearchBar = () => {
 	 * Triggers filter changes, updates selected folder, expands parent folders,
 	 * and resets the search UI.
 	 *
-	 * @param {string} folderId The ID of the selected folder.
+	 * @param {Object} folder The selected folder object (including its meta).
 	 */
-	const handleFolderSelect = ( folderId ) => {
+	const handleFolderSelect = ( folder ) => {
+		const folderId = folder?.id;
 		triggerFilterChange( folderId );
-		dispatch( changeSelectedFolder( { item: { id: folderId } } ) );
+		// Pass the whole folder (incl. meta) so its lock/bookmark state is preserved in
+		// state — selecting by id alone stripped the meta and defeated lock checks.
+		dispatch( changeSelectedFolder( { item: folder } ) );
 		dispatch( expandParents( { id: folderId } ) );
 
 		setSearchTerm( '' );
@@ -196,7 +199,7 @@ const SearchBar = () => {
 										<li key={ folder.id }>
 											<Button
 												className="search-result-item"
-												onClick={ () => handleFolderSelect( folder.id ) }
+												onClick={ () => handleFolderSelect( folder ) }
 											>
 												{ folder.name }
 											</Button>

--- a/pages/media-library/data/media-grid.js
+++ b/pages/media-library/data/media-grid.js
@@ -11,7 +11,49 @@ function getActiveMediaFrame() {
 }
 
 /**
- * This function triggers the select box change outside of the react component.
+ * Map a sidebar folder id to the `media-folder` Backbone query prop value.
+ * Mirrors the toolbar select's filter map: -1 = all, 0 = uncategorized,
+ * otherwise the numeric term id.
+ *
+ * @param {number|string} itemId Folder id from the sidebar.
+ * @return {number} The `media-folder` prop value.
+ */
+function normalizeFolderProp( itemId ) {
+	if ( itemId === 'all' || itemId === -1 || itemId === '-1' ) {
+		return -1;
+	}
+	if ( itemId === 'uncategorized' || itemId === 0 || itemId === '0' ) {
+		return 0;
+	}
+	const numeric = parseInt( itemId, 10 );
+	return Number.isNaN( numeric ) ? -1 : numeric;
+}
+
+/**
+ * Resolve the wp.media Attachments collection backing the active media frame.
+ * The frame is stashed on its own sidebar root (see
+ * assets/src/js/media-library/index.js) so we target THIS frame's collection,
+ * not a shared id / "last visible" guess.
+ *
+ * @param {Element} activeFrame The active `.media-frame` element.
+ * @return {Object|null} The Backbone Attachments collection (with `.props`), or null.
+ */
+function getActiveFrameCollection( activeFrame ) {
+	const root = activeFrame && activeFrame.querySelector( '#rt-transcoder-media-library-root' );
+	const frame = root && root._godamFrame;
+
+	if ( ! frame || typeof frame.state !== 'function' ) {
+		return null;
+	}
+
+	const state = frame.state();
+	const collection = ( state && typeof state.get === 'function' ) ? state.get( 'library' ) : null;
+
+	return ( collection && collection.props ) ? collection : null;
+}
+
+/**
+ * Apply a folder filter outside of the React component.
  *
  * @param {number} itemId The ID of the folder to be selected
  */
@@ -41,7 +83,19 @@ function triggerFilterChange( itemId ) {
 		return;
 	}
 
-	// Find the select box within the active frame
+	// In a media-picker modal, drive filtering through the frame's own Backbone
+	// query props. Setting the `media-folder` prop re-fetches the collection the
+	// modal renders — this is what the toolbar select does on change, but it works
+	// even when that grid-only DOM (#media-folder-filter / #post-query-submit) is
+	// absent, which is exactly why folder clicks used to silently no-op in the picker.
+	const collection = getActiveFrameCollection( activeFrame );
+
+	if ( collection ) {
+		collection.props.set( { 'media-folder': normalizeFolderProp( itemId ) } );
+		return;
+	}
+
+	// Fallback: the legacy grid-DOM path (standalone list/grid toolbar).
 	const selectBox = activeFrame.querySelector( '#media-folder-filter' );
 
 	if ( selectBox ) {

--- a/pages/media-library/index.js
+++ b/pages/media-library/index.js
@@ -84,116 +84,56 @@ function resetSidebarIfAllModalsClosed() {
  * and reset the React state to ensure fresh UI state for new modal instances
  */
 function setupMediaModalCloseDetection() {
-	// Track active media modal instances to detect when they close
-	let lastModalCount = 0;
+	// The authoritative "modal closed" signal is wp.media's own Modal.close(). The
+	// previous implementation ALSO ran a document.body subtree MutationObserver and a
+	// 500ms setInterval for the entire page lifetime — neither was ever disconnected/
+	// cleared — purely as fallbacks. That is needlessly chatty (especially in the block
+	// editor, where document.body mutates constantly). Rely on the single frame event.
+	if ( typeof wp === 'undefined' || ! wp.media || ! wp.media.view || ! wp.media.view.Modal ) {
+		return;
+	}
 
-	// Use MutationObserver to detect when modal elements are removed from DOM
-	const observer = new MutationObserver( ( mutations ) => {
-		mutations.forEach( ( mutation ) => {
-			if ( mutation.type === 'childList' ) {
-				// Check if any media modal elements were removed
-				mutation.removedNodes.forEach( ( node ) => {
-					if ( node.nodeType === Node.ELEMENT_NODE ) {
-						// Check if this is a media modal that was removed
-						if ( node.classList && node.classList.contains( 'media-modal' ) ) {
-							// Clean up React roots before resetting state
-							const rootElements = node.querySelectorAll( '#rt-transcoder-media-library-root' );
-							rootElements.forEach( ( element ) => {
-								if ( element._reactRoot ) {
-									try {
-										element._reactRoot.unmount();
-									} catch ( e ) {
-										// Ignore unmounting errors
-									}
-									element._reactRoot = null;
-								}
-							} );
+	// Guard against double-wrapping if this bundle is evaluated more than once.
+	if ( wp.media.view.Modal.prototype._godamClosePatched ) {
+		return;
+	}
+	wp.media.view.Modal.prototype._godamClosePatched = true;
 
-							// Media modal removed — reset only if no modal remains open.
-							resetSidebarIfAllModalsClosed();
-						// Also check if it contains media modal children
-						} else if ( node.querySelector && node.querySelector( '.media-modal' ) ) {
-							// Clean up any React roots in child modals
-							const rootElements = node.querySelectorAll( '#rt-transcoder-media-library-root' );
-							rootElements.forEach( ( element ) => {
-								if ( element._reactRoot ) {
-									try {
-										element._reactRoot.unmount();
-									} catch ( e ) {
-										// Ignore unmounting errors
-									}
-									element._reactRoot = null;
-								}
-							} );
+	const originalClose = wp.media.view.Modal.prototype.close;
+	wp.media.view.Modal.prototype.close = function( ...args ) {
+		// Capture the closing modal's element before the async cleanup runs.
+		const modalEl = this.el;
 
-							// Nested media modal removed — reset only if no modal remains open.
-							resetSidebarIfAllModalsClosed();
+		// Call original close method
+		const result = originalClose.apply( this, args );
+
+		// Clean up the React root in THIS closing modal before it is hidden/removed.
+		// Scoped to the closing modal so closing one frame never tears down a sibling
+		// frame's still-visible sidebar.
+		setTimeout( () => {
+			// Skip cleanup if the modal was reopened within this delay (still visible) —
+			// otherwise we would unmount a freshly-mounted sidebar.
+			const modalHidden = ! modalEl || ! modalEl.isConnected || getComputedStyle( modalEl ).display === 'none';
+
+			if ( modalHidden && modalEl ) {
+				modalEl.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( element ) => {
+					if ( element._reactRoot ) {
+						try {
+							element._reactRoot.unmount();
+						} catch ( e ) {
+							// Ignore unmounting errors
 						}
+						element._reactRoot = null;
 					}
 				} );
 			}
-		} );
-	} );
 
-	// Observe changes to the document body
-	observer.observe( document.body, {
-		childList: true,
-		subtree: true,
-	} );
-
-	// Also detect modal state changes by checking visibility periodically
-	// This is a fallback for cases where DOM removal isn't detected
-	setInterval( () => {
-		const currentModalCount = document.querySelectorAll( '.media-modal:not([style*="display: none"])' ).length;
-
-		// If modal count decreased a modal was closed — reset only once the last one
-		// is gone so closing a nested modal doesn't clobber the picker in use.
-		if ( currentModalCount < lastModalCount ) {
+			// Reset React state only once the last media modal has closed.
 			resetSidebarIfAllModalsClosed();
-		}
+		}, 100 ); // Small delay to ensure modal is fully closed
 
-		lastModalCount = currentModalCount;
-	}, 500 ); // Check every 500ms
-
-	// Listen for WordPress media frame close events if available
-	if ( typeof wp !== 'undefined' && wp.media ) {
-		// Hook into wp.media to detect when frames are closed
-		const originalClose = wp.media.view.Modal.prototype.close;
-		wp.media.view.Modal.prototype.close = function( ...args ) {
-			// Capture the closing modal's element before the async cleanup runs.
-			const modalEl = this.el;
-
-			// Call original close method
-			const result = originalClose.apply( this, args );
-
-			// Clean up the React root in THIS closing modal before it is hidden/removed.
-			// Scoped to the closing modal so closing one frame never tears down a sibling
-			// frame's still-visible sidebar.
-			setTimeout( () => {
-				// Skip cleanup if the modal was reopened within this delay (still visible) —
-				// otherwise we would unmount a freshly-mounted sidebar.
-				const modalHidden = ! modalEl || ! modalEl.isConnected || getComputedStyle( modalEl ).display === 'none';
-
-				if ( modalHidden && modalEl ) {
-					modalEl.querySelectorAll( '#rt-transcoder-media-library-root' ).forEach( ( element ) => {
-						if ( element._reactRoot ) {
-							try {
-								element._reactRoot.unmount();
-							} catch ( e ) {
-								// Ignore unmounting errors
-							}
-							element._reactRoot = null;
-						}
-					} );
-				}
-
-				// Reset React state only once the last media modal has closed.
-				resetSidebarIfAllModalsClosed();
-			}, 100 ); // Small delay to ensure modal is fully closed
-
-			return result;
-		};
-	}
+		return result;
+	};
 }
 
 /**

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -4,6 +4,11 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { getCurrentMimeTypeFilter } from '../../data/utilities';
@@ -33,6 +38,14 @@ export async function pollZipJobStatus( jobId, { intervalMs = 2000, timeoutMs = 
 				headers: { 'X-WP-Nonce': window.MediaLibrary.nonce },
 			} );
 			const json = await res.json();
+
+			// A WP_Error (e.g. 404 unknown/expired job, 403 not-owner) serialises as
+			// { code, message, data: { status: <httpCode> } } — so `res.ok` is the reliable
+			// signal, not `data.status` (which would be the HTTP code, not the job status).
+			if ( ! res.ok ) {
+				return { status: 'failed', message: json?.message || __( 'Failed to prepare the ZIP file.', 'godam' ) };
+			}
+
 			const data = json?.data || {};
 
 			if ( data.status === 'completed' || data.status === 'failed' ) {
@@ -45,7 +58,7 @@ export async function pollZipJobStatus( jobId, { intervalMs = 2000, timeoutMs = 
 		await new Promise( ( resolve ) => setTimeout( resolve, intervalMs ) );
 	}
 
-	return { status: 'failed', message: 'Timed out while preparing the ZIP file.' };
+	return { status: 'failed', message: __( 'Timed out while preparing the ZIP file.', 'godam' ) };
 }
 
 export const folderApi = createApi( {

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -10,6 +10,44 @@ import { getCurrentMimeTypeFilter } from '../../data/utilities';
 
 const restURL = window.godamRestRoute?.url || window.wpApiSettings?.root || '/wp-json/';
 
+/**
+ * Poll a folder-ZIP build job until it finishes.
+ *
+ * The download endpoint now returns a job id immediately and builds the archive in the
+ * background (so large folders no longer time out the request). This polls the status
+ * endpoint until the job is `completed` or `failed`, or the timeout is reached.
+ *
+ * @param {string} jobId                      The job id returned by the downloadZip mutation.
+ * @param {Object} [options]                  Polling options.
+ * @param {number} [options.intervalMs=2000]  Delay between polls.
+ * @param {number} [options.timeoutMs=180000] Give up after this long.
+ * @return {Promise<Object>} Resolves with { status, zip_url, zip_name, message }.
+ */
+export async function pollZipJobStatus( jobId, { intervalMs = 2000, timeoutMs = 180000 } = {} ) {
+	const url = `${ restURL }godam/v1/media-library/download-folder-status/${ jobId }`;
+	const start = Date.now();
+
+	while ( Date.now() - start < timeoutMs ) {
+		try {
+			const res = await fetch( url, {
+				headers: { 'X-WP-Nonce': window.MediaLibrary.nonce },
+			} );
+			const json = await res.json();
+			const data = json?.data || {};
+
+			if ( data.status === 'completed' || data.status === 'failed' ) {
+				return data;
+			}
+		} catch ( e ) {
+			// Transient network error — keep polling until the timeout.
+		}
+
+		await new Promise( ( resolve ) => setTimeout( resolve, intervalMs ) );
+	}
+
+	return { status: 'failed', message: 'Timed out while preparing the ZIP file.' };
+}
+
 export const folderApi = createApi( {
 	reducerPath: 'folderApi',
 	baseQuery: fetchBaseQuery( { baseUrl: restURL } ),

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -63,6 +63,12 @@ export const folderApi = createApi( {
 						per_page: 1,
 						...mimeTypeParams,
 					},
+					// Send the REST nonce so the count runs as the current user (matching the
+					// grid). Without it the request is anonymous and only counts public media,
+					// undercounting when private/pending attachments exist.
+					headers: {
+						'X-WP-Nonce': window.MediaLibrary.nonce,
+					},
 				} );
 
 				if ( result.error ) {
@@ -224,7 +230,10 @@ export const folderApi = createApi( {
 						search: searchTerm,
 						page,
 						per_page: perPage,
-						_fields: 'id,name',
+						// Include parent + meta so a folder selected from search keeps its
+						// lock/bookmark state. With only id,name the selected folder lost its
+						// meta, defeating the locked-folder checks downstream.
+						_fields: 'id,name,parent,meta',
 					},
 					headers: {
 						'X-WP-Nonce': window.MediaLibrary.nonce,

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -125,6 +125,11 @@ const slice = createSlice( {
 			if ( state.selectedFolder && state.selectedFolder.id === id ) {
 				state.selectedFolder.name = name;
 			}
+
+			// The rename modal renders currentContextMenuFolder.name, so keep it current too.
+			if ( state.currentContextMenuFolder && state.currentContextMenuFolder.id === id ) {
+				state.currentContextMenuFolder.name = name;
+			}
 		},
 		deleteFolder: ( state ) => {
 			if ( ! state.currentContextMenuFolder && ! state.isMultiSelecting ) {
@@ -162,9 +167,10 @@ const slice = createSlice( {
 			if ( state.selectedFolder && idsToDelete.has( state.selectedFolder.id ) ) {
 				state.selectedFolder = { id: -1 };
 
-				if ( window.godam ) {
-					window.godam.selectedFolder = state.selectedFolder;
-				}
+				// Mirror to the global the way changeSelectedFolder does, creating it if
+				// it doesn't exist yet so the reset isn't silently dropped.
+				window.godam = window.godam || {};
+				window.godam.selectedFolder = state.selectedFolder;
 			}
 
 			state.currentContextMenuFolder = {

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -17,7 +17,7 @@ if ( folderId ) {
 			selectedFolderId = 0;
 			break;
 		default:
-			selectedFolderId = parseInt( folderId );
+			selectedFolderId = parseInt( folderId, 10 );
 			break;
 	}
 }
@@ -101,10 +101,29 @@ const slice = createSlice( {
 				return;
 			}
 
-			const folder = state.folders.find( ( item ) => item.id === state.currentContextMenuFolder.id );
+			const id = state.currentContextMenuFolder.id;
+			const name = action.payload.name;
+
+			const folder = state.folders.find( ( item ) => item.id === id );
 
 			if ( folder ) {
-				folder.name = action.payload.name;
+				folder.name = name;
+			}
+
+			// The Bookmark/Locked tabs and the current selection hold separate copies of the
+			// folder, so update them too — otherwise a rename shows stale names in those views.
+			const bookmarked = state.bookmarks.find( ( item ) => item.id === id );
+			if ( bookmarked ) {
+				bookmarked.name = name;
+			}
+
+			const locked = state.lockedFolders.find( ( item ) => item.id === id );
+			if ( locked ) {
+				locked.name = name;
+			}
+
+			if ( state.selectedFolder && state.selectedFolder.id === id ) {
+				state.selectedFolder.name = name;
 			}
 		},
 		deleteFolder: ( state ) => {
@@ -132,6 +151,21 @@ const slice = createSlice( {
 			}
 
 			state.folders = state.folders.filter( ( item ) => ! idsToDelete.has( item.id ) );
+
+			// Keep the bookmark/locked tab lists in sync so deleted folders don't linger there.
+			state.bookmarks = state.bookmarks.filter( ( item ) => ! idsToDelete.has( item.id ) );
+			state.lockedFolders = state.lockedFolders.filter( ( item ) => ! idsToDelete.has( item.id ) );
+
+			// If the selected folder was deleted (or was a descendant of a deleted folder),
+			// reset the selection to "All" — otherwise the grid keeps filtering by a folder
+			// that no longer exists.
+			if ( state.selectedFolder && idsToDelete.has( state.selectedFolder.id ) ) {
+				state.selectedFolder = { id: -1 };
+
+				if ( window.godam ) {
+					window.godam.selectedFolder = state.selectedFolder;
+				}
+			}
 
 			state.currentContextMenuFolder = {
 				id: -1,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,6 +105,19 @@ const mediaLibrary = {
 	entry: {
 		'media-library': path.resolve( process.cwd(), 'assets', 'src', 'js', 'media-library', 'index.js' ),
 	},
+	// This entry now code-splits video.js into an async chunk (see videojs-loader). It
+	// shares the assets/build/js output dir and the default `webpackChunkgodam` global
+	// with godamPlayerFrontend / godamImageLayersFrontend, which ALSO emit video.js-family
+	// async chunks. Give this compilation its own runtime global (uniqueName) and prefixed,
+	// content-hashed chunk filenames so its async chunks can't collide with theirs on disk
+	// or clobber each other's chunk-loading runtime (the "TypeError: o[t] is not a function"
+	// class of bug documented on godamImageLayersFrontend below). The content hash also
+	// avoids a browser serving a stale videojs chunk after a plugin update.
+	output: {
+		...sharedConfig.output,
+		uniqueName: 'godamMediaLibrary',
+		chunkFilename: 'media-library-[name].[contenthash].min.js',
+	},
 };
 
 const godamPlayerFrontend = {


### PR DESCRIPTION
<html><head></head><body><h1>Media Library — Improvements &amp; Bug Fixes (Epic #23)</h1>
<p>Closes / addresses <strong><a href="https://github.com/rtCamp/godam-plugin-wp/issues/23">rtCamp/godam-plugin-wp#23</a></strong> — <em>[Epic] Media Library – Improvement and Bug fixes</em>.</p>
<p>This PR works through all 9 points of the epic (3 bugs, 3 security, 2 performance, 1 correctness-cleanup batch), each in its own commit. Every point below documents <strong>what was happening earlier</strong>, <strong>the fix</strong>, and <strong>how to test</strong>.</p>
<blockquote>
<p><strong>Build note:</strong> JS source changes require a rebuild — run <code>npm run build:js</code> before testing. <code>assets/build/**</code> is gitignored, so the build runs in CI/release.</p>
</blockquote>
<hr>
<h2>1. Folder operations break when the Media Library is opened as a wp.media selector popup</h2>
<p><strong>What was happening earlier</strong>
Folder-tree operations worked on the standalone grid (<code>upload.php</code>) but broke inside a picker modal (Add Media, block image picker, featured image). Root causes: the React tree never re-mounted on reopen (roots were unmounted on close but only injected on <code>initialize()</code>, and reused frames call <code>open()</code>); three redundant close-detectors reset the active folder mid-use; folder clicks drove filtering through grid-only DOM (<code>#media-folder-filter</code> / <code>#post-query-submit</code>) that isn't present in the modal, so clicks silently no-op'd; and a duplicate <code>#rt-transcoder-media-library-root</code> id + a "last visible frame" heuristic targeted the wrong frame.</p>
<p><strong>Fix</strong>
Re-inject and re-mount the tree on frame <code>open</code> (not only <code>initialize</code>); stop resetting UI state on unrelated modal churn (reset only once the last modal closes); make <code>triggerFilterChange</code> set the frame's Backbone <code>media-folder</code> collection prop directly (works without the grid DOM), which the server-side <code>ajax_query_attachments_args</code> filter then applies; and scope each root to its own frame via a <code>_godamFrame</code> handle instead of a shared id.</p>
<p><strong>How to test</strong></p>
<ol>
<li>Edit a post/page → open the block image picker.</li>
<li>Select a folder → the grid filters to that folder's media.</li>
<li>Close and reopen the picker → the folder tree is still present and select/create/rename/delete/drag all work.</li>
<li>Repeat on first and subsequent opens without the active folder resetting.</li>
</ol>
<hr>
<h2>2. Folder delete reports success even when the server rejects it</h2>
<p><strong>What was happening earlier</strong>
<code>DeleteModal.jsx</code> awaited <code>deleteFolderMutation</code> / <code>bulkDeleteFoldersMutation</code> <strong>without <code>.unwrap()</code></strong>. RTK Query <em>resolves</em> (does not throw) on HTTP 4xx/5xx, so the <code>catch</code> never ran — the UI showed "Folder deleted successfully," removed the folder from the tree, and re-filtered, even though the folder still existed server-side.</p>
<p><strong>Fix</strong>
Added <code>.unwrap()</code> to both mutation calls so a server rejection re-throws into the <code>catch</code>; the success snackbar and tree removal now only run on a real success (matching how Rename/Create already worked).</p>
<p><strong>How to test</strong></p>
<ol>
<li>Force a delete to fail (e.g. temporarily return a 500 / a locked folder / insufficient caps).</li>
<li>The UI shows "Failed to delete folder" and the folder <strong>stays</strong> in the tree; a refresh confirms it still exists.</li>
<li>Happy path: a normal delete still succeeds and removes the folder.</li>
</ol>
<hr>
<h2>3. "New Folder" button creates a sub-folder under the last right-clicked folder</h2>
<p><strong>What was happening earlier</strong>
The top-level <strong>New Folder</strong> button opened the creation modal without clearing <code>currentContextMenuFolder</code>. <code>FolderCreationModal</code> derives the new folder's parent from that value, and it was only cleared when clicking All/Uncategorized. So after right-clicking any folder, the top button created the new folder <strong>nested under that folder</strong> instead of at the root.</p>
<p><strong>Fix</strong>
The top-level button now dispatches <code>setCurrentContextMenuFolder( null )</code> before opening the modal, so <code>FolderCreationModal</code> falls into its root-parent branch. The right-click → "New Folder" (sub-folder) path is untouched.</p>
<p><strong>How to test</strong></p>
<ol>
<li>Right-click any folder (e.g. "Folder A"), then dismiss the menu.</li>
<li>Click the top-level <strong>New Folder</strong> button, create a folder → it appears at the <strong>root</strong>, not under A.</li>
<li>Regression: right-click "Folder A" → <strong>New Folder</strong> from the context menu → created <strong>inside</strong> A.</li>
</ol>
<hr>
<h2>4. [Security] "Locked" folders were not enforced on the server</h2>
<p><strong>What was happening earlier</strong>
Folder locking was enforced <strong>only in React</strong>, and <code>window.MediaLibrary.roles</code> is client-controllable. No PHP handler checked the <code>locked</code> term-meta, so a direct REST call could rename/delete/re-parent/populate a locked folder — the disabled UI buttons were the only protection.</p>
<p><strong>Fix</strong>
Added <code>is_folder_locked()</code> — a folder counts as locked if its own <code>locked</code> meta is truthy <strong>or any ancestor's</strong> is (a locked folder protects its whole subtree). Enforced it at every mutation path:</p>
<ul>
<li><strong>Native <code>wp/v2/media-folder</code> endpoints</strong> (rename/delete/re-parent/create-under) — a <code>rest_pre_dispatch</code> guard returns <strong>403</strong> for <code>POST/PUT/PATCH/DELETE</code> on a locked term and for creating/moving into a locked parent. Reads are untouched.</li>
<li><strong><code>assign_images_to_folder</code></strong> — 403 when assigning into (or removing out of) a locked folder.</li>
<li><strong><code>bulk_delete_folders</code></strong> — 403 upfront if any target is locked (never partially deletes).</li>
</ul>
<p><strong>How to test</strong> (as a REST client / browser console with your nonce)</p>
<ol>
<li><code>POST wp/v2/media-folder/{lockedId}</code> with a new name → <strong>403</strong> <code>godam_folder_locked</code>.</li>
<li><code>DELETE wp/v2/media-folder/{lockedId}?force=true</code> → <strong>403</strong>.</li>
<li>Rename/delete a <strong>child</strong> of the locked folder → <strong>403</strong> (cascade).</li>
<li><code>POST wp/v2/media-folder</code> with <code>parent = lockedId</code> → <strong>403</strong>.</li>
<li><code>POST .../assign-folder</code> with <code>folder_term_id = lockedId</code> → <strong>403</strong>.</li>
<li><code>DELETE .../bulk-delete-folders</code> with a locked id in the list → <strong>403</strong> (unlocked ones not deleted).</li>
<li>Regression: the same operations on <strong>unlocked</strong> folders return 200.</li>
</ol>
<hr>
<h2>5. [Security] Folder ZIP export was world-readable at a predictable URL and Contributor-triggerable</h2>
<p><strong>What was happening earlier</strong>
The export wrote to <code>uploads/godam/media-folder-{slug}.zip</code> — a <strong>guessable, unauthenticated</strong> URL in a directory with no listing protection, persisting 24h — and the endpoint was gated only by <code>edit_posts</code>, so Contributors could generate a ZIP of any folder (information disclosure + resource exhaustion).</p>
<p><strong>Fix</strong></p>
<ul>
<li><strong>Unguessable filename</strong>: <code>media-folder-{slug}-{random-20-char-token}.zip</code>.</li>
<li><strong>Directory hardening</strong>: write <code>index.php</code> (blank) and <code>.htaccess</code> (<code>Options -Indexes</code>) into <code>uploads/godam/</code> to prevent enumeration.</li>
<li><strong>Capability</strong>: raised the download-folder endpoint from <code>edit_posts</code> to <code>upload_files</code> (Author+), excluding Contributors.</li>
</ul>
<p><strong>How to test</strong></p>
<ol>
<li>Download a folder → the returned <code>zip_url</code> ends in a 20-char random token.</li>
<li>Fetch the real URL → 200 (<code>application/zip</code>); fetch a guessed <code>media-folder-{slug}.zip</code> → <strong>404</strong>.</li>
<li>Visit <code>/wp-content/uploads/godam/</code> → <strong>403</strong> (no listing).</li>
<li>As a Contributor, <code>POST .../download-folder/{id}</code> → <strong>403</strong>; as admin/author → success.</li>
</ol>
<hr>
<h2>6. [Security] Missing per-object capability check on folder assignment (IDOR)</h2>
<p><strong>What was happening earlier</strong>
<code>assign_images_to_folder</code> was gated only by the broad <code>edit_posts</code> capability and never checked <code>current_user_can( 'edit_post', $attachment_id )</code>, so a lower-privileged user could move <strong>anyone's</strong> attachments between folders. The remove branch (<code>folder_term_id = 0</code>) called <code>remove_all_terms_from_id()</code> on raw IDs without verifying they were attachments, allowing <code>media-folder</code> terms to be stripped from arbitrary objects.</p>
<p><strong>Fix</strong>
Added one upfront guard (covering both the assign and remove paths): every ID must be a real <code>attachment</code> <strong>and</strong> pass <code>current_user_can( 'edit_post', $id )</code>. Any failure rejects the whole request — <strong>400</strong> for a non-attachment, <strong>403</strong> for a permission failure — so there are no partial moves.</p>
<p><strong>How to test</strong></p>
<ol>
<li>Assign a <strong>post/page</strong> id via <code>.../assign-folder</code> → <strong>400</strong> <code>invalid_attachment</code> (both assign and remove paths).</li>
<li>A mixed batch (valid attachment + non-attachment) → <strong>400</strong>, and the valid one is <strong>not</strong> moved.</li>
<li>As an <strong>Author</strong>, try to move an <strong>admin-owned</strong> attachment → <strong>403</strong> <code>rest_forbidden</code>; moving the Author's <strong>own</strong> upload → <strong>200</strong>.</li>
</ol>
<hr>
<h2>7. [Performance] Media Library JS bundles loaded on every admin page (+ video.js code-split)</h2>
<p><strong>What was happening earlier</strong>
Both media-library bundles — <code>media-library.min.js</code> (bundles video.js) and <code>pages/media-library.min.js</code> (React/Redux/RTK/PostHog) — were enqueued via a globally-hooked <code>admin_enqueue_scripts</code>, so they downloaded and parsed on <strong>every</strong> wp-admin screen, not just where the media library / <code>wp.media</code> modal is used.</p>
<p><strong>Fix</strong></p>
<ul>
<li>Added <code>godam_should_load_media_library_assets( $screen )</code> — loads the bundles only on the Media grid, the post/page/attachment editors (which also covers the Elementor and WPBakery editors, both <code>post.php</code>), and GoDAM's own admin pages; extensible via the <code>godam_should_load_media_library_assets</code> filter. Gated both enqueues.</li>
<li><strong>Follow-up (code-split):</strong> converted the static <code>import 'video.js'</code> to a dynamic <code>import()</code> (via a small <code>videojs-loader</code>), so video.js is now a separate on-demand chunk loaded only when a video attachment's detail panel is opened. The always-loaded <code>media-library.min.js</code> dropped from ~803 KB to ~125 KB.</li>
</ul>
<p><strong>How to test</strong></p>
<ol>
<li>DevTools → Network → filter <code>media-library.min.js</code>. Load the Dashboard / Plugins page → <strong>0 hits</strong>. Load <code>upload.php</code> or a post editor → both bundles load.</li>
<li>On <code>upload.php</code>, the base bundle is ~125 KB and <strong>no</strong> video.js chunk loads. Open a virtual/GoDAM-proxy video's detail panel → the video.js chunk (~682 KB) loads on demand and the player plays.</li>
</ol>
<hr>
<h2>8. [Performance] <code>wp_cache_flush()</code> during ZIP build + never-cleaned polling/observer + synchronous ZIP</h2>
<p><strong>What was happening earlier</strong>
(a) The ZIP builder called <code>wp_cache_flush()</code> under memory pressure, flushing the <strong>entire site object cache</strong> to build one download. (b) The React app ran a 500ms <code>setInterval</code> and a <code>document.body</code> subtree <code>MutationObserver</code> for the whole page lifetime (never cleared/disconnected) just to detect modal close — very chatty in the block editor. (c) <code>download_folder</code> built the archive synchronously in-request (batches of 50, files up to 500 MB), risking timeouts on large folders.</p>
<p><strong>Fix</strong></p>
<ul>
<li><strong>(a)</strong> <code>cleanup_memory()</code> now uses <code>wp_cache_flush_runtime()</code> (WP 6.0+, guarded) — frees only the in-memory runtime cache, not the persistent site cache.</li>
<li><strong>(b)</strong> Removed the <code>setInterval</code> and the <code>MutationObserver</code>; rely on the single authoritative <code>wp.media</code> <code>Modal.close()</code> hook (made idempotent).</li>
<li><strong>(c)</strong> ZIP now builds in a <strong>background job</strong>: <code>download_folder</code> registers a job, enqueues it (Action Scheduler when available, else WP-Cron nudged with <code>spawn_cron()</code>), and returns a <code>job_id</code>. A new <code>run_folder_zip_job()</code> builds the archive and stores the result in a transient; a new <code>GET download-folder-status/{job_id}</code> endpoint (gated by <code>upload_files</code> + owner check) reports status. The frontend starts the job, polls every 2s (up to 3 min), then downloads when <code>completed</code> — failures/timeouts surface a snackbar.</li>
</ul>
<p><strong>How to test</strong></p>
<ol>
<li>Download a folder → the request returns immediately with a <code>job_id</code> (status <code>queued</code>); the frontend polls and downloads once ready. Large folders no longer time out the request.</li>
<li>Poll an unknown/expired <code>job_id</code> → <strong>404</strong>; a job started by another user → <strong>403</strong>.</li>
<li>Block editor: with DevTools → Performance, confirm there's no perpetual 500ms task or constant mutation-observer activity from the media library while idle; opening/closing the media modal still resets the sidebar correctly.</li>
</ol>
<blockquote>
<p>Note: the background job runs on the site's cron (Action Scheduler / WP-Cron). On sites with functioning cron (normal traffic or system cron) it processes within seconds; if cron is entirely broken the frontend degrades gracefully with a "timed out preparing the ZIP" error after 3 minutes.</p>
</blockquote>
<hr>
<h2>9. [Bug] Media Library correctness cleanup (batch of low-severity issues)</h2>
<p><strong>What was happening earlier &amp; the fixes</strong></p>
<ul>
<li><strong><code>update_folder_meta_status</code></strong> had identical <code>if/else</code> branches that always incremented <code>updated_count</code> and never populated <code>failed_ids</code>, so lock/bookmark <strong>failures reported as success</strong>. → Now distinguishes a no-op (value already set → success) from a genuine write failure (populates <code>failed_ids</code>/<code>errors</code>).</li>
<li><strong><code>getAllMediaCount</code></strong> omitted <code>X-WP-Nonce</code>, so the "All Media" count ran as an anonymous request. → Added the nonce header.</li>
<li><strong>Drag-move</strong> persisted optimistically with no <code>.unwrap()</code>/error path. → <code>.unwrap()</code> in a try/catch; on failure it shows a snackbar and does not commit the move.</li>
<li><strong>Bookmark/Locked tab copies</strong> went stale on rename/delete. → Synced those copies (and the current selection) in <code>renameFolder</code>, and pruned them in <code>deleteFolder</code>.</li>
<li><strong>Selecting a folder from search</strong> stripped its meta (search requested only <code>id,name</code>), defeating lock checks. → Search now requests <code>id,name,parent,meta</code> and select passes the full folder object.</li>
<li><strong><code>parseInt</code> without radix</strong> on the <code>media-folder</code> URL param, and <strong><code>deleteFolder</code> didn't reset <code>selectedFolder</code></strong>. → Added radix <code>10</code>; reset the selection to "All" when the selected folder (or an ancestor) is deleted.</li>
</ul>
<p><strong>How to test</strong></p>
<ol>
<li>Bulk-lock an already-locked folder → reports <strong>success</strong> (no spurious error); a genuine failure now reports as failed rather than success.</li>
<li>With private/pending media present, the "All Media" count matches the authenticated grid count.</li>
<li>Drag a folder onto a locked destination → move is rejected with a snackbar and the tree snaps back.</li>
<li>Rename a bookmarked/locked folder → the Bookmark/Locked tabs show the new name immediately; delete the selected folder → the grid resets to "All".</li>
<li>Select a folder from search → its lock/bookmark state is respected afterward.</li>
</ol>
<hr>
<h2>Commits (one per point)</h2>

Point | Commit
-- | --
1 | Folder operations breaking in wp.media popup (+ folder-filter gap)
2 | Folder delete reports success even when the server rejects it
3 | New Folder button nesting under the last right-clicked folder
4 | Folder locked state enforced on the server
5 | Media folder ZIP export hardening
6 | IDOR on folder assignment
7 | Media Library JS bundles load on every admin page (+ video.js code-split)
8 | wp_cache_flush() → runtime flush; consolidated close-detectors; async ZIP job
9 | Media Library correctness cleanup batch

</body></html># Media Library — Improvements & Bug Fixes (Epic #23)

Closes / addresses **[[rtCamp/godam-plugin-wp#23](https://github.com/rtCamp/godam-plugin-wp/issues/23)](https://github.com/rtCamp/godam-plugin-wp/issues/23)** — *[Epic] Media Library – Improvement and Bug fixes*.

This PR works through all 9 points of the epic (3 bugs, 3 security, 2 performance, 1 correctness-cleanup batch), each in its own commit. Every point below documents **what was happening earlier**, **the fix**, and **how to test**.

> **Build note:** JS source changes require a rebuild — run `npm run build:js` before testing. `assets/build/**` is gitignored, so the build runs in CI/release.

---

## 1. Folder operations break when the Media Library is opened as a wp.media selector popup

**What was happening earlier**
Folder-tree operations worked on the standalone grid (`upload.php`) but broke inside a picker modal (Add Media, block image picker, featured image). Root causes: the React tree never re-mounted on reopen (roots were unmounted on close but only injected on `initialize()`, and reused frames call `open()`); three redundant close-detectors reset the active folder mid-use; folder clicks drove filtering through grid-only DOM (`#media-folder-filter` / `#post-query-submit`) that isn't present in the modal, so clicks silently no-op'd; and a duplicate `#rt-transcoder-media-library-root` id + a "last visible frame" heuristic targeted the wrong frame.

**Fix**
Re-inject and re-mount the tree on frame `open` (not only `initialize`); stop resetting UI state on unrelated modal churn (reset only once the last modal closes); make `triggerFilterChange` set the frame's Backbone `media-folder` collection prop directly (works without the grid DOM), which the server-side `ajax_query_attachments_args` filter then applies; and scope each root to its own frame via a `_godamFrame` handle instead of a shared id.

**How to test**
1. Edit a post/page → open the block image picker.
2. Select a folder → the grid filters to that folder's media.
3. Close and reopen the picker → the folder tree is still present and select/create/rename/delete/drag all work.
4. Repeat on first and subsequent opens without the active folder resetting.

---

## 2. Folder delete reports success even when the server rejects it

**What was happening earlier**
`DeleteModal.jsx` awaited `deleteFolderMutation` / `bulkDeleteFoldersMutation` **without `.unwrap()`**. RTK Query *resolves* (does not throw) on HTTP 4xx/5xx, so the `catch` never ran — the UI showed "Folder deleted successfully," removed the folder from the tree, and re-filtered, even though the folder still existed server-side.

**Fix**
Added `.unwrap()` to both mutation calls so a server rejection re-throws into the `catch`; the success snackbar and tree removal now only run on a real success (matching how Rename/Create already worked).

**How to test**
1. Force a delete to fail (e.g. temporarily return a 500 / a locked folder / insufficient caps).
2. The UI shows "Failed to delete folder" and the folder **stays** in the tree; a refresh confirms it still exists.
3. Happy path: a normal delete still succeeds and removes the folder.

---

## 3. "New Folder" button creates a sub-folder under the last right-clicked folder

**What was happening earlier**
The top-level **New Folder** button opened the creation modal without clearing `currentContextMenuFolder`. `FolderCreationModal` derives the new folder's parent from that value, and it was only cleared when clicking All/Uncategorized. So after right-clicking any folder, the top button created the new folder **nested under that folder** instead of at the root.

**Fix**
The top-level button now dispatches `setCurrentContextMenuFolder( null )` before opening the modal, so `FolderCreationModal` falls into its root-parent branch. The right-click → "New Folder" (sub-folder) path is untouched.

**How to test**
1. Right-click any folder (e.g. "Folder A"), then dismiss the menu.
2. Click the top-level **New Folder** button, create a folder → it appears at the **root**, not under A.
3. Regression: right-click "Folder A" → **New Folder** from the context menu → created **inside** A.

---

## 4. [Security] "Locked" folders were not enforced on the server

**What was happening earlier**
Folder locking was enforced **only in React**, and `window.MediaLibrary.roles` is client-controllable. No PHP handler checked the `locked` term-meta, so a direct REST call could rename/delete/re-parent/populate a locked folder — the disabled UI buttons were the only protection.

**Fix**
Added `is_folder_locked()` — a folder counts as locked if its own `locked` meta is truthy **or any ancestor's** is (a locked folder protects its whole subtree). Enforced it at every mutation path:
- **Native `wp/v2/media-folder` endpoints** (rename/delete/re-parent/create-under) — a `rest_pre_dispatch` guard returns **403** for `POST/PUT/PATCH/DELETE` on a locked term and for creating/moving into a locked parent. Reads are untouched.
- **`assign_images_to_folder`** — 403 when assigning into (or removing out of) a locked folder.
- **`bulk_delete_folders`** — 403 upfront if any target is locked (never partially deletes).

**How to test** (as a REST client / browser console with your nonce)
1. `POST wp/v2/media-folder/{lockedId}` with a new name → **403** `godam_folder_locked`.
2. `DELETE wp/v2/media-folder/{lockedId}?force=true` → **403**.
3. Rename/delete a **child** of the locked folder → **403** (cascade).
4. `POST wp/v2/media-folder` with `parent = lockedId` → **403**.
5. `POST .../assign-folder` with `folder_term_id = lockedId` → **403**.
6. `DELETE .../bulk-delete-folders` with a locked id in the list → **403** (unlocked ones not deleted).
7. Regression: the same operations on **unlocked** folders return 200.

---

## 5. [Security] Folder ZIP export was world-readable at a predictable URL and Contributor-triggerable

**What was happening earlier**
The export wrote to `uploads/godam/media-folder-{slug}.zip` — a **guessable, unauthenticated** URL in a directory with no listing protection, persisting 24h — and the endpoint was gated only by `edit_posts`, so Contributors could generate a ZIP of any folder (information disclosure + resource exhaustion).

**Fix**
- **Unguessable filename**: `media-folder-{slug}-{random-20-char-token}.zip`.
- **Directory hardening**: write `index.php` (blank) and `.htaccess` (`Options -Indexes`) into `uploads/godam/` to prevent enumeration.
- **Capability**: raised the download-folder endpoint from `edit_posts` to `upload_files` (Author+), excluding Contributors.

**How to test**
1. Download a folder → the returned `zip_url` ends in a 20-char random token.
2. Fetch the real URL → 200 (`application/zip`); fetch a guessed `media-folder-{slug}.zip` → **404**.
3. Visit `/wp-content/uploads/godam/` → **403** (no listing).
4. As a Contributor, `POST .../download-folder/{id}` → **403**; as admin/author → success.

---

## 6. [Security] Missing per-object capability check on folder assignment (IDOR)

**What was happening earlier**
`assign_images_to_folder` was gated only by the broad `edit_posts` capability and never checked `current_user_can( 'edit_post', $attachment_id )`, so a lower-privileged user could move **anyone's** attachments between folders. The remove branch (`folder_term_id = 0`) called `remove_all_terms_from_id()` on raw IDs without verifying they were attachments, allowing `media-folder` terms to be stripped from arbitrary objects.

**Fix**
Added one upfront guard (covering both the assign and remove paths): every ID must be a real `attachment` **and** pass `current_user_can( 'edit_post', $id )`. Any failure rejects the whole request — **400** for a non-attachment, **403** for a permission failure — so there are no partial moves.

**How to test**
1. Assign a **post/page** id via `.../assign-folder` → **400** `invalid_attachment` (both assign and remove paths).
2. A mixed batch (valid attachment + non-attachment) → **400**, and the valid one is **not** moved.
3. As an **Author**, try to move an **admin-owned** attachment → **403** `rest_forbidden`; moving the Author's **own** upload → **200**.

---

## 7. [Performance] Media Library JS bundles loaded on every admin page (+ video.js code-split)

**What was happening earlier**
Both media-library bundles — `media-library.min.js` (bundles video.js) and `pages/media-library.min.js` (React/Redux/RTK/PostHog) — were enqueued via a globally-hooked `admin_enqueue_scripts`, so they downloaded and parsed on **every** wp-admin screen, not just where the media library / `wp.media` modal is used.

**Fix**
- Added `godam_should_load_media_library_assets( $screen )` — loads the bundles only on the Media grid, the post/page/attachment editors (which also covers the Elementor and WPBakery editors, both `post.php`), and GoDAM's own admin pages; extensible via the `godam_should_load_media_library_assets` filter. Gated both enqueues.
- **Follow-up (code-split):** converted the static `import 'video.js'` to a dynamic `import()` (via a small `videojs-loader`), so video.js is now a separate on-demand chunk loaded only when a video attachment's detail panel is opened. The always-loaded `media-library.min.js` dropped from ~803 KB to ~125 KB.

**How to test**
1. DevTools → Network → filter `media-library.min.js`. Load the Dashboard / Plugins page → **0 hits**. Load `upload.php` or a post editor → both bundles load.
2. On `upload.php`, the base bundle is ~125 KB and **no** video.js chunk loads. Open a virtual/GoDAM-proxy video's detail panel → the video.js chunk (~682 KB) loads on demand and the player plays.

---

## 8. [Performance] `wp_cache_flush()` during ZIP build + never-cleaned polling/observer + synchronous ZIP

**What was happening earlier**
(a) The ZIP builder called `wp_cache_flush()` under memory pressure, flushing the **entire site object cache** to build one download. (b) The React app ran a 500ms `setInterval` and a `document.body` subtree `MutationObserver` for the whole page lifetime (never cleared/disconnected) just to detect modal close — very chatty in the block editor. (c) `download_folder` built the archive synchronously in-request (batches of 50, files up to 500 MB), risking timeouts on large folders.

**Fix**
- **(a)** `cleanup_memory()` now uses `wp_cache_flush_runtime()` (WP 6.0+, guarded) — frees only the in-memory runtime cache, not the persistent site cache.
- **(b)** Removed the `setInterval` and the `MutationObserver`; rely on the single authoritative `wp.media` `Modal.close()` hook (made idempotent).
- **(c)** ZIP now builds in a **background job**: `download_folder` registers a job, enqueues it (Action Scheduler when available, else WP-Cron nudged with `spawn_cron()`), and returns a `job_id`. A new `run_folder_zip_job()` builds the archive and stores the result in a transient; a new `GET download-folder-status/{job_id}` endpoint (gated by `upload_files` + owner check) reports status. The frontend starts the job, polls every 2s (up to 3 min), then downloads when `completed` — failures/timeouts surface a snackbar.

**How to test**
1. Download a folder → the request returns immediately with a `job_id` (status `queued`); the frontend polls and downloads once ready. Large folders no longer time out the request.
2. Poll an unknown/expired `job_id` → **404**; a job started by another user → **403**.
3. Block editor: with DevTools → Performance, confirm there's no perpetual 500ms task or constant mutation-observer activity from the media library while idle; opening/closing the media modal still resets the sidebar correctly.

> Note: the background job runs on the site's cron (Action Scheduler / WP-Cron). On sites with functioning cron (normal traffic or system cron) it processes within seconds; if cron is entirely broken the frontend degrades gracefully with a "timed out preparing the ZIP" error after 3 minutes.

---

## 9. [Bug] Media Library correctness cleanup (batch of low-severity issues)

**What was happening earlier & the fixes**
- **`update_folder_meta_status`** had identical `if/else` branches that always incremented `updated_count` and never populated `failed_ids`, so lock/bookmark **failures reported as success**. → Now distinguishes a no-op (value already set → success) from a genuine write failure (populates `failed_ids`/`errors`).
- **`getAllMediaCount`** omitted `X-WP-Nonce`, so the "All Media" count ran as an anonymous request. → Added the nonce header.
- **Drag-move** persisted optimistically with no `.unwrap()`/error path. → `.unwrap()` in a try/catch; on failure it shows a snackbar and does not commit the move.
- **Bookmark/Locked tab copies** went stale on rename/delete. → Synced those copies (and the current selection) in `renameFolder`, and pruned them in `deleteFolder`.
- **Selecting a folder from search** stripped its meta (search requested only `id,name`), defeating lock checks. → Search now requests `id,name,parent,meta` and select passes the full folder object.
- **`parseInt` without radix** on the `media-folder` URL param, and **`deleteFolder` didn't reset `selectedFolder`**. → Added radix `10`; reset the selection to "All" when the selected folder (or an ancestor) is deleted.

**How to test**
1. Bulk-lock an already-locked folder → reports **success** (no spurious error); a genuine failure now reports as failed rather than success.
2. With private/pending media present, the "All Media" count matches the authenticated grid count.
3. Drag a folder onto a locked destination → move is rejected with a snackbar and the tree snaps back.
4. Rename a bookmarked/locked folder → the Bookmark/Locked tabs show the new name immediately; delete the selected folder → the grid resets to "All".
5. Select a folder from search → its lock/bookmark state is respected afterward.

---

## Commits (one per point)

| Point | Commit |
|---|---|
| 1 | Folder operations breaking in wp.media popup (+ folder-filter gap) |
| 2 | Folder delete reports success even when the server rejects it |
| 3 | New Folder button nesting under the last right-clicked folder |
| 4 | Folder locked state enforced on the server |
| 5 | Media folder ZIP export hardening |
| 6 | IDOR on folder assignment |
| 7 | Media Library JS bundles load on every admin page (+ video.js code-split) |
| 8 | `wp_cache_flush()` → runtime flush; consolidated close-detectors; async ZIP job |
| 9 | Media Library correctness cleanup batch |

## Demo

https://github.com/user-attachments/assets/babe2f3e-208a-45dc-b213-fc5ed78a4788


https://github.com/user-attachments/assets/22870b14-7cbd-4a7c-93fb-28d3613019c6


https://github.com/user-attachments/assets/d9eab648-23e1-4765-ad2d-977534bc6f79


https://github.com/user-attachments/assets/e6857519-2bef-418c-a9f4-1b8fecd675e0

<img width="1468" height="829" alt="Screenshot 2026-08-04 at 3 34 26 PM" src="https://github.com/user-attachments/assets/717d4a3d-6ef7-4ecc-8006-4847f005f370" />
