### PR TITLE
Single-currency Revenue KPI card + base_currency proxy

### DIFF
--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -851,6 +851,14 @@ class Analytics extends Base {
 				'api_key'       => $api_key,
 			)
 		);
+		// Single store currency: pass the store base currency so the service returns
+		// base-currency revenue plus a count of orders in other currencies (not
+		// converted). Only meaningful when WooCommerce is active; when absent the
+		// service simply omits the `revenue` object.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$params['base_currency'] = $base_currency;
+		}
 		$endpoint = add_query_arg(
 			$params,
 			RTGODAM_ANALYTICS_BASE . '/dashboard/metrics/fetch/'
@@ -1217,6 +1225,11 @@ class Analytics extends Base {
 		}
 		if ( ! empty( $order ) ) {
 			$query['order'] = $order;
+		}
+		// Single store currency: revenue/orders sum only the base currency.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$query['base_currency'] = $base_currency;
 		}
 
 		$endpoint = add_query_arg(

--- a/pages/analytics/RevenueCard.js
+++ b/pages/analytics/RevenueCard.js
@@ -1,0 +1,88 @@
+/**
+ * Internal dependencies
+ */
+import Tooltip from './Tooltip';
+import { formatRevenue } from '../dashboard/components/TopProductsTable';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Revenue KPI card for the dashboard Insights row (WooCommerce only).
+ *
+ * GoDAM commits to a single store currency: this shows total video-attributed
+ * revenue in the store's base currency, summing only orders placed in that
+ * currency. Orders in other currencies are not converted; when there are any, a
+ * sub-line reports how many were left out, e.g. "excluding 33 orders in other
+ * currencies". A single-currency store (the common case) excludes nothing and
+ * shows just the figure.
+ *
+ * @param {Object} props
+ * @param {Object} [props.revenue]   The revenue payload: { revenue_minor, currency, excluded_orders }.
+ * @param {string} [props.dataLabel] The active range label (e.g. "All time").
+ */
+export default function RevenueCard( { revenue, dataLabel } ) {
+	// Absent payload (an analytics service that predates the revenue read, or a
+	// non-Woo store where no base currency is passed) -> render nothing, so the
+	// card never asserts a misleading "0" for "metric unavailable". A present
+	// payload with a real 0 still renders.
+	if ( revenue === null || revenue === undefined ) {
+		return null;
+	}
+
+	const minor = Number( revenue.revenue_minor || 0 );
+	const currency = revenue.currency || '';
+	const excluded = Number( revenue.excluded_orders || 0 );
+
+	return (
+		<div
+			className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+			data-test-id="godam-revenue-card"
+		>
+			<div className="analytics-single-info">
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading">
+						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-revenue-label">{ __( 'Revenue', 'godam' ) }</p>
+						{ /* WooCommerce badge (per Figma): the metric comes from store data. */ }
+						<span
+							className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]"
+							data-test-id="godam-revenue-woo-tag"
+						>
+							Woo
+						</span>
+						<Tooltip
+							text={ __(
+								'Total video-attributed revenue in the store\'s base currency. Orders placed in other currencies are not converted, so they are excluded from this total and counted separately.',
+								'godam',
+							) }
+						/>
+					</div>
+				</div>
+				<div className="flex flex-row justify-between gap-2 items-end">
+					<div className="flex flex-col gap-2">
+						<div className="flex flex-row items-baseline gap-2">
+							<p className="single-metrics-value" data-test-id="godam-revenue-value">{ formatRevenue( minor, currency ) }</p>
+						</div>
+						{ excluded > 0 && (
+							<span className="text-xs text-zinc-500" data-test-id="godam-revenue-excluded">
+								{ sprintf(
+									/* translators: %s: number of orders placed in other currencies, not included in the total. */
+									_n(
+										'excluding %s order in other currencies',
+										'excluding %s orders in other currencies',
+										excluded,
+										'godam',
+									),
+									excluded.toLocaleString(),
+								) }
+							</span>
+						) }
+						<span className="text-[11px] text-zinc-400">{ dataLabel || __( 'All time', 'godam' ) }</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -21,6 +21,7 @@ import GodamHeader from '../godam/components/GoDAMHeader.jsx';
 import { getAPIKeyErrorInfo, hasAPIKey } from '../godam/utils';
 import SingleMetrics from '../analytics/SingleMetrics';
 import VideoToCartCard from '../analytics/VideoToCartCard';
+import RevenueCard from '../analytics/RevenueCard';
 import ViewersGauge from './components/ViewersGauge';
 import PlaybackPerformanceDashboard from '../analytics/PlaybackPerformance';
 import TopVideosTable from './components/TopVideosTable';
@@ -452,6 +453,16 @@ const Dashboard = () => {
 								{ hasWooProducts && (
 									<VideoToCartCard
 										videoToCart={ insightsMetrics?.video_to_cart }
+										dataLabel={ insightsCardLabel }
+									/>
+								) }
+
+								{ /* WooCommerce-only: video-attributed revenue in the store's
+								    base currency (single store currency; other currencies are
+								    counted, not converted). */ }
+								{ hasWooProducts && (
+									<RevenueCard
+										revenue={ insightsMetrics?.revenue }
 										dataLabel={ insightsCardLabel }
 									/>
 								) }


### PR DESCRIPTION
## What

The dashboard side of single store currency revenue (pairs with rtCamp/godam-analytics#257). GoDAM commits to one store currency: no conversion, no reliance on multi-currency plugins, no external FX.

- **WP proxy (`class-analytics.php`)**: pass `base_currency = get_option('woocommerce_currency')` to `/dashboard/metrics/fetch/` and `/dashboard/top-products/`. The service then returns base-currency revenue plus a count of orders in other currencies. The `revenue` object already forwards through the dashboard-metrics `array_merge`.
- **`RevenueCard.js`**: a WooCommerce-only Insights KPI card. Shows total video-attributed revenue via the existing `formatRevenue(minor, currency)` (so JPY/KWD fraction digits are correct), with an "excluding N orders in other currencies" sub-line only when that count is > 0. A single-currency store shows just the figure. Renders nothing when the payload is absent, so it never shows a misleading 0.
- **`Dashboard.js`**: render `RevenueCard` in the Insights row, gated on `hasWooProducts`.

## Display rule

Every revenue figure is one number in the store's base currency; orders in other currencies are excluded from the figure and disclosed once as the sub-line (Joel's format: "Revenue: $467 (excluding 33 orders in other currencies)"). No per-currency list anywhere.

## Base branch

Targets `feat/top-products` (where #2086 shipped the Top Products revenue column + `formatRevenue`), not `develop`. Nothing merges to `develop` until Phase 2 is complete.

Part of rtCamp/godam-plugin-wp#26.
