### PR TITLE
Fix the minor bugs GoDAM plugin detected by Videojet team

### DIFF
--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -508,14 +508,23 @@
 }
 
 .godam-gallery-v2-modal {
+
+	/* Vertical room reserved above the iframe for the close button, which sits
+	 * outside it (button height plus the gap beneath it) — mirrors the
+	 * godam/video lightbox. Without it the iframe could take the full 86vh and
+	 * push the button off screen. */
+	--godam-gallery-v2-close-gap: 54px;
+
 	position: fixed;
 	inset: 50% auto auto 50%;
-	transform: translate(-50%, -50%) scale(0.96);
+
+	/* Nudge down by half the reserved strip so the button-plus-iframe is centred
+	 * as one unit, which keeps the button on screen at any viewport height. */
+	transform: translate(-50%, calc(-50% + var(--godam-gallery-v2-close-gap) / 2)) scale(0.96);
 	width: min(92vw, 960px);
-	height: min(86vh, 720px);
+	height: min(calc(86vh - var(--godam-gallery-v2-close-gap)), 720px);
 	background: #111;
 	border-radius: 16px;
-	overflow: hidden;
 	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
 	opacity: 0;
 	visibility: hidden;
@@ -523,10 +532,15 @@
 	transition: opacity 0.2s ease, transform 0.2s ease;
 	z-index: 999999;
 
+	/* dvh accounts for mobile browser chrome; vh above is the fallback. */
+	@supports (height: 86dvh) {
+		height: min(calc(86dvh - var(--godam-gallery-v2-close-gap)), 720px);
+	}
+
 	&.is-active {
 		opacity: 1;
 		visibility: visible;
-		transform: translate(-50%, -50%) scale(1);
+		transform: translate(-50%, calc(-50% + var(--godam-gallery-v2-close-gap) / 2)) scale(1);
 		pointer-events: auto;
 	}
 }
@@ -536,13 +550,21 @@
 	width: 100%;
 	height: 100%;
 	border: 0;
+
+	/* The modal itself can no longer clip (the close button lives outside its
+	 * top edge), so the iframe rounds its own corners. */
+	border-radius: inherit;
 	background: #111;
 }
 
+/* Sits above the iframe, aligned to its right edge — outside the video area so
+ * it can never collide with the player's own transcript / share buttons, which
+ * live in the top-right corner of the video. Same placement as the
+ * godam/video lightbox close button. */
 .godam-gallery-v2-modal__close {
-	position: fixed;
-	top: max(24px, env(safe-area-inset-top, 0px) + 16px);
-	right: max(24px, env(safe-area-inset-right, 0px) + 16px);
+	position: absolute;
+	bottom: calc(100% + 10px);
+	right: 0;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -644,9 +666,29 @@ body.godam-gallery-v2-modal-open {
 	}
 
 	.godam-gallery-v2-modal {
+
+		/* Full-screen modal: nothing to reserve above the iframe. The unit is
+		 * required — a unitless 0 would make the `calc()` that mixes it with a
+		 * percentage invalid, dropping the centring transform. */
+		/* stylelint-disable-next-line length-zero-no-unit */
+		--godam-gallery-v2-close-gap: 0px;
+
 		width: 100vw;
 		height: 100vh;
 		border-radius: 0;
+	}
+
+	/* No room above a full-screen iframe, so the button stays overlaid on it as
+	 * before — just moved to the left, clear of the player's transcript / share
+	 * buttons in the top-right corner. (`absolute` rather than the old `fixed`:
+	 * the modal's transform makes it the containing block for both, so the two
+	 * resolve identically here, and `absolute` says so plainly.) */
+	.godam-gallery-v2-modal__close {
+		position: absolute;
+		top: max(24px, env(safe-area-inset-top, 0px) + 16px);
+		right: auto;
+		bottom: auto;
+		left: max(24px, env(safe-area-inset-left, 0px) + 16px);
 	}
 
 	.godam-gallery-v2-modal__nav--prev {

--- a/assets/src/blocks/godam-gallery-v2/style.scss
+++ b/assets/src/blocks/godam-gallery-v2/style.scss
@@ -564,7 +564,12 @@
 .godam-gallery-v2-modal__close {
 	position: absolute;
 	bottom: calc(100% + 10px);
-	right: 0;
+
+	/* Aligned to the iframe's right edge, except on a notched device held in
+	 * landscape: there the cutout can reach past the modal's own side margin
+	 * (at least 4vw, since the modal is min(92vw, 960px) wide), so pull the
+	 * button inward by whatever the margin does not already clear. */
+	right: max(0px, env(safe-area-inset-right, 0px) - 4vw);
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -676,6 +681,13 @@ body.godam-gallery-v2-modal-open {
 		width: 100vw;
 		height: 100vh;
 		border-radius: 0;
+
+		/* dvh keeps the full-screen modal — and so the close button, its only
+		 * exit control — clear of the mobile browser chrome that 100vh sits
+		 * behind. vh above is the fallback. */
+		@supports (height: 100dvh) {
+			height: 100dvh;
+		}
 	}
 
 	/* No room above a full-screen iframe, so the button stays overlaid on it as

--- a/assets/src/blocks/godam-player/edit.js
+++ b/assets/src/blocks/godam-player/edit.js
@@ -131,6 +131,7 @@ function VideoEdit( {
 		playerHeight,
 		showShareButton,
 		showTranscription,
+		showInLightbox,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const [ defaultPoster, setDefaultPoster ] = useState( '' );
@@ -429,22 +430,26 @@ function VideoEdit( {
 		}
 	}, [ id, src, attributes.seo, isVideoSelecting, setAttributes ] );
 
-	// When autoplay is enabled, hoverSelect is incompatible — reset it to 'none'.
-	// Only apply this when autoplay is toggled on after mount so older content
+	// hoverSelect is incompatible with both autoplay and "Show in lightbox" (the
+	// lightbox poster shows nothing but the play icon) — reset it to 'none'.
+	// Only apply this when one of them is toggled on after mount so older content
 	// is not rewritten as a side effect of opening the editor.
-	const previousAutoplayRef = useRef( autoplay );
+	const previousHoverBlockersRef = useRef( { autoplay, showInLightbox } );
 
 	useEffect( () => {
-		const previousAutoplay = previousAutoplayRef.current;
-		if ( previousAutoplay === autoplay ) {
+		const previous = previousHoverBlockersRef.current;
+		if ( previous.autoplay === autoplay && previous.showInLightbox === showInLightbox ) {
 			return;
 		}
-		previousAutoplayRef.current = autoplay;
+		previousHoverBlockersRef.current = { autoplay, showInLightbox };
 
-		if ( autoplay && attributes.hoverSelect !== 'none' ) {
+		const turnedOn = ( ! previous.autoplay && autoplay ) ||
+			( ! previous.showInLightbox && showInLightbox );
+
+		if ( turnedOn && attributes.hoverSelect !== 'none' ) {
 			setAttributes( { hoverSelect: 'none' } );
 		}
-	}, [ autoplay ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ autoplay, showInLightbox ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Keep overridden SEO thumbnail synced with block poster.
 	useEffect( () => {
@@ -843,6 +848,19 @@ function VideoEdit( {
 		</>
 	);
 
+	// Autoplay plays the video where it stands and the lightbox turns it into a
+	// click-to-open poster; either way hovering has nothing left to do. Mirrors
+	// the frontend guard in inc/templates/godam-player.php.
+	const hoverOptionsLockedReason = ( () => {
+		if ( autoplay ) {
+			return __( 'Hover option is disabled when autoplay is on.', 'godam' );
+		}
+		if ( showInLightbox ) {
+			return __( 'Hover option is disabled when the video opens in a lightbox.', 'godam' );
+		}
+		return null;
+	} )();
+
 	const hoverOptionsPanelContent = (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
@@ -851,9 +869,7 @@ function VideoEdit( {
 			data-test-id="godam-video-control-hover-select"
 			value={ attributes.hoverSelect || 'none' }
 			onChange={ ( value ) => setAttributes( { hoverSelect: value ?? 'none' } ) }
-			help={ autoplay
-				? __( 'Hover option is disabled when autoplay is on.', 'godam' )
-				: __( 'Choose the action to perform on video hover.', 'godam' ) }
+			help={ hoverOptionsLockedReason ?? __( 'Choose the action to perform on video hover.', 'godam' ) }
 		>
 			<ToggleGroupControlOption value="show-player-controls" label={ __( 'Show player', 'godam' ) } />
 			<ToggleGroupControlOption value="start-preview" label={ __( 'Start Preview', 'godam' ) } />
@@ -1042,8 +1058,8 @@ function VideoEdit( {
 				) }
 				{ ! isInsideQueryLoop && (
 					<PanelBody title={ __( 'Hover Options', 'godam' ) } data-test-id="godam-video-panel-hover-options">
-						{ /* Hover Options are disabled when autoplay is enabled or API key is invalid */ }
-						{ ( ! window.pluginInfo?.validApiKey || autoplay )
+						{ /* Hover Options are disabled when autoplay or "Show in lightbox" is enabled, or the API key is invalid */ }
+						{ ( ! window.pluginInfo?.validApiKey || hoverOptionsLockedReason )
 							? <div className="godam-components-disabled"><Disabled>{ hoverOptionsPanelContent }</Disabled></div>
 							: hoverOptionsPanelContent
 						}

--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -1129,10 +1129,13 @@ to ensure proper responsiveness and avoid layout issues.
 	}
 }
 
-// Visual "disabled" state for Elementor controls that are locked while
-// autoplay is on (Muted + Hover Option). Mirrors the block's disabled
-// SelectControl: visible, low-contrast, non-interactive.
-.elementor-control.godam-elementor-autoplay-locked.godam-control-is-disabled {
+// Visual "disabled" state for Elementor controls another setting has taken over
+// — autoplay locks Muted + Hover Option, "Show in lightbox" locks Hover Option.
+// editor.js decides which lock owns which control and adds
+// `godam-control-is-disabled`. Mirrors the block's disabled SelectControl:
+// visible, low-contrast, non-interactive.
+.elementor-control.godam-elementor-autoplay-locked.godam-control-is-disabled,
+.elementor-control.godam-elementor-lightbox-locked.godam-control-is-disabled {
 	opacity: 0.5;
 	pointer-events: none;
 

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -2523,6 +2523,46 @@ body.godam-share-modal-open {
 	cursor: pointer;
 }
 
+/* Closed state: the inline player is a click-to-open poster, so it shows the
+ * play icon and nothing else. `godam-lightbox-open` is added by modalManager.js
+ * while this player is the one inside the modal — that is where the real
+ * controls belong.
+ *
+ * `!important` is only needed to out-rank Video.js's own
+ * `.vjs-has-started .vjs-control-bar` and the hover-to-reveal rules earlier in
+ * this file. The rule is deliberately subtractive — nothing here ever re-shows
+ * the bar — so `.vjs-controls-disabled` / `.vjs-error` keep their own behaviour
+ * inside the lightbox. */
+.godam-video-wrapper.godam-show-in-lightbox:not(.godam-lightbox-open) {
+
+	/* stylelint-disable-next-line no-descending-specificity -- closed-state override of the earlier control-bar/button rules; it only removes them from the poster. */
+	.vjs-control-bar,
+	.vjs-button.godam-share-button,
+	.vjs-button.godam-transcript-button,
+	.godam-transcript-panel {
+		display: none !important;
+	}
+
+	/* A CTA, hotspot or form layer shown at the timestamp the viewer closed on
+	 * would otherwise stay overlaid on the poster. Only the display is suppressed,
+	 * so the layer's own state survives and it comes back on reopening. */
+	.easydam-layer {
+		display: none !important;
+	}
+
+	/* The poster is a button, so it keeps its play icon even when Video.js has
+	 * controls switched off — which also hides the big play button. That happens
+	 * for a video rendered without playback controls, and temporarily whenever a
+	 * form/CTA layer is on screen, since formLayerManager only switches controls
+	 * back on when the layer is dismissed: closing mid-layer would otherwise leave
+	 * a poster with no way in. An errored player keeps Video.js's own empty state.
+	 * Matches `.custom-play-image` too — it replaces the button and inherits its
+	 * classes (see controlsManager.setupCustomPlayButton). */
+	.video-js:not(.vjs-error) .vjs-big-play-button {
+		display: block !important;
+	}
+}
+
 /* Prevent the page from scrolling behind an open modal. */
 body.godam-player-modal-open {
 	overflow: hidden;

--- a/assets/src/js/elementor/editor.js
+++ b/assets/src/js/elementor/editor.js
@@ -9,6 +9,13 @@ import apiFetch from '@wordpress/api-fetch';
 import './controls/godam-media';
 
 /**
+ * Controls that another setting can take over, flagged server-side by the widget.
+ *
+ * @type {string}
+ */
+const LOCKED_CONTROL_SELECTOR = '.elementor-control.godam-elementor-autoplay-locked, .elementor-control.godam-elementor-lightbox-locked';
+
+/**
  * Make specific SEO fields read-only in the GoDAM Video widget.
  */
 window.addEventListener( 'load', function() {
@@ -321,20 +328,29 @@ function onSettingsChange( changedModel ) {
 		// Selection ring follows the poster, even when the user uploads via
 		// the godam-media tile above the grid.
 		scheduleThumbnailPickerRender();
-	} else if ( keys.indexOf( 'autoplay' ) !== -1 ) {
-		applyAutoplayLock( !! changed.autoplay && 'yes' === changed.autoplay );
+	} else if ( keys.indexOf( 'autoplay' ) !== -1 || keys.indexOf( 'show_in_lightbox' ) !== -1 ) {
+		applyControlLocks( changedModel );
 	}
 }
 
 /**
- * Toggle a visual "disabled" state on controls flagged with the
- * `godam-elementor-autoplay-locked` class (Muted + Hover Option), mirroring
- * the block which disables them when Autoplay is on.
+ * Toggle a visual "disabled" state on controls another setting has taken over.
  *
- * @param {boolean} locked Whether autoplay is currently on.
+ * Two independent locks, so each control is matched against the one that owns it
+ * rather than a single flag: Autoplay locks Muted + Hover Option, and "Show in
+ * lightbox" locks Hover Option (its inline render is a click-to-open poster, so
+ * there is nothing left to hover). Mirrors the block, which disables these
+ * controls rather than hiding them.
+ *
+ * @param {Object} settings Backbone settings model of the widget.
  */
-function applyAutoplayLock( locked ) {
-	document.querySelectorAll( '.elementor-control.godam-elementor-autoplay-locked' ).forEach( ( el ) => {
+function applyControlLocks( settings ) {
+	const autoplayOn = 'yes' === settings?.get?.( 'autoplay' );
+	const lightboxOn = 'yes' === settings?.get?.( 'show_in_lightbox' );
+
+	document.querySelectorAll( LOCKED_CONTROL_SELECTOR ).forEach( ( el ) => {
+		const locked = ( autoplayOn && el.classList.contains( 'godam-elementor-autoplay-locked' ) ) ||
+			( lightboxOn && el.classList.contains( 'godam-elementor-lightbox-locked' ) );
 		el.classList.toggle( 'godam-control-is-disabled', locked );
 	} );
 }
@@ -387,8 +403,8 @@ function hydrateWidget( model, view, panel ) {
 		panel.currentPageView.on( 'render', scheduleThumbnailPickerRender );
 	}
 
-	// Autoplay-lock doesn't depend on the picker DOM, so apply it on a short delay.
-	setTimeout( () => applyAutoplayLock( 'yes' === settings.get( 'autoplay' ) ), 100 );
+	// The control locks don't depend on the picker DOM, so apply them on a short delay.
+	setTimeout( () => applyControlLocks( settings ), 100 );
 
 	// Render the picker once Elementor has mounted its (conditional) control.
 	scheduleThumbnailPickerRender();

--- a/assets/src/js/godam-player/managers/modalManager.js
+++ b/assets/src/js/godam-player/managers/modalManager.js
@@ -42,6 +42,33 @@ const POSTER_SEMANTICS = [
 ];
 
 /**
+ * Marks the video wrapper of the player currently inside the lightbox.
+ *
+ * The closed poster hides every control but the play icon (see
+ * `.godam-show-in-lightbox:not(.godam-lightbox-open)` in godam-player.scss);
+ * this class is what tells that rule to step aside while the player is on
+ * screen in the modal, where the controls belong.
+ *
+ * @type {string}
+ */
+const OPEN_WRAPPER_CLASS = 'godam-lightbox-open';
+
+/**
+ * The video wrapper inside a movable player root, when the player is a
+ * click-to-open poster.
+ *
+ * The wrapper is a grandchild of the root (root > figure > .godam-video-wrapper,
+ * see inc/templates/godam-player.php), so it cannot inherit a class set on the
+ * root and has to be resolved on its own.
+ *
+ * @param {HTMLElement} playerRoot - The movable player root.
+ * @return {HTMLElement|null} The wrapper, or null for a non-lightbox player.
+ */
+function getLightboxWrapper( playerRoot ) {
+	return playerRoot?.querySelector?.( '.godam-video-wrapper.godam-show-in-lightbox' ) || null;
+}
+
+/**
  * How far a finger may travel and still count as a tap, in pixels.
  *
  * Matches Video.js's own tap detection, so a swipe that starts on the video
@@ -406,10 +433,16 @@ export class ModalManager {
 		modal.content.appendChild( playerRoot );
 		playerRoot.classList.add( 'godam-player-modal-item' );
 
+		// The poster's controls are hidden by CSS while it is closed; the player is
+		// on screen now, so let them back in.
+		const wrapper = getLightboxWrapper( playerRoot );
+		wrapper?.classList.add( OPEN_WRAPPER_CLASS );
+
 		this.activeEntry = {
 			mode: 'element',
 			video,
 			playerRoot,
+			wrapper,
 			anchor,
 			iframe: null,
 			hash: null,
@@ -683,7 +716,7 @@ export class ModalManager {
 			return;
 		}
 		const entry = this.activeEntry;
-		const { mode, video, playerRoot, anchor, iframe } = entry;
+		const { mode, video, playerRoot, wrapper, anchor, iframe } = entry;
 
 		// Clear first: `restoreHistory()` can trigger a popstate that re-enters
 		// close(), and an already-null entry makes that a no-op.
@@ -700,7 +733,23 @@ export class ModalManager {
 			// page unscrollable, because only the exit button releases that lock.
 			exitCustomFullscreen( player?.el?.() );
 
+			// Closing hands the poster its job back. Video.js sets `vjs-has-started`
+			// on the first play and never clears it, which hides the poster and the
+			// big play button and shows the control bar — the opposite of a
+			// click-to-open poster. Clearing it restores both and lets Video.js's own
+			// `display: none` hide the bar again. `currentTime` is left alone, so
+			// reopening resumes where the viewer stopped, and the next play() sets the
+			// flag again by itself.
+			//
+			// Only for players whose inline render *is* a poster: a trigger or deep
+			// link can open an ordinary inline player, and that one should keep its
+			// normal played-and-paused state.
+			if ( isLightboxVideo( video ) ) {
+				player?.hasStarted?.( false );
+			}
+
 			playerRoot.classList.remove( 'godam-player-modal-item' );
+			wrapper?.classList.remove( OPEN_WRAPPER_CLASS );
 
 			if ( anchor && anchor.parentNode ) {
 				anchor.parentNode.insertBefore( playerRoot, anchor );

--- a/assets/src/js/godam-player/managers/modalManager.test.js
+++ b/assets/src/js/godam-player/managers/modalManager.test.js
@@ -26,12 +26,16 @@ jest.mock( 'video.js', () => ( {
 /**
  * Render a lightbox player and return the pieces the manager works with.
  *
- * @param {Object} attrs       - Video data attributes.
- * @param {string} attrs.id    - Attachment ID.
- * @param {string} attrs.jobId - Transcoding job ID.
- * @return {Object} The video element and its movable root.
+ * Pass `lightbox: false` for an ordinary inline player — one a trigger or a deep
+ * link can still open, but whose inline render is not a click-to-open poster.
+ *
+ * @param {Object}  attrs          - Video data attributes.
+ * @param {string}  attrs.id       - Attachment ID.
+ * @param {string}  attrs.jobId    - Transcoding job ID.
+ * @param {boolean} attrs.lightbox - Whether "Show in lightbox" is on.
+ * @return {Object} The video element, its movable root and its wrapper.
  */
-function renderPlayer( { id = '4595', jobId = 'job-1' } = {} ) {
+function renderPlayer( { id = '4595', jobId = 'job-1', lightbox = true } = {} ) {
 	// Mirrors inc/templates/godam-player.php: an outer div carrying the
 	// aspect-ratio / brand-colour custom properties, then <figure>, then
 	// .godam-video-wrapper. The outer div is the movable root.
@@ -40,8 +44,8 @@ function renderPlayer( { id = '4595', jobId = 'job-1' } = {} ) {
 			<p id="before">before</p>
 			<div id="root" style="max-width:600px">
 				<figure id="godam-player-container-x">
-					<div class="godam-video-wrapper godam-show-in-lightbox">
-						<video id="v" data-id="${ id }" data-job_id="${ jobId }" data-show-in-lightbox="true"></video>
+					<div class="godam-video-wrapper${ lightbox ? ' godam-show-in-lightbox' : '' }">
+						<video id="v" data-id="${ id }" data-job_id="${ jobId }" data-show-in-lightbox="${ lightbox }"></video>
 					</div>
 				</figure>
 			</div>
@@ -52,6 +56,7 @@ function renderPlayer( { id = '4595', jobId = 'job-1' } = {} ) {
 	return {
 		video: document.getElementById( 'v' ),
 		playerRoot: document.getElementById( 'root' ),
+		wrapper: document.querySelector( '.godam-video-wrapper' ),
 	};
 }
 
@@ -137,6 +142,71 @@ describe( 'ModalManager', () => {
 
 			lightbox.close();
 			expect( document.activeElement ).toBe( trigger );
+		} );
+	} );
+
+	describe( 'closed poster', () => {
+		/**
+		 * A player stand-in with the surface close() touches.
+		 *
+		 * @return {Object} Fake Video.js player.
+		 */
+		const fakePlayer = () => ( {
+			pause: jest.fn(),
+			play: jest.fn( () => Promise.resolve() ),
+			hasStarted: jest.fn(),
+			currentTime: jest.fn( () => 12 ),
+			el: () => null,
+			isFullscreen: () => false,
+			on: () => {},
+			off: () => {},
+		} );
+
+		afterEach( () => {
+			videojs.getPlayer.mockReturnValue( null );
+		} );
+
+		it( 'flags the wrapper while open, so the closed-state rule steps aside', () => {
+			const { video, playerRoot, wrapper } = renderPlayer();
+
+			lightbox.openElement( playerRoot, { video } );
+			expect( wrapper.classList.contains( 'godam-lightbox-open' ) ).toBe( true );
+
+			lightbox.close();
+			expect( wrapper.classList.contains( 'godam-lightbox-open' ) ).toBe( false );
+		} );
+
+		it( 'clears the started flag on close, bringing the poster and play icon back', () => {
+			const { video, playerRoot } = renderPlayer();
+			const player = fakePlayer();
+			videojs.getPlayer.mockReturnValue( player );
+
+			lightbox.openElement( playerRoot, { video } );
+			lightbox.close();
+
+			expect( player.pause ).toHaveBeenCalled();
+			expect( player.hasStarted ).toHaveBeenCalledWith( false );
+			// Never rewound: reopening resumes where the viewer stopped.
+			expect( player.currentTime ).not.toHaveBeenCalledWith( expect.anything() );
+		} );
+
+		it( 'leaves an ordinary inline player opened by a trigger in its played state', () => {
+			const { video, playerRoot } = renderPlayer( { lightbox: false } );
+			const player = fakePlayer();
+			videojs.getPlayer.mockReturnValue( player );
+
+			lightbox.openElement( playerRoot, { video } );
+			lightbox.close();
+
+			expect( player.pause ).toHaveBeenCalled();
+			expect( player.hasStarted ).not.toHaveBeenCalled();
+		} );
+
+		it( 'has no wrapper to flag for an ordinary inline player', () => {
+			const { video, playerRoot, wrapper } = renderPlayer( { lightbox: false } );
+
+			lightbox.openElement( playerRoot, { video } );
+			expect( wrapper.classList.contains( 'godam-lightbox-open' ) ).toBe( false );
 		} );
 	} );
 
@@ -655,6 +725,7 @@ describe( 'fullscreen inside the lightbox', () => {
 			readyState: () => 4,
 			one: () => {},
 			currentTime: () => 0,
+			hasStarted: jest.fn(),
 		};
 	};
 

--- a/assets/src/js/godam-player/managers/transcriptManager.js
+++ b/assets/src/js/godam-player/managers/transcriptManager.js
@@ -1,8 +1,13 @@
 /**
  * Transcript Manager
- * Handles fetching and loading AI-generated transcription tracks from the GoDAM API.
+ * Handles loading transcription tracks for the player.
  *
- * Uses the public API endpoint with ETag/Cache-Control support:
+ * Resolution order (see the matching comment in inc/templates/godam-player.php):
+ * `data-transcript-url` (the transcript stored on the attachment by the media
+ * editor's Transcription tab, generated or user-uploaded) wins;
+ * `data-transcript-deleted` means the user deleted it, so show nothing;
+ * otherwise fall back to the public API endpoint, which supports
+ * ETag/Cache-Control:
  * GET /api/method/godam_core.api.process.get_public_transcription_path?job_name=<job_id>
  */
 export default class TranscriptManager {
@@ -18,6 +23,9 @@ export default class TranscriptManager {
 		this.video = video;
 		this.configManager = configManager;
 		this.jobId = video.dataset.job_id || '';
+		// Transcript cached on the attachment and printed by the server.
+		this.localTranscriptUrl = video.dataset.transcriptUrl || '';
+		this.transcriptDeleted = video.dataset.transcriptDeleted === 'true';
 		this.etag = null;
 		this.transcriptUrl = null;
 	}
@@ -48,16 +56,25 @@ export default class TranscriptManager {
 	 * @return {Promise<void>}
 	 */
 	async initialize() {
-		if ( ! this.jobId ) {
-			return;
-		}
-
 		if ( this.video.dataset.disableTranscript === 'true' ) {
 			return;
 		}
 
 		// Check if captions/subtitles are enabled in the player configuration
 		if ( ! this.isCaptionsEnabled() ) {
+			return;
+		}
+
+		// The transcript stored on the attachment wins over the SaaS copy, so an
+		// uploaded caption file is what visitors get.
+		if ( this.localTranscriptUrl ) {
+			this.transcriptUrl = this.localTranscriptUrl;
+			this.addTextTrack( this.localTranscriptUrl );
+			return;
+		}
+
+		// Deleted in the editor — don't resurrect it from the SaaS.
+		if ( this.transcriptDeleted || ! this.jobId ) {
 			return;
 		}
 

--- a/assets/src/js/godam-player/managers/transcriptPanelManager.js
+++ b/assets/src/js/godam-player/managers/transcriptPanelManager.js
@@ -54,8 +54,9 @@ const COPY_FEEDBACK_DELAY = 2000;
  * timestamped, clickable cues. Clicking a cue seeks the player; the cue under
  * the playhead is highlighted as the video plays.
  *
- * The transcript text reuses the same public API the TranscriptManager
- * uses to resolve the VTT URL, then loads the cues through a hidden Video.js
+ * The transcript text is resolved the same way TranscriptManager resolves it —
+ * the attachment's stored transcript first, the public API by job id as a
+ * fallback — then the cues are loaded through a hidden Video.js
  * `metadata` text track so the browser handles all WebVTT parsing (and so the
  * VTT is fetched by the media element, sidestepping cross-origin fetch issues).
  *
@@ -70,6 +71,9 @@ export default class TranscriptPanelManager {
 		this.video = video;
 		this.videoSetupOptions = videoSetupOptions;
 		this.jobId = video.dataset.job_id || '';
+		// Transcript cached on the attachment and printed by the server.
+		this.localTranscriptUrl = video.dataset.transcriptUrl || '';
+		this.transcriptDeleted = video.dataset.transcriptDeleted === 'true';
 		this.Button = videojs.getComponent( 'Button' );
 
 		this.container = null;
@@ -99,7 +103,13 @@ export default class TranscriptPanelManager {
 			return;
 		}
 
-		if ( ! this.jobId || this.video.dataset.disableTranscript === 'true' ) {
+		if ( this.video.dataset.disableTranscript === 'true' ) {
+			return;
+		}
+
+		// Nothing to show: deleted in the editor, or no stored transcript and no
+		// job id to look one up with.
+		if ( this.transcriptDeleted || ( ! this.jobId && ! this.localTranscriptUrl ) ) {
 			return;
 		}
 
@@ -133,6 +143,12 @@ export default class TranscriptPanelManager {
 	 * @return {Promise<string|null>} The VTT URL, or null when none exists.
 	 */
 	async resolveTranscriptUrl() {
+		// The transcript stored on the attachment (generated or uploaded in the
+		// media editor's Transcription tab) takes precedence.
+		if ( this.localTranscriptUrl ) {
+			return this.localTranscriptUrl;
+		}
+
 		const endpoint = `${ this.getApiBase() }/api/method/godam_core.api.process.get_public_transcription_path`;
 		const url = `${ endpoint }?job_name=${ encodeURIComponent( this.jobId ) }`;
 

--- a/inc/classes/elementor-widgets/class-godam-video.php
+++ b/inc/classes/elementor-widgets/class-godam-video.php
@@ -354,10 +354,12 @@ class GoDAM_Video extends Base {
 					'show-player-controls' => esc_html__( 'Show Player Controls', 'godam' ),
 					'start-preview'        => esc_html__( 'Start Preview', 'godam' ),
 				),
-				'description' => esc_html__( 'Choose the action to perform on video hover. Disabled when Autoplay is on.', 'godam' ),
-				// Visual disable when autoplay is on is applied by editor.js
-				// (mirrors the block, which disables rather than hides).
-				'classes'     => 'godam-elementor-autoplay-locked',
+				'description' => esc_html__( 'Choose the action to perform on video hover. Disabled when Autoplay or Show in lightbox is on.', 'godam' ),
+				// Visual disable is applied by editor.js (mirrors the block, which
+				// disables rather than hides). Two classes because the locks have
+				// different inputs: autoplay also locks Muted, while Show in lightbox
+				// locks only this control.
+				'classes'     => 'godam-elementor-autoplay-locked godam-elementor-lightbox-locked',
 				'condition'   => array(
 					'video-file[url]!' => '',
 				),
@@ -528,8 +530,10 @@ class GoDAM_Video extends Base {
 			'isFamilyFriendly' => 'yes' === ( $this->get_settings_for_display( 'seo_content_family_friendly' ) ?? 'yes' ),
 		);
 
-		// Mirror the block: hoverSelect is mutually exclusive with autoplay.
-		if ( $widget_autoplay ) {
+		// Mirror the block: hoverSelect is mutually exclusive with autoplay, and with
+		// "Show in lightbox" — whose inline render is a click-to-open poster showing
+		// nothing but the play icon.
+		if ( $widget_autoplay || $widget_show_in_lightbox ) {
 			$widget_hover_select = 'none';
 		}
 

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -76,6 +76,7 @@ class GoDAM_Player {
 			'rtgodam_media_video_placeholder_thumbnail',
 			'rtgodam_media_placeholder_thumbnails',
 			'rtgodam_transcript_path',
+			'rtgodam_transcript_deleted',
 		);
 
 		if ( ! in_array( $meta_key, $watched_keys, true ) ) {

--- a/inc/classes/wpbakery-elements/class-wpb-godam-video.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-video.php
@@ -191,8 +191,11 @@ class WPB_GoDAM_Video {
 					esc_html__( 'Start Preview', 'godam' ) => 'start-preview',
 				),
 				'std'         => 'none',
-				'description' => esc_html__( 'Choose the action to perform on video hover.', 'godam' ),
+				'description' => esc_html__( 'Choose the action to perform on video hover. Ignored when Show in Lightbox is on.', 'godam' ),
 				'save_always' => true,
+				// WPBakery allows a single dependency per param, spent here on `id`, so
+				// the "Show in Lightbox" exclusivity cannot be expressed in the UI. It
+				// is enforced at render time in inc/templates/godam-player.php instead.
 				'dependency'  => array(
 					'element'   => 'id',
 					'not_empty' => true,

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1598,7 +1598,8 @@ if ( ! defined( 'RTGODAM_WORK_CACHE_GROUP' ) ) {
 
 /** Cache version — bump to globally invalidate all work-cache entries. */
 if ( ! defined( 'RTGODAM_WORK_CACHE_VERSION' ) ) {
-	define( 'RTGODAM_WORK_CACHE_VERSION', 'v1' );
+	// v2: the cached attachment payload gained the transcript path/deleted keys.
+	define( 'RTGODAM_WORK_CACHE_VERSION', 'v2' );
 }
 
 /** Default TTL (seconds) used as hard-expiry fallback: 30 minutes. */

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -79,9 +79,18 @@ $godam_show_in_lightbox = ! empty( $attributes['showInLightbox'] );
 // again on opening). The lightbox wins because it is the more specific intent, and
 // the author still gets autoplay where it counts — opening the lightbox starts
 // playback.
+//
+// Hover modes are excluded for the same reason, and because the closed poster
+// shows nothing but the play icon: previewing (or revealing controls) in place
+// competes with the lightbox and re-introduces the very controls it hides. The
+// reset happens here as well as in the editors, so a value stored on existing
+// content — block, shortcode, Elementor or WPBakery — can never reach the
+// frontend player.
 if ( $godam_show_in_lightbox ) {
-	$godam_autoplay = false;
+	$godam_autoplay     = false;
+	$godam_hover_select = 'none';
 }
+
 // Raw "Show caption" block attribute: true/false when explicitly set, null when
 // unset (inherit from the attachment's Display-captions setting — resolved into
 // $godam_show_caption once the attachment meta is loaded, further below).

--- a/inc/templates/godam-player.php
+++ b/inc/templates/godam-player.php
@@ -235,6 +235,12 @@ if ( empty( $godam_attachment_data ) && $godam_numeric_id ) {
 		'video_src'          => $rtgodam_raw_video_src,
 		'video_src_type'     => $rtgodam_raw_video_src_type,
 		'job_id'             => $rtgodam_raw_job_id,
+		// Transcript resolved in the authenticated editor and cached on the
+		// attachment. Read only — never call godam_get_transcript_path() here:
+		// on a miss it makes a blocking SaaS request on public page loads and
+		// re-caches without the delete guard. Same rule as the audio block.
+		'transcript_path'    => get_post_meta( $godam_numeric_id, 'rtgodam_transcript_path', true ),
+		'transcript_deleted' => get_post_meta( $godam_numeric_id, 'rtgodam_transcript_deleted', true ),
 		'placeholder_map'    => get_post_meta( $godam_numeric_id, 'rtgodam_media_placeholder_thumbnails', true ),
 		'placeholder_single' => get_post_meta( $godam_numeric_id, 'rtgodam_media_video_placeholder_thumbnail', true ),
 		'attachment_meta'    => wp_get_attachment_metadata( $godam_numeric_id ),
@@ -639,15 +645,23 @@ if ( $godam_is_shortcode || $godam_is_elementor_widget ) {
 }
 
 /**
- * AI Generated video tracks (transcription) are now loaded dynamically from the frontend.
- * The frontend JavaScript will fetch the transcript URL using the job_id via the API endpoint:
- * GET /api/method/godam_core.api.process.get_public_transcription_path?job_name=<job_id>
+ * Transcription resolution order on the front end:
  *
- * This approach provides:
- * - Better caching with ETag/Cache-Control headers
- * - Reduced server-side processing on page load
- * - Automatic cache invalidation when transcription is updated
+ * 1. `data-transcript-url` — the transcript stored on the attachment
+ *    (`rtgodam_transcript_path`), i.e. whatever the Transcription tab of the
+ *    media editor last generated or the user uploaded. This wins so a
+ *    hand-uploaded .vtt/.srt is what visitors actually get.
+ * 2. `data-transcript-deleted` — set when the user deleted the transcript in
+ *    the editor. The player then shows nothing instead of resurrecting the
+ *    SaaS copy.
+ * 3. Otherwise the frontend JavaScript falls back to fetching the transcript
+ *    URL by job_id via the public API endpoint:
+ *    GET /api/method/godam_core.api.process.get_public_transcription_path?job_name=<job_id>
+ *    which keeps ETag/Cache-Control caching for attachments that were never
+ *    opened in the editor (and for virtual media with no local meta).
  */
+$godam_transcript_url     = (string) ( $godam_attachment_data['transcript_path'] ?? '' );
+$godam_transcript_deleted = ! empty( $godam_attachment_data['transcript_deleted'] );
 
 $godam_attachment_title = '';
 
@@ -752,6 +766,8 @@ if ( empty( $godam_attachment_title ) ) {
 							data-video-title="<?php echo esc_attr( $godam_attachment_title ); ?>"
 							data-autoplay-on-view="<?php echo esc_attr( ( $godam_autoplay && 'auto' !== $godam_preload ) ? 'true' : 'false' ); ?>"
 							data-disable-transcript="<?php echo esc_attr( $godam_disable_subtitles_and_transcript ? 'true' : 'false' ); ?>"
+							data-transcript-url="<?php echo esc_url( $godam_transcript_url ); ?>"
+							data-transcript-deleted="<?php echo esc_attr( $godam_transcript_deleted ? 'true' : 'false' ); ?>"
 							data-show-in-lightbox="<?php echo esc_attr( $godam_show_in_lightbox ? 'true' : 'false' ); ?>"
 						>
 							<?php


### PR DESCRIPTION
This pull request makes several improvements to the "Show in lightbox" feature for GoDAM video blocks and Elementor controls, focusing on accessibility, UI consistency, and user experience. The main changes ensure that when a video is set to open in a lightbox, its inline poster state is visually and functionally correct, and that related controls are properly locked or restored as needed. The update also refines the modal's layout and improves the logic for disabling incompatible controls both in the block editor and Elementor.

**Lightbox & Modal Behavior Improvements:**

- The modal layout (`godam-gallery-v2-modal`) now reserves vertical space above the iframe for the close button, ensuring the button is always visible and the modal remains centered regardless of viewport size. This includes support for `dvh` units for better mobile compatibility.
- The close button is repositioned to sit outside the iframe, mirroring the video lightbox behavior and preventing overlap with video player controls. Fullscreen modals remove this reserved space and adjust button placement accordingly. [[1]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR553-R567) [[2]](diffhunk://#diff-6ad8d1fcd76e5d2f0aa2ba161489b3f8f5ddf0ca597cffe555f642068893809eR669-R693)

**Player Poster and Control Handling:**

- When "Show in lightbox" is enabled, the inline player poster hides all controls except the play icon, ensuring a clear click-to-open experience. When the player is moved into the modal, controls are restored; upon closing, the poster state is reset, including clearing the `vjs-has-started` flag for correct UI restoration. [[1]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79R2526-R2565) [[2]](diffhunk://#diff-7d93261fd8f31f07893378082ffdd8f7b53ff984faf302bbb99769492c097de0R44-R70) [[3]](diffhunk://#diff-7d93261fd8f31f07893378082ffdd8f7b53ff984faf302bbb99769492c097de0R436-R445) [[4]](diffhunk://#diff-7d93261fd8f31f07893378082ffdd8f7b53ff984faf302bbb99769492c097de0L686-R719) [[5]](diffhunk://#diff-7d93261fd8f31f07893378082ffdd8f7b53ff984faf302bbb99769492c097de0R736-R752)

**Editor and Elementor Control Locking:**

- The block editor now disables hover options not only when autoplay is enabled but also when "Show in lightbox" is on, with clear user feedback. The logic for disabling these options is consolidated and clarified. [[1]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66R134) [[2]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L432-R452) [[3]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66R851-R863) [[4]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L854-R872) [[5]](diffhunk://#diff-7f3eed49285d53dd5ca33b2e1543d8964dcce2aa03553b162df3c1a9068dfa66L1045-R1062)
- Elementor controls now support dual locking: Muted and Hover Option controls are disabled when autoplay is on, and Hover Option is also disabled when "Show in lightbox" is on. This is managed with new CSS classes and improved logic in the editor JS. [[1]](diffhunk://#diff-b4c816476dac8b5b0eb773a3634b8a21986afe7fe1ed652e53d8c99e98dd9801L1132-R1138) [[2]](diffhunk://#diff-3ba710ac632c3745aa952b455f091b4eda5b4d7c79be3cd4ba19f9db03aa1236R11-R17) [[3]](diffhunk://#diff-3ba710ac632c3745aa952b455f091b4eda5b4d7c79be3cd4ba19f9db03aa1236L324-R353) [[4]](diffhunk://#diff-3ba710ac632c3745aa952b455f091b4eda5b4d7c79be3cd4ba19f9db03aa1236L390-R407)

**Testing and Maintainability:**

- The modal manager test utilities are updated to support both lightbox and non-lightbox player setups, improving test coverage and clarity. [[1]](diffhunk://#diff-349cdda44a27c56398701e76a6966f9fa176d13f98513ffdf7086e081b33bf45R29-R38) [[2]](diffhunk://#diff-349cdda44a27c56398701e76a6966f9fa176d13f98513ffdf7086e081b33bf45L43-R48) [[3]](diffhunk://#diff-349cdda44a27c56398701e76a6966f9fa176d13f98513ffdf7086e081b33bf45R59)

These changes collectively enhance the reliability, accessibility, and user experience of the lightbox video feature across both the block editor and Elementor environments.

## Demos
**Gallery block**
<img width="1470" height="809" alt="Screenshot 2026-08-19 at 3 05 59 PM" src="https://github.com/user-attachments/assets/b3152d27-131a-49f3-824f-d6a4e06c4f76" />
<img width="355" height="645" alt="Screenshot 2026-08-19 at 3 06 53 PM" src="https://github.com/user-attachments/assets/85ea5c71-67f6-4e58-9dbe-2b61b4445d78" />


**Hide the Lightbox player controls on lightbox get closed**

https://github.com/user-attachments/assets/8754241b-6d16-49f9-ba8d-00d8b773994d