### PR TITLE
Render actual revenue in TopProductsTable from analytics service

### DIFF
--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -102,6 +102,45 @@ const reachLabel = ( item ) => {
 // (e.g. a deleted product), so nothing is greyed without cause.
 const supportsDirect = ( item ) => item.supports_direct_add_to_cart !== false;
 
+// Whether this row carries real revenue data. `revenue_minor` (and its sibling
+// `orders`/`currency`) are only present once the analytics microservice has
+// shipped order-attribution; an older service build simply omits them. Treated
+// as absent rather than zero so a not-yet-instrumented row never shows a
+// misleading "£0" - it keeps the pre-existing empty placeholder instead.
+const hasRevenue = ( item ) => item.revenue_minor !== undefined && item.revenue_minor !== null;
+
+/**
+ * Format `revenue_minor` (integer minor currency units, e.g. pence) as a
+ * currency amount using the row's own ISO 4217 `currency` code. Assumes a
+ * single currency per response - no conversion is attempted; multi-currency
+ * handling is out of scope.
+ *
+ * @param {number} minor    Integer minor currency units.
+ * @param {string} currency ISO 4217 currency code (e.g. 'GBP', 'USD').
+ * @return {string} Formatted amount, e.g. "£12.34".
+ */
+export function formatRevenue( minor, currency ) {
+	const amount = Number( minor || 0 ) / 100;
+	try {
+		return new Intl.NumberFormat( undefined, {
+			style: 'currency',
+			currency,
+		} ).format( amount );
+	} catch ( e ) {
+		// Missing/invalid ISO code (or no Intl currency support) - fall back to a
+		// plain number so the cell never throws.
+		return currency ? `${ amount.toFixed( 2 ) } ${ currency }` : amount.toFixed( 2 );
+	}
+}
+
+// "N orders" secondary label for the Revenue cell, mirroring how
+// product_views_ctr is shown as secondary text next to product_views.
+const ordersLabel = ( item ) => {
+	const orders = Number( item.orders || 0 );
+	/* translators: %d: number of distinct orders contributing to this product's revenue. */
+	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
+};
+
 /**
  * Dashboard "Top Products" table.
  *
@@ -177,6 +216,8 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 		Number( item.added_to_cart || 0 ),
 		Number( item.added_to_cart_direct || 0 ),
 		Number( item.added_to_cart_assisted || 0 ),
+		hasRevenue( item ) ? formatRevenue( item.revenue_minor, item.currency ) : '',
+		hasRevenue( item ) ? Number( item.orders || 0 ) : '',
 	];
 
 	const handleExportCSV = async () => {
@@ -207,6 +248,8 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 			__( 'Add to Cart', 'godam' ),
 			__( 'Add to Cart (in-video)', 'godam' ),
 			__( 'Add to Cart (assisted)', 'godam' ),
+			__( 'Revenue', 'godam' ),
+			__( 'Orders', 'godam' ),
 		];
 
 		const csvContent = [ headers, ...exportProducts.map( buildCsvRow ) ]
@@ -374,7 +417,17 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 											) }
 										</p>
 									</td>
-									<td className="text-zinc-400">-</td>
+									<td data-test-id="godam-top-products-revenue">
+										{ hasRevenue( item ) ? (
+											<>
+												<span className="font-semibold">{ formatRevenue( item.revenue_minor, item.currency ) }</span>
+												{ ' ' }
+												<span className="text-zinc-400">{ ordersLabel( item ) }</span>
+											</>
+										) : (
+											<span className="text-zinc-400">-</span>
+										) }
+									</td>
 								</tr>
 							) )
 						) }

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -110,17 +110,51 @@ const supportsDirect = ( item ) => item.supports_direct_add_to_cart !== false;
 const hasRevenue = ( item ) => item.revenue_minor !== undefined && item.revenue_minor !== null;
 
 /**
+ * Number of minor-unit digits for an ISO 4217 currency, taken from Intl itself
+ * rather than assumed. Most currencies use 2 (GBP, USD), but JPY uses 0 and KWD
+ * uses 3, so a hardcoded /100 would misplace the decimal for those. Falls back
+ * to 2 when the code is unknown or Intl has no currency data.
+ *
+ * @param {string} currency ISO 4217 currency code.
+ * @return {number} Fraction digits for the currency (e.g. 2 for GBP, 0 for JPY, 3 for KWD).
+ */
+function currencyFractionDigits( currency ) {
+	try {
+		return new Intl.NumberFormat( undefined, {
+			style: 'currency',
+			currency,
+		} ).resolvedOptions().maximumFractionDigits;
+	} catch ( e ) {
+		return 2;
+	}
+}
+
+/**
+ * Convert integer minor currency units to a major-unit amount using the
+ * currency's own fraction digits (10 ** digits), so 1234 is 12.34 for GBP,
+ * 1234 for JPY, and 1.234 for KWD.
+ *
+ * @param {number} minor    Integer minor currency units.
+ * @param {string} currency ISO 4217 currency code.
+ * @return {number} Amount in major units.
+ */
+function revenueMajorUnits( minor, currency ) {
+	return Number( minor || 0 ) / ( 10 ** currencyFractionDigits( currency ) );
+}
+
+/**
  * Format `revenue_minor` (integer minor currency units, e.g. pence) as a
- * currency amount using the row's own ISO 4217 `currency` code. Assumes a
- * single currency per response - no conversion is attempted; multi-currency
- * handling is out of scope.
+ * currency amount using the row's own ISO 4217 `currency` code. The minor units
+ * are scaled by the currency's own fraction digits (not a fixed /100), so JPY
+ * (0 digits) and KWD (3 digits) render correctly. Assumes a single currency per
+ * response - no conversion is attempted; multi-currency handling is out of scope.
  *
  * @param {number} minor    Integer minor currency units.
  * @param {string} currency ISO 4217 currency code (e.g. 'GBP', 'USD').
  * @return {string} Formatted amount, e.g. "£12.34".
  */
 export function formatRevenue( minor, currency ) {
-	const amount = Number( minor || 0 ) / 100;
+	const amount = revenueMajorUnits( minor, currency );
 	try {
 		return new Intl.NumberFormat( undefined, {
 			style: 'currency',
@@ -131,6 +165,20 @@ export function formatRevenue( minor, currency ) {
 		// plain number so the cell never throws.
 		return currency ? `${ amount.toFixed( 2 ) } ${ currency }` : amount.toFixed( 2 );
 	}
+}
+
+/**
+ * Revenue as a plain, locale-independent number in major units for CSV export:
+ * a dot decimal separator, no thousands grouping, no currency symbol (the
+ * currency code travels in its own column). Uses the currency's own fraction
+ * digits so JPY has none and KWD has three.
+ *
+ * @param {number} minor    Integer minor currency units.
+ * @param {string} currency ISO 4217 currency code.
+ * @return {string} Plain number string, e.g. "12.34".
+ */
+export function formatRevenueNumeric( minor, currency ) {
+	return revenueMajorUnits( minor, currency ).toFixed( currencyFractionDigits( currency ) );
 }
 
 // "N orders" secondary label for the Revenue cell, mirroring how
@@ -216,7 +264,8 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 		Number( item.added_to_cart || 0 ),
 		Number( item.added_to_cart_direct || 0 ),
 		Number( item.added_to_cart_assisted || 0 ),
-		hasRevenue( item ) ? formatRevenue( item.revenue_minor, item.currency ) : '',
+		hasRevenue( item ) ? formatRevenueNumeric( item.revenue_minor, item.currency ) : '',
+		hasRevenue( item ) ? ( item.currency || '' ) : '',
 		hasRevenue( item ) ? Number( item.orders || 0 ) : '',
 	];
 
@@ -249,6 +298,7 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 			__( 'Add to Cart (in-video)', 'godam' ),
 			__( 'Add to Cart (assisted)', 'godam' ),
 			__( 'Revenue', 'godam' ),
+			__( 'Currency', 'godam' ),
 			__( 'Orders', 'godam' ),
 		];
 

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -88,5 +88,23 @@ describe( 'sourceLabel — Source chip label mapping', () => {
 
 	it( 'falls back to the raw value for an unknown source', () => {
 		expect( sourceLabel( 'something-new' ) ).toBe( 'something-new' );
+	} );
+} );
+
+describe( 'formatRevenue — revenue_minor -> currency amount', () => {
+	it( 'divides minor units by 100 and formats with the currency symbol', () => {
+		expect( formatRevenue( 1234, 'GBP' ) ).toBe( '£12.34' );
+	} );
+
+	it( 'formats a different ISO currency correctly', () => {
+		expect( formatRevenue( 500, 'USD' ) ).toBe( '$5.00' );
+	} );
+
+	it( 'treats a missing amount as zero rather than throwing', () => {
+		expect( formatRevenue( undefined, 'GBP' ) ).toBe( '£0.00' );
+	} );
+
+	it( 'falls back to a plain number when the currency code is invalid', () => {
+		expect( formatRevenue( 1234, 'NOT-A-CODE' ) ).toBe( '12.34 NOT-A-CODE' );
 	} );
 } );

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel, formatRevenue } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -92,12 +92,24 @@ describe( 'sourceLabel — Source chip label mapping', () => {
 } );
 
 describe( 'formatRevenue — revenue_minor -> currency amount', () => {
-	it( 'divides minor units by 100 and formats with the currency symbol', () => {
+	it( 'scales minor units by the currency fraction digits and formats with the symbol', () => {
 		expect( formatRevenue( 1234, 'GBP' ) ).toBe( '£12.34' );
 	} );
 
 	it( 'formats a different ISO currency correctly', () => {
 		expect( formatRevenue( 500, 'USD' ) ).toBe( '$5.00' );
+	} );
+
+	it( 'uses 0 fraction digits for a zero-decimal currency (JPY)', () => {
+		const formatted = formatRevenue( 1234, 'JPY' );
+		// 1234 minor units of a 0-decimal currency is 1,234 major units, not 12.34.
+		expect( formatted ).toContain( '1,234' );
+		expect( formatted ).not.toContain( '.' );
+	} );
+
+	it( 'uses 3 fraction digits for a three-decimal currency (KWD)', () => {
+		// 1234 minor units of a 3-decimal currency is 1.234 major units.
+		expect( formatRevenue( 1234, 'KWD' ) ).toContain( '1.234' );
 	} );
 
 	it( 'treats a missing amount as zero rather than throwing', () => {
@@ -106,5 +118,21 @@ describe( 'formatRevenue — revenue_minor -> currency amount', () => {
 
 	it( 'falls back to a plain number when the currency code is invalid', () => {
 		expect( formatRevenue( 1234, 'NOT-A-CODE' ) ).toBe( '12.34 NOT-A-CODE' );
+	} );
+} );
+
+describe( 'formatRevenueNumeric — CSV plain-number revenue', () => {
+	it( 'renders a dot-decimal number with no symbol for a 2-decimal currency', () => {
+		expect( formatRevenueNumeric( 1234, 'GBP' ) ).toBe( '12.34' );
+		expect( formatRevenueNumeric( 500, 'USD' ) ).toBe( '5.00' );
+	} );
+
+	it( 'uses the currency fraction digits (0 for JPY, 3 for KWD)', () => {
+		expect( formatRevenueNumeric( 1234, 'JPY' ) ).toBe( '1234' );
+		expect( formatRevenueNumeric( 1234, 'KWD' ) ).toBe( '1.234' );
+	} );
+
+	it( 'treats a missing amount as zero', () => {
+		expect( formatRevenueNumeric( undefined, 'GBP' ) ).toBe( '0.00' );
 	} );
 } );


### PR DESCRIPTION
This pull request enhances the "Top Products" dashboard table by adding support for displaying product revenue and order counts, improving both the UI and CSV export functionality. It introduces a robust currency formatting utility, ensures that only products with revenue data show these new fields, and adds comprehensive unit tests for the new formatting logic.

**Revenue and Orders Display Enhancements:**

- Added logic to display product revenue and order counts in the dashboard table, ensuring these fields only appear for products with available revenue data to avoid misleading "£0" placeholders.
- Included new "Revenue" and "Orders" columns in the CSV export, with corresponding data for each product row when available.

**Utility and Formatting Improvements:**

- Introduced the `formatRevenue` utility function to reliably format minor currency units (e.g., pence) as user-friendly currency strings, handling invalid or missing currency codes gracefully.
- Added the `ordersLabel` function to generate a localized string for the number of orders associated with each product's revenue.

**Testing:**

- Implemented unit tests for the new `formatRevenue` function to ensure correct formatting across various currencies, missing values, and invalid codes.