### PR TITLE
feat(analytics): show Influenced revenue in Top Products (Phase 2, Sub-task D)

### DIFF
--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -189,6 +189,22 @@ const ordersLabel = ( item ) => {
 	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
 };
 
+// Whether this row carries a real Influenced-revenue match (the third tier:
+// a product-page play matched to a later purchase of the same product). Shown
+// only when > 0 - an absent or zero match renders nothing, never a misleading
+// "£0", and Influenced is never folded into the product's own revenue total.
+export const hasInfluenced = ( item ) =>
+	item.influenced_revenue_minor !== undefined &&
+	item.influenced_revenue_minor !== null &&
+	Number( item.influenced_revenue_minor ) > 0;
+
+// "N orders" label for the Influenced sub-line.
+export const influencedOrdersLabel = ( item ) => {
+	const orders = Number( item.influenced_orders || 0 );
+	/* translators: %d: number of distinct orders influenced by a product-page view of a video. */
+	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
+};
+
 /**
  * Dashboard "Top Products" table.
  *
@@ -476,6 +492,28 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 											</>
 										) : (
 											<span className="text-zinc-400">-</span>
+										) }
+										{ /* Influenced revenue (third tier): a separate sub-line,
+										    shown only when there is a real match, never added into
+										    the product's own revenue above. */ }
+										{ hasInfluenced( item ) && (
+											<div
+												className="mt-1 text-xs text-zinc-500"
+												data-test-id="godam-top-products-influenced"
+											>
+												{ sprintf(
+													/* translators: 1: formatted influenced revenue amount, 2: order count phrase (e.g. "3 orders"). */
+													__( 'Influenced %1$s · %2$s', 'godam' ),
+													formatRevenue( item.influenced_revenue_minor, item.influenced_currency ),
+													influencedOrdersLabel( item ),
+												) }
+												{ item.influenced_provisional && (
+													<span className="text-zinc-400">
+														{ ' ' }
+														{ __( '(provisional)', 'godam' ) }
+													</span>
+												) }
+											</div>
 										) }
 									</td>
 								</tr>

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -118,6 +118,40 @@ describe( 'formatRevenue — revenue_minor -> currency amount', () => {
 
 	it( 'falls back to a plain number when the currency code is invalid', () => {
 		expect( formatRevenue( 1234, 'NOT-A-CODE' ) ).toBe( '12.34 NOT-A-CODE' );
+	} );
+} );
+
+describe( 'hasInfluenced — Influenced sub-line gate (third tier)', () => {
+	it( 'is true only when influenced_revenue_minor is a positive number', () => {
+		expect( hasInfluenced( { influenced_revenue_minor: 250000 } ) ).toBe( true );
+	} );
+
+	it( 'is false when there is no match (0), so no misleading £0 renders', () => {
+		expect( hasInfluenced( { influenced_revenue_minor: 0 } ) ).toBe( false );
+	} );
+
+	it( 'is false when the service omitted the field (older build / no match)', () => {
+		expect( hasInfluenced( {} ) ).toBe( false );
+		expect( hasInfluenced( { influenced_revenue_minor: null } ) ).toBe( false );
+	} );
+
+	it( 'renders its amount via the shipped formatRevenue (no new formatter)', () => {
+		// The sub-line uses the SAME formatRevenue as the Revenue cell, keyed on
+		// the separate influenced_currency: JPY has no decimals, USD has two.
+		expect( formatRevenue( 250000, 'INR' ) ).toContain( '2,500' );
+		expect( formatRevenue( 1234, 'JPY' ) ).not.toContain( '.' );
+		expect( formatRevenue( 500, 'USD' ) ).toBe( '$5.00' );
+	} );
+} );
+
+describe( 'influencedOrdersLabel — singular/plural order count', () => {
+	it( 'renders singular for one order', () => {
+		expect( influencedOrdersLabel( { influenced_orders: 1 } ) ).toBe( '1 order' );
+	} );
+
+	it( 'renders plural for several, and zero when absent', () => {
+		expect( influencedOrdersLabel( { influenced_orders: 3 } ) ).toBe( '3 orders' );
+		expect( influencedOrdersLabel( {} ) ).toBe( '0 orders' );
 	} );
 } );
 


### PR DESCRIPTION
## What

Shows the **Influenced revenue** tier (Sub-task D of the Woo Phase 2 track, parent rtCamp/godam-plugin-wp#26) in the dashboard **Top Products** table. Influenced is the third attribution tier: a shopper's product-page play matched to a later purchase of that same product. This is the display side of godam-analytics#260.

Base branch: `feat/top-products` (the merged Top Products revenue foundation, #2086). Does not target `develop`; the Phase 2 stack lands on the feature branches first.

## How

- Reads `influenced_revenue_minor` / `influenced_currency` / `influenced_orders` / `influenced_provisional` from each Top Products row (added by godam-analytics#260 as separate keys).
- Renders an **Influenced sub-line inside the Revenue cell**, below the product's own Direct/Assisted revenue and order count. Shown **only when there is a real match** (`influenced_revenue_minor > 0`); an absent or zero match renders nothing, never a misleading currency-zero.
- **Reuses the shipped `formatRevenue(minor, currency)`** with the row's own `influenced_currency` (no new formatter). A `(provisional)` marker appears when the service flags the figure as still settling (30-day window).
- Influenced is presented **separately** and is **never folded** into the product's own revenue/orders total.
- `data-test-id="godam-top-products-influenced"` on the sub-line for E2E.

## Tests (7 new; suite 31 pass)

- `hasInfluenced` gate: true only for a positive `influenced_revenue_minor`; false for 0, null, and an omitted field (older service build).
- `influencedOrdersLabel`: singular/plural/zero.
- The amount renders via the shipped `formatRevenue` (INR grouping, JPY 0-decimals, USD 2) — asserts no new formatter was introduced.

**Revert-proofed:** forcing the `hasInfluenced` gate to `false` fails the gate test; restoring returns all 31 green.

## Manual QA

1. On a store with a Woo product whose product page embeds a video: play the video on the product page, then buy the product.
2. Open the GoDAM dashboard Top Products for that range.
3. That product's Revenue cell shows an **Influenced** sub-line with the purchase amount and order count, separate from its own Direct/Assisted revenue.
4. A product with no product-page-play → purchase match shows **no** Influenced sub-line (not a zero).

## Notes

- Requires godam-analytics#260 on the analytics service to populate the `influenced_*` keys; degrades to no sub-line against an older service build (keys absent).
- Single store currency: Influenced inherits the track's single-currency assumption (every row is the store's base currency); no read-time conversion.
- `@since n.e.x.t` left as-is; no CHANGELOG/POT during development.

## Automation impact

New `data-test-id="godam-top-products-influenced"` on the Influenced sub-line; existing `godam-top-products-revenue` cell unchanged.
