### PR TITLE
fix(analytics): show only the hotspot label in the layer rail

### DIFF
--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -432,7 +432,24 @@ export function groupRows( rows, layerType, configIndex ) {
 				// path the parent uses so a raw composite UUID never reaches
 				// the rail. Falls back to a generic ordinal "<TypeLabel> #N"
 				// when nothing usable.
-				const rawSubName = md.product_name || row.layer_name || '';
+				let rawSubName = md.product_name || row.layer_name || '';
+				// The hotspot tracker packs the parent layer name, a separator
+				// dash, and "Hotspot N" into layer_name. The rail's card title
+				// already shows the parent, so that prefix is pure repetition
+				// and, once the row is truncated, it hides the "Hotspot N" that
+				// actually names the row. Drop the parent prefix (and the
+				// separator after it), keeping only the hotspot's own label.
+				// Woo rows carry a bare product_name and never match this, so
+				// they are left alone.
+				if (
+					! md.product_name &&
+					md.parent_layer_name &&
+					rawSubName.startsWith( md.parent_layer_name )
+				) {
+					rawSubName = rawSubName
+						.slice( md.parent_layer_name.length )
+						.replace( /^[\s\p{Pd}]+/u, '' );
+				}
 				let subName;
 				if (
 					rawSubName &&

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -143,6 +143,17 @@ const TRACKER_AUTO_NAME_RE = new RegExp(
 );
 
 /**
+ * Exact separator the hotspot tracker puts between the parent layer name
+ * and the hotspot's own label when it composes `layer_name`. It builds
+ * `<parentLayerName> — <subLabel>` (space, em dash, space) in
+ * `hotspotLayerManager.js`; keep this in sync with that string. Matching
+ * the full separator — rather than just the parent name — is what lets us
+ * strip the prefix without touching a hotspot label that legitimately
+ * begins with a dash.
+ */
+const HOTSPOT_NAME_SEPARATOR = ' — ';
+
+/**
  * Whether a server-delivered layer_name is missing, a bare UUID, or a
  * tracker-side auto-generated name — i.e. anything we should replace with
  * a locally generated (localized) fallback. Also drives the `name_is_auto`
@@ -433,22 +444,26 @@ export function groupRows( rows, layerType, configIndex ) {
 				// the rail. Falls back to a generic ordinal "<TypeLabel> #N"
 				// when nothing usable.
 				let rawSubName = md.product_name || row.layer_name || '';
-				// The hotspot tracker packs the parent layer name, a separator
-				// dash, and "Hotspot N" into layer_name. The rail's card title
-				// already shows the parent, so that prefix is pure repetition
-				// and, once the row is truncated, it hides the "Hotspot N" that
-				// actually names the row. Drop the parent prefix (and the
-				// separator after it), keeping only the hotspot's own label.
+				// The hotspot tracker packs the parent layer name, the
+				// `HOTSPOT_NAME_SEPARATOR`, and "Hotspot N" into layer_name. The
+				// rail's card title already shows the parent, so that prefix is
+				// pure repetition and, once the row is truncated, it hides the
+				// "Hotspot N" that actually names the row. Drop the exact
+				// "<parent> — " prefix, keeping only the hotspot's own label.
+				// Matching the full separator (not just the parent name) means:
+				// - a custom label that merely begins with the parent name
+				//   (parent "Sale", label "Sale special") is left intact, and
+				// - a label that itself starts with a dash (parent "Summer
+				//   sale", label "-50% off") keeps its leading dash instead of
+				//   having it eaten as part of the separator.
 				// Woo rows carry a bare product_name and never match this, so
 				// they are left alone.
-				if (
-					! md.product_name &&
-					md.parent_layer_name &&
-					rawSubName.startsWith( md.parent_layer_name )
-				) {
-					rawSubName = rawSubName
-						.slice( md.parent_layer_name.length )
-						.replace( /^[\s\p{Pd}]+/u, '' );
+				if ( ! md.product_name && md.parent_layer_name ) {
+					const parentPrefix =
+						md.parent_layer_name + HOTSPOT_NAME_SEPARATOR;
+					if ( rawSubName.startsWith( parentPrefix ) ) {
+						rawSubName = rawSubName.slice( parentPrefix.length );
+					}
 				}
 				let subName;
 				if (

--- a/pages/analytics/hooks/useVideoLayerData.test.js
+++ b/pages/analytics/hooks/useVideoLayerData.test.js
@@ -231,4 +231,51 @@ describe( 'groupRows — hotspot sub-name drops the redundant parent prefix', ()
 		const [ parent ] = groupRows( [ parentRow, custom ], 'hotspot', OPEN_CONFIG );
 		expect( parent.sub_hotspots.map( ( s ) => s.name ) ).toContain( 'Buy now' );
 	} );
+
+	// A custom label that merely begins with the parent name but is not the
+	// tracker composite (no separator). Stripping on the bare parent name
+	// would leave "special"; matching the full "<parent> — " separator keeps
+	// the label whole.
+	it( 'leaves a custom label that only shares the parent name as a prefix', () => {
+		const collidingParent = 'Sale';
+		const parentSale = {
+			...base,
+			layer_id: 'h-2',
+			layer_name: collidingParent,
+			viewed: 2, clicked: 1, hovered: 2, conversion_rate: 50,
+			layer_metadata: JSON.stringify( { parent_layer_id: 'h-2', parent_layer_name: collidingParent } ),
+		};
+		const sub = {
+			...base,
+			layer_id: 'h-2::a',
+			layer_name: 'Sale special',
+			viewed: 1, clicked: 0, hovered: 0, conversion_rate: 0,
+			layer_metadata: JSON.stringify( { parent_layer_id: 'h-2', parent_layer_name: collidingParent } ),
+		};
+		const [ parent ] = groupRows( [ parentSale, sub ], 'hotspot', OPEN_CONFIG );
+		expect( parent.sub_hotspots.map( ( s ) => s.name ) ).toEqual( [ 'Sale special' ] );
+	} );
+
+	// A hotspot whose own label starts with a dash. Only the single separator
+	// is the prefix; the label's leading dash must survive so "-50% off" does
+	// not become "50% off" (the opposite meaning).
+	it( 'keeps a hotspot label that itself begins with a dash', () => {
+		const dashParent = 'Summer sale';
+		const parentSummer = {
+			...base,
+			layer_id: 'h-3',
+			layer_name: dashParent,
+			viewed: 2, clicked: 1, hovered: 2, conversion_rate: 50,
+			layer_metadata: JSON.stringify( { parent_layer_id: 'h-3', parent_layer_name: dashParent } ),
+		};
+		const sub = {
+			...base,
+			layer_id: 'h-3::a',
+			layer_name: `${ dashParent }${ SEP }-50% off`,
+			viewed: 1, clicked: 0, hovered: 0, conversion_rate: 0,
+			layer_metadata: JSON.stringify( { parent_layer_id: 'h-3', parent_layer_name: dashParent } ),
+		};
+		const [ parent ] = groupRows( [ parentSummer, sub ], 'hotspot', OPEN_CONFIG );
+		expect( parent.sub_hotspots.map( ( s ) => s.name ) ).toEqual( [ '-50% off' ] );
+	} );
 } );

--- a/pages/analytics/hooks/useVideoLayerData.test.js
+++ b/pages/analytics/hooks/useVideoLayerData.test.js
@@ -165,3 +165,70 @@ describe( 'groupRows — a hotspot reports its own viewed, never the layer\'s', 
 		expect( byName[ 'Added yesterday' ] ).toEqual( [ 1, 1 ] );
 	} );
 } );
+
+describe( 'groupRows — hotspot sub-name drops the redundant parent prefix', () => {
+	// The tracker writes each hotspot event's layer_name as the parent layer
+	// name, a separator dash, then "Hotspot N" (e.g. the parent "Hotspot layer
+	// at 4.59s" followed by " <dash> Hotspot 2"). The rail already shows the
+	// parent as its card title, so the row must read just "Hotspot N". SEP is
+	// built from a code point so no literal em dash lives in this file.
+	const SEP = ` ${ String.fromCharCode( 0x2014 ) } `;
+	const PARENT = 'Hotspot layer at 4.59s';
+	const base = { layer_type: 'hotspot', page_url: 'https://example.com', timestamp: 4.59 };
+	const parentRow = {
+		...base,
+		layer_id: 'h-1',
+		layer_name: PARENT,
+		viewed: 2, clicked: 1, hovered: 2,
+		conversion_rate: 50,
+		layer_metadata: JSON.stringify( { parent_layer_id: 'h-1', parent_layer_name: PARENT } ),
+	};
+	const subRow = ( suffix, label, index ) => ( {
+		...base,
+		layer_id: `h-1::${ suffix }`,
+		layer_name: `${ PARENT }${ SEP }${ label }`,
+		viewed: 1, clicked: 0, hovered: 0,
+		conversion_rate: 0,
+		layer_metadata: JSON.stringify( {
+			parent_layer_id: 'h-1',
+			parent_layer_name: PARENT,
+			hotspot_index: index,
+		} ),
+	} );
+
+	it( 'strips the parent name and separator, leaving only "Hotspot N"', () => {
+		const rows = [ parentRow, subRow( 'a', 'Hotspot 1', 0 ), subRow( 'b', 'Hotspot 2', 1 ) ];
+		const [ parent ] = groupRows( rows, 'hotspot', OPEN_CONFIG );
+		expect( parent.sub_hotspots.map( ( s ) => s.name ).sort() ).toEqual( [ 'Hotspot 1', 'Hotspot 2' ] );
+	} );
+
+	it( 'leaves a Woo product name untouched (guarded by product_name)', () => {
+		const wooParent = {
+			...parentRow,
+			layer_type: 'woo',
+			layer_id: 'w-1',
+			layer_name: 'Woo layer at 9.90s',
+			layer_metadata: JSON.stringify( { parent_layer_id: 'w-1', parent_layer_name: 'Woo layer at 9.90s' } ),
+		};
+		const wooSub = {
+			...base,
+			layer_type: 'woo',
+			layer_id: 'w-1::p1',
+			layer_name: 'Lamp',
+			viewed: 0, hovered: 1, added_to_cart: 0, conversion_rate: 0,
+			layer_metadata: JSON.stringify( { parent_layer_id: 'w-1', product_id: 1, product_name: 'Lamp' } ),
+		};
+		const [ parent ] = groupRows( [ wooParent, wooSub ], 'woo', OPEN_CONFIG );
+		expect( parent.sub_hotspots.map( ( s ) => s.name ) ).toEqual( [ 'Lamp' ] );
+	} );
+
+	it( 'keeps a sub name that does not start with the parent prefix', () => {
+		const custom = {
+			...subRow( 'c', 'ignored', 2 ),
+			layer_name: 'Buy now',
+			layer_metadata: JSON.stringify( { parent_layer_id: 'h-1', parent_layer_name: PARENT } ),
+		};
+		const [ parent ] = groupRows( [ parentRow, custom ], 'hotspot', OPEN_CONFIG );
+		expect( parent.sub_hotspots.map( ( s ) => s.name ) ).toContain( 'Buy now' );
+	} );
+} );


### PR DESCRIPTION
Connected ticket - https://github.com/rtCamp/godam-analytics/issues/196

### What

In the Video Layer Timeline detail panel, every hotspot row in the "Hotspots in this layer" rail repeated the parent layer name and then truncated the part that identifies the hotspot. Every row read "Hotspot layer at 4.59s ..." so you could not tell the hotspots apart.

### Why it happened

The player tracker writes each hotspot event's `layer_name` as the parent layer name, then a separator dash, then "Hotspot N". The rail already shows the parent layer as its card title, so `groupRows` was rendering that whole string as the row name, and the rail's `truncate` style then clipped off the "Hotspot N".

Woo product rows were already fine, because they carry a bare `product_name` ("Lamp", "Sofa").

### The fix

In `groupRows` (`pages/analytics/hooks/useVideoLayerData.js`), strip the parent-name prefix from a hotspot sub-row's name so each row reads just "Hotspot N". It only runs for rows with no `product_name` (so Woo is untouched) and only when the name starts with the exact “<parent> — ” prefix the tracker composes (matching the full separator, not just the parent name, so a custom label that merely begins with the parent name or one that itself starts with a dash is left intact). It reads what is already stored, so it fixes existing and historical data too, with no change to the wire format.

### Verification

- Unit tests: 15/15 pass, including 5 new ones (the strip, the untouched Woo case, a custom name that does not start with the parent prefix, a label that only shares the parent name as a prefix, and a label that itself begins with a dash). The last two fail on the pre-review greedy logic and pass with the exact-separator match.
- On `godam-dev.local` pointed at the develop analytics service, video "People": the 4.59s hotspot rail now reads "Hotspot 1 / Hotspot 2", and the Woo layer still reads "Lamp / Sofa".

### Automation impact

Rail row labels changed from the prefixed form ("<parent layer name>" then "Hotspot N") to just "Hotspot N". Any test asserting the old, prefixed label needs updating.

### Known follow-up (not this PR)

Hotspots are numbered by position ("Hotspot N"), so when one is removed or reordered the numbers can collide (you can see two "Hotspot 2" rows, one active and one "Removed"). Giving each hotspot a stable identity label is a separate change.

## Screenshots
### Before
<img width="1219" height="530" alt="Screenshot 2026-08-13 at 5 08 21 PM" src="https://github.com/user-attachments/assets/0eeba247-2745-4bed-9f14-119a0ee5849f" />

### After
<img width="1512" height="802" alt="image" src="https://github.com/user-attachments/assets/9f1d6d48-b214-4de5-b086-da9f3498e4ef" />


