### PR TITLE
ci: test the merge result, not the pushed commit

### DIFF
--- a/.github/workflows/js_unit_tests_on_pull_request.yml
+++ b/.github/workflows/js_unit_tests_on_pull_request.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/php_unit_tests_on_pull_request.yml
+++ b/.github/workflows/php_unit_tests_on_pull_request.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       # 8.4, not the plugin's minimum of 7.4: composer.lock pins dev tools that
       # require PHP ^8.4 (doctrine/instantiator, symfony/finder), so


### PR DESCRIPTION
Both test workflows pinned `ref: github.event.pull_request.head.sha`, which opts out of checkout's default `refs/pull/N/merge`. They therefore tested the branch as written rather than as it will exist on the base, so a change landing on develop that breaks a branch stayed green on that branch's PR and only failed later, on the release PR into main.

Removing the override restores the default. plugin_check_on_pull_request.yml already checks out the merge ref, so this makes the three consistent.

phpcs_on_pull_request.yml keeps its override deliberately: it posts inline review comments, which have to anchor to commits that exist on the pull request.