### PR TITLE
Fix/godam blockspacing in columns

### DIFF
--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -156,10 +156,31 @@ class GoDAM_Player {
 			);
 		}
 
+		/**
+		 * Player wrapper styles (placeholder / poster / loading states).
+		 *
+		 * Shipped as a real stylesheet rather than an inline <style> emitted by
+		 * inc/templates/godam-player.php: the style tag rendered as a sibling of
+		 * the player markup, so in a flow-layout container (core/column, core/group)
+		 * the player became the second child and picked up the container's
+		 * `margin-block-start` blockGap rule, adding phantom spacing above the video.
+		 * The CSS is static — nothing per-video — so there is nothing to inline.
+		 *
+		 * Registered as a dependency of `godam-player-style` so every existing
+		 * enqueue point (block.json `style`, shortcodes, Elementor `depended_styles`,
+		 * gallery) pulls it in with no further changes.
+		 */
+		wp_register_style(
+			'godam-player-wrapper-style',
+			RTGODAM_URL . 'assets/build/css/godam-player-wrapper.css',
+			array(),
+			filemtime( RTGODAM_PATH . 'assets/build/css/godam-player-wrapper.css' )
+		);
+
 		wp_register_style(
 			'godam-player-style',
 			RTGODAM_URL . 'assets/build/css/godam-player.css',
-			array(),
+			array( 'godam-player-wrapper-style' ),
 			filemtime( RTGODAM_PATH . 'assets/build/css/godam-player.css' )
 		);
 
@@ -286,7 +307,7 @@ class GoDAM_Player {
 	 *
 	 * HTML output is NOT cached here by design.  Caching the full rendered blob
 	 * would suppress per-request side effects that the template performs on every
-	 * call: adding wrapper CSS to wp_head, suppressing Gravity Forms autoscroll,
+	 * call: enqueueing the player wrapper stylesheet, suppressing Gravity Forms autoscroll,
 	 * conditionally initialising the IMA SDK for ad-enabled videos, and generating
 	 * a unique per-render $godam_instance_id used in DOM IDs.
 	 *

--- a/inc/classes/wpforms/class-wpforms-field-godam-video.php
+++ b/inc/classes/wpforms/class-wpforms-field-godam-video.php
@@ -67,11 +67,11 @@ if ( class_exists( 'WPForms_Field' ) ) {
 				'type' => true,
 			);
 
-			// The GoDAM player template emits its wrapper styles as an inline
-			// <style id="godam-player-wrapper-inline-css"> block. wp_kses_post()
-			// strips <style> by default (keeping only its CSS text, which then
-			// leaks onto the page as a raw string), so it must be whitelisted for
-			// the rendered player to be styled on the entry view page.
+			// Player wrapper styles are enqueued as a stylesheet, so the player
+			// markup no longer carries an inline <style>. The allowance stays for
+			// player variants that still emit one (e.g. the audio no-JS block):
+			// wp_kses_post() strips <style> by default while keeping its CSS text,
+			// which then leaks onto the page as a raw string.
 			$allowed_tags['style'] = array(
 				'id'    => true,
 				'type'  => true,

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -14,38 +14,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Output player wrapper styles inline at render time. We deliberately do NOT
-// defer to wp_head/admin_head: those hooks never fire in some render paths
-// (Elementor editor preview, Elementor Pro REST-based widget refresh, custom
-// REST renders), so deferring would drop the styles on the editor canvas.
-// Inline <style> in body is valid HTML5 and applies document-wide in every
-// browser. The global flag guarantees it's emitted at most once per request.
-global $godam_player_wrapper_inline_css_added, $wp_filesystem;
-if ( empty( $godam_player_wrapper_inline_css_added ) ) {
-	$godam_player_wrapper_inline_css_added = true;
-	$godam_player_wrapper_css_path         = RTGODAM_PATH . 'assets/build/css/godam-player-wrapper.css';
-	$godam_player_wrapper_css_key          = 'godam_player_wrapper_css';
-
-	if ( file_exists( $godam_player_wrapper_css_path ) ) {
-		$godam_player_wrapper_css = get_transient( $godam_player_wrapper_css_key );
-
-		if ( false === $godam_player_wrapper_css ) {
-			// Initialize WP_Filesystem if not already done.
-			if ( empty( $wp_filesystem ) ) {
-				require_once ABSPATH . 'wp-admin/includes/file.php';
-				WP_Filesystem();
-			}
-
-			if ( ! empty( $wp_filesystem ) ) {
-				$godam_player_wrapper_css = $wp_filesystem->get_contents( $godam_player_wrapper_css_path );
-				set_transient( $godam_player_wrapper_css_key, $godam_player_wrapper_css, HOUR_IN_SECONDS );
-			}
-		}
-
-		if ( ! empty( $godam_player_wrapper_css ) ) {
-			echo '<style id="godam-player-wrapper-inline-css">' . wp_strip_all_tags( $godam_player_wrapper_css ) . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- CSS is stripped to plain text before inline output.
-		}
-	}
+// Player wrapper styles (placeholder / poster / loading states) ship as a real
+// stylesheet, not an inline <style>. An inline tag here rendered as a sibling of
+// the player markup, so inside a flow-layout container (core/column, core/group)
+// the player became the second child and inherited the container's blockGap
+// `margin-block-start`, adding phantom space above the video.
+//
+// `godam-player-wrapper-style` is a registered dependency of `godam-player-style`,
+// so every render path that enqueues the player CSS already pulls it in; this call
+// covers direct `require` of this template and is a no-op otherwise.
+if ( wp_style_is( 'godam-player-wrapper-style', 'registered' ) ) {
+	wp_enqueue_style( 'godam-player-wrapper-style' );
 }
 
 $godam_is_shortcode = false;


### PR DESCRIPTION
Partially Fixes: https://github.com/rtCamp/godam-core/issues/1341

This pull request refactors how player wrapper styles are loaded for the GoDAM player. Previously, these styles were output as an inline `<style>` tag at render time, which caused layout issues in some contexts. Now, the wrapper styles are shipped as a real stylesheet and registered as a dependency of the main player CSS, ensuring consistent loading across all render paths and eliminating the phantom spacing bug.

**Player Wrapper Styles Refactor:**

* The inline `<style>` output for player wrapper styles in `godam-player.php` has been removed and replaced with logic to enqueue the `godam-player-wrapper-style` stylesheet if it is registered. This prevents layout issues caused by the inline style tag and ensures styles are loaded consistently.
* The `register_scripts()` method in `class-godam-player.php` now registers `godam-player-wrapper-style` as a real stylesheet and makes it a dependency of `godam-player-style`, so it is automatically enqueued wherever the player is used.

**Documentation and Comments:**

* Updated comments in `godam_skin_styles_enqueue()` to reflect that wrapper styles are now enqueued as a stylesheet, not injected inline.
* Updated comments in `class-wpforms-field-godam-video.php` to clarify that while most player variants now use the stylesheet, the whitelist for inline `<style>` remains for legacy or special cases (e.g., audio no-JS block).


## Demo

<img width="1470" height="809" alt="Screenshot 2026-08-19 at 11 32 42 AM" src="https://github.com/user-attachments/assets/8fffb8f0-34e8-4952-a433-b75e745d6858" />

- [x] Self tested on Elementor's containers as well.


