### PR TITLE
Show per-hotspot Direct revenue in the layer panel

### DIFF
--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -408,6 +408,13 @@ class Analytics extends Base {
 		if ( ! empty( $job_id ) ) {
 			$query_params['job_id'] = $job_id;
 		}
+		// Single store currency: the service returns per-hotspot Direct revenue in
+		// this currency (Woo layers only); other currencies are excluded, not
+		// converted. Empty when WooCommerce is inactive, so the service omits it.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$query_params['base_currency'] = $base_currency;
+		}
 		$query_params = $this->append_range_params( $request, $query_params );
 
 		$endpoint = add_query_arg( $query_params, RTGODAM_ANALYTICS_BASE . '/processed-layer-analytics/' );

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -459,6 +459,12 @@ export function groupRows( rows, layerType, configIndex ) {
 					product_image: md.product_image || '',
 					product_price: md.product_price || null,
 					timestamp: Number( row.timestamp || 0 ),
+					// Per-hotspot Direct revenue (Woo layers), in the store's base
+					// currency; other currencies are excluded server-side, not
+					// converted. orders is exact for a single hotspot.
+					revenue_minor: Number( row.revenue_minor ) || 0,
+					orders: Number( row.orders ) || 0,
+					currency: row.currency || '',
 					isActive: subIsActive,
 				};
 			} )
@@ -506,6 +512,19 @@ export function groupRows( rows, layerType, configIndex ) {
 			no_action: parentNoAction,
 			conversion_rate: parentConversion,
 			sub_hotspots: subHotspots,
+			// Parent Direct revenue = sum of its hotspots' revenue (base currency).
+			// The order count is the summed children's, which can overcount an
+			// order that bought two products via two hotspots; the panel presents
+			// the parent figure as an aggregate, not an exact distinct-order total.
+			revenue_minor: subHotspots.reduce(
+				( sum, h ) => sum + ( Number( h.revenue_minor ) || 0 ),
+				0,
+			),
+			orders: subHotspots.reduce(
+				( sum, h ) => sum + ( Number( h.orders ) || 0 ),
+				0,
+			),
+			currency: ( subHotspots.find( ( h ) => h.currency )?.currency ) || '',
 			isActive: parentIsActive,
 			historical_positions: historicalPositions,
 			// wp-admin link to this form's entries / poll's results, when the

--- a/pages/analytics/hooks/useVideoLayerData.test.js
+++ b/pages/analytics/hooks/useVideoLayerData.test.js
@@ -77,3 +77,73 @@ describe( 'groupRows — conversion comes from the server, not a client recomput
 		expect( parent.conversion_rate ).toBe( 100 );
 	} );
 } );
+
+describe( 'groupRows — per-hotspot Direct revenue (single store currency)', () => {
+	const baseRow = {
+		layer_type: 'woo',
+		page_url: 'https://shop.example.com',
+		timestamp: 17,
+	};
+	// The endpoint attaches revenue_minor/orders/currency to each Woo row.
+	// Base currency is INR; a non-base (USD) order is excluded server-side, so
+	// its row arrives as revenue_minor 0 / orders 0 — never blended.
+	const rows = [
+		{
+			...baseRow,
+			layer_id: 'woo-9', layer_name: 'Deals',
+			viewed: 10, clicked: 4, hovered: 10, conversion_rate: 40,
+			layer_metadata: '{"parent_layer_id":"woo-9"}',
+		},
+		{
+			...baseRow,
+			layer_id: 'woo-9::p101', layer_name: 'Hoodie',
+			viewed: 0, clicked: 3, conversion_rate: 30,
+			revenue_minor: 120000, orders: 1, currency: 'INR',
+			layer_metadata: '{"parent_layer_id":"woo-9","product_id":101}',
+		},
+		{
+			...baseRow,
+			layer_id: 'woo-9::p102', layer_name: 'Cap',
+			viewed: 0, clicked: 1, conversion_rate: 10,
+			revenue_minor: 0, orders: 0, currency: '',
+			layer_metadata: '{"parent_layer_id":"woo-9","product_id":102}',
+		},
+		{
+			...baseRow,
+			layer_id: 'woo-9::p103', layer_name: 'Mug',
+			viewed: 0, clicked: 2, conversion_rate: 20,
+			revenue_minor: 30000, orders: 1, currency: 'INR',
+			layer_metadata: '{"parent_layer_id":"woo-9","product_id":103}',
+		},
+	];
+
+	it( 'maps each hotspot revenue/orders/currency from its endpoint row', () => {
+		const [ parent ] = groupRows( rows, 'woo', OPEN_CONFIG );
+		const byPid = Object.fromEntries(
+			parent.sub_hotspots.map( ( s ) => [ s.product_id, s ] ),
+		);
+		expect( byPid[ 101 ] ).toMatchObject( { revenue_minor: 120000, orders: 1, currency: 'INR' } );
+		expect( byPid[ 103 ] ).toMatchObject( { revenue_minor: 30000, orders: 1, currency: 'INR' } );
+		// Server-excluded non-base order arrives as 0; the panel hides it (orders 0).
+		expect( byPid[ 102 ] ).toMatchObject( { revenue_minor: 0, orders: 0 } );
+	} );
+
+	it( 'parent revenue is the sum of its hotspots, currency from a base-currency child', () => {
+		const [ parent ] = groupRows( rows, 'woo', OPEN_CONFIG );
+		expect( parent.revenue_minor ).toBe( 150000 ); // 120000 + 30000
+		expect( parent.orders ).toBe( 2 );
+		expect( parent.currency ).toBe( 'INR' );
+	} );
+
+	it( 'defaults revenue fields to 0/empty when the endpoint sends none', () => {
+		const plain = rows.map( ( { revenue_minor, orders, currency, ...rest } ) => rest );
+		const [ parent ] = groupRows( plain, 'woo', OPEN_CONFIG );
+		expect( parent.revenue_minor ).toBe( 0 );
+		expect( parent.orders ).toBe( 0 );
+		expect(
+			parent.sub_hotspots.every(
+				( s ) => s.revenue_minor === 0 && s.orders === 0 && s.currency === '',
+			),
+		).toBe( true );
+	} );
+} );

--- a/pages/analytics/timeline/LayerDetailPanel.js
+++ b/pages/analytics/timeline/LayerDetailPanel.js
@@ -6,13 +6,14 @@ import React, { useEffect, useState } from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { formatRevenue } from '../../dashboard/components/TopProductsTable';
 import {
 	LAYER_TYPE_BY_ID,
 	withAlpha,
@@ -21,6 +22,7 @@ import LayerIcon from './LayerIcon';
 import LayerInteractionFunnel from './LayerInteractionFunnel';
 import SubHotspotRail from './SubHotspotRail';
 import LayerModifiedNotice from './LayerModifiedNotice';
+import InfoTooltip from './InfoTooltip';
 
 /**
  * Build the deep-link URL into the video editor for a layer.
@@ -107,6 +109,20 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 		: null;
 	const funnelCounts = activeSub ? activeSub.counts : parent.counts;
 	const funnelNoAction = activeSub ? activeSub.no_action : parent.no_action;
+
+	// Direct in-video revenue for the selected hotspot, or the parent layer's
+	// aggregate (sum of its hotspots) when none is selected. Woo layers only,
+	// shown only when there is revenue. Base currency; other currencies are
+	// excluded (counted on the dashboard, not converted).
+	const revenueEntity = activeSub || parent;
+	const revenueMinor = Number( revenueEntity.revenue_minor ) || 0;
+	const revenueOrders = Number( revenueEntity.orders ) || 0;
+	const showRevenue = parent.layer_type === 'woo' && revenueMinor > 0;
+	const revenueOrdersPhrase = sprintf(
+		/* translators: %d: number of orders. */
+		_n( '%d order', '%d orders', revenueOrders, 'godam' ),
+		revenueOrders,
+	);
 
 	const showRail = meta.hasSubHotspots && ( parent.sub_hotspots || [] ).length > 0;
 
@@ -218,6 +234,27 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 						selectedSubId={ selectedSubId }
 						onSelect={ setSelectedSubId }
 					/>
+				) }
+
+				{ showRevenue && (
+					<div className="mb-4 flex items-center gap-2 flex-wrap text-sm text-zinc-700">
+						<span>
+							{ sprintf(
+								/* translators: 1: formatted revenue amount, 2: order count phrase (e.g. "3 orders"). */
+								activeSub
+									? __( 'This hotspot drove %1$s across %2$s', 'godam' )
+									: __( 'This layer drove %1$s across %2$s', 'godam' ),
+								formatRevenue( revenueMinor, revenueEntity.currency ),
+								revenueOrdersPhrase,
+							) }
+						</span>
+						<InfoTooltip
+							text={ __(
+								'Direct in-video contribution only, from add-to-carts inside the video. It is not the product\'s total revenue; purchases made after clicking through to the product page (Assisted) are not counted here.',
+								'godam',
+							) }
+						/>
+					</div>
 				) }
 
 				<LayerInteractionFunnel

--- a/pages/analytics/timeline/SubHotspotRail.js
+++ b/pages/analytics/timeline/SubHotspotRail.js
@@ -6,11 +6,12 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { formatRevenue } from '../../dashboard/components/TopProductsTable';
 import {
 	LAYER_TYPE_BY_ID,
 	subHotspotColor,
@@ -231,6 +232,20 @@ const SubHotspotRail = ( { parent, selectedSubId, onSelect } ) => {
 								>
 									{ ( Number( sub.conversion_rate ) || 0 ).toFixed( 1 ) }%
 								</span>
+								{ /* Per-hotspot Direct revenue (Woo only), shown only when
+								    this hotspot has attributed orders. Base currency; other
+								    currencies are excluded, not converted. */ }
+								{ parent.layer_type === 'woo' && Number( sub.orders ) > 0 && (
+									<span className="basis-full text-right text-xs text-zinc-500 tabular-nums">
+										{ formatRevenue( sub.revenue_minor, sub.currency ) }
+										{ ' · ' }
+										{ sprintf(
+											/* translators: %d: number of orders attributed to this hotspot. */
+											_n( '%d order', '%d orders', sub.orders, 'godam' ),
+											sub.orders,
+										) }
+									</span>
+								) }
 							</button>
 						</li>
 					);


### PR DESCRIPTION
## What

Shows per-hotspot Direct revenue in the video layer-analytics panel (Sub-task C core; pairs with rtCamp/godam-analytics#259).

- **`useVideoLayerData`**: maps `revenue_minor` / `orders` / `currency` onto each sub-hotspot from the endpoint row; the parent carries the sum of its hotspots' revenue (currency from any child).
- **`SubHotspotRail`**: a small secondary line per hotspot, "&lt;amount&gt; · N orders", shown only when that hotspot has orders (Woo layers only), so the rail stays scannable.
- **`LayerDetailPanel`**: a headline "This hotspot/layer drove &lt;amount&gt; across N orders" above the funnel, with an InfoTooltip stating it is the **Direct in-video contribution only**, not the product's total (Assisted purchases via the product page are excluded). Reuses the shipped `formatRevenue` (correct ISO fraction digits, full numbers).
- **WP proxy**: passes `base_currency = get_option('woocommerce_currency')` to `/processed-layer-analytics/`.

## Single store currency

Per-hotspot revenue sums base-currency orders only; other currencies are excluded server-side (counted on the dashboard, never converted here). Direct-only because a hotspot carries a `layer_id`; Assisted purchases have none.

## Base branch

Targets `feat/top-products` (#2086, where `formatRevenue` shipped). Nothing merges to `develop` until Phase 2 is complete.

Part of rtCamp/godam-plugin-wp#26.
