### PR TITLE
fix(layer-analytics): emit a viewed impression per hotspot

### DIFF
--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -14,6 +14,7 @@ import {
 } from './analytics-helpers';
 import {
 	addLayerInteraction as bufferAddLayerInteraction,
+	addLayerInteractions as bufferAddLayerInteractions,
 	getLayerInteractions as bufferGetLayerInteractions,
 	clearLayerInteractions as bufferClearLayerInteractions,
 } from './utils/storage';
@@ -358,6 +359,7 @@ function observePageLoadForVideo( video ) {
 	// shared pagehide flush. Single source of truth for layer-action semantics
 	// lives in utils/layerActions.js.
 	window.GoDAM.addLayerInteraction = bufferAddLayerInteraction;
+	window.GoDAM.addLayerInteractions = bufferAddLayerInteractions;
 	window.GoDAM.getLayerInteractions = bufferGetLayerInteractions;
 	window.GoDAM.clearLayerInteractions = bufferClearLayerInteractions;
 	window.GoDAM.LAYER_ACTIONS = LAYER_ACTIONS;

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -421,6 +421,17 @@ function observePageLoadForVideo( video ) {
 		// chunk so the back-half doesn't get rejected with 400.
 		const MAX_PER_REQUEST = 100;
 
+		// keepalive requests share a per-page ~64 KiB in-flight body budget
+		// (Fetch spec); once the aggregate crosses it the browser rejects the
+		// request outright with a network error. These type=3 flushes fire
+		// during pagehide alongside the type=1 and type=2 keepalive POSTs and
+		// share that budget, and per-hotspot `viewed` raises per-impression
+		// volume to 1 + hotspots, so a 100-entry chunk (~70 KB at a ~700-byte
+		// metadata blob) routinely overflows. Cap each chunk well under 64 KiB
+		// by serialized size, not just entry count, leaving room for the
+		// sibling flushes.
+		const MAX_BYTES_PER_REQUEST = 32 * 1024;
+
 		for ( const videoKey of videoKeys ) {
 			const events = Array.isArray( buffer[ videoKey ] ) ? buffer[ videoKey ] : [];
 			if ( events.length === 0 ) {
@@ -438,14 +449,37 @@ function observePageLoadForVideo( video ) {
 				? findVideoElementById( numericId )
 				: document.querySelector( `.video-js[data-job_id="${ videoKey }"]` );
 
-			for ( let i = 0; i < events.length; i += MAX_PER_REQUEST ) {
-				const chunk = events.slice( i, i + MAX_PER_REQUEST );
+			// Group events into chunks bounded by BOTH the 100-entry server
+			// limit and the byte budget above. A single oversized event still
+			// goes alone rather than looping forever.
+			const chunks = [];
+			let chunk = [];
+			let chunkBytes = 0;
+			for ( const event of events ) {
+				const eventBytes = JSON.stringify( event ).length + 1;
+				if (
+					chunk.length > 0 &&
+					( chunk.length >= MAX_PER_REQUEST ||
+						chunkBytes + eventBytes > MAX_BYTES_PER_REQUEST )
+				) {
+					chunks.push( chunk );
+					chunk = [];
+					chunkBytes = 0;
+				}
+				chunk.push( event );
+				chunkBytes += eventBytes;
+			}
+			if ( chunk.length ) {
+				chunks.push( chunk );
+			}
+
+			for ( const layers of chunks ) {
 				const { endpoint, body } = buildAnalyticsRequestBody( {
 					type: 3,
 					userToken: window.analytics?.user?.()?.anonymousId || '',
 					videoId: isNumeric ? numericId : 0,
 					jobId: isNumeric ? '' : videoKey,
-					layers: chunk,
+					layers,
 					blockSource: flushVideoEl?.dataset?.blockSource || '',
 					// From this video's own element, not a page-level lookup: a
 					// single host-stamped player must not re-attribute the rest.
@@ -456,12 +490,16 @@ function observePageLoadForVideo( video ) {
 					continue;
 				}
 
+				// keepalive can reject during pagehide; swallow so it does not
+				// surface as an unhandled rejection. The buffer is still cleared
+				// below by design (re-sending on a later flush would double-count
+				// composite rows, which aggregate with COUNT(*), not uniqExact).
 				fetch( endpoint + '/analytics/', {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify( body ),
 					keepalive: true,
-				} );
+				} ).catch( () => {} );
 			}
 		}
 

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -398,6 +398,17 @@ export default class HotspotLayerManager {
 			return;
 		}
 
+		// A writer must exist before we build anything. emitParentLayerEvent /
+		// emitHotspotEvent mark the per-session dedupe as they build (even in
+		// collector mode), so building with no sink would burn the dedupe key
+		// and the next visibility transition would emit nothing. Bailing here
+		// leaves the dedupe untouched so a later transition still retries.
+		const hasBatchWriter = typeof window.GoDAM?.addLayerInteractions === 'function';
+		const hasSingleWriter = typeof window.GoDAM?.addLayerInteraction === 'function';
+		if ( ! hasBatchWriter && ! hasSingleWriter ) {
+			return;
+		}
+
 		const batch = [];
 		this.emitParentLayerEvent( parentLayer, 'viewed', undefined, batch );
 
@@ -405,6 +416,15 @@ export default class HotspotLayerManager {
 			? parentLayer.hotspots
 			: [];
 		hotspots.forEach( ( hotspot, index ) => {
+			// Skip the per-hotspot `viewed` for a hotspot with no stable id.
+			// buildCompositeLayerId would fall back to a positional `idx<n>`
+			// key, which re-attributes a deleted hotspot's history to whoever
+			// takes its index — unacceptable now that `viewed` is the
+			// conversion denominator. Such a hotspot keeps the layer-level
+			// impression only (the pre-per-hotspot behaviour).
+			if ( ! hotspot?.id ) {
+				return;
+			}
 			this.emitHotspotEvent( parentLayer, hotspot, index, 'viewed', undefined, batch );
 		} );
 
@@ -412,15 +432,13 @@ export default class HotspotLayerManager {
 			return;
 		}
 
-		if ( typeof window.GoDAM?.addLayerInteractions === 'function' ) {
+		if ( hasBatchWriter ) {
 			window.GoDAM.addLayerInteractions( videoKey, batch );
 			return;
 		}
 
 		// Older bundle without the batch writer — still correct, just N writes.
-		if ( typeof window.GoDAM?.addLayerInteraction === 'function' ) {
-			batch.forEach( ( event ) => window.GoDAM.addLayerInteraction( videoKey, event ) );
-		}
+		batch.forEach( ( event ) => window.GoDAM.addLayerInteraction( videoKey, event ) );
 	}
 
 	/**

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -154,11 +154,12 @@ export default class HotspotLayerManager {
 		}
 		firedActions.add( actionType );
 
-		// Dwell measures consideration time — gap between parent visibility
-		// and this sub-hotspot interaction, minus time the tab was hidden
-		// during that window. Sub-hotspots no longer emit `viewed` themselves,
-		// so we fall back to the parent's first-visible timestamp keyed on
-		// parentLayer.id (seeded by emitParentLayerEvent).
+		// Dwell measures consideration time: the gap between parent visibility
+		// and this hotspot interaction, minus time the tab was hidden during
+		// that window. The per-hotspot `viewed` (emitted via emitLayerVisible)
+		// does not seed a first-visible timestamp of its own, so dwell keys off
+		// the parent's first-visible timestamp, seeded by emitParentLayerEvent
+		// on parentLayer.id.
 		const parentLayerId = parentLayer?.id ? String( parentLayer.id ) : '';
 		let firstVisibleAt = this._firstVisibleAt.get( compositeLayerId );
 		let hiddenAtStart = this._hiddenAtFirstVisible.get( compositeLayerId );

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -93,13 +93,16 @@ export default class HotspotLayerManager {
 	/**
 	 * Emit a sub-hotspot interaction event into the sessionStorage buffer.
 	 *
-	 * Sub-hotspots emit engagement events only — `hovered` and `clicked`.
-	 * Parent-level `viewed` is the layer-wide visibility signal and is
-	 * emitted separately via emitParentLayerEvent. All sub-hotspots in one
-	 * parent layer become visible at the same moment, so per-sub `viewed`
-	 * counts would be N redundant copies of the parent's visibility count;
-	 * the backend's per-parent aggregation pass derives "All Hotspots
-	 * (Cumulative)" engagement by grouping sub events by `parent_layer_id`.
+	 * Hotspots emit `viewed` (via emitLayerVisible when the layer becomes
+	 * visible) as well as the engagement actions `hovered` and `clicked`.
+	 * The layer also emits its own `viewed` via emitParentLayerEvent, which
+	 * remains the layer-wide impression the backend aggregates for "All
+	 * Hotspots (Cumulative)" by grouping on `parent_layer_id`.
+	 *
+	 * The per-hotspot `viewed` is what makes a hotspot's numbers correct when
+	 * hotspots are added or removed over time: only an impression row recorded
+	 * against the hotspot itself knows whether it existed when a viewer
+	 * watched.
 	 *
 	 * All actions deduped per (composite layer_id, action_type, page-session)
 	 * — one clicked, one hovered per sub-hotspot per session at most.
@@ -115,8 +118,10 @@ export default class HotspotLayerManager {
 	 * @param {number} index       Hotspot's position in parentLayer.hotspots.
 	 * @param {string} actionType  e.g. 'clicked', 'hovered'.
 	 * @param {Object} [metadata]  Extra fields merged into layer_metadata.
+	 * @param {Array}  [collector] When given, the built event is pushed here
+	 *                            instead of written, so a caller can batch.
 	 */
-	emitHotspotEvent( parentLayer, hotspot, index, actionType, metadata ) {
+	emitHotspotEvent( parentLayer, hotspot, index, actionType, metadata, collector ) {
 		if ( ! window.GoDAM || typeof window.GoDAM.addLayerInteraction !== 'function' ) {
 			return;
 		}
@@ -214,7 +219,7 @@ export default class HotspotLayerManager {
 			...( metadata || {} ),
 		};
 
-		window.GoDAM.addLayerInteraction( videoKey, {
+		const event = {
 			layer_id: compositeLayerId,
 			layer_type: parentLayer?.type || 'hotspot',
 			action_type: actionType,
@@ -222,7 +227,17 @@ export default class HotspotLayerManager {
 			layer_name: compositeName,
 			page_url: window.location.href,
 			layer_metadata: enrichedMetadata,
-		} );
+		};
+
+		// When a collector array is supplied the caller is batching several
+		// events into one storage write (see emitLayerVisible) — hand it over
+		// instead of paying a full read/parse/stringify/write cycle here.
+		if ( Array.isArray( collector ) ) {
+			collector.push( event );
+			return;
+		}
+
+		window.GoDAM.addLayerInteraction( videoKey, event );
 	}
 
 	/**
@@ -245,8 +260,10 @@ export default class HotspotLayerManager {
 	 * @param {Object} parentLayer Parent layer config (.id required; .name / .displayTime / .type preferred).
 	 * @param {string} actionType  e.g. 'viewed'.
 	 * @param {Object} [metadata]  Extra fields merged into layer_metadata.
+	 * @param {Array}  [collector] When given, the built event is pushed here
+	 *                            instead of written, so a caller can batch.
 	 */
-	emitParentLayerEvent( parentLayer, actionType, metadata ) {
+	emitParentLayerEvent( parentLayer, actionType, metadata, collector ) {
 		if ( ! window.GoDAM || typeof window.GoDAM.addLayerInteraction !== 'function' ) {
 			return;
 		}
@@ -325,7 +342,7 @@ export default class HotspotLayerManager {
 			...( metadata || {} ),
 		};
 
-		window.GoDAM.addLayerInteraction( videoKey, {
+		const event = {
 			layer_id: parentLayerId,
 			layer_type: parentLayer?.type || 'hotspot',
 			action_type: actionType,
@@ -333,7 +350,61 @@ export default class HotspotLayerManager {
 			layer_name: parentLayerName,
 			page_url: window.location.href,
 			layer_metadata: enrichedMetadata,
+		};
+
+		if ( Array.isArray( collector ) ) {
+			collector.push( event );
+			return;
+		}
+
+		window.GoDAM.addLayerInteraction( videoKey, event );
+	}
+
+	/**
+	 * Emit every impression event for a layer that has just become visible:
+	 * the layer-wide `viewed` plus one `viewed` per hotspot.
+	 *
+	 * A per-hotspot `viewed` is NOT redundant with the layer's, even though all
+	 * hotspots in a layer appear at the same instant. The *set* of hotspots
+	 * changes as the video is edited, so a per-hotspot impression row is the
+	 * only record of which hotspots actually existed when a viewer saw the
+	 * layer. Reconstructing that afterwards from saved config dates cannot
+	 * resolve an edit made the same day, because the analytics rollup buckets
+	 * by day.
+	 *
+	 * All events go into one array and are written in a single storage
+	 * operation, so an impression costs the same as it did when only the
+	 * layer-level event fired.
+	 *
+	 * @param {Object} parentLayer Layer config (.id, .hotspots).
+	 */
+	emitLayerVisible( parentLayer ) {
+		const videoKey = getVideoKey( this.player );
+		if ( ! videoKey ) {
+			return;
+		}
+
+		const batch = [];
+		this.emitParentLayerEvent( parentLayer, 'viewed', undefined, batch );
+
+		const hotspots = Array.isArray( parentLayer?.hotspots )
+			? parentLayer.hotspots
+			: [];
+		hotspots.forEach( ( hotspot, index ) => {
+			this.emitHotspotEvent( parentLayer, hotspot, index, 'viewed', undefined, batch );
 		} );
+
+		if ( ! batch.length ) {
+			return;
+		}
+
+		if ( typeof window.GoDAM?.addLayerInteractions === 'function' ) {
+			window.GoDAM.addLayerInteractions( videoKey, batch );
+			return;
+		}
+
+		// Older bundle without the batch writer — still correct, just N writes.
+		batch.forEach( ( event ) => window.GoDAM.addLayerInteraction( videoKey, event ) );
 	}
 
 	/**
@@ -384,15 +455,9 @@ export default class HotspotLayerManager {
 			if ( isActive ) {
 				if ( layerObj.layerElement.classList.contains( 'hidden' ) ) {
 					layerObj.layerElement.classList.remove( 'hidden' );
-					// Parent-level `viewed` fires once per session when the
-					// layer first becomes visible. Sub-hotspots don't emit
-					// their own `viewed` — every hotspot inside one parent
-					// layer becomes visible at the same moment, so per-sub
-					// `viewed` counts would all be identical to this one.
-					// Engagement (hovered / clicked) is still emitted per
-					// sub-hotspot; the backend aggregates those by
-					// parent_layer_id for the "All Hotspots" funnel.
-					this.emitParentLayerEvent( layerObj.layer, 'viewed' );
+					// One impression for the layer plus one per hotspot,
+					// written in a single storage operation.
+					this.emitLayerVisible( layerObj.layer );
 					if ( ! layerObj.layerElement.dataset?.hotspotsInitialized ) {
 						this.createHotspots( layerObj );
 						layerObj.layerElement.dataset.hotspotsInitialized = true;

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.js
@@ -122,7 +122,14 @@ export default class HotspotLayerManager {
 	 *                            instead of written, so a caller can batch.
 	 */
 	emitHotspotEvent( parentLayer, hotspot, index, actionType, metadata, collector ) {
-		if ( ! window.GoDAM || typeof window.GoDAM.addLayerInteraction !== 'function' ) {
+		// Build-only mode (a collector array is supplied) pushes the event for a
+		// later batched write, so it does not need the immediate writer. Only the
+		// direct-write path requires window.GoDAM.addLayerInteraction.
+		if (
+			! Array.isArray( collector ) &&
+			( ! window.GoDAM ||
+				typeof window.GoDAM.addLayerInteraction !== 'function' )
+		) {
 			return;
 		}
 
@@ -264,7 +271,13 @@ export default class HotspotLayerManager {
 	 *                            instead of written, so a caller can batch.
 	 */
 	emitParentLayerEvent( parentLayer, actionType, metadata, collector ) {
-		if ( ! window.GoDAM || typeof window.GoDAM.addLayerInteraction !== 'function' ) {
+		// Build-only mode (a collector array is supplied) only needs to push the
+		// event; the immediate writer is required just for the direct-write path.
+		if (
+			! Array.isArray( collector ) &&
+			( ! window.GoDAM ||
+				typeof window.GoDAM.addLayerInteraction !== 'function' )
+		) {
 			return;
 		}
 
@@ -404,7 +417,9 @@ export default class HotspotLayerManager {
 		}
 
 		// Older bundle without the batch writer — still correct, just N writes.
-		batch.forEach( ( event ) => window.GoDAM.addLayerInteraction( videoKey, event ) );
+		if ( typeof window.GoDAM?.addLayerInteraction === 'function' ) {
+			batch.forEach( ( event ) => window.GoDAM.addLayerInteraction( videoKey, event ) );
+		}
 	}
 
 	/**

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.test.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.test.js
@@ -126,4 +126,30 @@ describe( 'HotspotLayerManager.emitLayerVisible', () => {
 		expect( batched ).toHaveLength( 0 );
 		expect( single ).toHaveLength( 0 );
 	} );
+
+	it( 'does not burn the dedupe when no writer is present, so a later visibility retries', () => {
+		const layer = { id: 'l1', type: 'hotspot', displayTime: 1, hotspots: [ { id: 'A' } ] };
+		delete window.GoDAM.addLayerInteraction;
+		delete window.GoDAM.addLayerInteractions;
+		manager.emitLayerVisible( layer ); // no sink yet — must not mark dedupe
+		expect( batched ).toHaveLength( 0 );
+
+		// Core finishes initialising and the batch writer appears.
+		window.GoDAM.addLayerInteractions = ( key, events ) => batched.push( events );
+		manager.emitLayerVisible( layer ); // must now emit, not be deduped away
+		expect( batched ).toHaveLength( 1 );
+		expect( batched[ 0 ].map( ( e ) => e.layer_id ) ).toEqual( [ 'l1', 'l1::A' ] );
+	} );
+
+	it( 'skips the per-hotspot viewed for a hotspot with no stable id', () => {
+		// An id-less hotspot would key on a positional idx<n>, which
+		// re-attributes across a deletion; it keeps the layer impression only.
+		manager.emitLayerVisible( {
+			id: 'l1',
+			type: 'hotspot',
+			displayTime: 1,
+			hotspots: [ { id: 'A' }, {} ],
+		} );
+		expect( batched[ 0 ].map( ( e ) => e.layer_id ) ).toEqual( [ 'l1', 'l1::A' ] );
+	} );
 } );

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.test.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.test.js
@@ -105,4 +105,25 @@ describe( 'HotspotLayerManager.emitLayerVisible', () => {
 		expect( single.map( ( e ) => e.action_type ) ).toEqual( [ 'clicked' ] );
 		expect( batched ).toHaveLength( 0 );
 	} );
+
+	it( 'batches even when only the batch writer is present (no single writer)', () => {
+		delete window.GoDAM.addLayerInteraction;
+		manager.emitLayerVisible( {
+			id: 'l1', type: 'hotspot', displayTime: 1, hotspots: [ { id: 'A' } ],
+		} );
+		expect( batched ).toHaveLength( 1 );
+		expect( batched[ 0 ].map( ( e ) => e.layer_id ) ).toEqual( [ 'l1', 'l1::A' ] );
+	} );
+
+	it( 'does not throw when no writer is available at all', () => {
+		delete window.GoDAM.addLayerInteraction;
+		delete window.GoDAM.addLayerInteractions;
+		expect( () =>
+			manager.emitLayerVisible( {
+				id: 'l1', type: 'hotspot', displayTime: 1, hotspots: [ { id: 'A' } ],
+			} ),
+		).not.toThrow();
+		expect( batched ).toHaveLength( 0 );
+		expect( single ).toHaveLength( 0 );
+	} );
 } );

--- a/assets/src/js/godam-player/managers/layers/hotspotLayerManager.test.js
+++ b/assets/src/js/godam-player/managers/layers/hotspotLayerManager.test.js
@@ -1,0 +1,108 @@
+/**
+ * Internal dependencies
+ */
+import HotspotLayerManager from './hotspotLayerManager';
+
+/**
+ * Minimal player stub — emitLayerVisible only needs a videoKey off the element.
+ *
+ * @param {string} id data-id attribute value.
+ * @return {Object} Fake VideoJS player.
+ */
+const fakePlayer = ( id = 'vid-1' ) => ( {
+	el: () => ( {
+		getAttribute: ( attr ) => ( attr === 'data-id' ? id : null ),
+		dataset: { id },
+	} ),
+	currentTime: () => 5,
+	isFullscreen: () => false,
+} );
+
+describe( 'HotspotLayerManager.emitLayerVisible', () => {
+	let manager, batched, single;
+
+	beforeEach( () => {
+		batched = [];
+		single = [];
+		window.GoDAM = {
+			addLayerInteraction: ( key, event ) => single.push( event ),
+			addLayerInteractions: ( key, events ) => batched.push( events ),
+			getTabHiddenAccumulatedMs: () => 0,
+			getDeviceType: () => 'desktop',
+			wasFirstViewForVideo: () => true,
+		};
+		manager = new HotspotLayerManager( fakePlayer(), true, 'inst-1' );
+	} );
+
+	it( 'emits a layer viewed plus one viewed per hotspot, in one batch', () => {
+		manager.emitLayerVisible( {
+			id: 'l1',
+			type: 'hotspot',
+			displayTime: 4.5,
+			hotspots: [ { id: 'A' }, { id: 'B' } ],
+		} );
+
+		expect( batched ).toHaveLength( 1 );
+		expect( batched[ 0 ].map( ( e ) => e.layer_id ) ).toEqual( [
+			'l1',
+			'l1::A',
+			'l1::B',
+		] );
+		expect( batched[ 0 ].every( ( e ) => e.action_type === 'viewed' ) ).toBe( true );
+	} );
+
+	it( 'writes exactly once no matter how many hotspots there are', () => {
+		manager.emitLayerVisible( {
+			id: 'l1',
+			type: 'hotspot',
+			displayTime: 1,
+			hotspots: Array.from( { length: 12 }, ( _, i ) => ( { id: `h${ i }` } ) ),
+		} );
+
+		expect( batched ).toHaveLength( 1 );
+		expect( batched[ 0 ] ).toHaveLength( 13 );
+		expect( single ).toHaveLength( 0 );
+	} );
+
+	it( 'emits only the layer viewed when there are no hotspots', () => {
+		manager.emitLayerVisible( { id: 'l2', type: 'hotspot', displayTime: 1, hotspots: [] } );
+		expect( batched[ 0 ].map( ( e ) => e.layer_id ) ).toEqual( [ 'l2' ] );
+	} );
+
+	it( 'tolerates a missing hotspots array', () => {
+		manager.emitLayerVisible( { id: 'l3', type: 'hotspot', displayTime: 1 } );
+		expect( batched[ 0 ].map( ( e ) => e.layer_id ) ).toEqual( [ 'l3' ] );
+	} );
+
+	it( 'dedupes per session — a second call emits nothing', () => {
+		const layer = {
+			id: 'l1',
+			type: 'hotspot',
+			displayTime: 1,
+			hotspots: [ { id: 'A' } ],
+		};
+		manager.emitLayerVisible( layer );
+		manager.emitLayerVisible( layer );
+
+		expect( batched ).toHaveLength( 1 );
+		expect( batched[ 0 ] ).toHaveLength( 2 );
+	} );
+
+	it( 'falls back to single writes when the batch writer is absent', () => {
+		delete window.GoDAM.addLayerInteractions;
+		manager.emitLayerVisible( {
+			id: 'l1',
+			type: 'hotspot',
+			displayTime: 1,
+			hotspots: [ { id: 'A' } ],
+		} );
+		expect( single.map( ( e ) => e.layer_id ) ).toEqual( [ 'l1', 'l1::A' ] );
+	} );
+
+	it( 'still routes hovered/clicked through the single-event writer', () => {
+		const layer = { id: 'l1', type: 'hotspot', displayTime: 1, hotspots: [ { id: 'A' } ] };
+		manager.emitHotspotEvent( layer, { id: 'A' }, 0, 'clicked' );
+		expect( single.map( ( e ) => e.action_type ) ).toEqual( [ 'clicked' ] );
+		expect( batched ).toHaveLength( 0 );
+	} );
+} );

--- a/assets/src/js/godam-player/utils/storage.js
+++ b/assets/src/js/godam-player/utils/storage.js
@@ -95,9 +95,12 @@ export function getLayerInteractions() {
  * pays it once regardless of batch size.
  *
  * @param {string}        videoKey data-id or job_id of the video. Required and non-empty.
- * @param {Array<Object>} events   Event objects. Each must include layer_id,
- *                                 layer_type, action_type, layer_timestamp.
- *                                 Malformed entries are skipped, not fatal.
+ * @param {Array<Object>} events   Event objects. An entry is kept only if it has
+ *                                 a truthy layer_id, layer_type and action_type
+ *                                 (the fields the server requires); other entries
+ *                                 are skipped, not fatal. layer_timestamp is
+ *                                 expected downstream but not enforced here, since
+ *                                 0 (a layer at t=0) is a valid value.
  */
 export function addLayerInteractions( videoKey, events ) {
 	if ( ! videoKey || typeof videoKey !== 'string' ) {

--- a/assets/src/js/godam-player/utils/storage.js
+++ b/assets/src/js/godam-player/utils/storage.js
@@ -86,21 +86,38 @@ export function getLayerInteractions() {
 }
 
 /**
- * Append a layer interaction event to the buffer.
+ * Append many layer interaction events in ONE sessionStorage round trip.
  *
- * @param {string} videoKey data-id or job_id of the video. Required and non-empty.
- * @param {Object} event    Event object. Must include layer_id, layer_type, action_type, layer_timestamp.
+ * Reading, parsing, stringifying and writing the buffer is synchronous and
+ * costs O(buffer) every time. A layer becoming visible emits one event for the
+ * layer plus one per hotspot, so calling the single-event writer in a loop
+ * would repeat that whole cost N+1 times back to back, during playback. This
+ * pays it once regardless of batch size.
+ *
+ * @param {string}        videoKey data-id or job_id of the video. Required and non-empty.
+ * @param {Array<Object>} events   Event objects. Each must include layer_id,
+ *                                 layer_type, action_type, layer_timestamp.
+ *                                 Malformed entries are skipped, not fatal.
  */
-export function addLayerInteraction( videoKey, event ) {
+export function addLayerInteractions( videoKey, events ) {
 	if ( ! videoKey || typeof videoKey !== 'string' ) {
 		return;
 	}
-	if ( ! event || typeof event !== 'object' ) {
+	if ( ! Array.isArray( events ) || events.length === 0 ) {
 		return;
 	}
-	if ( ! event.layer_id || ! event.layer_type || ! event.action_type ) {
-		// Defensive — the manager classes set these, but if any caller forgets
-		// we silently drop rather than emit a malformed event the server will 4xx.
+
+	// Defensive — the manager classes set these, but if any caller forgets
+	// we silently drop rather than emit a malformed event the server will 4xx.
+	const valid = events.filter(
+		( event ) =>
+			event &&
+			typeof event === 'object' &&
+			event.layer_id &&
+			event.layer_type &&
+			event.action_type,
+	);
+	if ( valid.length === 0 ) {
 		return;
 	}
 
@@ -108,12 +125,25 @@ export function addLayerInteraction( videoKey, event ) {
 	if ( ! Array.isArray( buffer[ videoKey ] ) ) {
 		buffer[ videoKey ] = [];
 	}
+
 	// Drop new events past the cap rather than risk a quota-exceeded throw.
-	if ( buffer[ videoKey ].length >= MAX_EVENTS_PER_VIDEO ) {
+	const room = MAX_EVENTS_PER_VIDEO - buffer[ videoKey ].length;
+	if ( room <= 0 ) {
 		return;
 	}
-	buffer[ videoKey ].push( event );
+
+	buffer[ videoKey ].push( ...valid.slice( 0, room ) );
 	writeJSON( STORAGE_KEY, buffer );
+}
+
+/**
+ * Append a single layer interaction event to the buffer.
+ *
+ * @param {string} videoKey data-id or job_id of the video. Required and non-empty.
+ * @param {Object} event    Event object. Must include layer_id, layer_type, action_type, layer_timestamp.
+ */
+export function addLayerInteraction( videoKey, event ) {
+	addLayerInteractions( videoKey, [ event ] );
 }
 
 /**

--- a/assets/src/js/godam-player/utils/storage.test.js
+++ b/assets/src/js/godam-player/utils/storage.test.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import {
+	addLayerInteraction,
+	addLayerInteractions,
+	getLayerInteractions,
+	clearLayerInteractions,
+} from './storage';
+
+const evt = ( id ) => ( {
+	layer_id: id,
+	layer_type: 'hotspot',
+	action_type: 'viewed',
+	layer_timestamp: 1,
+} );
+
+describe( 'addLayerInteractions — batch writer', () => {
+	beforeEach( () => {
+		clearLayerInteractions();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'appends every event in order', () => {
+		addLayerInteractions( 'v1', [ evt( 'l1' ), evt( 'l1::A' ), evt( 'l1::B' ) ] );
+		expect( getLayerInteractions().v1.map( ( e ) => e.layer_id ) ).toEqual( [
+			'l1',
+			'l1::A',
+			'l1::B',
+		] );
+	} );
+
+	it( 'writes to sessionStorage exactly once regardless of batch size', () => {
+		const spy = jest.spyOn( Storage.prototype, 'setItem' );
+		addLayerInteractions( 'v1', [ evt( 'l1' ), evt( 'l1::A' ), evt( 'l1::B' ) ] );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'drops malformed events but keeps valid ones', () => {
+		addLayerInteractions( 'v1', [ evt( 'l1' ), { layer_id: 'bad' }, null ] );
+		expect( getLayerInteractions().v1 ).toHaveLength( 1 );
+	} );
+
+	it( 'respects the per-video cap', () => {
+		addLayerInteractions(
+			'v1',
+			Array.from( { length: 1200 }, ( _, i ) => evt( `l${ i }` ) ),
+		);
+		expect( getLayerInteractions().v1 ).toHaveLength( 1000 );
+	} );
+
+	it( 'does nothing on an empty or non-array batch', () => {
+		const spy = jest.spyOn( Storage.prototype, 'setItem' );
+		addLayerInteractions( 'v1', [] );
+		addLayerInteractions( 'v1', null );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the single-event writer working', () => {
+		addLayerInteraction( 'v1', evt( 'l1' ) );
+		expect( getLayerInteractions().v1 ).toHaveLength( 1 );
+	} );
+
+	it( 'ignores a missing or non-string videoKey', () => {
+		addLayerInteractions( '', [ evt( 'l1' ) ] );
+		addLayerInteractions( null, [ evt( 'l1' ) ] );
+		expect( getLayerInteractions() ).toEqual( {} );
+	} );
+} );

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -407,17 +407,18 @@ export function groupRows( rows, layerType, configIndex ) {
 		const subHotspots = bucket.subRows
 			.map( ( { row, md }, idx ) => {
 				const counts = pluckCounts( row );
-				const noAction = computeNoAction( layerType, {
-					...counts,
-					// Sub-hotspots inherit viewed from the parent (all sub-
-					// hotspots in one layer become visible together).
-					viewed: parentCounts.viewed,
-				} );
-				// Per-sub conversion comes from the server: the sub's converting
-				// sessions over the PARENT's viewed (subs don't emit their own
-				// viewed), a UNION over the layer type's conversion actions — so
-				// Woo counts cart-adds too — and already bounded ≤ 100%. Don't
-				// recompute from a single action.
+				// Each hotspot carries its own `viewed`: the player emits one
+				// impression per hotspot, and for days before that shipped the
+				// server substitutes the layer's count only for hotspots it can
+				// prove already existed. Either way `row.viewed` is the right
+				// denominator, so do NOT substitute the parent's here: that is
+				// what charged a newly added hotspot with the layer's whole
+				// history as "No Action".
+				const noAction = computeNoAction( layerType, counts );
+				// Per-hotspot conversion comes from the server: the hotspot's
+				// converting sessions over its own viewed, a UNION over the layer
+				// type's conversion actions — so Woo counts cart-adds too — and
+				// already bounded ≤ 100%. Don't recompute from a single action.
 				const conversion = Math.min(
 					100,
 					Math.max( 0, Number( row.conversion_rate ) || 0 ),
@@ -459,11 +460,7 @@ export function groupRows( rows, layerType, configIndex ) {
 				return {
 					id: subId,
 					name: subName,
-					counts: {
-						...counts,
-						// Inherit viewed; per-sub viewed isn't emitted anymore.
-						viewed: parentCounts.viewed,
-					},
+					counts,
 					no_action: noAction,
 					conversion_rate: conversion,
 					product_id: md.product_id || null,

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -393,6 +393,17 @@ export function groupRows( rows, layerType, configIndex ) {
 			? configIndex.activeSubIdsByParent.get( parentId )
 			: null;
 
+		// The hotspot list is built from recorded activity in the selected date
+		// range, NOT from the layer's saved configuration. A hotspot with no
+		// activity in the range is therefore absent from this list rather than
+		// rendered with zeros.
+		//
+		// That is a deliberate product decision (2026-08-06), not an oversight:
+		// a hotspot that did not exist during the range has nothing to report,
+		// so showing it would invite the reader to compare it against hotspots
+		// that were actually live. It is a documented exception to the
+		// otherwise-general rule that a metric renders greyed rather than
+		// hidden. Do not "fix" it by enumerating from configIndex.
 		const subHotspots = bucket.subRows
 			.map( ( { row, md }, idx ) => {
 				const counts = pluckCounts( row );

--- a/pages/analytics/hooks/useVideoLayerData.test.js
+++ b/pages/analytics/hooks/useVideoLayerData.test.js
@@ -140,4 +140,28 @@ describe( 'groupRows — a hotspot reports its own viewed, never the layer\'s', 
 		expect( parent.counts.viewed ).toBe( 9 );
 		expect( parent.no_action ).toBe( 4 );
 	} );
+
+	// Woo product hotspots go through this same code path, and the two types
+	// must behave identically. Asserted separately because `layerType` selects
+	// the No Action formula, so a woo-only regression would not be caught above.
+	it( 'treats a Woo product hotspot exactly the same way', () => {
+		const wooRows = rows.map( ( r ) => ( {
+			...r,
+			layer_type: 'woo',
+			layer_id: r.layer_id.replace( '::a', '::p1' ).replace( '::b', '::p2' ),
+			layer_metadata: r.layer_id.includes( '::' )
+				? JSON.stringify( {
+					parent_layer_id: 'h-1',
+					product_id: r.layer_id.endsWith( 'a' ) ? 1 : 2,
+					product_name: r.layer_id.endsWith( 'a' ) ? 'Established product' : 'Added yesterday',
+				} )
+				: '{"parent_layer_id":"h-1"}',
+		} ) );
+		const [ parent ] = groupRows( wooRows, 'woo', OPEN_CONFIG );
+		const byName = Object.fromEntries(
+			parent.sub_hotspots.map( ( s ) => [ s.name, [ s.counts.viewed, s.no_action ] ] ),
+		);
+		expect( byName[ 'Established product' ] ).toEqual( [ 7, 4 ] );
+		expect( byName[ 'Added yesterday' ] ).toEqual( [ 1, 1 ] );
+	} );
 } );

--- a/pages/analytics/hooks/useVideoLayerData.test.js
+++ b/pages/analytics/hooks/useVideoLayerData.test.js
@@ -77,3 +77,67 @@ describe( 'groupRows — conversion comes from the server, not a client recomput
 		expect( parent.conversion_rate ).toBe( 100 );
 	} );
 } );
+
+describe( 'groupRows — a hotspot reports its own viewed, never the layer\'s', () => {
+	// The layer was seen 9 times. Hotspot A has been there throughout and was
+	// seen 7 of those times; hotspot B was added late and has been seen once.
+	// Substituting the layer's 9 onto either of them is the bug: it charges B
+	// with 9 impressions it was never present for, all landing in "No Action".
+	const base = {
+		layer_type: 'hotspot',
+		page_url: 'https://example.com',
+		timestamp: 4.59,
+	};
+	const rows = [
+		{
+			...base,
+			layer_id: 'h-1',
+			layer_name: 'Hotspot layer at 4.59s',
+			viewed: 9, clicked: 2, hovered: 5,
+			conversion_rate: 22.2,
+			layer_metadata: '{"parent_layer_id":"h-1"}',
+		},
+		{
+			...base,
+			layer_id: 'h-1::a',
+			layer_name: 'Long-standing hotspot',
+			viewed: 7, clicked: 1, hovered: 3,
+			conversion_rate: 14.3,
+			layer_metadata: '{"parent_layer_id":"h-1"}',
+		},
+		{
+			...base,
+			layer_id: 'h-1::b',
+			layer_name: 'Added yesterday',
+			viewed: 1, clicked: 0, hovered: 0,
+			conversion_rate: 0,
+			layer_metadata: '{"parent_layer_id":"h-1"}',
+		},
+	];
+
+	it( 'keeps each hotspot\'s own viewed instead of the parent\'s', () => {
+		const [ parent ] = groupRows( rows, 'hotspot', OPEN_CONFIG );
+		const byName = Object.fromEntries(
+			parent.sub_hotspots.map( ( s ) => [ s.name, s.counts.viewed ] ),
+		);
+		expect( byName[ 'Long-standing hotspot' ] ).toBe( 7 );
+		expect( byName[ 'Added yesterday' ] ).toBe( 1 );
+	} );
+
+	it( 'computes No Action against the hotspot\'s own viewed', () => {
+		const [ parent ] = groupRows( rows, 'hotspot', OPEN_CONFIG );
+		const byName = Object.fromEntries(
+			parent.sub_hotspots.map( ( s ) => [ s.name, s.no_action ] ),
+		);
+		// 7 - 3, not the parent's 9 - 3 = 6.
+		expect( byName[ 'Long-standing hotspot' ] ).toBe( 4 );
+		// 1 - 0, not the parent's 9 - 0 = 9. This is the reported bug.
+		expect( byName[ 'Added yesterday' ] ).toBe( 1 );
+	} );
+
+	it( 'leaves the layer row itself on its own aggregate', () => {
+		const [ parent ] = groupRows( rows, 'hotspot', OPEN_CONFIG );
+		expect( parent.counts.viewed ).toBe( 9 );
+		expect( parent.no_action ).toBe( 4 );
+	} );
+} );

--- a/pages/analytics/timeline/LayerInteractionFunnel.js
+++ b/pages/analytics/timeline/LayerInteractionFunnel.js
@@ -143,7 +143,12 @@ const LayerInteractionFunnel = ( { layerType, counts, noAction } ) => {
 				action === 'no_action'
 					? Math.max( 0, Number( noAction ) || 0 )
 					: Math.max( 0, Number( counts?.[ action ] ) || 0 );
-			const pct = viewed > 0 ? ( value / viewed ) * 100 : 0;
+			// Clamp the share to 100%. A hotspot can now carry hovered > its own
+			// viewed (e.g. engagement recorded before per-hotspot `viewed` shipped,
+			// or a dropped view), which would otherwise render a bar overflowing
+			// its fixed-height track and a nonsensical ">100% of viewers" label.
+			// The counts row keeps the true raw numbers.
+			const pct = viewed > 0 ? Math.min( 100, ( value / viewed ) * 100 ) : 0;
 			return { action, value, pct };
 		} );
 	}, [ meta, counts, noAction ] );


### PR DESCRIPTION
Issue - https://github.com/rtCamp/godam-analytics/issues/196

Hotspots never emitted their own impression. The layer fired one `viewed` and every hotspot in it inherited that number, so a hotspot's Views (and therefore its conversion and its "No Action") described the layer, not the hotspot.

That inheritance is wrong the moment hotspots are added or removed. A hotspot added today is immediately credited with impressions from before it existed; a deleted one keeps accruing forever.

## What this does

Each hotspot emits its own `viewed` when the layer becomes visible, keyed by the composite id the pipeline already uses (`<layer>::<hotspot>`). The layer keeps emitting its own `viewed`, which remains the denominator for the layer-aggregate row and "All Hotspots (Cumulative)".

**No schema change.** A hotspot impression is just another `video_analytics` row whose `layer_id` contains `::`.

Service half: rtCamp/godam-analytics#246.

## Deploy order (required)

godam-analytics#246 must be live before this plugin release reaches a site. This PR ships **both** the emitter and the dashboard read, and plugin updates reach sites independently of the analytics SaaS deploy, so the ordering is a release-checklist item. Until #246 is live, the old service still overwrites each hotspot's `viewed` with the layer's inherited count, so per-hotspot Views and No-Action show the pre-fix **inflated** numbers (not zeros), and the layer-type rollup (`cumulative` / `daily_breakdown` `viewed`) over-counts by 1 + hotspots per impression with a correspondingly deflated type-level conversion rate.

### The fix on screen

The layer from the bug report, after the fix. Both hotspots read **50.0%**: each now has its own denominator instead of the layer's. Before, one of them read 0.0% with a "No Action" charged to it for a viewing that happened before it existed.

<img src="https://cuunl3cre4.gdcdn.us/8mok6vf5bb/godam-layer-analytics-after.webp" width="900" alt="Video Layer Timeline with the 4.59s hotspot layer selected, both hotspots at 50.0 percent" />

## What it looks like

Each circle is a hotspot, held on screen at 4.7 seconds. Every one of them now writes its own impression the moment this frame appears. Before this change the whole screen produced a single record saying only "the layer was seen".

<img src="https://cuunl3cre4.gdcdn.us/tbjhapl13j/godam-hotspots-live.webp" width="900" alt="Video paused on a hotspot layer with four hotspots visible as circles" />

## Why not fix the inheritance arithmetic instead

That was the previous attempt (#2064, now superseded). It recorded add/delete **dates** in postmeta and had the service subtract days a hotspot did not exist.

It cannot work. `processed_analytics` buckets by day, so there is no sub-day resolution to slice on. Add a hotspot at 2pm after a view at 11am and both fall in the same bucket: the map says "added today", the filter is `day >= added_at`, and the 11am view is still counted. Metadata knows a date; only an event knows a moment. Verified on a real dev site before abandoning that approach.

## Performance

Emitting N+1 events per impression would have been a real regression. `addLayerInteraction()` reads, `JSON.parse`s, `JSON.stringify`s and writes the whole buffer **per call**, synchronously, and the buffer holds up to 1000 events each carrying a ~700-byte metadata blob. In a `forEach` that is N+1 full serialisations of a growing buffer, fired the instant a layer appears during playback.

So this adds `addLayerInteractions( videoKey, events )`: one read-parse-push-many-stringify-write regardless of batch size. `emitLayerVisible()` builds its events in memory via a `collector` parameter threaded through the existing emitters, then makes a single call. **Cost per impression is unchanged from before**, not N× it. Every existing caller omits `collector` and behaves exactly as it did, so `hovered`/`clicked` are untouched.

Measured in a real browser: **5 storage writes for 9 events**, with each 3-event layer impression costing exactly 1.

## Verified end to end on godam-dev.local

Real playback in Chrome, real build, against a local ClickHouse and the local analytics service.

Raw `video_analytics` for the "Hotspot layer at 4.59s":

| `layer_id` | before | after |
|---|---|---|
| `9a8620a0-…` (layer) | `viewed` 6 | `viewed` 8 |
| `9a8620a0-…::dcd6e421-…` | **no rows existed** | `viewed` 2, `hovered` 5, `clicked` 3 |
| `9a8620a0-…::bbf47ab5-…` | **no rows existed** | `viewed` 2, `hovered` 2, `clicked` 1 |

After `/process-analytics/`, `processed_analytics.layer_details` carries `viewed 2` for each hotspot against the layer's `viewed 4` — each hotspot has its own denominator instead of inheriting.

On the dashboard, both hotspots in that layer now read **50.0%**. Before, one read 0.0% with a phantom "No Action" contributed by an impression that predated it.

| Check | Result |
|---|---|
| Per-hotspot `viewed` reaches ClickHouse | Confirmed, real playback |
| Storage writes per impression | 1, regardless of hotspot count |
| `hovered` / `clicked` still emit | Confirmed, unchanged |
| Dashboard per-hotspot conversion | Both hotspots 50.0% |
| JS unit tests | 39 pass (7 new for the batch writer, 7 new for emission) |

## The dashboard was throwing the fix away

Found while capturing screenshots for this PR, after the service work was already merged-ready.

`pages/analytics/hooks/useVideoLayerData.js` overwrote every hotspot's `viewed` with the parent layer's, in two places, each justified by a comment saying hotspots do not emit their own impressions. They do now. The result: the API returned the correct per-hotspot number and the screen discarded it.

```js
// before
const noAction = computeNoAction( layerType, {
    ...counts,
    // Sub-hotspots inherit viewed from the parent (all sub-
    // hotspots in one layer become visible together).
    viewed: parentCounts.viewed,
} );
...
counts: {
    ...counts,
    // Inherit viewed; per-sub viewed isn't emitted anymore.
    viewed: parentCounts.viewed,
},
```

```js
// after
const noAction = computeNoAction( layerType, counts );
...
counts,
```

What it looked like on screen, same data, same day:

| hotspot | API returns | screen before | screen now |
|---|---|---|---|
| Hotspot 1, long-standing | 7 viewed, 4 No Action | 9 viewed, **6** No Action | 7 viewed, **4** No Action |
| Hotspot 4, added late then deleted | 1 viewed, 1 No Action | 9 viewed, **9** No Action | 1 viewed, **1** No Action |

`hovered` and `clicked` were already correct on that panel, which is exactly why this survived: three of the four tiles agreed with the API, so a glance at the panel looked right.

Three tests over `groupRows` cover it; two of them fail against the previous code.

## Add and delete, on a dev site

The full lifecycle, driven through the editor and the real player, with the numbers read off the dashboard.

**Add.** A fourth hotspot was added to a layer that had already been viewed 8 times, then the video was played once. It recorded 1 view, not 9.

**Delete.** That hotspot was then deleted in the editor, the video saved, and played once more.

| row | before delete | after one more play | expected |
|---|---|---|---|
| Hotspot 1 `dcd6e421` | 6 | 7 | +1 |
| Hotspot 2 `bbf47ab5` | 6 | 7 | +1 |
| Hotspot 3 `cb3d95ea` | 3 | 4 | +1 |
| Hotspot 4 `3aa14ff5` (deleted) | 1 | 1 | unchanged |
| Layer `9a8620a0` | 12 | 13 | +1 |

Dashboard after a reprocess, last 7 days:

| row | viewed | hovered | clicked | No Action |
|---|---|---|---|---|
| Hotspot layer @4.59s | 9 | 5 | 2 | 4 |
| Hotspot 1 | 7 | 3 | 1 | 4 |
| Hotspot 2 | 7 | 3 | 1 | 4 |
| Hotspot 3 | 4 | 2 | 0 | 2 |
| Hotspot 4 (added late, then deleted) | **1** | 0 | 0 | **1** |

That last row is the bug: it used to read 9 views with 9 charged to "No Action" for a layer it was not part of yet.

## Not covered here

- **Woo product hotspots** get the identical change in rtCamp/godam-for-woo#192, verified end to end alongside this one. Not in this PR.
- **Removing `layer_lifetimes`** (this repo's PHP + godam-analytics#209) is deferred until this is confirmed live. It is inert either way.
- **Config-driven hotspot rows.** `groupRows()` builds the hotspot list from analytics rows, so a hotspot with no data in the range does not render at all, which breaks the always-render rule. This change makes a *seen* hotspot appear; a never-seen one still will not. Separate fix.

## Automation impact

No UI changes and no new `data-test-id`s. The player change is covered by new unit tests; the analytics hook is unchanged in this PR.





### Review fixes (commit dae675ec)

- `emitHotspotEvent` / `emitParentLayerEvent`: build-only mode (a `collector` array) no longer requires `window.GoDAM.addLayerInteraction`, so batched emission works against a bundle that provides only `addLayerInteractions`. (Copilot)
- `emitLayerVisible` fallback guarded so it never calls a missing writer.
- `addLayerInteractions` JSDoc corrected to the fields actually enforced (`layer_id`, `layer_type`, `action_type`); `layer_timestamp` is not enforced since 0 is a valid value. (Copilot)
- Tests added for the batch-only and no-writer cases.



### Known limitation: analytics event buffer cap

The player batches analytics events in sessionStorage (one list per video) and sends them to the server in a single request on each flush. That list is capped at `MAX_EVENTS_PER_VIDEO` = 1000; once it is full, further events are dropped. Per-hotspot `viewed` raises the number of records a layer impression adds from 1 to 1 + (number of hotspots shown), but 1000 is still far above realistic content: reaching it in one session would take on the order of a few hundred distinct hotspots/products on a single video, all seen before any flush empties the list. On such an extreme video a hotspot's `viewed` could be dropped while a later click or hover is not, leaving that hotspot with engagement and no view for that session (the once-per-session dedupe means a dropped view is not re-emitted). Accepted as a known limitation given how far 1000 is from real usage; not addressed in this PR.

## Recording
https://app.godam.io/web/video/ftimopdeko

The recording is an end-to-end check of the per-hotspot / per-product view feature: a brand-new hotspot reads its own 1 view (not the layer's 13), a brand-new product reads its own 1 view at 100% (not a diluted 10%), and removed items retain their real history instead of borrowing or losing the layer's numbers. It behaves exactly as intended.


