### PR TITLE
Fix: Media Library Delete folder issue

### DIFF
--- a/pages/media-library/components/folder-tree/FolderTree.jsx
+++ b/pages/media-library/components/folder-tree/FolderTree.jsx
@@ -67,10 +67,17 @@ const FolderTree = ( { handleContextMenu } ) => {
 	const [ updateFolderMutation ] = useUpdateFolderMutation();
 
 	useEffect( () => {
-		if ( folders ) {
-			dispatch( setTree( openLocalStorageItem( folders?.data ) ) );
+		// Only sync once the query has settled — syncing an in-flight (stale) response
+		// could momentarily re-introduce a just-deleted folder. On the first page we
+		// REPLACE the list so server-side removals (deletes) are reflected; on load-more
+		// pages we append, preserving the already-loaded pages.
+		if ( folders && ! isFetching ) {
+			dispatch( setTree( {
+				folders: openLocalStorageItem( folders?.data ),
+				replace: currentPage === 1,
+			} ) );
 
-			if ( Array.isArray( folders?.data ) && ! isFetching ) {
+			if ( Array.isArray( folders?.data ) ) {
 				// If no folders are returned, reset to the first page
 				dispatch( updatePage( { totalPages: folders.totalPages } ) );
 			}

--- a/pages/media-library/components/modal/DeleteModal.jsx
+++ b/pages/media-library/components/modal/DeleteModal.jsx
@@ -56,17 +56,21 @@ const DeleteModal = () => {
 			// folder from the tree even though it still exists on the server. unwrap()
 			// re-throws the error payload so failures reach the catch (matching how
 			// Rename/Create already handle their mutations).
+			let partialMessage = null;
+
 			if ( ! isMultiSelecting ) {
 				await deleteFolderMutation( selectedFolder.id ).unwrap();
 			} else if ( multiSelectedFolderIds && multiSelectedFolderIds.length ) {
 				// The bulk endpoint returns HTTP 200 with `errors` on *partial* failure, so
-				// .unwrap() alone won't throw — inspect the payload and surface it as a
-				// failure rather than reporting "deleted successfully" and dropping every
-				// selected folder from the tree.
+				// .unwrap() alone won't throw. On a partial failure we still remove the whole
+				// selection optimistically and surface a WARNING (not "deleted successfully");
+				// the invalidation refetch below re-adds any folder that wasn't actually
+				// deleted, so successfully-deleted folders don't linger (even on load-more
+				// pages, where the reducer removes them from the flat list).
 				const bulkResult = await bulkDeleteFoldersMutation( multiSelectedFolderIds ).unwrap();
 
 				if ( bulkResult?.errors?.length ) {
-					throw new Error( bulkResult.message || __( 'Some folders could not be deleted', 'godam' ) );
+					partialMessage = bulkResult.message || __( 'Some folders could not be deleted', 'godam' );
 				}
 			}
 
@@ -74,8 +78,8 @@ const DeleteModal = () => {
 
 			dispatch( updateSnackbar(
 				{
-					message: isMultiSelecting ? __( 'Folders deleted successfully', 'godam' ) : __( 'Folder deleted successfully', 'godam' ),
-					type: 'success',
+					message: partialMessage || ( isMultiSelecting ? __( 'Folders deleted successfully', 'godam' ) : __( 'Folder deleted successfully', 'godam' ) ),
+					type: partialMessage ? 'fail' : 'success',
 				},
 			) );
 

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -64,6 +64,7 @@ export async function pollZipJobStatus( jobId, { intervalMs = 2000, timeoutMs = 
 export const folderApi = createApi( {
 	reducerPath: 'folderApi',
 	baseQuery: fetchBaseQuery( { baseUrl: restURL } ),
+	tagTypes: [ 'Folder' ],
 	endpoints: ( builder ) => ( {
 		getAllMediaCount: builder.query( {
 			async queryFn( arg, api, extraOptions, baseQuery ) {
@@ -141,6 +142,7 @@ export const folderApi = createApi( {
 					totalPages: totalPages ? parseInt( totalPages, 10 ) : 0,
 				};
 			},
+			providesTags: [ 'Folder' ],
 		} ),
 		createFolder: builder.mutation( {
 			query: ( data ) => ( {
@@ -151,6 +153,9 @@ export const folderApi = createApi( {
 					'X-WP-Nonce': window.MediaLibrary.nonce,
 				},
 			} ),
+			// Refetch the authoritative folder list after list-changing mutations so the
+			// tree reconciles (create adds, delete removes) instead of drifting from cache.
+			invalidatesTags: [ 'Folder' ],
 		} ),
 		updateFolder: builder.mutation( {
 			query: ( data ) => ( {
@@ -173,6 +178,7 @@ export const folderApi = createApi( {
 					'X-WP-Nonce': window.MediaLibrary.nonce,
 				},
 			} ),
+			invalidatesTags: [ 'Folder' ],
 		} ),
 		bulkDeleteFolders: builder.mutation( {
 			query: ( folderIds ) => ( {
@@ -184,6 +190,7 @@ export const folderApi = createApi( {
 					'Content-Type': 'application/json',
 				},
 			} ),
+			invalidatesTags: [ 'Folder' ],
 		} ),
 		bulkLockFolders: builder.mutation( {
 			query: ( { folderIds, lockedStatus } ) => ( {

--- a/pages/media-library/redux/api/folders.js
+++ b/pages/media-library/redux/api/folders.js
@@ -153,9 +153,10 @@ export const folderApi = createApi( {
 					'X-WP-Nonce': window.MediaLibrary.nonce,
 				},
 			} ),
-			// Refetch the authoritative folder list after list-changing mutations so the
-			// tree reconciles (create adds, delete removes) instead of drifting from cache.
-			invalidatesTags: [ 'Folder' ],
+			// NOTE: intentionally NOT invalidating 'Folder' here. The createFolder reducer
+			// pushes the new folder optimistically; a refetch would replace page 1 with the
+			// server's first 20 (name ASC) and drop a freshly-created folder that sorts onto
+			// a later page until Load More / reload.
 		} ),
 		updateFolder: builder.mutation( {
 			query: ( data ) => ( {

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -181,24 +181,33 @@ const slice = createSlice( {
 			state.multiSelectedFolderIds = [];
 		},
 		setTree: ( state, action ) => {
-			const newFolders = action.payload;
+			const payload = action.payload;
 
-			if ( state.folders.length > 0 ) {
-				const folderMap = new Map( state.folders.map( ( folder ) => [ folder.id, folder ] ) );
+			// Backward compatible: an array payload keeps the legacy merge/append behavior
+			// (drag-reorder / count updates always pass the full current list). An object
+			// payload `{ folders, replace }` lets callers REPLACE the list so removals are
+			// reflected. The merge branch can only add/update — it never removes — so a
+			// deleted folder used to reappear (whenever this ran with the still-cached query
+			// data) and only cleared on a hard refresh, where state started empty.
+			const newFolders = Array.isArray( payload ) ? payload : ( payload?.folders || [] );
+			const replace = ! Array.isArray( payload ) && Boolean( payload?.replace );
 
-				newFolders.forEach( ( folder ) => {
-					if ( folderMap.has( folder.id ) ) {
-						// Update existing folder
-						Object.assign( folderMap.get( folder.id ), folder );
-					} else {
-						// Add new folder
-						state.folders.push( folder );
-					}
-				} );
-			} else {
-				// No existing folders, just set
+			if ( replace || state.folders.length === 0 ) {
 				state.folders = newFolders;
+				return;
 			}
+
+			const folderMap = new Map( state.folders.map( ( folder ) => [ folder.id, folder ] ) );
+
+			newFolders.forEach( ( folder ) => {
+				if ( folderMap.has( folder.id ) ) {
+					// Update existing folder
+					Object.assign( folderMap.get( folder.id ), folder );
+				} else {
+					// Add new folder
+					state.folders.push( folder );
+				}
+			} );
 		},
 
 		toggleMultiSelectMode: ( state ) => {

--- a/pages/media-library/redux/slice/folders.js
+++ b/pages/media-library/redux/slice/folders.js
@@ -193,7 +193,19 @@ const slice = createSlice( {
 			const replace = ! Array.isArray( payload ) && Boolean( payload?.replace );
 
 			if ( replace || state.folders.length === 0 ) {
-				state.folders = newFolders;
+				// Sort a mutable copy: `newFolders` comes straight from the RTK Query cache,
+				// which is frozen (read-only), so sorting it in place throws. The server
+				// always returns name ASC; re-applying the active sort keeps a "By Name (Z-A)"
+				// selection from silently resetting to A-Z when the list is replaced.
+				const sorted = [ ...newFolders ];
+
+				if ( 'name-desc' === state.sortOrder ) {
+					sorted.sort( ( a, b ) => a.name.localeCompare( b.name ) * -1 );
+				} else if ( 'name-asc' === state.sortOrder ) {
+					sorted.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+				}
+
+				state.folders = sorted;
 				return;
 			}
 
@@ -405,11 +417,11 @@ const slice = createSlice( {
 				type: 'success',
 			};
 
-			// Reset page to first page
-			state.page.current = 1;
-
-			// Note: We preserve folders, bookmarks, lockedFolders, and sortOrder
-			// for performance and user experience
+			// NOTE: page.current is intentionally NOT reset here. We preserve the loaded
+			// folders (and bookmarks/lockedFolders/sortOrder) across modal open/close for
+			// performance and UX — resetting the page to 1 while keeping those folders made
+			// the sync effect re-fetch page 1 and REPLACE the tree with just the first page,
+			// collapsing everything the user had loaded via "Load more".
 		},
 	},
 } );


### PR DESCRIPTION
## Root cause

The folder tree renders from state.FolderReducer.folders. When you delete, the deleteFolder reducer removes the folder from that array — but the tree re-syncs from the cached folders query via setTree, and setTree only ever merges (add/update); it never removes. So the deleted folder gets re-added from the still-cached query data. It only disappears on a hard refresh, because then the slice starts empty and setTree takes its "replace" branch. (The merge exists on purpose — it's how the "Load more" pagination appends pages — which is why the bug was subtle.)

## The fix (3 coordinated changes, all JS)

- redux/slice/folders.js — setTree now supports removal. An array payload keeps the legacy merge/append (used by drag-reorder and attachment-count updates, which pass the full list). A new { folders, replace } payload replaces the list, so deletions actually stick.
- components/folder-tree/FolderTree.jsx — the sync effect now replaces on page 1 (reflecting deletes) and appends on load-more pages, and only syncs once the fetch has settled (!isFetching) so an in-flight/stale response can't momentarily re-add a just-deleted folder.
- redux/api/folders.js — cache invalidation. Tagged getFolders with 'Folder'; createFolder, deleteFolder, and bulkDeleteFolders now invalidatesTags: ['Folder'], so after any add/remove the tree refetches authoritative data instead of drifting from the cache.

Net effect: delete a folder → it's removed optimistically and the refetched authoritative list replaces the tree, so it disappears immediately and stays gone (single and multi-select).

## Testing instruction

On `http://<site>/wp-admin/upload.php` after a `npm run build:js`:

- Create a folder, delete it (single) → it disappears immediately, no refresh.
- Multi-select a few folders, delete → all disappear immediately.
- Delete a folder with subfolders → the whole subtree goes.
- If you have >20 folders: "Load more", then delete → the deleted one goes and the loaded pages stay.

## Demo

https://github.com/user-attachments/assets/494499ae-2948-4b0d-8d87-7807bb4744eb

