### PR TITLE
fix(layer-analytics): slice sub-hotspot inherited viewed to its lifetime (#196)

### DIFF
--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -358,11 +358,37 @@ class Analytics extends Base {
 		}
 		$query_params = $this->append_range_params( $request, $query_params );
 
+		// #196: for layer types that have sub-hotspots, forward the per-sub
+		// lifetime map (added_at / deleted_at, recorded on save) so the service
+		// credits a sub's inherited `viewed` only for the days it existed. The
+		// endpoint accepts GET or POST and reads `layer_lifetimes` from the body;
+		// atomic layer types send nothing and keep the GET path. A sub absent
+		// from the map is treated as full-history, so this is a no-op until the
+		// map is populated.
+		$layer_lifetimes = array();
+		if ( $attachment_id && in_array( $layer_type, array( 'hotspot', 'woo' ), true ) ) {
+			$meta = get_post_meta( $attachment_id, 'rtgodam_meta', true );
+			if ( is_array( $meta ) && ! empty( $meta['layer_lifetimes'] ) && is_array( $meta['layer_lifetimes'] ) ) {
+				$layer_lifetimes = $meta['layer_lifetimes'];
+			}
+		}
+
 		$endpoint = add_query_arg( $query_params, RTGODAM_ANALYTICS_BASE . '/processed-layer-analytics/' );
 		// Bounded timeout: useVideoLayerData fires one of these per layer type
 		// (5 in parallel) on page load, so a hung upstream must not pin a PHP
 		// worker for the full default (5s) — and certainly not 5s × 5.
-		$response = wp_remote_get( $endpoint, array( 'timeout' => 3 ) );
+		if ( ! empty( $layer_lifetimes ) ) {
+			$response = wp_remote_post(
+				$endpoint,
+				array(
+					'timeout' => 3,
+					'headers' => array( 'Content-Type' => 'application/json' ),
+					'body'    => wp_json_encode( $layer_lifetimes ),
+				)
+			);
+		} else {
+			$response = wp_remote_get( $endpoint, array( 'timeout' => 3 ) );
+		}
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_REST_Response(

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -360,9 +360,16 @@ class Analytics extends Base {
 
 		// #196: for layer types that have sub-hotspots, forward the per-sub
 		// lifetime map (added_at / deleted_at, recorded on save) so the service
-		// credits a sub's inherited `viewed` only for the days it existed. The
-		// endpoint accepts GET or POST and reads `layer_lifetimes` from the body;
-		// atomic layer types send nothing and keep the GET path. A sub absent
+		// credits a sub's inherited `viewed` only for the days it existed.
+		//
+		// The endpoint accepts GET or POST. On POST the map IS the JSON body
+		// root, not wrapped in a `layer_lifetimes` key — the body is
+		// `{ "<parent>::<sub>": { "added_at": "Y-m-d"|null, "deleted_at": ... } }`.
+		// The service's handler declares a single `layer_lifetimes` body
+		// parameter, which FastAPI binds to the whole body when it is the only
+		// one (no `embed`), so the bare map is what it expects.
+		//
+		// Atomic layer types send nothing and keep the GET path. A sub absent
 		// from the map is treated as full-history, so this is a no-op until the
 		// map is populated.
 		$layer_lifetimes = array();

--- a/inc/classes/rest-api/class-meta-rest-fields.php
+++ b/inc/classes/rest-api/class-meta-rest-fields.php
@@ -40,6 +40,7 @@ class Meta_Rest_Fields {
 					return get_post_meta( $post['id'], 'rtgodam_meta', true );
 				},
 				'update_callback' => function ( $value, $post ) {
+					$value = $this->record_layer_lifetimes( $post->ID, $value );
 					return update_post_meta( $post->ID, 'rtgodam_meta', $value );
 				},
 			)
@@ -125,5 +126,111 @@ class Meta_Rest_Fields {
 				},
 			)
 		);
+	}
+
+	/**
+	 * Record per-sub-hotspot lifetimes (added_at / deleted_at) when a video's
+	 * layer config is saved, so the analytics service can credit a sub-hotspot's
+	 * inherited `viewed` only for the days it actually existed
+	 * (rtCamp/godam-analytics#196).
+	 *
+	 * Diffs the incoming layers against the previously-saved ones, keyed by the
+	 * composite sub-hotspot id the player emits (`parent.id::<hotspot.id>` or
+	 * `parent.id::p<productId>`):
+	 *  - a sub that appears this save (and was not present before) gets
+	 *    added_at=today and a cleared deleted_at (covers re-adds too);
+	 *  - a sub that disappears gets deleted_at=today.
+	 * A sub that is unchanged is left untouched, and a pre-existing sub never
+	 * touched after this ships gets NO entry at all — the service treats a
+	 * sub absent from the map as "full history" (open-ended), so historical
+	 * content is not retroactively truncated. The map is stored back into
+	 * rtgodam_meta['layer_lifetimes'] and survives deletion (a removed sub is
+	 * gone from layers[] but its lifetime row must persist). Dates are UTC
+	 * Y-m-d to match the service's daily buckets.
+	 *
+	 * @param int   $post_id Attachment ID.
+	 * @param mixed $value   Incoming rtgodam_meta value being saved.
+	 * @return mixed The value with an updated `layer_lifetimes` map.
+	 */
+	private function record_layer_lifetimes( $post_id, $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$old_meta = get_post_meta( $post_id, 'rtgodam_meta', true );
+
+		// The authoritative existing map is read from storage, never trusted
+		// from the incoming $value (the editor does not manage this field).
+		$lifetimes = ( is_array( $old_meta ) && ! empty( $old_meta['layer_lifetimes'] ) && is_array( $old_meta['layer_lifetimes'] ) )
+			? $old_meta['layer_lifetimes']
+			: array();
+
+		$old_ids = $this->collect_subhotspot_ids( is_array( $old_meta ) ? ( $old_meta['layers'] ?? array() ) : array() );
+		$new_ids = $this->collect_subhotspot_ids( $value['layers'] ?? array() );
+
+		$today = gmdate( 'Y-m-d' );
+
+		// Appeared this save (new or re-added) -> start a fresh live window.
+		foreach ( $new_ids as $id ) {
+			if ( ! in_array( $id, $old_ids, true ) ) {
+				$lifetimes[ $id ] = array(
+					'added_at'   => $today,
+					'deleted_at' => null,
+				);
+			}
+		}
+
+		// Disappeared this save -> stamp deleted_at once, keep the row.
+		foreach ( $old_ids as $id ) {
+			if ( ! in_array( $id, $new_ids, true ) && empty( $lifetimes[ $id ]['deleted_at'] ) ) {
+				if ( empty( $lifetimes[ $id ] ) ) {
+					$lifetimes[ $id ] = array( 'added_at' => null );
+				}
+				$lifetimes[ $id ]['deleted_at'] = $today;
+			}
+		}
+
+		if ( ! empty( $lifetimes ) ) {
+			$value['layer_lifetimes'] = $lifetimes;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Build the set of composite sub-hotspot ids present in a layers array,
+	 * matching the ids the player emits and the analytics service keys on:
+	 * `parent.id::<hotspot.id>` for hotspot layers and `parent.id::p<productId>`
+	 * for woo layers. Atomic layer types (cta/form/poll) have no sub-hotspots
+	 * and are skipped.
+	 *
+	 * @param mixed $layers Layers array from rtgodam_meta.
+	 * @return string[] Unique composite sub-hotspot ids.
+	 */
+	private function collect_subhotspot_ids( $layers ) {
+		$ids = array();
+		if ( ! is_array( $layers ) ) {
+			return $ids;
+		}
+		foreach ( $layers as $layer ) {
+			if ( empty( $layer['id'] ) || empty( $layer['type'] ) ) {
+				continue;
+			}
+			$parent = (string) $layer['id'];
+			if ( 'hotspot' === $layer['type'] && ! empty( $layer['hotspots'] ) && is_array( $layer['hotspots'] ) ) {
+				foreach ( $layer['hotspots'] as $hotspot ) {
+					if ( ! empty( $hotspot['id'] ) ) {
+						$ids[] = $parent . '::' . (string) $hotspot['id'];
+					}
+				}
+			} elseif ( 'woo' === $layer['type'] && ! empty( $layer['productHotspots'] ) && is_array( $layer['productHotspots'] ) ) {
+				foreach ( $layer['productHotspots'] as $product ) {
+					if ( ! empty( $product['productId'] ) ) {
+						$ids[] = $parent . '::p' . (int) $product['productId'];
+					}
+				}
+			}
+		}
+		return array_values( array_unique( $ids ) );
 	}
 }

--- a/inc/classes/rest-api/class-meta-rest-fields.php
+++ b/inc/classes/rest-api/class-meta-rest-fields.php
@@ -161,18 +161,24 @@ class Meta_Rest_Fields {
 
 		// The authoritative existing map is read from storage, never trusted
 		// from the incoming $value (the editor does not manage this field).
-		$lifetimes = ( is_array( $old_meta ) && ! empty( $old_meta['layer_lifetimes'] ) && is_array( $old_meta['layer_lifetimes'] ) )
-			? $old_meta['layer_lifetimes']
-			: array();
+		$stored_lifetimes = is_array( $old_meta ) ? ( $old_meta['layer_lifetimes'] ?? null ) : null;
+		$lifetimes        = is_array( $stored_lifetimes ) ? $stored_lifetimes : array();
 
 		$old_ids = $this->collect_subhotspot_ids( is_array( $old_meta ) ? ( $old_meta['layers'] ?? array() ) : array() );
 		$new_ids = $this->collect_subhotspot_ids( $value['layers'] ?? array() );
+
+		// Membership sets so the two diff loops below stay O(n) rather than
+		// O(n²). collect_subhotspot_ids() already dedupes, so flipping is
+		// lossless, and every id contains '::' so none can be cast to an
+		// integer key.
+		$old_set = array_flip( $old_ids );
+		$new_set = array_flip( $new_ids );
 
 		$today = gmdate( 'Y-m-d' );
 
 		// Appeared this save (new or re-added) -> start a fresh live window.
 		foreach ( $new_ids as $id ) {
-			if ( ! in_array( $id, $old_ids, true ) ) {
+			if ( ! isset( $old_set[ $id ] ) ) {
 				$lifetimes[ $id ] = array(
 					'added_at'   => $today,
 					'deleted_at' => null,
@@ -182,7 +188,7 @@ class Meta_Rest_Fields {
 
 		// Disappeared this save -> stamp deleted_at once, keep the row.
 		foreach ( $old_ids as $id ) {
-			if ( ! in_array( $id, $new_ids, true ) && empty( $lifetimes[ $id ]['deleted_at'] ) ) {
+			if ( ! isset( $new_set[ $id ] ) && empty( $lifetimes[ $id ]['deleted_at'] ) ) {
 				if ( empty( $lifetimes[ $id ] ) ) {
 					$lifetimes[ $id ] = array( 'added_at' => null );
 				}

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -396,12 +396,11 @@ export function groupRows( rows, layerType, configIndex ) {
 		const subHotspots = bucket.subRows
 			.map( ( { row, md }, idx ) => {
 				const counts = pluckCounts( row );
-				const noAction = computeNoAction( layerType, {
-					...counts,
-					// Sub-hotspots inherit viewed from the parent (all sub-
-					// hotspots in one layer become visible together).
-					viewed: parentCounts.viewed,
-				} );
+				// Use the server's per-sub `viewed`: it inherits the parent's
+				// impression, sliced to the sub's lifetime when the proxy
+				// forwards a lifetime map (#196), else the full range — identical
+				// to the parent's count until the map is populated.
+				const noAction = computeNoAction( layerType, counts );
 				// Per-sub conversion comes from the server: the sub's converting
 				// sessions over the PARENT's viewed (subs don't emit their own
 				// viewed), a UNION over the layer type's conversion actions — so
@@ -448,11 +447,10 @@ export function groupRows( rows, layerType, configIndex ) {
 				return {
 					id: subId,
 					name: subName,
-					counts: {
-						...counts,
-						// Inherit viewed; per-sub viewed isn't emitted anymore.
-						viewed: parentCounts.viewed,
-					},
+					// `viewed` is the server's per-sub value: the parent's
+					// impression, sliced to the sub's lifetime when a lifetime
+					// map is forwarded (#196), else the full range.
+					counts,
 					no_action: noAction,
 					conversion_rate: conversion,
 					product_id: md.product_id || null,


### PR DESCRIPTION
Supersedes #1956, which was closed on 2026-07-28 as a scope decision: sub-hotspot data was not going to be displayed, so correcting its view inheritance was not worth shipping. **That reasoning no longer holds.** The Woo analytics plan (rtCamp/godam-plugin-wp#26) puts per-hotspot rows on screen with revenue attached, so these are numbers users will read.

Same branch, rebased onto current `develop`. WordPress companion for rtCamp/godam-analytics#196 (analytics side: rtCamp/godam-analytics#209, **merged and live since 2026-06-16**).

## Why this matters now

The analytics half is already in production **and currently does nothing.** It treats a sub-hotspot absent from the lifetime map as full-history, and nothing sends the map, so every sub still inherits the parent's full-range `viewed`. The bug is live for users and the shipped backend code stays inert until this lands.

## The problem

Sub-hotspots (hotspot items, Woo product hotspots) do not emit their own `viewed`. The parent layer fires one impression per session and the service copies the parent's **full-range** `viewed` onto every sub. So a **deleted** sub keeps gaining Views forever, and a **newly added** sub instantly shows Views from before it existed.

## What this does

1. **Record lifetimes on save** (`class-meta-rest-fields.php`): the `rtgodam_meta` update callback diffs old against new layers and records `added_at` / `deleted_at` per composite sub id (`parent::hotspot.id` / `parent::p<productId>`, matching what the player emits) into `rtgodam_meta['layer_lifetimes']`.
   - A sub that **appears** this save gets `added_at = today` (covers re-adds).
   - A sub that **disappears** gets `deleted_at = today`; the row persists past deletion.
   - A **pre-existing, untouched** sub gets no entry, so the service treats it as full-history and historical content is not retroactively truncated.
   - Dates are UTC `Y-m-d`, matching the service's daily buckets.
2. **Forward the map** (`class-analytics.php`): for `hotspot` and `woo` layer types the proxy POSTs the lifetime map to `/processed-layer-analytics/`, preserving the existing query params, 3s timeout and soft-error handling. Atomic types (cta/form/poll) keep the GET path.
3. **Use the server's sliced `viewed`** (`useVideoLayerData.js`): the hook stops re-inheriting the parent's full-range `viewed` onto sub rows client-side, which would have undone the slice, and uses the server's per-sub value.

## Verification done on this rebase

| Check | Result |
|---|---|
| Rebase onto `develop` (was 74 commits behind) | Clean, zero conflicts |
| PHPCS | Clean |
| `useVideoLayerData.test.js` | 6/6 pass |
| Request body contract against the merged service | Verified |
| Lifetime-diff logic, 418-case equivalence harness | 0 divergences |

**On the body contract:** the map is POSTed as the JSON body root, with no `layer_lifetimes` wrapper key. The service declares `layer_lifetimes: Optional[Dict[str, LayerLifetime]] = Body(default=None)` as its only body parameter, which FastAPI binds to the whole body, and its own test posts `json={sub: {"deleted_at": ...}}`, the map as body root. `wp_json_encode( $layer_lifetimes )` produces exactly that. The inline comment in `class-analytics.php` spells the wire shape out so the parameter name cannot be misread as a wrapper key.

Conflicts looked likely in `class-analytics.php` since placements and the date-range picker both touched it. The change slotted in after `append_range_params` instead, so it composed rather than collided.

## Backward compatibility

**Nothing changes for anyone until a layer config is saved.** The map is only written on save, and a sub absent from the map means "full history" to the service, which is today's behaviour.

The mechanism that guarantees this: `record_layer_lifetimes()` builds `$old_ids` from the **previously saved layers**, not from the lifetimes map. So a sub that already existed is present in both old and new, is therefore not "appeared", and gets no entry. If no sub appeared or disappeared, `$lifetimes` stays empty and the `layer_lifetimes` key is never even added to the meta.

| Scenario | Map sent? | Result |
|---|---|---|
| Existing video, never re-saved after upgrade | No key written, GET path used | **Identical to today** |
| Existing video re-saved, sub-hotspots unchanged | Key never added, GET path used | **Identical to today** |
| Existing video, one sub deleted | `deleted_at = today`, `added_at = null` | History before today preserved, stops accruing from today |
| Existing video, one sub added | `added_at = today` | Only counts from today forward |
| Old plugin + current service | No map sent | Service treats all subs as full history, i.e. today's behaviour. This is why rtCamp/godam-analytics#209 is currently inert in production |
| Current plugin + service without #209 | Map POSTed | Body ignored, query params still apply. No error |
| CTA / Form / Poll layers | Never, they have no sub-hotspots | GET path untouched |
| Malformed or missing `rtgodam_meta` | No | `is_array()` guarded at every read |

`added_at = null` means "since the start of the data", so a deleted sub keeps everything it earned before deletion. Nothing is retroactively truncated.

## Worked example

A Woo layer `woo-1` with one product hotspot `woo-1::p101`. The parent was shown **40 times yesterday** and **60 times today**. The product hotspot was **deleted today**, so it only genuinely existed yesterday. It was clicked **10 times** while it existed.

Sub-hotspots never emit their own `viewed`, so the service copies the parent's total onto each sub.

| | Parent `viewed` | Sub `viewed` (inherited) | Sub clicks | Conversion shown |
|---|---|---|---|---|
| Yesterday, hotspot live | 40 | 40 | 10 | 25% |
| Today, hotspot deleted | 60 | 60 | 0 | 0% |
| **Range total, before this PR** | 100 | **100** | 10 | **10%** |
| **Range total, with this PR** | 100 | **40** | 10 | **25%** |

Before the fix the deleted hotspot keeps absorbing the parent's impressions forever, so its conversion rate decays towards zero for no reason other than time passing. **25% is the true figure**: 10 clicks against the 40 impressions that happened while it existed.

The mirror case is a hotspot **added** today: before the fix it instantly shows all 100 views, including the 40 from yesterday when it did not exist, making a brand new hotspot look like it is underperforming.

This matches the end-to-end assertion in the merged service test (`test_analytics.py`), which posts `{sub: {"deleted_at": yesterday}}` and asserts `viewed == 40` and `conversion_rate == 25.0`.

## Known behaviour worth recording

- **Re-adding a deleted sub starts a fresh window.** Delete a hotspot in March, re-add the same id in August, and it gets `added_at = August` with `deleted_at` cleared. Its January to March history is excluded. Intentional, but it means a re-added hotspot cannot show its earlier life.
- **The map only grows.** Deleted subs keep their rows permanently, since the row must outlive the hotspot. On a video edited many times this adds rows to `rtgodam_meta`. Small, but unbounded.

## Testing steps

1. Open a video with a Woo or hotspot layer containing multiple sub-hotspots. Note the per-sub Views.
2. Delete one sub-hotspot and save. Add a new one and save.
3. Confirm `rtgodam_meta['layer_lifetimes']` now holds `deleted_at` for the removed sub and `added_at` for the new one.
4. Trigger analytics processing for that day. Lifetimes slice on daily buckets, so a processing run must have happened; a page refresh is not enough.
5. Confirm the deleted sub stops accruing Views for days after removal, and the new sub shows no Views from before it was added.
6. Confirm a pre-existing, untouched sub is unchanged, so no historical truncation.
7. Confirm CTA / Form / Poll layers still load over GET and are unaffected.

## Automation impact

No UI changes and no new `data-test-id`s needed. The JS change is to a data hook; its existing unit tests cover the behaviour and pass.


