### PR TITLE
feat(analytics): Woo Phase 2 revenue UI (single-currency card, per-hotspot, influenced)

### DIFF
--- a/.github/workflows/js_unit_tests_on_pull_request.yml
+++ b/.github/workflows/js_unit_tests_on_pull_request.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - develop
       - main
+      - 'feat/**'
 
 name: JS Unit Tests
 

--- a/assets/src/blocks/godam-image/render.php
+++ b/assets/src/blocks/godam-image/render.php
@@ -99,13 +99,31 @@ if ( $godam_has_layers ) {
 	// whenever the block renders (reliable on block themes / FSE, unlike a late
 	// wp_enqueue_style() here), so nothing else needs enqueuing here.
 	//
-	// Analytics is intentionally NOT enqueued for images: they have no analytics
-	// view (`image` capability sets `showStats: false`) and no transcoding job,
-	// so a beacon per hotspot interaction would only collect data nothing
-	// consumes. Without `godam-player-analytics-script`,
-	// `window.GoDAM.addLayerInteraction` is absent, so every emit in the shared
-	// managers / frontend.js is a guarded no-op. Re-enable here when an image
-	// analytics view ships.
+	// Layer analytics: enqueue the standalone runtime that registers
+	// `window.GoDAM.addLayerInteraction` + the page-hide flush WITHOUT the video
+	// player (image pages never load `godam-player-analytics.min.js`). Without it
+	// every emit in the shared hotspot managers is a guarded no-op. This is a small
+	// bundle built from `assets/src/js/godam-player/layer-analytics.js`.
+	$godam_la_asset_path = RTGODAM_PATH . 'assets/build/js/godam-layer-analytics.min.asset.php';
+	$godam_la_asset      = file_exists( $godam_la_asset_path )
+		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is a plugin constant + hardcoded build filename.
+		? include $godam_la_asset_path
+		: array(
+			'dependencies' => array(),
+			'version'      => RTGODAM_VERSION,
+		);
+
+	if ( ! wp_script_is( 'godam-layer-analytics-script', 'registered' ) ) {
+		wp_register_script(
+			'godam-layer-analytics-script',
+			RTGODAM_URL . 'assets/build/js/godam-layer-analytics.min.js',
+			$godam_la_asset['dependencies'],
+			$godam_la_asset['version'],
+			true
+		);
+	}
+
+	wp_enqueue_script( 'godam-layer-analytics-script' );
 }
 
 $godam_instance_id = 'img_' . bin2hex( random_bytes( 8 ) );
@@ -137,6 +155,7 @@ if ( empty( $godam_is_shortcode ) ) {
 		<?php if ( $godam_has_layers ) : ?>
 			data-id="<?php echo esc_attr( (string) $godam_attachment_id ); ?>"
 			data-instance-id="<?php echo esc_attr( $godam_instance_id ); ?>"
+			data-block-source="godam-image"
 			data-godam-image-layers="<?php echo esc_attr( wp_json_encode( $godam_layers ) ); ?>"
 		<?php endif; ?>
 	>

--- a/assets/src/blocks/godam-image/render.php
+++ b/assets/src/blocks/godam-image/render.php
@@ -67,43 +67,17 @@ if ( $godam_show_layers && $godam_attachment_id ) {
 
 $godam_has_layers = ! empty( $godam_layers );
 
-// Enqueue the shared image-layers front-end renderer (+ hotspot styles) only
-// when there are layers to draw. Registered lazily here as footer scripts, so
-// the Woo add-on's `godam_image_layers_frontend_dependencies` hook (added on
+// Enqueue the shared image-layers front-end renderer (+ its analytics runtime)
+// only when there are layers to draw. Registered lazily here as footer scripts,
+// so the Woo add-on's `godam_image_layers_frontend_dependencies` hook (added on
 // wp_enqueue_scripts) is already in place.
 if ( $godam_has_layers ) {
-	$godam_img_asset_path = RTGODAM_PATH . 'assets/build/js/godam-image-layers-frontend.min.asset.php';
-	$godam_img_asset      = file_exists( $godam_img_asset_path )
-		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is a plugin constant + hardcoded build filename.
-		? include $godam_img_asset_path
-		: array(
-			'dependencies' => array(),
-			'version'      => RTGODAM_VERSION,
-		);
-
-	if ( ! wp_script_is( 'godam-image-layers-frontend', 'registered' ) ) {
-		$godam_img_deps = apply_filters( 'godam_image_layers_frontend_dependencies', $godam_img_asset['dependencies'] );
-		wp_register_script(
-			'godam-image-layers-frontend',
-			RTGODAM_URL . 'assets/build/js/godam-image-layers-frontend.min.js',
-			$godam_img_deps,
-			$godam_img_asset['version'],
-			true
-		);
-	}
-
-	wp_enqueue_script( 'godam-image-layers-frontend' );
-
-	// The hotspot stylesheet (`godam-player-style`) is tied to this block via
-	// wp_enqueue_block_style() in class-blocks.php, so WordPress prints it
-	// whenever the block renders (reliable on block themes / FSE, unlike a late
-	// wp_enqueue_style() here), so nothing else needs enqueuing here.
-	//
-	// Layer analytics: enqueue the standalone runtime that registers
-	// `window.GoDAM.addLayerInteraction` + the page-hide flush WITHOUT the video
-	// player (image pages never load `godam-player-analytics.min.js`). Without it
-	// every emit in the shared hotspot managers is a guarded no-op. This is a small
-	// bundle built from `assets/src/js/godam-player/layer-analytics.js`.
+	// Layer-analytics runtime: registers `window.GoDAM.addLayerInteraction` + the
+	// page-hide flush WITHOUT the video player (image pages never load
+	// `godam-player-analytics.min.js`). Without it every emit in the shared hotspot
+	// managers is a guarded no-op. Registered FIRST and made a DEPENDENCY of the
+	// renderer below, so `window.GoDAM` exists before the renderer's DOMContentLoaded
+	// handler fires the parent-layer 'viewed' impression beacon on render.
 	$godam_la_asset_path = RTGODAM_PATH . 'assets/build/js/godam-layer-analytics.min.asset.php';
 	$godam_la_asset      = file_exists( $godam_la_asset_path )
 		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is a plugin constant + hardcoded build filename.
@@ -123,7 +97,38 @@ if ( $godam_has_layers ) {
 		);
 	}
 
+	$godam_img_asset_path = RTGODAM_PATH . 'assets/build/js/godam-image-layers-frontend.min.asset.php';
+	$godam_img_asset      = file_exists( $godam_img_asset_path )
+		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable -- file path is a plugin constant + hardcoded build filename.
+		? include $godam_img_asset_path
+		: array(
+			'dependencies' => array(),
+			'version'      => RTGODAM_VERSION,
+		);
+
+	if ( ! wp_script_is( 'godam-image-layers-frontend', 'registered' ) ) {
+		// Depend on the analytics runtime so `window.GoDAM.addLayerInteraction` is
+		// registered before the renderer runs and fires the 'viewed' beacon.
+		$godam_img_deps   = apply_filters( 'godam_image_layers_frontend_dependencies', $godam_img_asset['dependencies'] );
+		$godam_img_deps[] = 'godam-layer-analytics-script';
+		wp_register_script(
+			'godam-image-layers-frontend',
+			RTGODAM_URL . 'assets/build/js/godam-image-layers-frontend.min.js',
+			$godam_img_deps,
+			$godam_img_asset['version'],
+			true
+		);
+	}
+
+	// Enqueue the runtime explicitly too (in case the renderer was pre-registered
+	// without the dependency), then the renderer, which pulls the runtime first.
 	wp_enqueue_script( 'godam-layer-analytics-script' );
+	wp_enqueue_script( 'godam-image-layers-frontend' );
+
+	// The hotspot stylesheet (`godam-player-style`) is tied to this block via
+	// wp_enqueue_block_style() in class-blocks.php, so WordPress prints it
+	// whenever the block renders (reliable on block themes / FSE, unlike a late
+	// wp_enqueue_style() here), so nothing else needs enqueuing here.
 }
 
 $godam_instance_id = 'img_' . bin2hex( random_bytes( 8 ) );

--- a/assets/src/js/godam-image-layers/render-image-frame.js
+++ b/assets/src/js/godam-image-layers/render-image-frame.js
@@ -194,9 +194,11 @@ export function initImageFrame( frame ) {
 				hotspotManager.computeContentRect = () => adapter.computeContentRect();
 				hotspotManager.setupHotspotLayer( mergedLayer, hotspotGroup );
 				const layerObj = hotspotManager.hotspotLayers[ hotspotManager.hotspotLayers.length - 1 ];
-				// No analytics on images (see godam-image/render.php): the block does
-				// not load the analytics buffer, so the managers' interaction emits are
-				// guarded no-ops — there is no `viewed` beacon to fire here.
+				// The analytics runtime is loaded on image pages now (see
+				// godam-image/render.php), so plain-hotspot interaction emits are
+				// captured like on video. Commerce impressions (Top Products) come from
+				// the Woo layer's parent 'viewed' below; a plain hotspot has no product
+				// row, so no impression beacon is fired here.
 				hotspotManager.createHotspots( layerObj );
 			}
 
@@ -230,6 +232,15 @@ export function initImageFrame( frame ) {
 						wooManager.setupLayer( layer, layerEl );
 						const layerObj = wooManager.wooLayers[ wooManager.wooLayers.length - 1 ];
 						wooManager.createProductHotspots( layerObj );
+						// A still image has no play/visibility transition, so fire the
+						// parent-layer 'viewed' impression beacon once, now, on render.
+						// This is the impressions signal the product rollup reads; without
+						// it image Woo hotspots would always show 0 impressions. Guarded
+						// no-op until the analytics runtime is loaded (it is a dependency
+						// of this script, so it is present by now).
+						if ( typeof wooManager.emitLayerVisible === 'function' ) {
+							wooManager.emitLayerVisible( layerObj.layer );
+						}
 					} );
 				}
 			}

--- a/assets/src/js/godam-player/analytics.js
+++ b/assets/src/js/godam-player/analytics.js
@@ -346,8 +346,15 @@ function observePageLoadForVideo( video ) {
 ( function() {
 	function findVideoElementById( videoId, root ) {
 		const ctx = root && root.querySelector ? root : document;
-		return ctx.querySelector(
-			`.easydam-player.video-js[data-id="${ videoId }"], .video-js[data-id="${ videoId }"]`,
+		// Image-block hotspot frames carry the same data-id (attachment id) but are
+		// not `.video-js`. The fallback lets the layer flush find an image frame and
+		// read its `data-block-source` ('godam-image'), so on a page that has BOTH a
+		// video and an image the tag is not dropped to ''. Attachment ids are unique,
+		// so a video and an image never share one; the video match always wins first.
+		return (
+			ctx.querySelector(
+				`.easydam-player.video-js[data-id="${ videoId }"], .video-js[data-id="${ videoId }"]`,
+			) || ctx.querySelector( `.godam-image__frame[data-id="${ videoId }"]` )
 		);
 	}
 	window.GoDAM = window.GoDAM || {};

--- a/assets/src/js/godam-player/layer-analytics-runtime.js
+++ b/assets/src/js/godam-player/layer-analytics-runtime.js
@@ -1,0 +1,175 @@
+/**
+ * Standalone layer-analytics runtime.
+ *
+ * Registers `window.GoDAM.addLayerInteraction` + `flushLayerInteractions` and the
+ * page-hide flush listeners WITHOUT the video player. It exists so a page that has
+ * only a GoDAM Image block (product hotspots on a still image) can capture hotspot
+ * interactions: those pages never load `godam-player-analytics.min.js` (which pulls
+ * in the whole video player), so the emit calls in the shared hotspot managers were
+ * previously guarded no-ops.
+ *
+ * The video-player analytics bundle (`analytics.js`) still registers the same buffer
+ * API for video pages. This module is deliberately idempotent and does NOT overwrite
+ * an existing registration, so on a page that somehow has both a video and an image
+ * the first loader wins and there is exactly one buffer + one set of flush listeners.
+ * (Folding `analytics.js` onto this shared module to remove the remaining duplication
+ * is a tracked follow-up; kept separate here so the in-review video analytics is
+ * untouched.)
+ *
+ * @package
+ */
+
+/**
+ * Internal dependencies
+ */
+import { shouldSkipAnalytics, buildAnalyticsRequestBody } from './analytics-helpers';
+import {
+	addLayerInteraction as bufferAddLayerInteraction,
+	getLayerInteractions as bufferGetLayerInteractions,
+	clearLayerInteractions as bufferClearLayerInteractions,
+} from './utils/storage';
+import { LAYER_ACTIONS, LAYER_TYPE_WHITELIST, getLayerDisplayName } from './utils/layerActions';
+
+/**
+ * Find the element carrying analytics identity for a numeric key.
+ *
+ * A video lives on `.video-js[data-id]`; an image-block hotspot frame lives on
+ * `.godam-image__frame[data-id]`. The image fallback is why a still image's
+ * `block_source` ('godam-image') survives the flush: without it the lookup finds
+ * nothing and the surface tag falls back to '' (unattributed).
+ *
+ * @param {number}           videoId Numeric attachment id (video or image).
+ * @param {Element|Document} [root]  Optional search root.
+ * @return {HTMLElement|null} The identity element, or null.
+ */
+export function findVideoElementById( videoId, root ) {
+	const ctx = root && root.querySelector ? root : document;
+	return (
+		ctx.querySelector(
+			`.easydam-player.video-js[data-id="${ videoId }"], .video-js[data-id="${ videoId }"]`,
+		) || ctx.querySelector( `.godam-image__frame[data-id="${ videoId }"]` )
+	);
+}
+
+/**
+ * Host-post attribution for a single identity element.
+ *
+ * @param {HTMLElement|null} el The element (or null).
+ * @return {number|null} The host page's post ID, or null when not stamped.
+ */
+function elementHostPostId( el ) {
+	const id = parseInt( el?.dataset?.hostPostId, 10 );
+	return id > 0 ? id : null;
+}
+
+/**
+ * Drain the buffered type=3 layer interactions and POST them, grouped by the
+ * effective video/image key. Mirrors the video bundle's flush, plus the image
+ * fallback in findVideoElementById above.
+ */
+function flushLayerInteractions() {
+	if ( shouldSkipAnalytics() ) {
+		bufferClearLayerInteractions();
+		return;
+	}
+
+	const buffer = bufferGetLayerInteractions();
+	const videoKeys = Object.keys( buffer );
+	if ( videoKeys.length === 0 ) {
+		return;
+	}
+
+	// The microservice enforces a max of 100 layer entries per request.
+	const MAX_PER_REQUEST = 100;
+
+	for ( const videoKey of videoKeys ) {
+		const events = Array.isArray( buffer[ videoKey ] ) ? buffer[ videoKey ] : [];
+		if ( events.length === 0 ) {
+			continue;
+		}
+
+		// videoKey is the WP attachment id (numeric) or the job_id.
+		const numericId = parseInt( videoKey, 10 );
+		const isNumeric = Number.isFinite( numericId ) && String( numericId ) === videoKey;
+
+		// Surface + host attribution rides along when the identity element is still
+		// in the DOM at flush time; best-effort, '' otherwise.
+		const flushVideoEl = isNumeric
+			? findVideoElementById( numericId )
+			: document.querySelector( `.video-js[data-job_id="${ videoKey }"]` );
+
+		for ( let i = 0; i < events.length; i += MAX_PER_REQUEST ) {
+			const chunk = events.slice( i, i + MAX_PER_REQUEST );
+			const { endpoint, body } = buildAnalyticsRequestBody( {
+				type: 3,
+				userToken: window.analytics?.user?.()?.anonymousId || '',
+				videoId: isNumeric ? numericId : 0,
+				jobId: isNumeric ? '' : videoKey,
+				layers: chunk,
+				blockSource: flushVideoEl?.dataset?.blockSource || '',
+				hostPostId: elementHostPostId( flushVideoEl ),
+			} );
+
+			if ( ! endpoint ) {
+				continue;
+			}
+
+			fetch( endpoint + '/analytics/', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify( body ),
+				keepalive: true,
+			} );
+		}
+	}
+
+	// Clear after dispatch (keepalive carries the requests even through teardown);
+	// re-sending on a later flush would double-count.
+	bufferClearLayerInteractions();
+}
+
+/**
+ * Register the layer buffer API and bind the page-hide flush listeners, once.
+ *
+ * Idempotent and non-destructive: an existing `window.GoDAM.addLayerInteraction`
+ * (registered by the video bundle) is left in place, and the flush listeners bind
+ * only once across all evaluations via `window.godamLayerFlushBound`.
+ */
+export function initLayerAnalytics() {
+	window.GoDAM = window.GoDAM || {};
+
+	// Register the buffer API only if the video bundle has not already done so, so
+	// the two bundles never install competing implementations on one page.
+	if ( typeof window.GoDAM.addLayerInteraction !== 'function' ) {
+		window.GoDAM.addLayerInteraction = bufferAddLayerInteraction;
+		window.GoDAM.getLayerInteractions = bufferGetLayerInteractions;
+		window.GoDAM.clearLayerInteractions = bufferClearLayerInteractions;
+		window.GoDAM.flushLayerInteractions = flushLayerInteractions;
+		window.GoDAM.findVideoElementById = findVideoElementById;
+		window.GoDAM.LAYER_ACTIONS = LAYER_ACTIONS;
+		window.GoDAM.LAYER_TYPE_WHITELIST = LAYER_TYPE_WHITELIST;
+		window.GoDAM.getLayerDisplayName = getLayerDisplayName;
+	}
+
+	if ( window.godamLayerFlushBound ) {
+		return;
+	}
+	window.godamLayerFlushBound = true;
+
+	const flush = () => {
+		try {
+			window.GoDAM?.flushLayerInteractions?.();
+		} catch ( e ) {
+			// Best-effort: a flush failure must never throw on unload.
+		}
+	};
+	const flushOnHidden = () => {
+		if ( document.visibilityState === 'hidden' ) {
+			flush();
+		}
+	};
+
+	window.addEventListener( 'beforeunload', flush );
+	window.addEventListener( 'pagehide', flush ); // Mobile / bfcache.
+	document.addEventListener( 'visibilitychange', flushOnHidden ); // Tab switch, minimize.
+}

--- a/assets/src/js/godam-player/layer-analytics-runtime.js
+++ b/assets/src/js/godam-player/layer-analytics-runtime.js
@@ -132,8 +132,11 @@ function flushLayerInteractions() {
  * Register the layer buffer API and bind the page-hide flush listeners, once.
  *
  * Idempotent and non-destructive: an existing `window.GoDAM.addLayerInteraction`
- * (registered by the video bundle) is left in place, and the flush listeners bind
- * only once across all evaluations via `window.godamLayerFlushBound`.
+ * (registered by the video bundle) is left in place, and THIS module binds its
+ * flush listeners at most once, guarded by `window.godamLayerFlushBound`. On a
+ * mixed video+image page the video bundle (`analytics.js`) also flushes the buffer
+ * from its own unload handler; that is harmless because `flushLayerInteractions`
+ * clears the buffer after dispatch, so the later flush is a no-op.
  */
 export function initLayerAnalytics() {
 	window.GoDAM = window.GoDAM || {};

--- a/assets/src/js/godam-player/layer-analytics-runtime.test.js
+++ b/assets/src/js/godam-player/layer-analytics-runtime.test.js
@@ -1,0 +1,71 @@
+/**
+ * Tests for the standalone layer-analytics runtime that image pages boot
+ * (no video player). Guards the two behaviours the image feature relies on:
+ * the findVideoElementById image fallback (so a still image resolves its
+ * data-block-source at flush) and initLayerAnalytics's idempotent registration
+ * plus single flush-listener bind.
+ */
+/**
+ * Internal dependencies
+ */
+import { initLayerAnalytics, findVideoElementById } from './layer-analytics-runtime';
+
+describe( 'findVideoElementById', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'resolves the video-js element by data-id', () => {
+		document.body.innerHTML = '<div class="easydam-player video-js" data-id="7"></div>';
+		expect( findVideoElementById( 7 )?.getAttribute( 'data-id' ) ).toBe( '7' );
+	} );
+
+	it( 'falls back to the image frame, so an image page can read its data-block-source', () => {
+		document.body.innerHTML =
+			'<div class="godam-image__frame" data-id="31" data-block-source="godam-image"></div>';
+		const el = findVideoElementById( 31 );
+		expect( el ).not.toBeNull();
+		expect( el.dataset.blockSource ).toBe( 'godam-image' );
+	} );
+
+	it( 'prefers the video element over an image frame sharing the id', () => {
+		document.body.innerHTML =
+			'<div class="godam-image__frame" data-id="9"></div><div class="video-js" data-id="9"></div>';
+		expect( findVideoElementById( 9 )?.classList.contains( 'video-js' ) ).toBe( true );
+	} );
+
+	it( 'returns null when neither is present', () => {
+		expect( findVideoElementById( 404 ) ).toBeNull();
+	} );
+} );
+
+describe( 'initLayerAnalytics', () => {
+	beforeEach( () => {
+		delete window.GoDAM;
+		delete window.godamLayerFlushBound;
+	} );
+
+	it( 'registers the buffer API when the video bundle has not', () => {
+		initLayerAnalytics();
+		expect( typeof window.GoDAM.addLayerInteraction ).toBe( 'function' );
+		expect( typeof window.GoDAM.flushLayerInteractions ).toBe( 'function' );
+	} );
+
+	it( 'does not overwrite an existing addLayerInteraction (video bundle wins)', () => {
+		const existing = jest.fn();
+		window.GoDAM = { addLayerInteraction: existing };
+		initLayerAnalytics();
+		expect( window.GoDAM.addLayerInteraction ).toBe( existing );
+	} );
+
+	it( 'binds the flush listeners only once across repeated calls', () => {
+		const spy = jest.spyOn( window, 'addEventListener' );
+		const count = () =>
+			spy.mock.calls.filter( ( [ e ] ) => e === 'pagehide' || e === 'beforeunload' ).length;
+		initLayerAnalytics();
+		expect( count() ).toBe( 2 ); // beforeunload + pagehide
+		initLayerAnalytics(); // godamLayerFlushBound already set -> no re-bind
+		expect( count() ).toBe( 2 );
+		spy.mockRestore();
+	} );
+} );

--- a/assets/src/js/godam-player/layer-analytics.js
+++ b/assets/src/js/godam-player/layer-analytics.js
@@ -1,0 +1,17 @@
+/**
+ * Standalone layer-analytics entry.
+ *
+ * For pages that carry hotspot layers but no video player, chiefly the GoDAM Image
+ * block with product hotspots. It registers the layer buffer API and the page-hide
+ * flush without loading the video-player analytics bundle. Video pages keep using
+ * `godam-player-analytics.min.js`, which registers the same API for themselves.
+ *
+ * @package
+ */
+
+/**
+ * Internal dependencies
+ */
+import { initLayerAnalytics } from './layer-analytics-runtime';
+
+initLayerAnalytics();

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -639,6 +639,15 @@ class Analytics extends Base {
 		);
 		$query_params = $this->append_range_params( $request, $query_params );
 
+		// Single store currency: pass the store base currency so the per-video
+		// record carries base-currency revenue (and a count of orders in other
+		// currencies). Only when WooCommerce is active; otherwise the service
+		// returns revenue 0 / '' and the card stays hidden.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$query_params['base_currency'] = $base_currency;
+		}
+
 		$analytics_url = add_query_arg( $query_params, $analytics_endpoint );
 
 		// Send request to analytics microservice.

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -851,6 +851,14 @@ class Analytics extends Base {
 				'api_key'       => $api_key,
 			)
 		);
+		// Single store currency: pass the store base currency so the service returns
+		// base-currency revenue plus a count of orders in other currencies (not
+		// converted). Only meaningful when WooCommerce is active; when absent the
+		// service simply omits the `revenue` object.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$params['base_currency'] = $base_currency;
+		}
 		$endpoint = add_query_arg(
 			$params,
 			RTGODAM_ANALYTICS_BASE . '/dashboard/metrics/fetch/'
@@ -1217,6 +1225,11 @@ class Analytics extends Base {
 		}
 		if ( ! empty( $order ) ) {
 			$query['order'] = $order;
+		}
+		// Single store currency: revenue/orders sum only the base currency.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$query['base_currency'] = $base_currency;
 		}
 
 		$endpoint = add_query_arg(

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -38,7 +38,12 @@ class Analytics extends Base {
 				'args'      => array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'fetch_analytics_data' ),
-					'permission_callback' => '__return_true', // Publicly accessible.
+					// Admin-dashboard read; gated like top-products/top-videos: Phase 2 added
+					// revenue to this response (it was public for view/play analytics only).
+					// Only the admin apps call it, never the public front end.
+					'permission_callback' => function () {
+						return current_user_can( 'upload_files' );
+					},
 					'args'                => array(
 						'video_id' => array(
 							'required'          => true,
@@ -90,7 +95,11 @@ class Analytics extends Base {
 				'args'      => array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'fetch_dashboard_metrics' ),
-					'permission_callback' => '__return_true',
+					// Admin-dashboard read; gated like the sibling analytics routes (revenue is
+					// account-scoped and returned to the dashboard only).
+					'permission_callback' => function () {
+						return current_user_can( 'upload_files' );
+					},
 					'args'                => array(
 						'site_url' => array(
 							'required'          => true,
@@ -234,7 +243,10 @@ class Analytics extends Base {
 					'callback'            => array( $this, 'fetch_placement_funnels' ),
 					// Account-scoped server-side (api_key / account_token injected,
 					// never client-supplied), like the sibling dashboard reads.
-					'permission_callback' => '__return_true',
+					// Admin-dashboard read; gated like the sibling analytics routes.
+					'permission_callback' => function () {
+						return current_user_can( 'upload_files' );
+					},
 					'args'                => array(
 						'site_url' => array(
 							'required'          => true,
@@ -256,7 +268,11 @@ class Analytics extends Base {
 					// return this site's own non-PII aggregate analytics. Locking down
 					// analytics reads, if ever wanted, should be done uniformly across
 					// all analytics routes rather than just this one.
-					'permission_callback' => '__return_true',
+					// Admin-dashboard read; gated uniformly with the sibling analytics routes
+					// (see note above): revenue must not be readable without auth.
+					'permission_callback' => function () {
+						return current_user_can( 'upload_files' );
+					},
 					'args'                => array(
 						'video_id'   => array(
 							'required'          => true,
@@ -514,10 +530,10 @@ class Analytics extends Base {
 	 * first 100 rows as a defensive bound on per-request DB work; rows past the
 	 * cap still get a constant-cost attributable label so none render blank.
 	 *
-	 * The /analytics/fetch route is public (permission_callback __return_true),
-	 * so this never leaks non-public pages (private, draft, pending, trashed) to
-	 * anonymous callers: the real title/permalink is revealed only when the page
-	 * is publicly viewable, or the current user can edit it.
+	 * The analytics read routes are gated on `upload_files` (authors and above),
+	 * but this still never leaks non-public pages (private, draft, pending,
+	 * trashed) beyond what the caller may see: the real title/permalink is
+	 * revealed only when the page is publicly viewable, or the caller can edit it.
 	 *
 	 * @param array $placements Placement rows from the microservice.
 	 * @return array Enriched placement rows.

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -220,6 +220,24 @@ class Analytics extends Base {
 			),
 			array(
 				'namespace' => $this->namespace,
+				'route'     => '/' . $this->rest_base . '/placement-funnels',
+				'args'      => array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'fetch_placement_funnels' ),
+					// Account-scoped server-side (api_key / account_token injected,
+					// never client-supplied), like the sibling dashboard reads.
+					'permission_callback' => '__return_true',
+					'args'                => array(
+						'site_url' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'esc_url_raw',
+						),
+					),
+				),
+			),
+			array(
+				'namespace' => $this->namespace,
 				'route'     => '/' . $this->rest_base . '/layer-analytics',
 				'args'      => array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -859,7 +877,7 @@ class Analytics extends Base {
 			);
 		}
 
-		$params   = $this->append_range_params(
+		$params = $this->append_range_params(
 			$request,
 			array(
 				'site_url'      => $site_url,
@@ -1189,6 +1207,77 @@ class Analytics extends Base {
 		}
 
 		return $ids;
+	}
+
+	/**
+	 * Proxy the per-placement funnel (the "Funnel by placement" card) from the
+	 * analytics microservice. Account-scoped server-side (api_key / account_token
+	 * injected, never client-supplied); the selected date range is forwarded.
+	 *
+	 * @param WP_REST_Request $request REST API request.
+	 * @return WP_REST_Response
+	 */
+	public function fetch_placement_funnels( WP_REST_Request $request ) {
+		$site_url      = $request->get_param( 'site_url' );
+		$account_token = get_option( 'rtgodam-account-token', 'unverified' );
+		$api_key       = get_option( 'rtgodam-api-key', '' );
+
+		if ( empty( $api_key ) || empty( $account_token ) || 'unverified' === $account_token ) {
+			return new WP_REST_Response(
+				array(
+					'status'    => 'error',
+					'message'   => __( 'Missing API key.', 'godam' ),
+					'errorType' => 'missing_key',
+				),
+				200
+			);
+		}
+
+		$params   = $this->append_range_params(
+			$request,
+			array(
+				'site_url'      => $site_url,
+				'account_token' => $account_token,
+				'api_key'       => $api_key,
+			)
+		);
+		$endpoint = add_query_arg(
+			$params,
+			RTGODAM_ANALYTICS_BASE . '/dashboard/placement-funnels/'
+		);
+
+		$response = wp_remote_get( $endpoint );
+		if ( is_wp_error( $response ) ) {
+			return new WP_REST_Response(
+				array(
+					'status'    => 'error',
+					'message'   => __( 'Unable to reach analytics server.', 'godam' ),
+					'errorType' => 'microservice_error',
+				),
+				200
+			);
+		}
+
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body      = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $http_code || ! is_array( $body ) ) {
+			$detail = ( is_array( $body ) && isset( $body['detail'] ) ) ? $body['detail'] : __( 'Unexpected error from analytics server.', 'godam' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => $detail,
+				),
+				200
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'placement_funnels' => $body['placement_funnels'] ?? array(),
+			),
+			200
+		);
 	}
 
 	/**

--- a/inc/classes/rest-api/class-analytics.php
+++ b/inc/classes/rest-api/class-analytics.php
@@ -408,6 +408,13 @@ class Analytics extends Base {
 		if ( ! empty( $job_id ) ) {
 			$query_params['job_id'] = $job_id;
 		}
+		// Single store currency: the service returns per-hotspot Direct revenue in
+		// this currency (Woo layers only); other currencies are excluded, not
+		// converted. Empty when WooCommerce is inactive, so the service omits it.
+		$base_currency = get_option( 'woocommerce_currency', '' );
+		if ( ! empty( $base_currency ) ) {
+			$query_params['base_currency'] = $base_currency;
+		}
 		$query_params = $this->append_range_params( $request, $query_params );
 
 		$endpoint = add_query_arg( $query_params, RTGODAM_ANALYTICS_BASE . '/processed-layer-analytics/' );

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -27,6 +27,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 import { Button, Spinner, Icon } from '@wordpress/components';
 import SingleMetrics from './SingleMetrics.js';
 import VideoToCartCard from './VideoToCartCard.js';
+import VideoToPurchaseCard from './VideoToPurchaseCard.js';
 import RevenueCard from './RevenueCard.js';
 import RevenueTips from './RevenueTips.js';
 import PlaysVsViewers from './PlaysVsViewers.js';
@@ -601,7 +602,7 @@ const Analytics = ( { attachmentID } ) => {
 										testIdPrefix="godam-video-insights-daterange"
 									/>
 								</div>
-								<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-row items-stretch flex-wrap justify-center lg:flex-nowrap">
+								<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-row items-stretch flex-wrap justify-center lg:flex-wrap lg:[&>*]:grow lg:[&>*]:basis-40">
 									<SingleMetrics
 										metricType={ 'engagement-rate' }
 										label={ __( 'Average Engagement', 'godam' ) }
@@ -638,6 +639,15 @@ const Analytics = ( { attachmentID } ) => {
 									{ isWoo && (
 										<VideoToCartCard
 											videoToCart={ rangedAnalyticsData?.video_to_cart }
+											dataLabel={ rangeLabel }
+										/>
+									) }
+
+									{ /* Video-to-Purchase: the purchase sibling of Video-to-Cart.
+									    Woo-gated; renders nothing when the payload is absent. */ }
+									{ isWoo && (
+										<VideoToPurchaseCard
+											videoToPurchase={ rangedAnalyticsData?.video_to_purchase }
 											dataLabel={ rangeLabel }
 										/>
 									) }

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -667,7 +667,7 @@ const Analytics = ( { attachmentID } ) => {
 							    split Direct/Assisted. Full-width card; Influenced is
 							    account-level so the per-video payload omits it and the
 							    card hides that box. Woo-gated. */ }
-							{ isWoo && rangedAnalyticsData?.revenue !== undefined && (
+							{ isWoo && rangedAnalyticsData?.revenue !== undefined && rangedAnalyticsData?.revenue !== null && (
 								<RevenueCard
 									revenue={ {
 										revenue_minor: rangedAnalyticsData.revenue,

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -693,6 +693,7 @@ const Analytics = ( { attachmentID } ) => {
 								<PurchaseFunnelCard
 									funnel={ rangedAnalyticsData?.video_funnel }
 									dataLabel={ rangeLabel }
+									scope="video"
 								/>
 							) }
 

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -30,6 +30,7 @@ import VideoToCartCard from './VideoToCartCard.js';
 import VideoToPurchaseCard from './VideoToPurchaseCard.js';
 import RevenueCard from './RevenueCard.js';
 import RevenueTips from './RevenueTips.js';
+import PurchaseFunnelCard from './PurchaseFunnelCard.js';
 import PlaysVsViewers from './PlaysVsViewers.js';
 import PlaybackPerformanceDashboard from './PlaybackPerformance.js';
 import VideoLayerTimeline from './VideoLayerTimeline.js';
@@ -683,6 +684,16 @@ const Analytics = ( { attachmentID } ) => {
 							    nothing when there is nothing worth saying. */ }
 							{ isWoo && rangedAnalyticsData?.revenue_tips && (
 								<RevenueTips tips={ rangedAnalyticsData.revenue_tips } />
+							) }
+
+							{ /* Purchase Funnel — Viewers -> Added to cart -> Purchased,
+							    a re-plot of the Insights counts. Woo-gated; renders
+							    nothing when the funnel payload is absent. */ }
+							{ isWoo && (
+								<PurchaseFunnelCard
+									funnel={ rangedAnalyticsData?.video_funnel }
+									dataLabel={ rangeLabel }
+								/>
 							) }
 
 							{ /* Viewer Retention Curve — standalone chart of per-second

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -27,6 +27,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 import { Button, Spinner, Icon } from '@wordpress/components';
 import SingleMetrics from './SingleMetrics.js';
 import VideoToCartCard from './VideoToCartCard.js';
+import RevenueCard from './RevenueCard.js';
 import PlaysVsViewers from './PlaysVsViewers.js';
 import PlaybackPerformanceDashboard from './PlaybackPerformance.js';
 import VideoLayerTimeline from './VideoLayerTimeline.js';
@@ -636,6 +637,22 @@ const Analytics = ( { attachmentID } ) => {
 									{ isWoo && (
 										<VideoToCartCard
 											videoToCart={ rangedAnalyticsData?.video_to_cart }
+											dataLabel={ rangeLabel }
+										/>
+									) }
+
+									{ /* Per-video revenue (single store currency). The
+									    record carries flat revenue/revenue_currency/
+									    revenue_excluded_orders keys; map them to the
+									    payload RevenueCard reads. Woo-gated; RevenueCard
+									    renders nothing when the keys are absent. */ }
+									{ isWoo && rangedAnalyticsData?.revenue !== undefined && (
+										<RevenueCard
+											revenue={ {
+												revenue_minor: rangedAnalyticsData.revenue,
+												currency: rangedAnalyticsData.revenue_currency,
+												excluded_orders: rangedAnalyticsData.revenue_excluded_orders,
+											} }
 											dataLabel={ rangeLabel }
 										/>
 									) }

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -28,6 +28,7 @@ import { Button, Spinner, Icon } from '@wordpress/components';
 import SingleMetrics from './SingleMetrics.js';
 import VideoToCartCard from './VideoToCartCard.js';
 import RevenueCard from './RevenueCard.js';
+import RevenueTips from './RevenueTips.js';
 import PlaysVsViewers from './PlaysVsViewers.js';
 import PlaybackPerformanceDashboard from './PlaybackPerformance.js';
 import VideoLayerTimeline from './VideoLayerTimeline.js';
@@ -666,6 +667,13 @@ const Analytics = ( { attachmentID } ) => {
 									/>
 								</div>
 							</div>
+
+							{ /* Comparative revenue tips (EASY WIN B), Woo-gated. The
+							    component renders only the favourable comparisons and
+							    nothing when there is nothing worth saying. */ }
+							{ isWoo && rangedAnalyticsData?.revenue_tips && (
+								<RevenueTips tips={ rangedAnalyticsData.revenue_tips } />
+							) }
 
 							{ /* Viewer Retention Curve — standalone chart of per-second
 							    viewer counts across the video timeline (converted from

--- a/pages/analytics/Analytics.js
+++ b/pages/analytics/Analytics.js
@@ -653,22 +653,6 @@ const Analytics = ( { attachmentID } ) => {
 										/>
 									) }
 
-									{ /* Per-video revenue (single store currency). The
-									    record carries flat revenue/revenue_currency/
-									    revenue_excluded_orders keys; map them to the
-									    payload RevenueCard reads. Woo-gated; RevenueCard
-									    renders nothing when the keys are absent. */ }
-									{ isWoo && rangedAnalyticsData?.revenue !== undefined && (
-										<RevenueCard
-											revenue={ {
-												revenue_minor: rangedAnalyticsData.revenue,
-												currency: rangedAnalyticsData.revenue_currency,
-												excluded_orders: rangedAnalyticsData.revenue_excluded_orders,
-											} }
-											dataLabel={ rangeLabel }
-										/>
-									) }
-
 									<PlaysVsViewers
 										plays={ rangedAnalyticsData?.plays ?? 0 }
 										uniqueViewers={ rangedAnalyticsData?.unique_viewers ?? null }
@@ -678,6 +662,23 @@ const Analytics = ( { attachmentID } ) => {
 									/>
 								</div>
 							</div>
+
+							{ /* Per-video Video-Attributed Revenue (single store currency),
+							    split Direct/Assisted. Full-width card; Influenced is
+							    account-level so the per-video payload omits it and the
+							    card hides that box. Woo-gated. */ }
+							{ isWoo && rangedAnalyticsData?.revenue !== undefined && (
+								<RevenueCard
+									revenue={ {
+										revenue_minor: rangedAnalyticsData.revenue,
+										currency: rangedAnalyticsData.revenue_currency,
+										excluded_orders: rangedAnalyticsData.revenue_excluded_orders,
+										direct_minor: rangedAnalyticsData.revenue_direct_minor,
+										assisted_minor: rangedAnalyticsData.revenue_assisted_minor,
+									} }
+									dataLabel={ rangeLabel }
+								/>
+							) }
 
 							{ /* Comparative revenue tips (EASY WIN B), Woo-gated. The
 							    component renders only the favourable comparisons and

--- a/pages/analytics/MetricTrend.js
+++ b/pages/analytics/MetricTrend.js
@@ -31,12 +31,22 @@ export default function MetricTrend( { change, deltaLabel, dataLabel, testId } )
 		) : null;
 	}
 
-	const positive = change >= 0;
+	// Exactly 0% is flat, not growth: render it neutral (grey, flat arrow) so a
+	// static metric is never shown as green upward movement.
+	let trendColor = 'text-zinc-500';
+	let trendArrow = '→';
+	if ( change > 0 ) {
+		trendColor = 'text-[#15803D]';
+		trendArrow = '↗';
+	} else if ( change < 0 ) {
+		trendColor = 'text-[#B91C1C]';
+		trendArrow = '↘';
+	}
 
 	return (
 		<div className="flex items-center flex-wrap gap-x-1.5 gap-y-0.5" data-test-id={ testId }>
-			<span className={ `text-xs font-semibold whitespace-nowrap ${ positive ? 'text-[#15803D]' : 'text-[#B91C1C]' }` }>
-				{ `${ positive ? '↗' : '↘' } ${ Math.abs( change ).toFixed( 2 ) }%` }
+			<span className={ `text-xs font-semibold whitespace-nowrap ${ trendColor }` }>
+				{ `${ trendArrow } ${ Math.abs( change ).toFixed( 2 ) }%` }
 			</span>
 			<span className="text-[11px] text-zinc-400 whitespace-nowrap">
 				{ deltaLabel || __( 'vs prev period', 'godam' ) }

--- a/pages/analytics/MetricTrend.js
+++ b/pages/analytics/MetricTrend.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The bottom row of a metric card: a period-over-period trend badge when there is
+ * a change to show, otherwise the active range sub-label. Matches the SingleMetrics
+ * badge (green up / red down arrow, coloured %, muted "vs prev" label) so every
+ * card reads the same.
+ *
+ * The server only sends a `change` on a fully bounded range (all-time and
+ * open-ended ranges have no comparison window), so the badge appears only then and
+ * the card falls back to the range label otherwise.
+ *
+ * @param {Object}      props
+ * @param {number|null} [props.change]     Percentage change vs the previous window, or null/undefined for none.
+ * @param {string}      [props.deltaLabel] Label beside the badge, e.g. "vs previous 7 days".
+ * @param {string}      [props.dataLabel]  Fallback range label, e.g. "All time".
+ * @param {string}      [props.testId]     Optional data-test-id for the badge.
+ */
+export default function MetricTrend( { change, deltaLabel, dataLabel, testId } ) {
+	const hasChange = change !== null && change !== undefined;
+
+	if ( ! hasChange ) {
+		// No comparison window: show the range label if the caller wants one (the
+		// KPI tiles do), otherwise render nothing (the revenue card supplies its own
+		// "before refunds" line beside this).
+		return dataLabel ? (
+			<span className="text-[11px] text-zinc-400">{ dataLabel }</span>
+		) : null;
+	}
+
+	const positive = change >= 0;
+
+	return (
+		<div className="flex items-center flex-wrap gap-x-1.5 gap-y-0.5" data-test-id={ testId }>
+			<span className={ `text-xs font-semibold whitespace-nowrap ${ positive ? 'text-[#15803D]' : 'text-[#B91C1C]' }` }>
+				{ `${ positive ? '↗' : '↘' } ${ Math.abs( change ).toFixed( 2 ) }%` }
+			</span>
+			<span className="text-[11px] text-zinc-400 whitespace-nowrap">
+				{ deltaLabel || __( 'vs prev period', 'godam' ) }
+			</span>
+		</div>
+	);
+}

--- a/pages/analytics/MetricTrend.test.js
+++ b/pages/analytics/MetricTrend.test.js
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for MetricTrend — the metric-card footer that shows a trend badge
+ * when there is a period-over-period change, and otherwise the range label (or
+ * nothing when the caller supplies neither).
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import MetricTrend from './MetricTrend';
+
+describe( 'MetricTrend', () => {
+	it( 'shows an up arrow and green colour for a positive change', () => {
+		const html = renderToString(
+			<MetricTrend change={ 12.4 } deltaLabel="vs previous 7 days" />,
+		);
+		expect( html ).toContain( '↗' );
+		expect( html ).toContain( '12.40%' );
+		expect( html ).toContain( 'vs previous 7 days' );
+		expect( html ).toContain( '#15803D' ); // green
+	} );
+
+	it( 'shows a down arrow and red colour for a negative change', () => {
+		const html = renderToString( <MetricTrend change={ -8 } deltaLabel="vs previous 7 days" /> );
+		expect( html ).toContain( '↘' );
+		expect( html ).toContain( '8.00%' );
+		expect( html ).toContain( '#B91C1C' ); // red
+	} );
+
+	it( 'falls back to the range label when there is no change (KPI tiles)', () => {
+		const html = renderToString( <MetricTrend change={ null } dataLabel="All time" /> );
+		expect( html ).toContain( 'All time' );
+		expect( html ).not.toContain( '↗' );
+		expect( html ).not.toContain( '↘' );
+	} );
+
+	it( 'renders nothing when there is neither a change nor a range label (revenue card)', () => {
+		expect( renderToString( <MetricTrend change={ undefined } /> ) ).toBe( '' );
+	} );
+} );

--- a/pages/analytics/MetricTrend.test.js
+++ b/pages/analytics/MetricTrend.test.js
@@ -34,6 +34,14 @@ describe( 'MetricTrend', () => {
 		expect( html ).toContain( '#B91C1C' ); // red
 	} );
 
+	it( 'shows a flat neutral badge for exactly 0%, not green growth', () => {
+		const html = renderToString( <MetricTrend change={ 0 } deltaLabel="vs previous 7 days" /> );
+		expect( html ).toContain( '→' ); // flat arrow
+		expect( html ).toContain( '0.00%' );
+		expect( html ).not.toContain( '↗' ); // not an up arrow
+		expect( html ).not.toContain( '#15803D' ); // not green
+	} );
+
 	it( 'falls back to the range label when there is no change (KPI tiles)', () => {
 		const html = renderToString( <MetricTrend change={ null } dataLabel="All time" /> );
 		expect( html ).toContain( 'All time' );

--- a/pages/analytics/PlacementFunnelCard.js
+++ b/pages/analytics/PlacementFunnelCard.js
@@ -93,10 +93,37 @@ function PlacementRow( { placement } ) {
 export default function PlacementFunnelCard( { siteUrl, startDate, endDate, dataLabel } ) {
 	const { data, isFetching } = useFetchPlacementFunnelsQuery( { siteUrl, startDate, endDate } );
 	const placements = Array.isArray( data ) ? data : [];
+	// A microservice error comes back as an { error, message } object, which is
+	// NOT the same as "no placement activity" -- surface it rather than hiding.
+	const isError = !! ( data && ! Array.isArray( data ) && data.error );
 
-	// Once loaded, a store with no placement activity shows nothing.
-	if ( ! isFetching && placements.length === 0 ) {
+	// Once loaded, a store with genuinely no placement activity shows nothing; an
+	// error is not "empty", so keep the card to show the message below.
+	if ( ! isFetching && ! isError && placements.length === 0 ) {
 		return null;
+	}
+
+	let body;
+	if ( isError ) {
+		body = (
+			<div className="text-[13px] text-[#B91C1C] py-6 text-center" data-test-id="godam-placement-funnel-error">
+				{ __( 'Could not load placement data. Please try again.', 'godam' ) }
+			</div>
+		);
+	} else if ( isFetching && placements.length === 0 ) {
+		body = (
+			<div className="text-[13px] text-zinc-400 py-6 text-center" data-test-id="godam-placement-funnel-loading">
+				{ __( 'Loading placements…', 'godam' ) }
+			</div>
+		);
+	} else {
+		body = (
+			<div className="flex flex-col gap-4">
+				{ placements.map( ( placement ) => (
+					<PlacementRow key={ placement.block_source } placement={ placement } />
+				) ) }
+			</div>
+		);
 	}
 
 	return (
@@ -116,17 +143,7 @@ export default function PlacementFunnelCard( { siteUrl, startDate, endDate, data
 				{ __( 'Different placements do different jobs, so averaging them hides both winners and losers.', 'godam' ) }
 			</p>
 
-			{ isFetching && placements.length === 0 ? (
-				<div className="text-[13px] text-zinc-400 py-6 text-center" data-test-id="godam-placement-funnel-loading">
-					{ __( 'Loading placements…', 'godam' ) }
-				</div>
-			) : (
-				<div className="flex flex-col gap-4">
-					{ placements.map( ( placement ) => (
-						<PlacementRow key={ placement.block_source } placement={ placement } />
-					) ) }
-				</div>
-			) }
+			{ body }
 		</div>
 	);
 }

--- a/pages/analytics/PlacementFunnelCard.js
+++ b/pages/analytics/PlacementFunnelCard.js
@@ -1,0 +1,132 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useFetchPlacementFunnelsQuery } from '../dashboard/redux/api/dashboardAnalyticsApi';
+
+const fmt = ( n ) => Number( n || 0 ).toLocaleString();
+const pct = ( n ) => `${ Number( n || 0 ).toFixed( 1 ) }%`;
+
+/**
+ * One Played / Added / Purchased number box.
+ *
+ * @param {Object} props
+ * @param {string} props.label The stat name.
+ * @param {number} props.count The count.
+ * @param {string} [props.sub] A sub-label (e.g. the % of players).
+ */
+function StatBox( { label, count, sub } ) {
+	return (
+		<div className="flex-1 min-w-[120px] border border-[#e4e4e7] rounded-lg px-4 py-3 bg-white">
+			<div className="text-[13px] text-zinc-500 mb-1">{ label }</div>
+			<div className="flex items-baseline gap-2">
+				<span className="text-[26px] font-bold text-[#1e1e1e] tabular-nums leading-none">{ fmt( count ) }</span>
+				{ sub && <span className="text-[13px] text-zinc-500">{ sub }</span> }
+			</div>
+		</div>
+	);
+}
+
+/**
+ * One placement's funnel: a header (name, reach, play-to-purchase rate) and the
+ * three Played -> Added -> Purchased number boxes.
+ *
+ * @param {Object} props
+ * @param {Object} props.placement A placement_funnels entry.
+ */
+function PlacementRow( { placement } ) {
+	const reach = [];
+	if ( placement.units !== null && placement.units !== undefined && placement.unit_label ) {
+		reach.push( `${ fmt( placement.units ) } ${ placement.unit_label }` );
+	}
+	reach.push( sprintf(
+		/* translators: %s: number of videos. */
+		_n( '%s video', '%s videos', placement.videos, 'godam' ),
+		fmt( placement.videos ),
+	) );
+
+	return (
+		<div
+			className="border border-[#e4e4e7] rounded-xl p-4 bg-[#fbfbfc]"
+			data-test-id={ `godam-placement-funnel-${ placement.block_source }` }
+		>
+			<div className="flex items-center justify-between flex-wrap gap-2 mb-3">
+				<div className="flex items-baseline gap-2.5">
+					<span className="text-[15px] font-semibold text-[#1e1e1e]">{ placement.label }</span>
+					<span className="text-[13px] text-zinc-500">{ reach.join( ' · ' ) }</span>
+				</div>
+				<span className="text-[13px] text-zinc-600">
+					{ sprintf(
+						/* translators: %s: play-to-purchase conversion rate. */
+						__( 'Play to purchase %s', 'godam' ),
+						pct( placement.purchase_rate ),
+					) }
+				</span>
+			</div>
+			<div className="flex flex-wrap gap-3">
+				<StatBox label={ __( 'Played', 'godam' ) } count={ placement.played } />
+				<StatBox label={ __( 'Added to cart', 'godam' ) } count={ placement.added } sub={ pct( placement.add_rate ) } />
+				<StatBox label={ __( 'Purchased', 'godam' ) } count={ placement.purchased } sub={ pct( placement.purchase_rate ) } />
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Funnel by placement.
+ *
+ * A Play-to-Cart-to-Purchase funnel broken out per commerce placement (Shoppable
+ * Video block / Woo hotspot layer / Reel Pop), so a strong placement is not
+ * hidden by a weak one in the account-wide average. Fetches its own data (the
+ * per-placement queries are heavier, so they don't block the main dashboard).
+ *
+ * @param {Object} props
+ * @param {string} props.siteUrl     The site URL.
+ * @param {string} [props.startDate] ISO range start.
+ * @param {string} [props.endDate]   ISO range end.
+ * @param {string} [props.dataLabel] The active range label (e.g. "Last 30 days").
+ */
+export default function PlacementFunnelCard( { siteUrl, startDate, endDate, dataLabel } ) {
+	const { data, isFetching } = useFetchPlacementFunnelsQuery( { siteUrl, startDate, endDate } );
+	const placements = Array.isArray( data ) ? data : [];
+
+	// Once loaded, a store with no placement activity shows nothing.
+	if ( ! isFetching && placements.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="godam-card godam-placement-funnel-card" data-test-id="godam-placement-funnel-card">
+			<div className="godam-card__head">
+				<div className="flex items-center gap-2.5">
+					<h2>{ __( 'Funnel by placement', 'godam' ) }</h2>
+					<span className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]">Woo</span>
+					<span className="text-[10px] font-bold leading-none px-1.5 py-0.5 rounded bg-[#FEF3C7] text-[#92400E] tracking-wide">{ __( 'NEW', 'godam' ) }</span>
+				</div>
+				{ dataLabel && (
+					<span className="text-[13px] text-[#50575e] border border-[#e2e4e7] rounded-md px-3 py-1">{ dataLabel }</span>
+				) }
+			</div>
+
+			<p className="text-[13px] text-zinc-500 -mt-1 mb-5">
+				{ __( 'Different placements do different jobs, so averaging them hides both winners and losers.', 'godam' ) }
+			</p>
+
+			{ isFetching && placements.length === 0 ? (
+				<div className="text-[13px] text-zinc-400 py-6 text-center" data-test-id="godam-placement-funnel-loading">
+					{ __( 'Loading placements…', 'godam' ) }
+				</div>
+			) : (
+				<div className="flex flex-col gap-4">
+					{ placements.map( ( placement ) => (
+						<PlacementRow key={ placement.block_source } placement={ placement } />
+					) ) }
+				</div>
+			) }
+		</div>
+	);
+}

--- a/pages/analytics/PlacementFunnelCard.test.js
+++ b/pages/analytics/PlacementFunnelCard.test.js
@@ -62,4 +62,12 @@ describe( 'PlacementFunnelCard', () => {
 		const html = renderToString( <PlacementFunnelCard siteUrl="x" /> );
 		expect( html ).toContain( 'godam-placement-funnel-loading' );
 	} );
+
+	it( 'surfaces a service error instead of rendering it as an empty store', () => {
+		useFetchPlacementFunnelsQuery.mockReturnValue( { data: { error: true, message: 'boom' }, isFetching: false } );
+		const html = renderToString( <PlacementFunnelCard siteUrl="x" /> );
+		expect( html ).not.toBe( '' ); // not silently hidden like a store with no placements
+		expect( html ).toContain( 'godam-placement-funnel-error' );
+		expect( html ).toContain( 'Could not load placement data' );
+	} );
 } );

--- a/pages/analytics/PlacementFunnelCard.test.js
+++ b/pages/analytics/PlacementFunnelCard.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the Funnel by placement card.
+ *
+ * Mocks the placement-funnels query and asserts the card renders one funnel per
+ * placement with its counts, reach and play-to-purchase rate, a loading state,
+ * and nothing when a loaded store has no placement activity.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+jest.mock( '../dashboard/redux/api/dashboardAnalyticsApi', () => ( {
+	useFetchPlacementFunnelsQuery: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { useFetchPlacementFunnelsQuery } from '../dashboard/redux/api/dashboardAnalyticsApi';
+import PlacementFunnelCard from './PlacementFunnelCard';
+
+const DATA = [
+	{ block_source: 'shoppable-video', label: 'Shoppable Video block', played: 612, added: 49, purchased: 21, add_rate: 8.0, purchase_rate: 3.4, videos: 14, units: null, unit_label: null },
+	{ block_source: 'woo-layer', label: 'Woo hotspot layer', played: 488, added: 14, purchased: 6, add_rate: 2.9, purchase_rate: 1.2, videos: 9, units: 22, unit_label: 'layers' },
+	{ block_source: 'reel-pop', label: 'Reel Pop', played: 312, added: 1, purchased: 0, add_rate: 0.3, purchase_rate: 0, videos: 2, units: 3, unit_label: 'reel pops' },
+];
+
+describe( 'PlacementFunnelCard', () => {
+	it( 'renders nothing when a loaded store has no placements', () => {
+		useFetchPlacementFunnelsQuery.mockReturnValue( { data: [], isFetching: false } );
+		expect( renderToString( <PlacementFunnelCard siteUrl="x" /> ) ).toBe( '' );
+	} );
+
+	it( 'renders a funnel per placement with counts, reach and rate', () => {
+		useFetchPlacementFunnelsQuery.mockReturnValue( { data: DATA, isFetching: false } );
+		const html = renderToString( <PlacementFunnelCard siteUrl="x" dataLabel="Last 30 days" /> );
+		expect( html ).toContain( 'godam-placement-funnel-card' );
+		expect( html ).toContain( 'Funnel by placement' );
+		expect( html ).toContain( 'Last 30 days' );
+		// Each placement, its counts and per-placement box.
+		expect( html ).toContain( 'Shoppable Video block' );
+		expect( html ).toContain( '612' );
+		expect( html ).toContain( '49' );
+		expect( html ).toContain( '21' );
+		expect( html ).toContain( 'godam-placement-funnel-shoppable-video' );
+		expect( html ).toContain( 'godam-placement-funnel-woo-layer' );
+		expect( html ).toContain( 'godam-placement-funnel-reel-pop' );
+		// Play-to-purchase rate.
+		expect( html ).toContain( 'Play to purchase 3.4%' );
+		// Reach labels: units + videos, or just videos when there is no unit count.
+		expect( html ).toContain( '22 layers · 9 videos' );
+		expect( html ).toContain( '3 reel pops · 2 videos' );
+		expect( html ).toContain( '14 videos' ); // Shoppable has no per-block id
+	} );
+
+	it( 'shows a loading state while fetching with no data yet', () => {
+		useFetchPlacementFunnelsQuery.mockReturnValue( { data: undefined, isFetching: true } );
+		const html = renderToString( <PlacementFunnelCard siteUrl="x" /> );
+		expect( html ).toContain( 'godam-placement-funnel-loading' );
+	} );
+} );

--- a/pages/analytics/PurchaseFunnelCard.js
+++ b/pages/analytics/PurchaseFunnelCard.js
@@ -132,7 +132,7 @@ export default function PurchaseFunnelCard( { funnel, dataLabel, scope = 'accoun
 		<div className="godam-card godam-funnel-card" data-test-id="godam-purchase-funnel-card">
 			<div className="godam-card__head">
 				<div className="flex items-center gap-2.5">
-					<h2>{ __( 'Play to Cart to Purchase', 'godam' ) }</h2>
+					<h2>{ __( 'Purchase Funnel', 'godam' ) }</h2>
 					<span className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]">Woo</span>
 					<span className="text-[10px] font-bold leading-none px-1.5 py-0.5 rounded bg-[#FEF3C7] text-[#92400E] tracking-wide">{ __( 'NEW', 'godam' ) }</span>
 				</div>

--- a/pages/analytics/PurchaseFunnelCard.js
+++ b/pages/analytics/PurchaseFunnelCard.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+const STAGE_LABELS = {
+	viewers: __( 'Viewers', 'godam' ),
+	added_to_cart: __( 'Added to cart', 'godam' ),
+	purchased: __( 'Purchased', 'godam' ),
+};
+
+// Woo purple at the top of the funnel, easing to GoDAM pink at the purchase end.
+const BAR_BACKGROUNDS = {
+	viewers: 'linear-gradient(90deg, #8b5fc0, #7f54b3)',
+	added_to_cart: 'linear-gradient(90deg, #9a6fca, #8a5cc0)',
+	purchased: 'linear-gradient(90deg, #ab3a6c, #95305d)',
+};
+
+/**
+ * Per-video Purchase Funnel.
+ *
+ * The three distinct-visitor stages a shopper passes through — Viewers -> Added
+ * to cart -> Purchased — each bar proportional to its share of viewers, with the
+ * drop-off between stages called out. A "still counting" note appears when the
+ * selected range is recent enough that purchase attribution is still settling
+ * (the backend decides that; the card only toggles the note).
+ *
+ * @param {Object} props
+ * @param {Object} [props.funnel]    The video_funnel payload { stages, still_counting }.
+ * @param {string} [props.dataLabel] The active range label (e.g. "Last 7 days").
+ */
+export default function PurchaseFunnelCard( { funnel, dataLabel } ) {
+	// Render nothing when the payload is absent (an analytics service that predates
+	// the funnel read), so the card never asserts a misleading empty funnel.
+	if ( ! funnel || ! Array.isArray( funnel.stages ) || funnel.stages.length === 0 ) {
+		return null;
+	}
+
+	const { stages } = funnel;
+
+	return (
+		<div className="godam-card godam-funnel-card" data-test-id="godam-purchase-funnel-card">
+			<div className="godam-card__head">
+				<h2>{ __( 'Purchase Funnel', 'godam' ) }</h2>
+				<span className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]">Woo</span>
+			</div>
+
+			<div className="godam-funnel flex flex-col" data-test-id="godam-purchase-funnel">
+				{ stages.map( ( stage, i ) => {
+					const count = Number( stage.count || 0 );
+					const rate = Math.max( 0, Math.min( 100, Number( stage.rate || 0 ) ) );
+					const prevCount = i > 0 ? Number( stages[ i - 1 ].count || 0 ) : null;
+					const drop = prevCount && prevCount > 0
+						? Math.round( ( 1 - ( count / prevCount ) ) * 100 )
+						: null;
+					// Keep a thin sliver visible so a 0% stage still reads as a bar.
+					const barWidth = Math.max( rate, count > 0 ? 6 : 2 );
+
+					return (
+						<div key={ stage.key } className="godam-funnel__stage">
+							{ i > 0 && (
+								<div
+									className="godam-funnel__drop text-[11px] text-zinc-400 text-center py-1.5"
+									data-test-id="godam-purchase-funnel-drop"
+								>
+									{ drop !== null && drop > 0
+										? sprintf(
+											/* translators: %d: drop-off percentage between funnel stages. */
+											__( '▼ %d%% drop-off', 'godam' ),
+											drop,
+										)
+										: __( 'no drop-off', 'godam' ) }
+								</div>
+							) }
+
+							<div className="flex items-baseline justify-between mb-1.5">
+								<span className="text-sm font-semibold text-[#1e1e1e]">
+									{ STAGE_LABELS[ stage.key ] || stage.key }
+								</span>
+								<span className="text-xs text-zinc-500" data-test-id={ `godam-purchase-funnel-share-${ stage.key }` }>
+									{ sprintf(
+										/* translators: 1: visitor count, 2: percentage of viewers. */
+										__( '%1$s · %2$s%% of viewers', 'godam' ),
+										count.toLocaleString(),
+										rate.toFixed( rate % 1 ? 1 : 0 ),
+									) }
+								</span>
+							</div>
+
+							<div className="godam-funnel__track w-full flex justify-center">
+								<div
+									className="godam-funnel__bar h-12 rounded-md flex items-center justify-center text-white font-bold text-lg"
+									style={ { width: `${ barWidth }%`, background: BAR_BACKGROUNDS[ stage.key ] || '#7f54b3' } }
+									data-test-id={ `godam-purchase-funnel-bar-${ stage.key }` }
+								>
+									{ count.toLocaleString() }
+								</div>
+							</div>
+						</div>
+					);
+				} ) }
+			</div>
+
+			{ funnel.still_counting && (
+				<div
+					className="godam-funnel__note mt-4 inline-flex items-center gap-2 text-[13px] text-[#0a7f2e] bg-[#0a7f2e]/10 border border-[#0a7f2e]/20 rounded-lg px-3 py-2"
+					data-test-id="godam-purchase-funnel-still-counting"
+				>
+					<span className="w-2 h-2 rounded-full bg-[#0a7f2e]" aria-hidden="true" />
+					{ sprintf(
+						/* translators: %s: the selected date range label. */
+						__( 'Still counting — purchases for %s keep settling for up to 30 days.', 'godam' ),
+						dataLabel || __( 'this range', 'godam' ),
+					) }
+				</div>
+			) }
+		</div>
+	);
+}

--- a/pages/analytics/PurchaseFunnelCard.js
+++ b/pages/analytics/PurchaseFunnelCard.js
@@ -106,12 +106,18 @@ export default function PurchaseFunnelCard( { funnel, dataLabel, scope = 'accoun
 	const purchased = Number( byKey.purchased?.count || 0 );
 
 	// Bar segments are fractions of the track, denominated by players (the top).
-	const frac = ( n ) => ( played > 0 ? n / played : 0 );
+	// Clamp to [0,1] so a stale-service deploy skew can never invert the funnel
+	// (the backend range_video_funnel already guarantees purchased <= added <= played).
+	const frac = ( n ) => ( played > 0 ? Math.max( 0, Math.min( 1, n / played ) ) : 0 );
 	// Assisted-only = added but not in-video, so direct + assistedOnly = carts.
 	const assistedOnly = Math.max( 0, carts - direct );
 
 	const cartAdvanced = played > 0 ? pct( ( carts / played ) * 100 ) : pct( 0 );
-	const buyAdvanced = carts > 0 ? pct( ( purchased / carts ) * 100 ) : pct( 0 );
+	// cart -> purchase conversion, drop annotation only; clamp to 100%.
+	const buyAdvanced = carts > 0 ? pct( Math.min( ( purchased / carts ) * 100, 100 ) ) : pct( 0 );
+	// purchased as a share OF PLAYERS (bar + server stage rate denominator),
+	// for the Purchased row's "of players" subtitle — NOT purchased/carts.
+	const buyShare = played > 0 ? pct( ( purchased / played ) * 100 ) : pct( 0 );
 	const didNotAdd = Math.max( 0, played - carts );
 	const abandoned = Math.max( 0, carts - purchased );
 
@@ -180,13 +186,13 @@ export default function PurchaseFunnelCard( { funnel, dataLabel, scope = 'accoun
 				/>
 				<FunnelRow
 					label={ __( 'Purchased', 'godam' ) }
-					descriptor={ __( 'net of refunds', 'godam' ) }
+					descriptor={ __( 'of those who added', 'godam' ) }
 					segments={ purchased > 0 ? [ { color: COLOR_DIRECT, frac: frac( purchased ) } ] : [] }
 					count={ purchased }
 					rightSub={ sprintf(
 						/* translators: %s: percentage of players. */
 						__( '%s of players', 'godam' ),
-						buyAdvanced,
+						buyShare,
 					) }
 					testId="godam-purchase-funnel-bar-purchased"
 				/>

--- a/pages/analytics/PurchaseFunnelCard.js
+++ b/pages/analytics/PurchaseFunnelCard.js
@@ -112,7 +112,9 @@ export default function PurchaseFunnelCard( { funnel, dataLabel, scope = 'accoun
 	// Assisted-only = added but not in-video, so direct + assistedOnly = carts.
 	const assistedOnly = Math.max( 0, carts - direct );
 
-	const cartAdvanced = played > 0 ? pct( ( carts / played ) * 100 ) : pct( 0 );
+	// Clamp to 100% like buyAdvanced below: a stale-service skew (carts > played)
+	// must not print an above-100% "advanced" annotation.
+	const cartAdvanced = played > 0 ? pct( Math.min( ( carts / played ) * 100, 100 ) ) : pct( 0 );
 	// cart -> purchase conversion, drop annotation only; clamp to 100%.
 	const buyAdvanced = carts > 0 ? pct( Math.min( ( purchased / carts ) * 100, 100 ) ) : pct( 0 );
 	// purchased as a share OF PLAYERS (bar + server stage rate denominator),

--- a/pages/analytics/PurchaseFunnelCard.js
+++ b/pages/analytics/PurchaseFunnelCard.js
@@ -3,102 +3,199 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 
-const STAGE_LABELS = {
-	viewers: __( 'Viewers', 'godam' ),
-	added_to_cart: __( 'Added to cart', 'godam' ),
-	purchased: __( 'Purchased', 'godam' ),
-};
+// Direct = added in-video (dark blue); Assisted = clicked out then added (light
+// blue); the rest of each track stays grey ("did not reach this stage").
+const COLOR_DIRECT = '#2563eb';
+const COLOR_ASSISTED = '#93c5fd';
 
-// Woo purple at the top of the funnel, easing to GoDAM pink at the purchase end.
-const BAR_BACKGROUNDS = {
-	viewers: 'linear-gradient(90deg, #8b5fc0, #7f54b3)',
-	added_to_cart: 'linear-gradient(90deg, #9a6fca, #8a5cc0)',
-	purchased: 'linear-gradient(90deg, #ab3a6c, #95305d)',
-};
+const fmt = ( n ) => Number( n || 0 ).toLocaleString();
+const pct = ( n ) => `${ Number( n || 0 ).toFixed( 1 ) }%`;
 
 /**
- * Per-video Purchase Funnel.
+ * A single funnel row: label + descriptor on the left, a proportional bar in a
+ * grey track (split into coloured segments), and the count + sub-label on the right.
  *
- * The three distinct-visitor stages a shopper passes through — Viewers -> Added
- * to cart -> Purchased — each bar proportional to its share of viewers, with the
- * drop-off between stages called out. A "still counting" note appears when the
- * selected range is recent enough that purchase attribution is still settling
- * (the backend decides that; the card only toggles the note).
+ * @param {Object} props
+ * @param {string} props.label      Stage name.
+ * @param {string} props.descriptor Grey sub-label under the stage name.
+ * @param {Array}  props.segments   [{ color, frac }] left-aligned bar segments (frac of the track).
+ * @param {number} props.count      The stage count.
+ * @param {string} props.rightSub   The sub-label under the count (e.g. "4.5% of players").
+ * @param {string} props.testId     data-test-id for the bar.
+ */
+function FunnelRow( { label, descriptor, segments, count, rightSub, testId } ) {
+	return (
+		<div className="grid grid-cols-[minmax(150px,210px)_1fr_minmax(88px,auto)] items-center gap-x-5">
+			<div>
+				<div className="text-[15px] font-semibold text-[#1e1e1e] leading-tight">{ label }</div>
+				<div className="text-[13px] text-zinc-500 leading-tight">{ descriptor }</div>
+			</div>
+			<div className="h-14 rounded-md overflow-hidden flex" style={ { background: '#eef0f3' } } data-test-id={ testId }>
+				{ segments.map( ( seg, i ) => (
+					<div
+						key={ i }
+						style={ { width: `${ Math.max( 0, Math.min( 100, seg.frac * 100 ) ) }%`, background: seg.color } }
+					/>
+				) ) }
+			</div>
+			<div className="text-right">
+				<div className="text-[28px] font-bold text-[#1e1e1e] leading-none tabular-nums">{ fmt( count ) }</div>
+				<div className="text-[13px] text-zinc-500 mt-1">{ rightSub }</div>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * The drop-off annotation between two stages: "X% advanced" plus how many were
+ * lost, indented to sit under the bar.
+ *
+ * @param {Object}  props
+ * @param {string}  props.advanced        The "X% advanced" percentage string.
+ * @param {string}  props.lostLabel       Text for how many were lost at this step.
+ * @param {boolean} [props.lostIsWarning] Render the lost label as a red pill.
+ */
+function DropRow( { advanced, lostLabel, lostIsWarning } ) {
+	return (
+		<div className="grid grid-cols-[minmax(150px,210px)_1fr_minmax(88px,auto)] gap-x-5">
+			<div />
+			<div className="flex items-center gap-3 py-2 text-[13px]">
+				<span className="font-semibold text-[#1e1e1e]">
+					{ sprintf(
+						/* translators: %s: percentage of visitors that advanced to the next stage. */
+						__( '↓ %s advanced', 'godam' ),
+						advanced,
+					) }
+				</span>
+				{ lostIsWarning ? (
+					<span className="text-[13px] font-semibold text-[#dc2626] bg-[#fef2f2] rounded-md px-2 py-0.5">{ lostLabel }</span>
+				) : (
+					<span className="text-zinc-500">{ lostLabel }</span>
+				) }
+			</div>
+			<div />
+		</div>
+	);
+}
+
+/**
+ * Play-to-Cart-to-Purchase funnel.
+ *
+ * Three distinct-visitor stages — Played a video -> Added to cart -> Purchased.
+ * Each bar is left-aligned in a grey track and sized to its share of players;
+ * the "Added to cart" bar is split into Direct (added in-video) and Assisted
+ * (clicked out then added). A "still counting" note appears when the backend
+ * flags the range as recent enough that purchase attribution is still settling.
  *
  * @param {Object} props
  * @param {Object} [props.funnel]    The video_funnel payload { stages, still_counting }.
- * @param {string} [props.dataLabel] The active range label (e.g. "Last 7 days").
+ * @param {string} [props.dataLabel] The active range label (e.g. "Last 30 days").
+ * @param {string} [props.scope]     'account' (default) or 'video' — sets the top descriptor + subtitle.
  */
-export default function PurchaseFunnelCard( { funnel, dataLabel } ) {
-	// Render nothing when the payload is absent (an analytics service that predates
-	// the funnel read), so the card never asserts a misleading empty funnel.
-	if ( ! funnel || ! Array.isArray( funnel.stages ) || funnel.stages.length === 0 ) {
+export default function PurchaseFunnelCard( { funnel, dataLabel, scope = 'account' } ) {
+	// Render nothing when the payload is absent, so the card never asserts an
+	// empty funnel for "metric unavailable".
+	if ( ! funnel || ! Array.isArray( funnel.stages ) || funnel.stages.length < 3 ) {
 		return null;
 	}
 
-	const { stages } = funnel;
+	const byKey = Object.fromEntries( funnel.stages.map( ( s ) => [ s.key, s ] ) );
+	const played = Number( byKey.played?.count || 0 );
+	const carts = Number( byKey.added_to_cart?.count || 0 );
+	const direct = Number( byKey.added_to_cart?.direct || 0 );
+	const purchased = Number( byKey.purchased?.count || 0 );
+
+	// Bar segments are fractions of the track, denominated by players (the top).
+	const frac = ( n ) => ( played > 0 ? n / played : 0 );
+	// Assisted-only = added but not in-video, so direct + assistedOnly = carts.
+	const assistedOnly = Math.max( 0, carts - direct );
+
+	const cartAdvanced = played > 0 ? pct( ( carts / played ) * 100 ) : pct( 0 );
+	const buyAdvanced = carts > 0 ? pct( ( purchased / carts ) * 100 ) : pct( 0 );
+	const didNotAdd = Math.max( 0, played - carts );
+	const abandoned = Math.max( 0, carts - purchased );
+
+	const topDescriptor = scope === 'video'
+		? __( 'this video', 'godam' )
+		: __( 'any GoDAM video', 'godam' );
+	const subtitle = scope === 'video'
+		? __( 'Distinct viewers of this video. Covers Direct and Assisted.', 'godam' )
+		: __( 'Distinct visitors, counted across page visits. Covers Direct and Assisted.', 'godam' );
 
 	return (
 		<div className="godam-card godam-funnel-card" data-test-id="godam-purchase-funnel-card">
 			<div className="godam-card__head">
-				<h2>{ __( 'Purchase Funnel', 'godam' ) }</h2>
-				<span className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]">Woo</span>
+				<div className="flex items-center gap-2.5">
+					<h2>{ __( 'Play to Cart to Purchase', 'godam' ) }</h2>
+					<span className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]">Woo</span>
+					<span className="text-[10px] font-bold leading-none px-1.5 py-0.5 rounded bg-[#FEF3C7] text-[#92400E] tracking-wide">{ __( 'NEW', 'godam' ) }</span>
+				</div>
+				{ dataLabel && (
+					<span className="text-[13px] text-[#50575e] border border-[#e2e4e7] rounded-md px-3 py-1">{ dataLabel }</span>
+				) }
 			</div>
 
-			<div className="godam-funnel flex flex-col" data-test-id="godam-purchase-funnel">
-				{ stages.map( ( stage, i ) => {
-					const count = Number( stage.count || 0 );
-					const rate = Math.max( 0, Math.min( 100, Number( stage.rate || 0 ) ) );
-					const prevCount = i > 0 ? Number( stages[ i - 1 ].count || 0 ) : null;
-					const drop = prevCount && prevCount > 0
-						? Math.round( ( 1 - ( count / prevCount ) ) * 100 )
-						: null;
-					// Keep a thin sliver visible so a 0% stage still reads as a bar.
-					const barWidth = Math.max( rate, count > 0 ? 6 : 2 );
+			<p className="text-[13px] text-zinc-500 -mt-1 mb-5">{ subtitle }</p>
 
-					return (
-						<div key={ stage.key } className="godam-funnel__stage">
-							{ i > 0 && (
-								<div
-									className="godam-funnel__drop text-[11px] text-zinc-400 text-center py-1.5"
-									data-test-id="godam-purchase-funnel-drop"
-								>
-									{ drop !== null && drop > 0
-										? sprintf(
-											/* translators: %d: drop-off percentage between funnel stages. */
-											__( '▼ %d%% drop-off', 'godam' ),
-											drop,
-										)
-										: __( 'no drop-off', 'godam' ) }
-								</div>
-							) }
+			<div className="flex flex-col gap-0.5" data-test-id="godam-purchase-funnel">
+				<FunnelRow
+					label={ __( 'Played a video', 'godam' ) }
+					descriptor={ topDescriptor }
+					segments={ played > 0 ? [ { color: COLOR_DIRECT, frac: 1 } ] : [] }
+					count={ played }
+					rightSub={ __( 'visitors', 'godam' ) }
+					testId="godam-purchase-funnel-bar-played"
+				/>
+				<DropRow
+					advanced={ cartAdvanced }
+					lostLabel={ sprintf(
+						/* translators: %s: number of visitors who did not add to cart. */
+						__( '%s did not add to cart', 'godam' ),
+						fmt( didNotAdd ),
+					) }
+				/>
+				<FunnelRow
+					label={ __( 'Added to cart', 'godam' ) }
+					descriptor={ __( 'in-video or after clicking out', 'godam' ) }
+					segments={ [
+						{ color: COLOR_DIRECT, frac: frac( direct ) },
+						{ color: COLOR_ASSISTED, frac: frac( assistedOnly ) },
+					] }
+					count={ carts }
+					rightSub={ sprintf(
+						/* translators: %s: percentage of players. */
+						__( '%s of players', 'godam' ),
+						cartAdvanced,
+					) }
+					testId="godam-purchase-funnel-bar-added_to_cart"
+				/>
+				<DropRow
+					advanced={ buyAdvanced }
+					lostIsWarning
+					lostLabel={ sprintf(
+						/* translators: %s: number of visitors who added to cart but did not buy. */
+						__( '%s abandoned after adding', 'godam' ),
+						fmt( abandoned ),
+					) }
+				/>
+				<FunnelRow
+					label={ __( 'Purchased', 'godam' ) }
+					descriptor={ __( 'net of refunds', 'godam' ) }
+					segments={ purchased > 0 ? [ { color: COLOR_DIRECT, frac: frac( purchased ) } ] : [] }
+					count={ purchased }
+					rightSub={ sprintf(
+						/* translators: %s: percentage of players. */
+						__( '%s of players', 'godam' ),
+						buyAdvanced,
+					) }
+					testId="godam-purchase-funnel-bar-purchased"
+				/>
+			</div>
 
-							<div className="flex items-baseline justify-between mb-1.5">
-								<span className="text-sm font-semibold text-[#1e1e1e]">
-									{ STAGE_LABELS[ stage.key ] || stage.key }
-								</span>
-								<span className="text-xs text-zinc-500" data-test-id={ `godam-purchase-funnel-share-${ stage.key }` }>
-									{ sprintf(
-										/* translators: 1: visitor count, 2: percentage of viewers. */
-										__( '%1$s · %2$s%% of viewers', 'godam' ),
-										count.toLocaleString(),
-										rate.toFixed( rate % 1 ? 1 : 0 ),
-									) }
-								</span>
-							</div>
-
-							<div className="godam-funnel__track w-full flex justify-center">
-								<div
-									className="godam-funnel__bar h-12 rounded-md flex items-center justify-center text-white font-bold text-lg"
-									style={ { width: `${ barWidth }%`, background: BAR_BACKGROUNDS[ stage.key ] || '#7f54b3' } }
-									data-test-id={ `godam-purchase-funnel-bar-${ stage.key }` }
-								>
-									{ count.toLocaleString() }
-								</div>
-							</div>
-						</div>
-					);
-				} ) }
+			<div className="flex flex-wrap items-center gap-x-6 gap-y-2 mt-6 pt-4 border-t border-[#eef0f3] text-[13px] text-zinc-600">
+				<span className="flex items-center gap-2"><span className="w-3 h-3 rounded-sm" style={ { background: COLOR_DIRECT } } />{ __( 'Direct, added to cart in-video', 'godam' ) }</span>
+				<span className="flex items-center gap-2"><span className="w-3 h-3 rounded-sm" style={ { background: COLOR_ASSISTED } } />{ __( 'Assisted, clicked out then bought', 'godam' ) }</span>
+				<span className="flex items-center gap-2"><span className="w-3 h-3 rounded-sm border border-zinc-300" style={ { background: '#eef0f3' } } />{ __( 'did not reach this stage', 'godam' ) }</span>
 			</div>
 
 			{ funnel.still_counting && (

--- a/pages/analytics/PurchaseFunnelCard.test.js
+++ b/pages/analytics/PurchaseFunnelCard.test.js
@@ -63,6 +63,21 @@ describe( 'PurchaseFunnelCard', () => {
 		expect( html ).toContain( '37 abandoned after adding' );
 	} );
 
+	it( 'clamps the cart-advanced annotation to 100% when a skewed payload has carts > played', () => {
+		// A stale/skewed service deploy could report added_to_cart > played; the
+		// "advanced" annotation must cap at 100.0%, never print an above-100% value.
+		const skewed = {
+			stages: [
+				{ key: 'played', count: 100, rate: 100 },
+				{ key: 'added_to_cart', count: 150, direct: 100, assisted: 50, rate: 150 },
+				{ key: 'purchased', count: 10, rate: 10 },
+			],
+		};
+		const html = renderToString( <PurchaseFunnelCard funnel={ skewed } /> );
+		expect( html ).toContain( '100.0% advanced' );
+		expect( html ).not.toContain( '150.0% advanced' );
+	} );
+
 	it( 'renders the legend', () => {
 		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
 		expect( html ).toContain( 'Direct, added to cart in-video' );

--- a/pages/analytics/PurchaseFunnelCard.test.js
+++ b/pages/analytics/PurchaseFunnelCard.test.js
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the per-video Purchase Funnel card.
+ *
+ * Covers the null guard (absent payload -> renders nothing), the three stages
+ * with their counts and shares, the drop-off between stages, and the
+ * "still counting" note toggling purely on the backend flag.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseFunnelCard from './PurchaseFunnelCard';
+
+const FUNNEL = {
+	stages: [
+		{ key: 'viewers', count: 4, rate: 100 },
+		{ key: 'added_to_cart', count: 1, rate: 25 },
+		{ key: 'purchased', count: 1, rate: 25 },
+	],
+	still_counting: false,
+};
+
+describe( 'PurchaseFunnelCard', () => {
+	it( 'renders nothing when the payload is absent', () => {
+		expect( renderToString( <PurchaseFunnelCard funnel={ null } /> ) ).toBe( '' );
+		expect( renderToString( <PurchaseFunnelCard /> ) ).toBe( '' );
+		expect( renderToString( <PurchaseFunnelCard funnel={ { stages: [] } } /> ) ).toBe( '' );
+	} );
+
+	it( 'renders the three stages with counts and labels', () => {
+		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
+		expect( html ).toContain( 'godam-purchase-funnel-card' );
+		expect( html ).toContain( 'Viewers' );
+		expect( html ).toContain( 'Added to cart' );
+		expect( html ).toContain( 'Purchased' );
+		// A bar per stage.
+		expect( html ).toContain( 'godam-purchase-funnel-bar-viewers' );
+		expect( html ).toContain( 'godam-purchase-funnel-bar-added_to_cart' );
+		expect( html ).toContain( 'godam-purchase-funnel-bar-purchased' );
+		// Counts and the share text.
+		expect( html ).toContain( '25% of viewers' );
+	} );
+
+	it( 'shows the drop-off between stages', () => {
+		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
+		// Viewers 4 -> cart 1 is a 75% drop; cart 1 -> purchased 1 is none.
+		expect( html ).toContain( '75% drop-off' );
+		expect( html ).toContain( 'no drop-off' );
+	} );
+
+	it( 'shows the "still counting" note only when the flag is set', () => {
+		const withNote = renderToString(
+			<PurchaseFunnelCard funnel={ { ...FUNNEL, still_counting: true } } dataLabel="Last 7 days" />,
+		);
+		expect( withNote ).toContain( 'godam-purchase-funnel-still-counting' );
+		expect( withNote ).toContain( 'Still counting' );
+		expect( withNote ).toContain( 'Last 7 days' );
+
+		const withoutNote = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
+		expect( withoutNote ).not.toContain( 'godam-purchase-funnel-still-counting' );
+	} );
+} );

--- a/pages/analytics/PurchaseFunnelCard.test.js
+++ b/pages/analytics/PurchaseFunnelCard.test.js
@@ -1,9 +1,9 @@
 /**
- * Unit tests for the per-video Purchase Funnel card.
+ * Unit tests for the Play-to-Cart-to-Purchase funnel card.
  *
- * Covers the null guard (absent payload -> renders nothing), the three stages
- * with their counts and shares, the drop-off between stages, and the
- * "still counting" note toggling purely on the backend flag.
+ * Covers the null guard, the three stages with counts and shares, the Direct/
+ * Assisted split bar, the drop-off annotations (advanced %, did-not-add, and the
+ * red "abandoned after adding" pill), the legend, and the "still counting" note.
  *
  * @package
  */
@@ -20,48 +20,69 @@ import PurchaseFunnelCard from './PurchaseFunnelCard';
 
 const FUNNEL = {
 	stages: [
-		{ key: 'viewers', count: 4, rate: 100 },
-		{ key: 'added_to_cart', count: 1, rate: 25 },
-		{ key: 'purchased', count: 1, rate: 25 },
+		{ key: 'played', count: 1412, rate: 100 },
+		{ key: 'added_to_cart', count: 64, direct: 27, assisted: 40, rate: 4.53 },
+		{ key: 'purchased', count: 27, rate: 1.91 },
 	],
 	still_counting: false,
 };
 
 describe( 'PurchaseFunnelCard', () => {
-	it( 'renders nothing when the payload is absent', () => {
+	it( 'renders nothing when the payload is absent or incomplete', () => {
 		expect( renderToString( <PurchaseFunnelCard funnel={ null } /> ) ).toBe( '' );
 		expect( renderToString( <PurchaseFunnelCard /> ) ).toBe( '' );
 		expect( renderToString( <PurchaseFunnelCard funnel={ { stages: [] } } /> ) ).toBe( '' );
 	} );
 
-	it( 'renders the three stages with counts and labels', () => {
-		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
+	it( 'renders the title, the three stages and their counts', () => {
+		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } dataLabel="Last 30 days" /> );
 		expect( html ).toContain( 'godam-purchase-funnel-card' );
-		expect( html ).toContain( 'Viewers' );
+		expect( html ).toContain( 'Play to Cart to Purchase' );
+		expect( html ).toContain( 'Played a video' );
 		expect( html ).toContain( 'Added to cart' );
 		expect( html ).toContain( 'Purchased' );
+		// Counts, thousands-formatted.
+		expect( html ).toContain( '1,412' );
+		expect( html ).toContain( '64' );
+		expect( html ).toContain( '27' );
+		// Range pill.
+		expect( html ).toContain( 'Last 30 days' );
 		// A bar per stage.
-		expect( html ).toContain( 'godam-purchase-funnel-bar-viewers' );
+		expect( html ).toContain( 'godam-purchase-funnel-bar-played' );
 		expect( html ).toContain( 'godam-purchase-funnel-bar-added_to_cart' );
 		expect( html ).toContain( 'godam-purchase-funnel-bar-purchased' );
-		// Counts and the share text.
-		expect( html ).toContain( '25% of viewers' );
 	} );
 
-	it( 'shows the drop-off between stages', () => {
+	it( 'renders the drop-off annotations, including the abandoned pill', () => {
 		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
-		// Viewers 4 -> cart 1 is a 75% drop; cart 1 -> purchased 1 is none.
-		expect( html ).toContain( '75% drop-off' );
-		expect( html ).toContain( 'no drop-off' );
+		// 64 / 1412 = 4.5% advanced; 1348 did not add.
+		expect( html ).toContain( '4.5% advanced' );
+		expect( html ).toContain( '1,348 did not add to cart' );
+		// 27 / 64 = 42.2% advanced; 37 abandoned after adding.
+		expect( html ).toContain( '42.2% advanced' );
+		expect( html ).toContain( '37 abandoned after adding' );
+	} );
+
+	it( 'renders the legend', () => {
+		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
+		expect( html ).toContain( 'Direct, added to cart in-video' );
+		expect( html ).toContain( 'Assisted, clicked out then bought' );
+		expect( html ).toContain( 'did not reach this stage' );
+	} );
+
+	it( 'uses the per-video descriptor when scope is "video"', () => {
+		const account = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } scope="account" /> );
+		const video = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } scope="video" /> );
+		expect( account ).toContain( 'any GoDAM video' );
+		expect( video ).toContain( 'this video' );
 	} );
 
 	it( 'shows the "still counting" note only when the flag is set', () => {
 		const withNote = renderToString(
-			<PurchaseFunnelCard funnel={ { ...FUNNEL, still_counting: true } } dataLabel="Last 7 days" />,
+			<PurchaseFunnelCard funnel={ { ...FUNNEL, still_counting: true } } dataLabel="Last 30 days" />,
 		);
 		expect( withNote ).toContain( 'godam-purchase-funnel-still-counting' );
 		expect( withNote ).toContain( 'Still counting' );
-		expect( withNote ).toContain( 'Last 7 days' );
 
 		const withoutNote = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
 		expect( withoutNote ).not.toContain( 'godam-purchase-funnel-still-counting' );

--- a/pages/analytics/PurchaseFunnelCard.test.js
+++ b/pages/analytics/PurchaseFunnelCard.test.js
@@ -37,7 +37,7 @@ describe( 'PurchaseFunnelCard', () => {
 	it( 'renders the title, the three stages and their counts', () => {
 		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } dataLabel="Last 30 days" /> );
 		expect( html ).toContain( 'godam-purchase-funnel-card' );
-		expect( html ).toContain( 'Play to Cart to Purchase' );
+		expect( html ).toContain( 'Purchase Funnel' );
 		expect( html ).toContain( 'Played a video' );
 		expect( html ).toContain( 'Added to cart' );
 		expect( html ).toContain( 'Purchased' );

--- a/pages/analytics/PurchaseFunnelCard.test.js
+++ b/pages/analytics/PurchaseFunnelCard.test.js
@@ -77,6 +77,29 @@ describe( 'PurchaseFunnelCard', () => {
 		expect( video ).toContain( 'this video' );
 	} );
 
+	it( 'shows purchased as a share OF PLAYERS on the Purchased row, not of carts', () => {
+		const html = renderToString( <PurchaseFunnelCard funnel={ FUNNEL } /> );
+		// 27 / 1412 = 1.9% of players (matches the bar and the server stage rate).
+		expect( html ).toContain( '1.9% of players' );
+		// The 42.2% (27/64) figure is the cart->purchase drop annotation only; it
+		// must never be shown as an "of players" share (the bug this fixes).
+		expect( html ).not.toContain( '42.2% of players' );
+	} );
+
+	it( 'clamps the advanced % so a stale purchased>carts payload cannot exceed 100%', () => {
+		const skew = {
+			stages: [
+				{ key: 'played', count: 100, rate: 100 },
+				{ key: 'added_to_cart', count: 10, direct: 6, assisted: 5, rate: 10 },
+				{ key: 'purchased', count: 15, rate: 15 },
+			],
+			still_counting: false,
+		};
+		const html = renderToString( <PurchaseFunnelCard funnel={ skew } /> );
+		expect( html ).toContain( '100.0% advanced' );
+		expect( html ).not.toContain( '150.0% advanced' );
+	} );
+
 	it( 'shows the "still counting" note only when the flag is set', () => {
 		const withNote = renderToString(
 			<PurchaseFunnelCard funnel={ { ...FUNNEL, still_counting: true } } dataLabel="Last 30 days" />,

--- a/pages/analytics/RevenueCard.js
+++ b/pages/analytics/RevenueCard.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import Tooltip from './Tooltip';
+import MetricTrend from './MetricTrend';
 import { formatRevenue } from '../dashboard/components/TopProductsTable';
 
 /**
@@ -28,10 +29,11 @@ const COLOR_ASSISTED = '#93c5fd';
  * shown per video (the payload omits it there).
  *
  * @param {Object} props
- * @param {Object} [props.revenue]   { revenue_minor, currency, excluded_orders, direct_minor, assisted_minor, influenced_minor }.
- * @param {string} [props.dataLabel] The active range label (e.g. "All time").
+ * @param {Object} [props.revenue]    { revenue_minor, currency, excluded_orders, direct_minor, assisted_minor, influenced_minor, change }.
+ * @param {string} [props.dataLabel]  The active range label (e.g. "All time").
+ * @param {string} [props.deltaLabel] Label for the trend badge, e.g. "vs previous 7 days".
  */
-export default function RevenueCard( { revenue, dataLabel } ) {
+export default function RevenueCard( { revenue, dataLabel, deltaLabel } ) {
 	// Absent payload (an analytics service that predates the revenue read, or a
 	// non-Woo store where no base currency is passed) -> render nothing, so the
 	// card never asserts a misleading "0" for "metric unavailable". A present
@@ -78,20 +80,26 @@ export default function RevenueCard( { revenue, dataLabel } ) {
 				{ /* Left: headline total + Direct/Assisted split. */ }
 				<div className="flex-1 min-w-0">
 					<p className="text-4xl font-bold text-[#1e1e1e] leading-none" data-test-id="godam-revenue-value">{ formatRevenue( total, currency ) }</p>
-					<p className="text-[13px] text-zinc-500 mt-2">
-						{ excluded > 0
-							? sprintf(
-								/* translators: %s: number of orders placed in other currencies, not included in the total. */
-								_n(
-									'before refunds · excluding %s order in other currencies',
-									'before refunds · excluding %s orders in other currencies',
-									excluded,
-									'godam',
-								),
-								excluded.toLocaleString(),
-							)
-							: __( 'before refunds', 'godam' ) }
-					</p>
+					<div className="flex items-center flex-wrap gap-x-1.5 mt-2 text-[13px] text-zinc-500">
+						<MetricTrend change={ revenue.change } deltaLabel={ deltaLabel } testId="godam-revenue-trend" />
+						{ revenue.change !== null && revenue.change !== undefined && (
+							<span className="text-zinc-400">·</span>
+						) }
+						<span>
+							{ excluded > 0
+								? sprintf(
+									/* translators: %s: number of orders placed in other currencies, not included in the total. */
+									_n(
+										'before refunds · excluding %s order in other currencies',
+										'before refunds · excluding %s orders in other currencies',
+										excluded,
+										'godam',
+									),
+									excluded.toLocaleString(),
+								)
+								: __( 'before refunds', 'godam' ) }
+						</span>
+					</div>
 
 					{ /* Split bar: Direct + Assisted, summing to the base total. */ }
 					<div className="flex h-2.5 w-full rounded-full overflow-hidden bg-zinc-100 mt-4" data-test-id="godam-revenue-split-bar">

--- a/pages/analytics/RevenueCard.js
+++ b/pages/analytics/RevenueCard.js
@@ -1,0 +1,88 @@
+/**
+ * Internal dependencies
+ */
+import Tooltip from './Tooltip';
+import { formatRevenue } from '../dashboard/components/TopProductsTable';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Revenue KPI card for the dashboard Insights row (WooCommerce only).
+ *
+ * GoDAM commits to a single store currency: this shows total video-attributed
+ * revenue in the store's base currency, summing only orders placed in that
+ * currency. Orders in other currencies are not converted; when there are any, a
+ * sub-line reports how many were left out, e.g. "excluding 33 orders in other
+ * currencies". A single-currency store (the common case) excludes nothing and
+ * shows just the figure.
+ *
+ * @param {Object} props
+ * @param {Object} [props.revenue]   The revenue payload: { revenue_minor, currency, excluded_orders }.
+ * @param {string} [props.dataLabel] The active range label (e.g. "All time").
+ */
+export default function RevenueCard( { revenue, dataLabel } ) {
+	// Absent payload (an analytics service that predates the revenue read, or a
+	// non-Woo store where no base currency is passed) -> render nothing, so the
+	// card never asserts a misleading "0" for "metric unavailable". A present
+	// payload with a real 0 still renders.
+	if ( revenue === null || revenue === undefined ) {
+		return null;
+	}
+
+	const minor = Number( revenue.revenue_minor || 0 );
+	const currency = revenue.currency || '';
+	const excluded = Number( revenue.excluded_orders || 0 );
+
+	return (
+		<div
+			className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+			data-test-id="godam-revenue-card"
+		>
+			<div className="analytics-single-info">
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading">
+						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-revenue-label">{ __( 'Revenue', 'godam' ) }</p>
+						{ /* WooCommerce badge (per Figma): the metric comes from store data. */ }
+						<span
+							className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]"
+							data-test-id="godam-revenue-woo-tag"
+						>
+							Woo
+						</span>
+						<Tooltip
+							text={ __(
+								'Total video-attributed revenue in the store\'s base currency. Orders placed in other currencies are not converted, so they are excluded from this total and counted separately.',
+								'godam',
+							) }
+						/>
+					</div>
+				</div>
+				<div className="flex flex-row justify-between gap-2 items-end">
+					<div className="flex flex-col gap-2">
+						<div className="flex flex-row items-baseline gap-2">
+							<p className="single-metrics-value" data-test-id="godam-revenue-value">{ formatRevenue( minor, currency ) }</p>
+						</div>
+						{ excluded > 0 && (
+							<span className="text-xs text-zinc-500" data-test-id="godam-revenue-excluded">
+								{ sprintf(
+									/* translators: %s: number of orders placed in other currencies, not included in the total. */
+									_n(
+										'excluding %s order in other currencies',
+										'excluding %s orders in other currencies',
+										excluded,
+										'godam',
+									),
+									excluded.toLocaleString(),
+								) }
+							</span>
+						) }
+						<span className="text-[11px] text-zinc-400">{ dataLabel || __( 'All time', 'godam' ) }</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/pages/analytics/RevenueCard.js
+++ b/pages/analytics/RevenueCard.js
@@ -9,18 +9,26 @@ import { formatRevenue } from '../dashboard/components/TopProductsTable';
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
 
+// Direct = added to cart in-video (dark blue); Assisted = clicked through, then
+// bought (light blue). Same palette as the Purchase Funnel so the two read as one
+// system.
+const COLOR_DIRECT = '#2563eb';
+const COLOR_ASSISTED = '#93c5fd';
+
 /**
- * Revenue KPI card for the dashboard Insights row (WooCommerce only).
+ * Video-Attributed Revenue card (WooCommerce only).
  *
- * GoDAM commits to a single store currency: this shows total video-attributed
- * revenue in the store's base currency, summing only orders placed in that
- * currency. Orders in other currencies are not converted; when there are any, a
- * sub-line reports how many were left out, e.g. "excluding 33 orders in other
- * currencies". A single-currency store (the common case) excludes nothing and
- * shows just the figure.
+ * Shows total video-attributed revenue in the store's single base currency, split
+ * into Direct (added to cart in-video) and Assisted (clicked through to the product
+ * page, then bought). Orders placed in other currencies are not converted; when
+ * there are any, a sub-line reports how many were left out. On the account-wide
+ * dashboard a separate Influenced figure is shown too (bought on a product page
+ * after playing its video, with no click), reported on its own and never added to
+ * the Direct + Assisted total. Influenced is a product-page concept, so it is not
+ * shown per video (the payload omits it there).
  *
  * @param {Object} props
- * @param {Object} [props.revenue]   The revenue payload: { revenue_minor, currency, excluded_orders }.
+ * @param {Object} [props.revenue]   { revenue_minor, currency, excluded_orders, direct_minor, assisted_minor, influenced_minor }.
  * @param {string} [props.dataLabel] The active range label (e.g. "All time").
  */
 export default function RevenueCard( { revenue, dataLabel } ) {
@@ -32,56 +40,101 @@ export default function RevenueCard( { revenue, dataLabel } ) {
 		return null;
 	}
 
-	const minor = Number( revenue.revenue_minor || 0 );
+	const total = Number( revenue.revenue_minor || 0 );
 	const currency = revenue.currency || '';
 	const excluded = Number( revenue.excluded_orders || 0 );
+	const direct = Number( revenue.direct_minor || 0 );
+	const assisted = Number( revenue.assisted_minor || 0 );
+	const splitTotal = direct + assisted;
+	const directFrac = splitTotal > 0 ? ( direct / splitTotal ) * 100 : 0;
+	const assistedFrac = splitTotal > 0 ? ( assisted / splitTotal ) * 100 : 0;
+
+	// Influenced is account-level (dashboard only); the per-video payload omits the
+	// key, so the box is hidden there rather than showing a misleading 0.
+	const hasInfluenced =
+		revenue.influenced_minor !== undefined && revenue.influenced_minor !== null;
+	const influenced = Number( revenue.influenced_minor || 0 );
 
 	return (
-		<div
-			className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
-			data-test-id="godam-revenue-card"
-		>
-			<div className="analytics-single-info">
-				<div className="flex justify-between items-start flex-row w-full gap-2">
-					<div className="analytics-info-heading">
-						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-revenue-label">{ __( 'Revenue', 'godam' ) }</p>
-						{ /* WooCommerce badge (per Figma): the metric comes from store data. */ }
-						<span
-							className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]"
-							data-test-id="godam-revenue-woo-tag"
-						>
-							Woo
-						</span>
-						<Tooltip
-							text={ __(
-								'Total video-attributed revenue in the store\'s base currency. Orders placed in other currencies are not converted, so they are excluded from this total and counted separately.',
-								'godam',
-							) }
-						/>
-					</div>
-				</div>
-				<div className="flex flex-row justify-between gap-2 items-end">
-					<div className="flex flex-col gap-2">
-						<div className="flex flex-row items-baseline gap-2">
-							<p className="single-metrics-value" data-test-id="godam-revenue-value">{ formatRevenue( minor, currency ) }</p>
-						</div>
-						{ excluded > 0 && (
-							<span className="text-xs text-zinc-500" data-test-id="godam-revenue-excluded">
-								{ sprintf(
-									/* translators: %s: number of orders placed in other currencies, not included in the total. */
-									_n(
-										'excluding %s order in other currencies',
-										'excluding %s orders in other currencies',
-										excluded,
-										'godam',
-									),
-									excluded.toLocaleString(),
-								) }
-							</span>
+		<div className="godam-card godam-revenue-card" data-test-id="godam-revenue-card">
+			<div className="godam-card__head">
+				<div className="flex items-center gap-2.5">
+					<h2>{ __( 'Video-Attributed Revenue', 'godam' ) }</h2>
+					<span className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]" data-test-id="godam-revenue-woo-tag">Woo</span>
+					<span className="text-[10px] font-bold leading-none px-1.5 py-0.5 rounded bg-[#FEF3C7] text-[#92400E] tracking-wide">{ __( 'NEW', 'godam' ) }</span>
+					<Tooltip
+						text={ __(
+							'Order value traced back to the video that earned it, in the store\'s base currency. Direct means added to cart inside the video; Assisted means the shopper clicked through to the product page and bought there. Orders in other currencies are counted separately, not converted. Shown before refunds.',
+							'godam',
 						) }
-						<span className="text-[11px] text-zinc-400">{ dataLabel || __( 'All time', 'godam' ) }</span>
+					/>
+				</div>
+				{ dataLabel && (
+					<span className="text-[13px] text-[#50575e] border border-[#e2e4e7] rounded-md px-3 py-1">{ dataLabel }</span>
+				) }
+			</div>
+
+			<div className="flex gap-6 max-lg:flex-col">
+				{ /* Left: headline total + Direct/Assisted split. */ }
+				<div className="flex-1 min-w-0">
+					<p className="text-4xl font-bold text-[#1e1e1e] leading-none" data-test-id="godam-revenue-value">{ formatRevenue( total, currency ) }</p>
+					<p className="text-[13px] text-zinc-500 mt-2">
+						{ excluded > 0
+							? sprintf(
+								/* translators: %s: number of orders placed in other currencies, not included in the total. */
+								_n(
+									'before refunds · excluding %s order in other currencies',
+									'before refunds · excluding %s orders in other currencies',
+									excluded,
+									'godam',
+								),
+								excluded.toLocaleString(),
+							)
+							: __( 'before refunds', 'godam' ) }
+					</p>
+
+					{ /* Split bar: Direct + Assisted, summing to the base total. */ }
+					<div className="flex h-2.5 w-full rounded-full overflow-hidden bg-zinc-100 mt-4" data-test-id="godam-revenue-split-bar">
+						<div style={ { width: `${ directFrac }%`, background: COLOR_DIRECT } } />
+						<div style={ { width: `${ assistedFrac }%`, background: COLOR_ASSISTED } } />
+					</div>
+
+					<div className="flex flex-col gap-2 mt-4">
+						<div className="flex items-center justify-between gap-4">
+							<span className="flex items-center gap-2 text-[13px] text-zinc-600">
+								<span className="w-3 h-3 rounded-sm" style={ { background: COLOR_DIRECT } } />
+								{ __( 'Direct · added to cart in-video', 'godam' ) }
+							</span>
+							<span className="text-[14px] font-semibold text-[#1e1e1e]" data-test-id="godam-revenue-direct">{ formatRevenue( direct, currency ) }</span>
+						</div>
+						<div className="flex items-center justify-between gap-4">
+							<span className="flex items-center gap-2 text-[13px] text-zinc-600">
+								<span className="w-3 h-3 rounded-sm" style={ { background: COLOR_ASSISTED } } />
+								{ __( 'Assisted · clicked through, then bought', 'godam' ) }
+							</span>
+							<span className="text-[14px] font-semibold text-[#1e1e1e]" data-test-id="godam-revenue-assisted">{ formatRevenue( assisted, currency ) }</span>
+						</div>
 					</div>
 				</div>
+
+				{ /* Right: Influenced, reported separately (dashboard only). */ }
+				{ hasInfluenced && (
+					<div className="lg:w-[34%] rounded-lg border border-dashed border-zinc-300 p-4" data-test-id="godam-revenue-influenced">
+						<div className="flex items-center gap-1.5">
+							<span className="text-[13px] text-zinc-500">{ __( 'Influenced', 'godam' ) }</span>
+							<Tooltip
+								text={ __(
+									'Bought on a product page after playing its video, with no click to prove the video caused the sale. Worked out at the product level, shown on its own, and never added to the Direct + Assisted figure.',
+									'godam',
+								) }
+							/>
+						</div>
+						<p className="text-2xl font-bold text-[#1e1e1e] mt-1" data-test-id="godam-revenue-influenced-value">{ formatRevenue( influenced, currency ) }</p>
+						<p className="text-[12px] text-zinc-500 mt-2 leading-snug">
+							{ __( 'Bought on a product page after playing its video. Reported separately because there is no click-through to prove intent, so it is not added to the figure on the left.', 'godam' ) }
+						</p>
+					</div>
+				) }
 			</div>
 		</div>
 	);

--- a/pages/analytics/RevenueCard.js
+++ b/pages/analytics/RevenueCard.js
@@ -42,6 +42,15 @@ export default function RevenueCard( { revenue, dataLabel, deltaLabel } ) {
 		return null;
 	}
 
+	// null-not-zero: a payload whose revenue_minor is null/undefined means "no
+	// revenue-bearing row" (the service's sentinel), so hide rather than render a
+	// misleading "0". A real measured 0 (numeric) still renders. This also guards
+	// the per-video page, which always builds the payload object inline and so
+	// cannot rely on the whole-prop null check above.
+	if ( revenue.revenue_minor === null || revenue.revenue_minor === undefined ) {
+		return null;
+	}
+
 	const total = Number( revenue.revenue_minor || 0 );
 	const currency = revenue.currency || '';
 	const excluded = Number( revenue.excluded_orders || 0 );

--- a/pages/analytics/RevenueCard.js
+++ b/pages/analytics/RevenueCard.js
@@ -51,12 +51,20 @@ export default function RevenueCard( { revenue, dataLabel, deltaLabel } ) {
 		return null;
 	}
 
-	const total = Number( revenue.revenue_minor || 0 );
 	const currency = revenue.currency || '';
 	const excluded = Number( revenue.excluded_orders || 0 );
 	const direct = Number( revenue.direct_minor || 0 );
 	const assisted = Number( revenue.assisted_minor || 0 );
 	const splitTotal = direct + assisted;
+	// When the Direct/Assisted split is present, the headline is their sum, so the
+	// total always equals the parts shown beneath it. Every paid order line carries
+	// a tier, so this can never hide revenue; without a split, use the service total.
+	const hasSplit =
+		revenue.direct_minor !== undefined &&
+		revenue.direct_minor !== null &&
+		revenue.assisted_minor !== undefined &&
+		revenue.assisted_minor !== null;
+	const total = hasSplit ? splitTotal : Number( revenue.revenue_minor || 0 );
 	const directFrac = splitTotal > 0 ? ( direct / splitTotal ) * 100 : 0;
 	const assistedFrac = splitTotal > 0 ? ( assisted / splitTotal ) * 100 : 0;
 

--- a/pages/analytics/RevenueCard.test.js
+++ b/pages/analytics/RevenueCard.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the Revenue KPI card (single store currency).
+ *
+ * Used by both the dashboard Insights row and the per-video Analytics page. It
+ * must: render nothing when the payload is absent (metric unavailable, so no
+ * misleading "0"), render the base-currency amount via the shipped formatRevenue,
+ * show the "excluding N orders in other currencies" sub-line only when there are
+ * any, and still render a real measured 0.
+ *
+ * Rendered to a static HTML string (no DOM needed) so the test asserts the actual
+ * output the component produces.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import RevenueCard from './RevenueCard';
+
+describe( 'RevenueCard — single store currency', () => {
+	it( 'renders nothing when the payload is null (metric unavailable)', () => {
+		expect( renderToString( <RevenueCard revenue={ null } /> ) ).toBe( '' );
+	} );
+
+	it( 'renders nothing when the payload is undefined (prop omitted)', () => {
+		expect( renderToString( <RevenueCard /> ) ).toBe( '' );
+	} );
+
+	it( 'renders the base-currency amount via formatRevenue', () => {
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 250000, currency: 'INR', excluded_orders: 0 } } />,
+		);
+		expect( html ).toContain( 'godam-revenue-card' );
+		expect( html ).toContain( '2,500' ); // 250000 minor INR = 2,500.00, full number
+		expect( html ).not.toContain( 'excluding' ); // nothing excluded
+	} );
+
+	it( 'shows the excluded-orders sub-line when there are orders in other currencies', () => {
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 46700, currency: 'USD', excluded_orders: 33 } } />,
+		);
+		expect( html ).toContain( 'excluding 33 orders in other currencies' );
+	} );
+
+	it( 'uses the singular for exactly one excluded order', () => {
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 1200, currency: 'INR', excluded_orders: 1 } } />,
+		);
+		expect( html ).toContain( 'excluding 1 order in other currencies' );
+	} );
+
+	it( 'renders a real measured 0 (present payload), not nothing', () => {
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 0, currency: 'INR', excluded_orders: 0 } } />,
+		);
+		expect( html ).toContain( 'godam-revenue-card' );
+		expect( html ).not.toBe( '' );
+	} );
+} );

--- a/pages/analytics/RevenueCard.test.js
+++ b/pages/analytics/RevenueCard.test.js
@@ -63,6 +63,17 @@ describe( 'RevenueCard — single store currency', () => {
 		expect( html ).not.toBe( '' );
 	} );
 
+	it( 'renders nothing when revenue_minor is null (no revenue-bearing row)', () => {
+		// The per-video page always builds the payload object inline, so a service
+		// revenue:null arrives as { revenue_minor: null, ... } (a truthy object).
+		// The card must still hide it, not render a misleading "0".
+		expect(
+			renderToString(
+				<RevenueCard revenue={ { revenue_minor: null, currency: 'INR', excluded_orders: 0 } } />,
+			),
+		).toBe( '' );
+	} );
+
 	it( 'renders the "Video-Attributed Revenue" title and the before-refunds label', () => {
 		const html = renderToString(
 			<RevenueCard revenue={ { revenue_minor: 324000, currency: 'GBP', excluded_orders: 0, direct_minor: 239800, assisted_minor: 84200, influenced_minor: 191000 } } />,

--- a/pages/analytics/RevenueCard.test.js
+++ b/pages/analytics/RevenueCard.test.js
@@ -62,4 +62,36 @@ describe( 'RevenueCard — single store currency', () => {
 		expect( html ).toContain( 'godam-revenue-card' );
 		expect( html ).not.toBe( '' );
 	} );
+
+	it( 'renders the "Video-Attributed Revenue" title and the before-refunds label', () => {
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 324000, currency: 'GBP', excluded_orders: 0, direct_minor: 239800, assisted_minor: 84200, influenced_minor: 191000 } } />,
+		);
+		expect( html ).toContain( 'Video-Attributed Revenue' );
+		expect( html ).toContain( 'before refunds' );
+	} );
+
+	it( 'renders the Direct and Assisted split amounts', () => {
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 324000, currency: 'GBP', excluded_orders: 0, direct_minor: 239800, assisted_minor: 84200 } } />,
+		);
+		expect( html ).toContain( 'godam-revenue-direct' );
+		expect( html ).toContain( 'godam-revenue-assisted' );
+		expect( html ).toContain( '2,398' ); // direct: 239800 minor = 2,398.00
+		expect( html ).toContain( '842' ); // assisted: 84200 minor = 842.00
+	} );
+
+	it( 'shows the Influenced box only when influenced_minor is present (dashboard, not per-video)', () => {
+		const withInfluenced = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 100, currency: 'GBP', direct_minor: 100, assisted_minor: 0, influenced_minor: 191000 } } />,
+		);
+		expect( withInfluenced ).toContain( 'godam-revenue-influenced' );
+		expect( withInfluenced ).toContain( '1,910' ); // 191000 minor = 1,910.00
+
+		// The per-video payload omits influenced_minor, so the box is hidden.
+		const perVideo = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 100, currency: 'GBP', direct_minor: 100, assisted_minor: 0 } } />,
+		);
+		expect( perVideo ).not.toContain( 'godam-revenue-influenced' );
+	} );
 } );

--- a/pages/analytics/RevenueCard.test.js
+++ b/pages/analytics/RevenueCard.test.js
@@ -92,6 +92,16 @@ describe( 'RevenueCard — single store currency', () => {
 		expect( html ).toContain( '842' ); // assisted: 84200 minor = 842.00
 	} );
 
+	it( 'headlines Direct + Assisted so the total equals the parts, even if the service total differs', () => {
+		// Service total (10000 -> 100.00) diverges from the split (4000 + 4000 ->
+		// 80.00). The headline shows the split sum so it matches the bar below.
+		const html = renderToString(
+			<RevenueCard revenue={ { revenue_minor: 10000, currency: 'INR', excluded_orders: 0, direct_minor: 4000, assisted_minor: 4000 } } />,
+		);
+		expect( html ).toContain( '80.00' ); // Direct + Assisted
+		expect( html ).not.toContain( '100.00' ); // not the diverging service total
+	} );
+
 	it( 'shows the Influenced box only when influenced_minor is present (dashboard, not per-video)', () => {
 		const withInfluenced = renderToString(
 			<RevenueCard revenue={ { revenue_minor: 100, currency: 'GBP', direct_minor: 100, assisted_minor: 0, influenced_minor: 191000 } } />,

--- a/pages/analytics/RevenueTips.js
+++ b/pages/analytics/RevenueTips.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatRevenue } from '../dashboard/components/TopProductsTable';
+
+/**
+ * Comparative revenue tips for the single-video Analytics page (WooCommerce only).
+ *
+ * The service computes each comparison and a `*_favourable` flag; this renders a
+ * tip ONLY when its flag is set, so an unfavourable or absent comparison shows
+ * nothing (never a discouraging "below average" line). Amounts use the shipped
+ * formatRevenue in the store's base currency.
+ *
+ * @param {Object} props        Component props.
+ * @param {Object} [props.tips] The tips payload from the service, or null.
+ * @return {JSX.Element|null} The tips banner, or null when there is nothing to say.
+ */
+export default function RevenueTips( { tips } ) {
+	if ( ! tips ) {
+		return null;
+	}
+
+	const messages = [];
+	if ( tips.aov_favourable ) {
+		messages.push(
+			sprintf(
+				/* translators: 1: this video's average order value, 2: the store's average order value. */
+				__( 'This video’s average order value (%1$s) beats your store average (%2$s).', 'godam' ),
+				formatRevenue( tips.video_aov_minor, tips.currency ),
+				formatRevenue( tips.store_aov_minor, tips.currency ),
+			),
+		);
+	}
+	if ( tips.revenue_per_session_favourable ) {
+		messages.push(
+			sprintf(
+				/* translators: %s: revenue earned per viewer, formatted with the currency. */
+				__( 'This video earns %s in revenue per viewer.', 'godam' ),
+				formatRevenue( tips.revenue_per_session_minor, tips.currency ),
+			),
+		);
+	}
+
+	if ( ! messages.length ) {
+		return null;
+	}
+
+	return (
+		<div
+			className="godam-revenue-tips rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900"
+			data-test-id="godam-revenue-tips"
+		>
+			{ messages.map( ( message, i ) => (
+				<p key={ i } className="m-0">{ message }</p>
+			) ) }
+		</div>
+	);
+}

--- a/pages/analytics/RevenueTips.test.js
+++ b/pages/analytics/RevenueTips.test.js
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the comparative revenue tips banner (single store currency).
+ *
+ * A tip renders only when the service marks that comparison favourable, so an
+ * unfavourable or absent comparison shows nothing (never a discouraging line).
+ * Rendered to a static HTML string so the test asserts the real output.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import RevenueTips from './RevenueTips';
+
+describe( 'RevenueTips — comparative tips', () => {
+	it( 'renders nothing when tips are null/undefined', () => {
+		expect( renderToString( <RevenueTips tips={ null } /> ) ).toBe( '' );
+		expect( renderToString( <RevenueTips /> ) ).toBe( '' );
+	} );
+
+	it( 'renders nothing when no comparison is favourable', () => {
+		const html = renderToString(
+			<RevenueTips tips={ {
+				video_aov_minor: 500, store_aov_minor: 1000, aov_favourable: false,
+				revenue_per_session_minor: 0, revenue_per_session_favourable: false,
+				currency: 'INR',
+			} } />,
+		);
+		expect( html ).toBe( '' );
+	} );
+
+	it( 'renders the AOV tip with both amounts when favourable', () => {
+		const html = renderToString(
+			<RevenueTips tips={ {
+				video_aov_minor: 200000, store_aov_minor: 100000, aov_favourable: true,
+				revenue_per_session_minor: 0, revenue_per_session_favourable: false,
+				currency: 'INR',
+			} } />,
+		);
+		expect( html ).toContain( 'godam-revenue-tips' );
+		expect( html ).toContain( 'average order value' );
+		expect( html ).toContain( '2,000' ); // video AOV 200000 minor INR
+		expect( html ).toContain( '1,000' ); // store AOV 100000 minor INR
+	} );
+
+	it( 'renders the revenue-per-session tip when favourable', () => {
+		const html = renderToString(
+			<RevenueTips tips={ {
+				video_aov_minor: 0, store_aov_minor: 0, aov_favourable: false,
+				revenue_per_session_minor: 5000, revenue_per_session_favourable: true,
+				currency: 'INR',
+			} } />,
+		);
+		expect( html ).toContain( 'per viewer' );
+		expect( html ).toContain( '50' ); // 5000 minor INR = 50.00
+	} );
+} );

--- a/pages/analytics/VideoToCartCard.js
+++ b/pages/analytics/VideoToCartCard.js
@@ -67,10 +67,10 @@ export default function VideoToCartCard( { videoToCart, dataLabel } ) {
 						    numbers sum. */ }
 						<div className="flex flex-row items-baseline gap-2">
 							<p className="single-metrics-value" data-test-id="godam-video-to-cart-value">{ carts.toLocaleString() }</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">
+							<span className="text-xs text-zinc-500">
 								{ sprintf(
-									/* translators: %s: percentage of viewers who added to cart. */
-									__( '%s%% of viewers', 'godam' ),
+									/* translators: %s: percentage of viewers who played and then added to cart. */
+									__( 'carts from video, %s%% of viewers who played', 'godam' ),
 									rate.toFixed( 1 ),
 								) }
 							</span>

--- a/pages/analytics/VideoToCartCard.js
+++ b/pages/analytics/VideoToCartCard.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import Tooltip from './Tooltip';
+import MetricTrend from './MetricTrend';
 
 /**
  * WordPress dependencies
@@ -17,10 +18,11 @@ import { __, sprintf } from '@wordpress/i18n';
  * counts add up cleanly.
  *
  * @param {Object} props
- * @param {Object} [props.videoToCart] The video_to_cart payload (uses carts + rate).
+ * @param {Object} [props.videoToCart] The video_to_cart payload (uses carts + rate + change).
  * @param {string} [props.dataLabel]   The active range label (e.g. "All time").
+ * @param {string} [props.deltaLabel]  Label for the trend badge, e.g. "vs previous 7 days".
  */
-export default function VideoToCartCard( { videoToCart, dataLabel } ) {
+export default function VideoToCartCard( { videoToCart, dataLabel, deltaLabel } ) {
 	// Render nothing when the payload is entirely absent (an analytics service that
 	// predates the video_to_cart roll-up), so the card never asserts a misleading
 	// "0 carts" for "metric unavailable". A present payload with zero carts is a
@@ -75,7 +77,7 @@ export default function VideoToCartCard( { videoToCart, dataLabel } ) {
 								) }
 							</span>
 						</div>
-						<span className="text-[11px] text-zinc-400">{ dataLabel || __( 'All time', 'godam' ) }</span>
+						<MetricTrend change={ vtc.change } deltaLabel={ deltaLabel } dataLabel={ dataLabel } testId="godam-video-to-cart-trend" />
 					</div>
 				</div>
 			</div>

--- a/pages/analytics/VideoToCartCard.test.js
+++ b/pages/analytics/VideoToCartCard.test.js
@@ -40,6 +40,9 @@ describe( 'VideoToCartCard — null vs zero', () => {
 		// The count leads the card.
 		expect( html ).toContain( '42' );
 		expect( html ).toContain( 'Video to Cart' );
+		// Subtitle copy matches the design: what the number is + share of players.
+		expect( html ).toContain( 'carts from video' );
+		expect( html ).toContain( '12.5% of viewers who played' );
 	} );
 
 	it( 'still renders for a measured zero-carts payload (0 is a real value, not "unavailable")', () => {

--- a/pages/analytics/VideoToPurchaseCard.js
+++ b/pages/analytics/VideoToPurchaseCard.js
@@ -62,10 +62,10 @@ export default function VideoToPurchaseCard( { videoToPurchase, dataLabel } ) {
 					<div className="flex flex-col gap-2">
 						<div className="flex flex-row items-baseline gap-2">
 							<p className="single-metrics-value" data-test-id="godam-video-to-purchase-value">{ purchases.toLocaleString() }</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">
+							<span className="text-xs text-zinc-500">
 								{ sprintf(
-									/* translators: %s: percentage of viewers who purchased. */
-									__( '%s%% of viewers', 'godam' ),
+									/* translators: %s: percentage of viewers who played and then purchased. */
+									__( 'orders from video, %s%% of viewers who played', 'godam' ),
 									rate.toFixed( 1 ),
 								) }
 							</span>

--- a/pages/analytics/VideoToPurchaseCard.js
+++ b/pages/analytics/VideoToPurchaseCard.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import Tooltip from './Tooltip';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Video-to-Purchase KPI card for the Insights row.
+ *
+ * The purchase sibling of VideoToCartCard: shows the count of distinct people who
+ * played a video and then bought an attributed product, plus the rate (share of
+ * viewers). Each person is counted once, whatever they bought. Sits beside Video
+ * to Cart and Revenue so the cart rate and the purchase rate read the same way.
+ *
+ * @param {Object} props
+ * @param {Object} [props.videoToPurchase] The video_to_purchase payload (uses purchases + rate).
+ * @param {string} [props.dataLabel]       The active range label (e.g. "All time").
+ */
+export default function VideoToPurchaseCard( { videoToPurchase, dataLabel } ) {
+	// Render nothing when the payload is entirely absent (an analytics service that
+	// predates the video_to_purchase read), so the card never asserts a misleading
+	// "0 purchases" for "metric unavailable". A present payload with zero purchases
+	// is a real value and still renders.
+	if ( videoToPurchase === null || videoToPurchase === undefined ) {
+		return null;
+	}
+
+	const vtp = videoToPurchase || {};
+	const purchases = Number( vtp.purchases || 0 );
+	const rate = Number( vtp.rate || 0 );
+
+	return (
+		<div
+			className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+			data-test-id="godam-video-to-purchase-card"
+		>
+			<div className="analytics-single-info">
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading">
+						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-video-to-purchase-label">{ __( 'Video to Purchase', 'godam' ) }</p>
+						{ /* WooCommerce badge (per Figma): signals the metric comes from
+						    the WooCommerce add-on / store data. */ }
+						<span
+							className="text-[10px] font-semibold leading-none px-1.5 py-0.5 rounded bg-[#EDE9FE] text-[#6D28D9]"
+							data-test-id="godam-video-to-purchase-woo-tag"
+						>
+							Woo
+						</span>
+						<Tooltip
+							text={ __(
+								'Distinct people who played a video and then bought an attributed product. Each person is counted once.',
+								'godam',
+							) }
+						/>
+					</div>
+				</div>
+				<div className="flex flex-row justify-between gap-2 items-end">
+					<div className="flex flex-col gap-2">
+						<div className="flex flex-row items-baseline gap-2">
+							<p className="single-metrics-value" data-test-id="godam-video-to-purchase-value">{ purchases.toLocaleString() }</p>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">
+								{ sprintf(
+									/* translators: %s: percentage of viewers who purchased. */
+									__( '%s%% of viewers', 'godam' ),
+									rate.toFixed( 1 ),
+								) }
+							</span>
+						</div>
+						<span className="text-[11px] text-zinc-400">{ dataLabel || __( 'All time', 'godam' ) }</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/pages/analytics/VideoToPurchaseCard.js
+++ b/pages/analytics/VideoToPurchaseCard.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import Tooltip from './Tooltip';
+import MetricTrend from './MetricTrend';
 
 /**
  * WordPress dependencies
@@ -17,10 +18,11 @@ import { __, sprintf } from '@wordpress/i18n';
  * to Cart and Revenue so the cart rate and the purchase rate read the same way.
  *
  * @param {Object} props
- * @param {Object} [props.videoToPurchase] The video_to_purchase payload (uses purchases + rate).
+ * @param {Object} [props.videoToPurchase] The video_to_purchase payload (uses purchases + rate + change).
  * @param {string} [props.dataLabel]       The active range label (e.g. "All time").
+ * @param {string} [props.deltaLabel]      Label for the trend badge, e.g. "vs previous 7 days".
  */
-export default function VideoToPurchaseCard( { videoToPurchase, dataLabel } ) {
+export default function VideoToPurchaseCard( { videoToPurchase, dataLabel, deltaLabel } ) {
 	// Render nothing when the payload is entirely absent (an analytics service that
 	// predates the video_to_purchase read), so the card never asserts a misleading
 	// "0 purchases" for "metric unavailable". A present payload with zero purchases
@@ -70,7 +72,7 @@ export default function VideoToPurchaseCard( { videoToPurchase, dataLabel } ) {
 								) }
 							</span>
 						</div>
-						<span className="text-[11px] text-zinc-400">{ dataLabel || __( 'All time', 'godam' ) }</span>
+						<MetricTrend change={ vtp.change } deltaLabel={ deltaLabel } dataLabel={ dataLabel } testId="godam-video-to-purchase-trend" />
 					</div>
 				</div>
 			</div>

--- a/pages/analytics/VideoToPurchaseCard.test.js
+++ b/pages/analytics/VideoToPurchaseCard.test.js
@@ -38,6 +38,9 @@ describe( 'VideoToPurchaseCard — null vs zero', () => {
 		// The count leads the card.
 		expect( html ).toContain( '7' );
 		expect( html ).toContain( 'Video to Purchase' );
+		// Subtitle copy matches the design: what the number is + share of players.
+		expect( html ).toContain( 'orders from video' );
+		expect( html ).toContain( '17.5% of viewers who played' );
 	} );
 
 	it( 'still renders for a measured zero-purchases payload (0 is a real value, not "unavailable")', () => {

--- a/pages/analytics/VideoToPurchaseCard.test.js
+++ b/pages/analytics/VideoToPurchaseCard.test.js
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the Video-to-Purchase KPI card's null-vs-zero guard.
+ *
+ * Mirrors VideoToCartCard: the card must distinguish "metric unavailable" (an
+ * analytics service that predates the video_to_purchase read: payload
+ * null/undefined) from a real measured "0 purchases". The former renders nothing
+ * so the Insights row never asserts a misleading zero; the latter is a real value
+ * and must still render.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import VideoToPurchaseCard from './VideoToPurchaseCard';
+
+describe( 'VideoToPurchaseCard — null vs zero', () => {
+	it( 'renders nothing when the payload is null (metric unavailable)', () => {
+		expect( renderToString( <VideoToPurchaseCard videoToPurchase={ null } /> ) ).toBe( '' );
+	} );
+
+	it( 'renders nothing when the payload is undefined (prop omitted)', () => {
+		expect( renderToString( <VideoToPurchaseCard /> ) ).toBe( '' );
+	} );
+
+	it( 'renders the card with the count for a real payload', () => {
+		const html = renderToString(
+			<VideoToPurchaseCard videoToPurchase={ { purchases: 7, rate: 17.5 } } />,
+		);
+		expect( html ).not.toBe( '' );
+		expect( html ).toContain( 'godam-video-to-purchase-card' );
+		// The count leads the card.
+		expect( html ).toContain( '7' );
+		expect( html ).toContain( 'Video to Purchase' );
+	} );
+
+	it( 'still renders for a measured zero-purchases payload (0 is a real value, not "unavailable")', () => {
+		const html = renderToString(
+			<VideoToPurchaseCard videoToPurchase={ { purchases: 0, rate: 0 } } />,
+		);
+		expect( html ).not.toBe( '' );
+		expect( html ).toContain( 'godam-video-to-purchase-value' );
+		expect( html ).toContain( '0' );
+	} );
+
+	it( 'treats an empty-object payload as present (falls back to zeros, still renders)', () => {
+		const html = renderToString( <VideoToPurchaseCard videoToPurchase={ {} } /> );
+		expect( html ).not.toBe( '' );
+		expect( html ).toContain( 'godam-video-to-purchase-card' );
+	} );
+} );

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -512,10 +512,11 @@ export function groupRows( rows, layerType, configIndex ) {
 			no_action: parentNoAction,
 			conversion_rate: parentConversion,
 			sub_hotspots: subHotspots,
-			// Parent Direct revenue = sum of its hotspots' revenue (base currency).
-			// The order count is the summed children's, which can overcount an
-			// order that bought two products via two hotspots; the panel presents
-			// the parent figure as an aggregate, not an exact distinct-order total.
+			// Parent Direct revenue = sum of its hotspots' revenue (base currency),
+			// which is sum-safe. The summed `orders` below is NOT a distinct count
+			// (an order that bought via two hotspots is counted twice), so the panel
+			// shows the parent's revenue WITHOUT an order total; only a single
+			// hotspot (one composite layer_id) shows its exact distinct order count.
 			revenue_minor: subHotspots.reduce(
 				( sum, h ) => sum + ( Number( h.revenue_minor ) || 0 ),
 				0,

--- a/pages/analytics/hooks/useVideoLayerData.js
+++ b/pages/analytics/hooks/useVideoLayerData.js
@@ -459,6 +459,12 @@ export function groupRows( rows, layerType, configIndex ) {
 					product_image: md.product_image || '',
 					product_price: md.product_price || null,
 					timestamp: Number( row.timestamp || 0 ),
+					// Per-hotspot Direct revenue (Woo layers), in the store's base
+					// currency; other currencies are excluded server-side, not
+					// converted. orders is exact for a single hotspot.
+					revenue_minor: Number( row.revenue_minor ) || 0,
+					orders: Number( row.orders ) || 0,
+					currency: row.currency || '',
 					isActive: subIsActive,
 				};
 			} )
@@ -506,6 +512,19 @@ export function groupRows( rows, layerType, configIndex ) {
 			no_action: parentNoAction,
 			conversion_rate: parentConversion,
 			sub_hotspots: subHotspots,
+			// Parent Direct revenue = sum of its hotspots' revenue (base currency).
+			// The order count is the summed children's, which can overcount an
+			// order that bought two products via two hotspots; the panel presents
+			// the parent figure as an aggregate, not an exact distinct-order total.
+			revenue_minor: subHotspots.reduce(
+				( sum, h ) => sum + ( Number( h.revenue_minor ) || 0 ),
+				0,
+			),
+			orders: subHotspots.reduce(
+				( sum, h ) => sum + ( Number( h.orders ) || 0 ),
+				0,
+			),
+			currency: ( subHotspots.find( ( h ) => h.currency )?.currency ) || '',
 			isActive: parentIsActive,
 			historical_positions: historicalPositions,
 			// wp-admin link to this form's entries / poll's results, when the

--- a/pages/analytics/hooks/useVideoLayerData.test.js
+++ b/pages/analytics/hooks/useVideoLayerData.test.js
@@ -77,3 +77,73 @@ describe( 'groupRows — conversion comes from the server, not a client recomput
 		expect( parent.conversion_rate ).toBe( 100 );
 	} );
 } );
+
+describe( 'groupRows — per-hotspot Direct revenue (single store currency)', () => {
+	const baseRow = {
+		layer_type: 'woo',
+		page_url: 'https://shop.example.com',
+		timestamp: 17,
+	};
+	// The endpoint attaches revenue_minor/orders/currency to each Woo row.
+	// Base currency is INR; a non-base (USD) order is excluded server-side, so
+	// its row arrives as revenue_minor 0 / orders 0 — never blended.
+	const rows = [
+		{
+			...baseRow,
+			layer_id: 'woo-9', layer_name: 'Deals',
+			viewed: 10, clicked: 4, hovered: 10, conversion_rate: 40,
+			layer_metadata: '{"parent_layer_id":"woo-9"}',
+		},
+		{
+			...baseRow,
+			layer_id: 'woo-9::p101', layer_name: 'Hoodie',
+			viewed: 0, clicked: 3, conversion_rate: 30,
+			revenue_minor: 120000, orders: 1, currency: 'INR',
+			layer_metadata: '{"parent_layer_id":"woo-9","product_id":101}',
+		},
+		{
+			...baseRow,
+			layer_id: 'woo-9::p102', layer_name: 'Cap',
+			viewed: 0, clicked: 1, conversion_rate: 10,
+			revenue_minor: 0, orders: 0, currency: '',
+			layer_metadata: '{"parent_layer_id":"woo-9","product_id":102}',
+		},
+		{
+			...baseRow,
+			layer_id: 'woo-9::p103', layer_name: 'Mug',
+			viewed: 0, clicked: 2, conversion_rate: 20,
+			revenue_minor: 30000, orders: 1, currency: 'INR',
+			layer_metadata: '{"parent_layer_id":"woo-9","product_id":103}',
+		},
+	];
+
+	it( 'maps each hotspot revenue/orders/currency from its endpoint row', () => {
+		const [ parent ] = groupRows( rows, 'woo', OPEN_CONFIG );
+		const byPid = Object.fromEntries(
+			parent.sub_hotspots.map( ( s ) => [ s.product_id, s ] ),
+		);
+		expect( byPid[ 101 ] ).toMatchObject( { revenue_minor: 120000, orders: 1, currency: 'INR' } );
+		expect( byPid[ 103 ] ).toMatchObject( { revenue_minor: 30000, orders: 1, currency: 'INR' } );
+		// Server-excluded non-base order arrives as 0; the panel hides it (orders 0).
+		expect( byPid[ 102 ] ).toMatchObject( { revenue_minor: 0, orders: 0 } );
+	} );
+
+	it( 'parent revenue is the sum of its hotspots, currency from a base-currency child', () => {
+		const [ parent ] = groupRows( rows, 'woo', OPEN_CONFIG );
+		expect( parent.revenue_minor ).toBe( 150000 ); // 120000 + 30000
+		expect( parent.orders ).toBe( 2 );
+		expect( parent.currency ).toBe( 'INR' );
+	} );
+
+	it( 'defaults revenue fields to 0/empty when the endpoint sends none', () => {
+		const plain = rows.map( ( { revenue_minor, orders, currency, ...rest } ) => rest );
+		const [ parent ] = groupRows( plain, 'woo', OPEN_CONFIG );
+		expect( parent.revenue_minor ).toBe( 0 );
+		expect( parent.orders ).toBe( 0 );
+		expect(
+			parent.sub_hotspots.every(
+				( s ) => s.revenue_minor === 0 && s.orders === 0 && s.currency === '',
+			),
+		).toBe( true );
+	} );
+} );

--- a/pages/analytics/timeline/LayerDetailPanel.js
+++ b/pages/analytics/timeline/LayerDetailPanel.js
@@ -239,14 +239,24 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 				{ showRevenue && (
 					<div className="mb-4 flex items-center gap-2 flex-wrap text-sm text-zinc-700">
 						<span>
-							{ sprintf(
-								/* translators: 1: formatted revenue amount, 2: order count phrase (e.g. "3 orders"). */
-								activeSub
-									? __( 'This hotspot drove %1$s across %2$s', 'godam' )
-									: __( 'This layer drove %1$s across %2$s', 'godam' ),
-								formatRevenue( revenueMinor, revenueEntity.currency ),
-								revenueOrdersPhrase,
-							) }
+							{ activeSub
+								// A single hotspot maps to one composite layer_id, so its
+								// order count is an exact distinct count.
+								? sprintf(
+									/* translators: 1: formatted revenue amount, 2: order count phrase (e.g. "3 orders"). */
+									__( 'This hotspot drove %1$s across %2$s', 'godam' ),
+									formatRevenue( revenueMinor, revenueEntity.currency ),
+									revenueOrdersPhrase,
+								)
+								// Parent aggregate: revenue only. Summing the hotspots'
+								// distinct order counts would overcount an order bought via two
+								// hotspots in this layer, so no parent order total is shown
+								// (order counts are not additive).
+								: sprintf(
+									/* translators: %s: formatted revenue amount. */
+									__( 'This layer drove %s', 'godam' ),
+									formatRevenue( revenueMinor, revenueEntity.currency ),
+								) }
 						</span>
 						<InfoTooltip
 							text={ __(

--- a/pages/analytics/timeline/LayerDetailPanel.js
+++ b/pages/analytics/timeline/LayerDetailPanel.js
@@ -6,13 +6,14 @@ import React, { useEffect, useState } from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { formatRevenue } from '../../dashboard/components/TopProductsTable';
 import {
 	LAYER_TYPE_BY_ID,
 	withAlpha,
@@ -21,6 +22,7 @@ import LayerIcon from './LayerIcon';
 import LayerInteractionFunnel from './LayerInteractionFunnel';
 import SubHotspotRail from './SubHotspotRail';
 import LayerModifiedNotice from './LayerModifiedNotice';
+import InfoTooltip from './InfoTooltip';
 
 /**
  * Build the deep-link URL into the video editor for a layer.
@@ -107,6 +109,20 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 		: null;
 	const funnelCounts = activeSub ? activeSub.counts : parent.counts;
 	const funnelNoAction = activeSub ? activeSub.no_action : parent.no_action;
+
+	// Direct in-video revenue for the selected hotspot, or the parent layer's
+	// aggregate (sum of its hotspots) when none is selected. Woo layers only,
+	// shown only when there is revenue. Base currency; other currencies are
+	// excluded (counted on the dashboard, not converted).
+	const revenueEntity = activeSub || parent;
+	const revenueMinor = Number( revenueEntity.revenue_minor ) || 0;
+	const revenueOrders = Number( revenueEntity.orders ) || 0;
+	const showRevenue = parent.layer_type === 'woo' && revenueMinor > 0;
+	const revenueOrdersPhrase = sprintf(
+		/* translators: %d: number of orders. */
+		_n( '%d order', '%d orders', revenueOrders, 'godam' ),
+		revenueOrders,
+	);
 
 	const showRail = meta.hasSubHotspots && ( parent.sub_hotspots || [] ).length > 0;
 
@@ -218,6 +234,27 @@ const LayerDetailPanel = ( { parent, attachmentID } ) => {
 						selectedSubId={ selectedSubId }
 						onSelect={ setSelectedSubId }
 					/>
+				) }
+
+				{ showRevenue && (
+					<div className="mb-4 flex items-center gap-2 flex-wrap text-sm text-zinc-700">
+						<span>
+							{ sprintf(
+								/* translators: 1: formatted revenue amount, 2: order count phrase (e.g. "3 orders"). */
+								activeSub
+									? __( 'This hotspot drove %1$s across %2$s', 'godam' )
+									: __( 'This layer drove %1$s across %2$s', 'godam' ),
+								formatRevenue( revenueMinor, revenueEntity.currency ),
+								revenueOrdersPhrase,
+							) }
+						</span>
+						<InfoTooltip
+							text={ __(
+								'Direct in-video contribution only, from add-to-carts inside the video. It is not the product\'s total revenue; purchases made after clicking through to the product page (Assisted) are not counted here.',
+								'godam',
+							) }
+						/>
+					</div>
 				) }
 
 				<LayerInteractionFunnel

--- a/pages/analytics/timeline/SubHotspotRail.js
+++ b/pages/analytics/timeline/SubHotspotRail.js
@@ -6,11 +6,12 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { formatRevenue } from '../../dashboard/components/TopProductsTable';
 import {
 	LAYER_TYPE_BY_ID,
 	subHotspotColor,
@@ -231,6 +232,20 @@ const SubHotspotRail = ( { parent, selectedSubId, onSelect } ) => {
 								>
 									{ ( Number( sub.conversion_rate ) || 0 ).toFixed( 1 ) }%
 								</span>
+								{ /* Per-hotspot Direct revenue (Woo only), shown only when
+								    this hotspot has attributed orders. Base currency; other
+								    currencies are excluded, not converted. */ }
+								{ parent.layer_type === 'woo' && Number( sub.orders ) > 0 && (
+									<span className="basis-full text-right text-xs text-zinc-500 tabular-nums">
+										{ formatRevenue( sub.revenue_minor, sub.currency ) }
+										{ ' · ' }
+										{ sprintf(
+											/* translators: %d: number of orders attributed to this hotspot. */
+											_n( '%d order', '%d orders', sub.orders, 'godam' ),
+											sub.orders,
+										) }
+									</span>
+								) }
 							</button>
 						</li>
 					);

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -444,31 +444,30 @@ const Dashboard = () => {
 									analyticsDataFetched={ insightsMetrics }
 								/>
 
-								{ /* Engagement Rate is intentionally not shown on the dashboard
-								    (it keeps the row to four cards on Woo / three on non-Woo,
-								    matching the design and avoiding a cramped, clipping row).
+								{ /* Engagement Rate is intentionally not shown on the dashboard;
 								    Average Engagement still appears on each video's own
 								    analytics page. */ }
+							</div>
 
-								{ /* WooCommerce-only: Video-to-Cart has no meaning without a
-								    store, and the card would otherwise read a permanent,
-								    misleading "0" on non-Woo sites. */ }
-								{ hasWooProducts && (
+							{ /* WooCommerce metrics on their own row below the core Insights:
+							    Video-to-Cart and Video-to-Purchase side by side (per the
+							    design), each with its range-aware trend badge. Woo-gated:
+							    both would otherwise read a permanent, misleading "0" on a
+							    non-Woo store. */ }
+							{ hasWooProducts && (
+								<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-col items-stretch flex-wrap gap-4 mt-4 lg:[&>*]:grow lg:[&>*]:basis-40">
 									<VideoToCartCard
 										videoToCart={ insightsMetrics?.video_to_cart }
 										dataLabel={ insightsCardLabel }
+										deltaLabel={ insightsDeltaLabel }
 									/>
-								) }
-
-								{ /* WooCommerce-only: the purchase sibling of Video-to-Cart --
-								    distinct viewers who went on to buy an attributed product. */ }
-								{ hasWooProducts && (
 									<VideoToPurchaseCard
 										videoToPurchase={ insightsMetrics?.video_to_purchase }
 										dataLabel={ insightsCardLabel }
+										deltaLabel={ insightsDeltaLabel }
 									/>
-								) }
-							</div>
+								</div>
+							) }
 						</div>
 
 						<div className="playback-performance" id="global-analytics-container">
@@ -487,6 +486,7 @@ const Dashboard = () => {
 					<RevenueCard
 						revenue={ insightsMetrics?.revenue }
 						dataLabel={ insightsCardLabel }
+						deltaLabel={ insightsDeltaLabel }
 					/>
 				) }
 

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -460,16 +460,6 @@ const Dashboard = () => {
 									/>
 								) }
 
-								{ /* WooCommerce-only: video-attributed revenue in the store's
-								    base currency (single store currency; other currencies are
-								    counted, not converted). */ }
-								{ hasWooProducts && (
-									<RevenueCard
-										revenue={ insightsMetrics?.revenue }
-										dataLabel={ insightsCardLabel }
-									/>
-								) }
-
 								{ /* WooCommerce-only: the purchase sibling of Video-to-Cart --
 								    distinct viewers who went on to buy an attributed product. */ }
 								{ hasWooProducts && (
@@ -489,6 +479,16 @@ const Dashboard = () => {
 						</div>
 					</div>
 				</div>
+
+				{ /* Video-Attributed Revenue (WooCommerce only): the headline revenue
+				    figure, split Direct/Assisted, with account-wide Influenced shown
+				    separately. Full-width card, single store currency. */ }
+				{ hasWooProducts && (
+					<RevenueCard
+						revenue={ insightsMetrics?.revenue }
+						dataLabel={ insightsCardLabel }
+					/>
+				) }
 
 				{ /* Account-wide Play-to-Cart-to-Purchase funnel (WooCommerce only). */ }
 				{ hasWooProducts && (

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -21,6 +21,7 @@ import GodamHeader from '../godam/components/GoDAMHeader.jsx';
 import { getAPIKeyErrorInfo, hasAPIKey } from '../godam/utils';
 import SingleMetrics from '../analytics/SingleMetrics';
 import VideoToCartCard from '../analytics/VideoToCartCard';
+import VideoToPurchaseCard from '../analytics/VideoToPurchaseCard';
 import RevenueCard from '../analytics/RevenueCard';
 import ViewersGauge from './components/ViewersGauge';
 import PlaybackPerformanceDashboard from '../analytics/PlaybackPerformance';
@@ -395,7 +396,7 @@ const Dashboard = () => {
 									testIdPrefix="godam-dashboard-insights-daterange"
 								/>
 							</div>
-							<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-row items-stretch flex-wrap justify-center lg:flex-nowrap">
+							<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-row items-stretch flex-wrap justify-center lg:flex-wrap lg:[&>*]:grow lg:[&>*]:basis-40">
 
 								<SingleMetrics
 									mode="dashboard"
@@ -463,6 +464,15 @@ const Dashboard = () => {
 								{ hasWooProducts && (
 									<RevenueCard
 										revenue={ insightsMetrics?.revenue }
+										dataLabel={ insightsCardLabel }
+									/>
+								) }
+
+								{ /* WooCommerce-only: the purchase sibling of Video-to-Cart --
+								    distinct viewers who went on to buy an attributed product. */ }
+								{ hasWooProducts && (
+									<VideoToPurchaseCard
+										videoToPurchase={ insightsMetrics?.video_to_purchase }
 										dataLabel={ insightsCardLabel }
 									/>
 								) }

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -24,6 +24,7 @@ import VideoToCartCard from '../analytics/VideoToCartCard';
 import VideoToPurchaseCard from '../analytics/VideoToPurchaseCard';
 import RevenueCard from '../analytics/RevenueCard';
 import PurchaseFunnelCard from '../analytics/PurchaseFunnelCard';
+import PlacementFunnelCard from '../analytics/PlacementFunnelCard';
 import ViewersGauge from './components/ViewersGauge';
 import PlaybackPerformanceDashboard from '../analytics/PlaybackPerformance';
 import TopVideosTable from './components/TopVideosTable';
@@ -495,6 +496,16 @@ const Dashboard = () => {
 						funnel={ insightsMetrics?.video_funnel }
 						dataLabel={ insightsCardLabel }
 						scope="account"
+					/>
+				) }
+
+				{ /* Funnel by placement (WooCommerce only) — fetches its own data. */ }
+				{ hasWooProducts && (
+					<PlacementFunnelCard
+						siteUrl={ siteUrl }
+						startDate={ insightsRange.startDate }
+						endDate={ insightsRange.endDate }
+						dataLabel={ insightsCardLabel }
 					/>
 				) }
 

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -21,6 +21,7 @@ import GodamHeader from '../godam/components/GoDAMHeader.jsx';
 import { getAPIKeyErrorInfo, hasAPIKey } from '../godam/utils';
 import SingleMetrics from '../analytics/SingleMetrics';
 import VideoToCartCard from '../analytics/VideoToCartCard';
+import RevenueCard from '../analytics/RevenueCard';
 import ViewersGauge from './components/ViewersGauge';
 import PlaybackPerformanceDashboard from '../analytics/PlaybackPerformance';
 import TopVideosTable from './components/TopVideosTable';
@@ -452,6 +453,16 @@ const Dashboard = () => {
 								{ hasWooProducts && (
 									<VideoToCartCard
 										videoToCart={ insightsMetrics?.video_to_cart }
+										dataLabel={ insightsCardLabel }
+									/>
+								) }
+
+								{ /* WooCommerce-only: video-attributed revenue in the store's
+								    base currency (single store currency; other currencies are
+								    counted, not converted). */ }
+								{ hasWooProducts && (
+									<RevenueCard
+										revenue={ insightsMetrics?.revenue }
 										dataLabel={ insightsCardLabel }
 									/>
 								) }

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -23,6 +23,7 @@ import SingleMetrics from '../analytics/SingleMetrics';
 import VideoToCartCard from '../analytics/VideoToCartCard';
 import VideoToPurchaseCard from '../analytics/VideoToPurchaseCard';
 import RevenueCard from '../analytics/RevenueCard';
+import PurchaseFunnelCard from '../analytics/PurchaseFunnelCard';
 import ViewersGauge from './components/ViewersGauge';
 import PlaybackPerformanceDashboard from '../analytics/PlaybackPerformance';
 import TopVideosTable from './components/TopVideosTable';
@@ -487,6 +488,15 @@ const Dashboard = () => {
 						</div>
 					</div>
 				</div>
+
+				{ /* Account-wide Play-to-Cart-to-Purchase funnel (WooCommerce only). */ }
+				{ hasWooProducts && (
+					<PurchaseFunnelCard
+						funnel={ insightsMetrics?.video_funnel }
+						dataLabel={ insightsCardLabel }
+						scope="account"
+					/>
+				) }
 
 				{ hasWooProducts && topTab === 'products'
 					? <TopProductsTable siteUrl={ siteUrl } skip={ shouldSkipSecondaryQueries } tabSwitcher={ topTabSwitcher } />

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -491,7 +491,9 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 												<span className="text-zinc-400">{ ordersLabel( item ) }</span>
 											</>
 										) : (
-											<span className="text-zinc-400">-</span>
+											// null-not-zero: the service sends null revenue for a
+											// product with no orders yet; say so rather than "0".
+											<span className="text-zinc-400" data-test-id="godam-top-products-revenue-empty">{ __( 'No data', 'godam' ) }</span>
 										) }
 										{ /* Influenced revenue (third tier): a separate sub-line,
 										    shown only when there is a real match, never added into

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -205,6 +205,15 @@ export const influencedOrdersLabel = ( item ) => {
 	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
 };
 
+// Per-placement revenue breakdown (EASY WIN A): the placements (block_source)
+// that drove this product's revenue, high-to-low, with revenue > 0. The service
+// splits revenue by the block_source it already stores.
+export const revenuePlacements = ( item ) =>
+	Object.entries( item.revenue_by_placement || {} )
+		.map( ( [ source, v ] ) => ( { source, revenue_minor: Number( v?.revenue_minor || 0 ) } ) )
+		.filter( ( p ) => p.revenue_minor > 0 )
+		.sort( ( a, b ) => b.revenue_minor - a.revenue_minor );
+
 /**
  * Dashboard "Top Products" table.
  *
@@ -515,6 +524,23 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 														{ __( '(provisional)', 'godam' ) }
 													</span>
 												) }
+											</div>
+										) }
+										{ /* Per-placement revenue split — only when 2+ surfaces
+										    drove revenue (a single placement just repeats the
+										    total above). */ }
+										{ hasRevenue( item ) && revenuePlacements( item ).length >= 2 && (
+											<div
+												className="mt-1 text-xs text-zinc-400"
+												data-test-id="godam-top-products-placement-split"
+											>
+												{ revenuePlacements( item ).map( ( p, i ) => (
+													<span key={ p.source }>
+														{ i > 0 && ' · ' }
+														{ sourceLabel( p.source ) }{ ' ' }
+														{ formatRevenue( p.revenue_minor, item.currency ) }
+													</span>
+												) ) }
 											</div>
 										) }
 									</td>

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -91,10 +91,10 @@ const cartRate = ( item ) => {
 const reachLabel = ( item ) => {
 	const layers = Number( item.layer_count || 0 );
 	const videos = Number( item.video_count || 0 );
-	/* translators: %d: number of layers the product appears in. */
-	const layersText = sprintf( _n( '%d layer', '%d layers', layers, 'godam' ), layers );
-	/* translators: %d: number of videos the product appears in. */
-	const videosText = sprintf( _n( '%d video', '%d videos', videos, 'godam' ), videos );
+	/* translators: %s: number of layers the product appears in. */
+	const layersText = sprintf( _n( '%s layer', '%s layers', layers, 'godam' ), layers.toLocaleString() );
+	/* translators: %s: number of videos the product appears in. */
+	const videosText = sprintf( _n( '%s video', '%s videos', videos, 'godam' ), videos.toLocaleString() );
 	return `${ layersText } · ${ videosText }`;
 };
 
@@ -203,8 +203,8 @@ export function formatRevenueNumeric( minor, currency ) {
 // product_views_ctr is shown as secondary text next to product_views.
 const ordersLabel = ( item ) => {
 	const orders = Number( item.orders || 0 );
-	/* translators: %d: number of distinct orders contributing to this product's revenue. */
-	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
+	/* translators: %s: number of distinct orders contributing to this product's revenue. */
+	return sprintf( _n( '%s order', '%s orders', orders, 'godam' ), orders.toLocaleString() );
 };
 
 // Whether this row carries a real Influenced-revenue match (the third tier:
@@ -219,8 +219,8 @@ export const hasInfluenced = ( item ) =>
 // "N orders" label for the Influenced sub-line.
 export const influencedOrdersLabel = ( item ) => {
 	const orders = Number( item.influenced_orders || 0 );
-	/* translators: %d: number of distinct orders influenced by a product-page view of a video. */
-	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
+	/* translators: %s: number of distinct orders influenced by a product-page view of a video. */
+	return sprintf( _n( '%s order', '%s orders', orders, 'godam' ), orders.toLocaleString() );
 };
 
 // Per-placement revenue breakdown (EASY WIN A): the placements (block_source)

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -258,6 +258,69 @@ export const hasRevenueTierSplit = ( item ) =>
  * @param {boolean} props.skip          Skip the query while the dashboard is gated.
  * @param {Object}  [props.tabSwitcher] Optional switcher node rendered in the table head in place of the title.
  */
+// Export column headers, matched 1:1 with buildCsvRow below, mirroring every
+// column and sub-line shown in the on-screen Top Products table.
+export const CSV_HEADERS = [
+	__( 'Product', 'godam' ),
+	__( 'Product ID', 'godam' ),
+	__( 'Layers', 'godam' ),
+	__( 'Videos', 'godam' ),
+	__( 'Source', 'godam' ),
+	__( 'Product Views', 'godam' ),
+	__( 'Product Views Rate', 'godam' ),
+	__( 'Add to Cart', 'godam' ),
+	__( 'Add to Cart (in-video)', 'godam' ),
+	__( 'Add to Cart (assisted)', 'godam' ),
+	__( 'Revenue', 'godam' ),
+	__( 'Revenue (direct)', 'godam' ),
+	__( 'Revenue (assisted)', 'godam' ),
+	__( 'Currency', 'godam' ),
+	__( 'Orders', 'godam' ),
+	__( 'Influenced Revenue', 'godam' ),
+	__( 'Influenced Currency', 'godam' ),
+	__( 'Influenced Orders', 'godam' ),
+	__( 'Influenced Provisional', 'godam' ),
+	__( 'Revenue by Placement', 'godam' ),
+];
+
+// One CSV cell per column, in CSV_HEADERS order. Mirrors every value the table
+// renders so an export reconciles cell-for-cell with what the merchant sees.
+export const buildCsvRow = ( item ) => {
+	const placements = revenuePlacements( item );
+	let influencedProvisional = '';
+	if ( hasInfluenced( item ) ) {
+		influencedProvisional = item.influenced_provisional ? __( 'Yes', 'godam' ) : __( 'No', 'godam' );
+	}
+	return [
+		item.title || item.product_id,
+		`ID: ${ item.product_id }`,
+		Number( item.layer_count || 0 ),
+		Number( item.video_count || 0 ),
+		( item.sources || [] ).map( sourceLabel ).join( ' | ' ),
+		Number( item.product_views || 0 ),
+		Number( item.product_views_ctr || 0 ).toFixed( 2 ) + '%',
+		Number( item.added_to_cart || 0 ),
+		Number( item.added_to_cart_direct || 0 ),
+		Number( item.added_to_cart_assisted || 0 ),
+		hasRevenue( item ) ? formatRevenueNumeric( item.revenue_minor, item.currency ) : '',
+		hasRevenueTierSplit( item ) ? formatRevenueNumeric( item.revenue_direct_minor, item.currency ) : '',
+		hasRevenueTierSplit( item ) ? formatRevenueNumeric( item.revenue_assisted_minor, item.currency ) : '',
+		hasRevenue( item ) ? ( item.currency || '' ) : '',
+		hasRevenue( item ) ? Number( item.orders || 0 ) : '',
+		hasInfluenced( item ) ? formatRevenueNumeric( item.influenced_revenue_minor, item.influenced_currency ) : '',
+		hasInfluenced( item ) ? ( item.influenced_currency || '' ) : '',
+		hasInfluenced( item ) ? Number( item.influenced_orders || 0 ) : '',
+		influencedProvisional,
+		// Per-placement split mirrors the on-screen sub-line: shown only when 2+
+		// surfaces drove revenue (a single placement just repeats the total).
+		placements.length >= 2
+			? placements
+				.map( ( pl ) => `${ sourceLabel( pl.source ) }: ${ formatRevenueNumeric( pl.revenue_minor, item.currency ) }` )
+				.join( ' | ' )
+			: '',
+	];
+};
+
 export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher = null } ) {
 	const [ page, setPage ] = useState( 1 );
 	const [ searchInput, setSearchInput ] = useState( '' );
@@ -310,22 +373,6 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 			?.scrollIntoView( { behavior: 'smooth' } );
 	}, [ page ] );
 
-	const buildCsvRow = ( item ) => [
-		item.title || item.product_id,
-		`ID: ${ item.product_id }`,
-		( item.sources || [] ).map( sourceLabel ).join( ' | ' ),
-		Number( item.product_views || 0 ),
-		Number( item.product_views_ctr || 0 ).toFixed( 2 ) + '%',
-		Number( item.added_to_cart || 0 ),
-		Number( item.added_to_cart_direct || 0 ),
-		Number( item.added_to_cart_assisted || 0 ),
-		hasRevenue( item ) ? formatRevenueNumeric( item.revenue_minor, item.currency ) : '',
-		hasRevenueTierSplit( item ) ? formatRevenueNumeric( item.revenue_direct_minor, item.currency ) : '',
-		hasRevenueTierSplit( item ) ? formatRevenueNumeric( item.revenue_assisted_minor, item.currency ) : '',
-		hasRevenue( item ) ? ( item.currency || '' ) : '',
-		hasRevenue( item ) ? Number( item.orders || 0 ) : '',
-	];
-
 	const handleExportCSV = async () => {
 		setIsExporting( true );
 		// try/finally so the button never sticks on "Exporting…" if anything below
@@ -371,23 +418,7 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 			const fetched = pageProducts.flat();
 			const exportProducts = fetched.length ? fetched : products;
 
-			const headers = [
-				__( 'Product', 'godam' ),
-				__( 'Product ID', 'godam' ),
-				__( 'Source', 'godam' ),
-				__( 'Product Views', 'godam' ),
-				__( 'Product Views Rate', 'godam' ),
-				__( 'Add to Cart', 'godam' ),
-				__( 'Add to Cart (in-video)', 'godam' ),
-				__( 'Add to Cart (assisted)', 'godam' ),
-				__( 'Revenue', 'godam' ),
-				__( 'Revenue (direct)', 'godam' ),
-				__( 'Revenue (assisted)', 'godam' ),
-				__( 'Currency', 'godam' ),
-				__( 'Orders', 'godam' ),
-			];
-
-			const csvContent = [ headers, ...exportProducts.map( buildCsvRow ) ]
+			const csvContent = [ CSV_HEADERS, ...exportProducts.map( buildCsvRow ) ]
 				.map( ( row ) => row.map( escapeCsvCell ).join( ',' ) )
 				.join( '\n' );
 

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -189,6 +189,22 @@ const ordersLabel = ( item ) => {
 	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
 };
 
+// Whether this row carries a real Influenced-revenue match (the third tier:
+// a product-page play matched to a later purchase of the same product). Shown
+// only when > 0 - an absent or zero match renders nothing, never a misleading
+// "£0", and Influenced is never folded into the product's own revenue total.
+export const hasInfluenced = ( item ) =>
+	item.influenced_revenue_minor !== undefined &&
+	item.influenced_revenue_minor !== null &&
+	Number( item.influenced_revenue_minor ) > 0;
+
+// "N orders" label for the Influenced sub-line.
+export const influencedOrdersLabel = ( item ) => {
+	const orders = Number( item.influenced_orders || 0 );
+	/* translators: %d: number of distinct orders influenced by a product-page view of a video. */
+	return sprintf( _n( '%d order', '%d orders', orders, 'godam' ), orders );
+};
+
 /**
  * Dashboard "Top Products" table.
  *
@@ -476,6 +492,28 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 											</>
 										) : (
 											<span className="text-zinc-400">-</span>
+										) }
+										{ /* Influenced revenue (third tier): a separate sub-line,
+										    shown only when there is a real match, never added into
+										    the product's own revenue above. */ }
+										{ hasInfluenced( item ) && (
+											<div
+												className="mt-1 text-xs text-zinc-500"
+												data-test-id="godam-top-products-influenced"
+											>
+												{ sprintf(
+													/* translators: 1: formatted influenced revenue amount, 2: order count phrase (e.g. "3 orders"). */
+													__( 'Influenced %1$s · %2$s', 'godam' ),
+													formatRevenue( item.influenced_revenue_minor, item.influenced_currency ),
+													influencedOrdersLabel( item ),
+												) }
+												{ item.influenced_provisional && (
+													<span className="text-zinc-400">
+														{ ' ' }
+														{ __( '(provisional)', 'godam' ) }
+													</span>
+												) }
+											</div>
 										) }
 									</td>
 								</tr>

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -21,16 +21,17 @@ const PER_PAGE = 10;
 // export pages through it 100 at a time rather than asking for everything at once.
 const EXPORT_PAGE_SIZE = 100;
 
-// block_source value -> human label for the Source chips. Phase 1 only ever emits
-// 'woo-layer' (and 'shoppable-video' once that emit ships); the rest are here so the
-// chips read correctly when later surfaces start contributing. Unknown values fall
-// back to the raw string.
+// block_source value -> human label for the Source chips. The Woo hotspot layer
+// ships on two media, so the labels name the medium ('Video Woo Layer' vs 'Image
+// Woo Layer') rather than a bare 'Woo Layer' / 'Image': an image can carry other
+// layer types later, so the label says which layer, not just which medium. Unknown
+// values fall back to the raw string.
 const SOURCE_LABELS = {
-	'woo-layer': __( 'Woo Layer', 'godam' ),
+	'woo-layer': __( 'Video Woo Layer', 'godam' ),
 	'shoppable-video': __( 'Shoppable Video', 'godam' ),
 	'reel-pop': __( 'Reel Pop', 'godam' ),
 	'wc-product-gallery': __( 'Product Gallery', 'godam' ),
-	'godam-image': __( 'Image', 'godam' ),
+	'godam-image': __( 'Image Woo Layer', 'godam' ),
 };
 
 export const sourceLabel = ( value ) => SOURCE_LABELS[ value ] || value;

--- a/pages/dashboard/components/TopProductsTable.js
+++ b/pages/dashboard/components/TopProductsTable.js
@@ -10,6 +10,7 @@ import { SearchControl } from '@wordpress/components';
  */
 import { useFetchTopProductsQuery, useLazyFetchTopProductsQuery } from '../redux/api/dashboardAnalyticsApi';
 import DateRangePicker from '../../analytics/components/DateRangePicker';
+import Tooltip from '../../analytics/Tooltip';
 import DefaultThumbnail from '../../../assets/src/images/video-thumbnail-default.png';
 import ExportBtn from '../../../assets/src/images/export.svg';
 import chevronLeft from '../../../assets/src/images/chevron-left.svg';
@@ -214,6 +215,18 @@ export const revenuePlacements = ( item ) =>
 		.filter( ( p ) => p.revenue_minor > 0 )
 		.sort( ( a, b ) => b.revenue_minor - a.revenue_minor );
 
+// Whether this row carries a Direct/Assisted revenue split. The service sends
+// `revenue_direct_minor` / `revenue_assisted_minor` only for a WooCommerce store
+// (a base currency) once a product has at least one attributed order line; an
+// older service build, or a product with no orders, omits both. Treated as
+// absent rather than zero so a row without the split shows nothing, never a
+// misleading "£0 direct · £0 assisted".
+export const hasRevenueTierSplit = ( item ) =>
+	item.revenue_direct_minor !== undefined &&
+	item.revenue_direct_minor !== null &&
+	item.revenue_assisted_minor !== undefined &&
+	item.revenue_assisted_minor !== null;
+
 /**
  * Dashboard "Top Products" table.
  *
@@ -290,6 +303,8 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 		Number( item.added_to_cart_direct || 0 ),
 		Number( item.added_to_cart_assisted || 0 ),
 		hasRevenue( item ) ? formatRevenueNumeric( item.revenue_minor, item.currency ) : '',
+		hasRevenueTierSplit( item ) ? formatRevenueNumeric( item.revenue_direct_minor, item.currency ) : '',
+		hasRevenueTierSplit( item ) ? formatRevenueNumeric( item.revenue_assisted_minor, item.currency ) : '',
 		hasRevenue( item ) ? ( item.currency || '' ) : '',
 		hasRevenue( item ) ? Number( item.orders || 0 ) : '',
 	];
@@ -323,6 +338,8 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 			__( 'Add to Cart (in-video)', 'godam' ),
 			__( 'Add to Cart (assisted)', 'godam' ),
 			__( 'Revenue', 'godam' ),
+			__( 'Revenue (direct)', 'godam' ),
+			__( 'Revenue (assisted)', 'godam' ),
 			__( 'Currency', 'godam' ),
 			__( 'Orders', 'godam' ),
 		];
@@ -390,10 +407,50 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 					<thead>
 						<tr>
 							<th scope="col">{ __( 'Product', 'godam' ) }</th>
-							<th scope="col">{ __( 'Source', 'godam' ) }</th>
-							<th scope="col">{ __( 'Product Views', 'godam' ) }</th>
-							<th scope="col">{ __( 'Add to Cart', 'godam' ) }</th>
-							<th scope="col">{ __( 'Revenue', 'godam' ) }</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Source', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'Where in your videos this product appeared: a Woo layer, a shoppable video, a reel pop, and so on.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Product Views', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'How many times shoppers opened this product from a video, with the click-through rate beside it (product opens / times the product was shown).',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Add to Cart', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'How many times the product was added to cart from a video, with the add-to-cart rate. In-video means added inside the player; via product page means added after clicking through.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Revenue', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'Order value traced to this product\'s videos, in the store\'s base currency, before refunds. Direct means added to cart in-video; Assisted means bought after clicking through to the product page.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -503,6 +560,23 @@ export default function TopProductsTable( { siteUrl, skip = false, tabSwitcher =
 											// null-not-zero: the service sends null revenue for a
 											// product with no orders yet; say so rather than "0".
 											<span className="text-zinc-400" data-test-id="godam-top-products-revenue-empty">{ __( 'No data', 'godam' ) }</span>
+										) }
+										{ /* Direct/Assisted split of this product's revenue,
+										    mirroring the dashboard revenue card. Shown only when
+										    the service sent the split (WooCommerce store, product
+										    with orders); never a "£0 direct · £0 assisted". */ }
+										{ hasRevenue( item ) && hasRevenueTierSplit( item ) && (
+											<div
+												className="mt-1 text-xs text-zinc-500"
+												data-test-id="godam-top-products-tier-split"
+											>
+												{ sprintf(
+													/* translators: 1: direct (in-video) revenue amount, 2: assisted (via product page) revenue amount. */
+													__( '%1$s direct · %2$s assisted', 'godam' ),
+													formatRevenue( item.revenue_direct_minor, item.currency ),
+													formatRevenue( item.revenue_assisted_minor, item.currency ),
+												) }
+											</div>
 										) }
 										{ /* Influenced revenue (third tier): a separate sub-line,
 										    shown only when there is a real match, never added into

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -290,3 +290,10 @@ describe( 'buildCsvRow — the CSV mirrors the on-screen table', () => {
 		expect( cell( row, 'Revenue by Placement' ) ).toBe( '' );
 	} );
 } );
+
+describe( 'order-count labels use grouped thousands', () => {
+	it( 'groups a 1,000+ order count and keeps the singular for one', () => {
+		expect( influencedOrdersLabel( { influenced_orders: 1234 } ) ).toBe( '1,234 orders' );
+		expect( influencedOrdersLabel( { influenced_orders: 1 } ) ).toBe( '1 order' );
+	} );
+} );

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -79,11 +79,11 @@ describe( 'escapeCsvCell — formula-injection guard', () => {
 
 describe( 'sourceLabel — Source chip label mapping', () => {
 	it( 'maps each implemented/known block_source to its human label', () => {
-		expect( sourceLabel( 'woo-layer' ) ).toBe( 'Woo Layer' );
+		expect( sourceLabel( 'woo-layer' ) ).toBe( 'Video Woo Layer' );
 		expect( sourceLabel( 'shoppable-video' ) ).toBe( 'Shoppable Video' );
 		expect( sourceLabel( 'reel-pop' ) ).toBe( 'Reel Pop' );
 		expect( sourceLabel( 'wc-product-gallery' ) ).toBe( 'Product Gallery' );
-		expect( sourceLabel( 'godam-image' ) ).toBe( 'Image' );
+		expect( sourceLabel( 'godam-image' ) ).toBe( 'Image Woo Layer' );
 	} );
 
 	it( 'falls back to the raw value for an unknown source', () => {

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel, revenuePlacements } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel, revenuePlacements, hasRevenueTierSplit } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -141,6 +141,25 @@ describe( 'hasInfluenced — Influenced sub-line gate (third tier)', () => {
 		expect( formatRevenue( 250000, 'INR' ) ).toContain( '2,500' );
 		expect( formatRevenue( 1234, 'JPY' ) ).not.toContain( '.' );
 		expect( formatRevenue( 500, 'USD' ) ).toBe( '$5.00' );
+	} );
+} );
+
+describe( 'hasRevenueTierSplit — Direct/Assisted revenue sub-line gate', () => {
+	it( 'is true only when both tier amounts are present (Woo store, product with orders)', () => {
+		expect( hasRevenueTierSplit( { revenue_direct_minor: 1000, revenue_assisted_minor: 300 } ) ).toBe( true );
+		// A real zero on one side is still a present split (all revenue on one tier).
+		expect( hasRevenueTierSplit( { revenue_direct_minor: 0, revenue_assisted_minor: 800 } ) ).toBe( true );
+	} );
+
+	it( 'is false when the service omitted the split (older build / no base currency / no orders)', () => {
+		expect( hasRevenueTierSplit( {} ) ).toBe( false );
+		expect( hasRevenueTierSplit( { revenue_direct_minor: 1000 } ) ).toBe( false );
+		expect( hasRevenueTierSplit( { revenue_direct_minor: null, revenue_assisted_minor: null } ) ).toBe( false );
+	} );
+
+	it( 'renders both amounts via the shipped formatRevenue', () => {
+		expect( formatRevenue( 1000, 'GBP' ) ).toBe( '£10.00' );
+		expect( formatRevenue( 300, 'GBP' ) ).toBe( '£3.00' );
 	} );
 } );
 

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel, revenuePlacements, hasRevenueTierSplit } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel, revenuePlacements, hasRevenueTierSplit, buildCsvRow, CSV_HEADERS } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -226,5 +226,67 @@ describe( 'formatRevenueNumeric — CSV plain-number revenue', () => {
 
 	it( 'treats a missing amount as zero', () => {
 		expect( formatRevenueNumeric( undefined, 'GBP' ) ).toBe( '0.00' );
+	} );
+} );
+
+describe( 'buildCsvRow — the CSV mirrors the on-screen table', () => {
+	const cell = ( row, header ) => row[ CSV_HEADERS.indexOf( header ) ];
+
+	it( 'emits exactly one cell per header, in order', () => {
+		const row = buildCsvRow( { product_id: 5, title: 'Sofa' } );
+		expect( row ).toHaveLength( CSV_HEADERS.length );
+	} );
+
+	it( 'carries reach, the Influenced tier and the per-placement split, matching the row on screen', () => {
+		const item = {
+			product_id: 5,
+			title: 'Sofa',
+			layer_count: 3,
+			video_count: 3,
+			sources: [ 'shoppable-video', 'woo-layer', 'reel-pop' ],
+			product_views: 9,
+			product_views_ctr: 50,
+			added_to_cart: 17,
+			added_to_cart_direct: 0,
+			added_to_cart_assisted: 17,
+			revenue_minor: 8000,
+			currency: 'INR',
+			orders: 2,
+			revenue_direct_minor: 0,
+			revenue_assisted_minor: 8000,
+			influenced_revenue_minor: 6000,
+			influenced_currency: 'INR',
+			influenced_orders: 1,
+			influenced_provisional: true,
+			revenue_by_placement: {
+				'shoppable-video': { revenue_minor: 5000 },
+				'woo-layer': { revenue_minor: 3000 },
+			},
+		};
+		const row = buildCsvRow( item );
+		expect( cell( row, 'Layers' ) ).toBe( 3 );
+		expect( cell( row, 'Videos' ) ).toBe( 3 );
+		expect( cell( row, 'Source' ) ).toContain( 'Shoppable Video' );
+		expect( cell( row, 'Revenue' ) ).toBe( '80.00' );
+		expect( cell( row, 'Revenue (assisted)' ) ).toBe( '80.00' );
+		expect( cell( row, 'Influenced Revenue' ) ).toBe( '60.00' );
+		expect( cell( row, 'Influenced Orders' ) ).toBe( 1 );
+		expect( cell( row, 'Influenced Provisional' ) ).toBe( 'Yes' );
+		expect( cell( row, 'Revenue by Placement' ) ).toContain( 'Shoppable Video: 50.00' );
+		expect( cell( row, 'Revenue by Placement' ) ).toContain( 'Video Woo Layer: 30.00' );
+	} );
+
+	it( 'leaves Influenced and the placement split empty when the row has neither (matches the table)', () => {
+		const item = {
+			product_id: 6,
+			title: 'Lamp',
+			revenue_minor: 1000,
+			currency: 'INR',
+			orders: 1,
+			revenue_by_placement: { 'woo-layer': { revenue_minor: 1000 } }, // single placement
+		};
+		const row = buildCsvRow( item );
+		expect( cell( row, 'Influenced Revenue' ) ).toBe( '' );
+		expect( cell( row, 'Revenue by Placement' ) ).toBe( '' );
 	} );
 } );

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel, revenuePlacements } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -141,6 +141,34 @@ describe( 'hasInfluenced — Influenced sub-line gate (third tier)', () => {
 		expect( formatRevenue( 250000, 'INR' ) ).toContain( '2,500' );
 		expect( formatRevenue( 1234, 'JPY' ) ).not.toContain( '.' );
 		expect( formatRevenue( 500, 'USD' ) ).toBe( '$5.00' );
+	} );
+} );
+
+describe( 'revenuePlacements — per-placement revenue split (EASY WIN A)', () => {
+	it( 'returns placements with revenue, sorted high-to-low', () => {
+		const out = revenuePlacements( {
+			revenue_by_placement: {
+				'reel-pop': { revenue_minor: 400, orders: 1 },
+				'woo-layer': { revenue_minor: 600, orders: 1 },
+			},
+		} );
+		expect( out.map( ( p ) => p.source ) ).toEqual( [ 'woo-layer', 'reel-pop' ] );
+		expect( out[ 0 ].revenue_minor ).toBe( 600 );
+	} );
+
+	it( 'drops placements with zero revenue', () => {
+		const out = revenuePlacements( {
+			revenue_by_placement: {
+				'woo-layer': { revenue_minor: 600, orders: 1 },
+				'reel-pop': { revenue_minor: 0, orders: 0 },
+			},
+		} );
+		expect( out.map( ( p ) => p.source ) ).toEqual( [ 'woo-layer' ] );
+	} );
+
+	it( 'is empty when there is no split', () => {
+		expect( revenuePlacements( {} ) ).toEqual( [] );
+		expect( revenuePlacements( { revenue_by_placement: {} } ) ).toEqual( [] );
 	} );
 } );
 

--- a/pages/dashboard/components/TopProductsTable.test.js
+++ b/pages/dashboard/components/TopProductsTable.test.js
@@ -14,7 +14,7 @@
 /**
  * Internal dependencies
  */
-import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric } from './TopProductsTable';
+import { escapeCsvCell, sourceLabel, formatRevenue, formatRevenueNumeric, hasInfluenced, influencedOrdersLabel } from './TopProductsTable';
 
 describe( 'escapeCsvCell — formula-injection guard', () => {
 	// A value whose FIRST character is one of these is what a spreadsheet would
@@ -118,6 +118,40 @@ describe( 'formatRevenue — revenue_minor -> currency amount', () => {
 
 	it( 'falls back to a plain number when the currency code is invalid', () => {
 		expect( formatRevenue( 1234, 'NOT-A-CODE' ) ).toBe( '12.34 NOT-A-CODE' );
+	} );
+} );
+
+describe( 'hasInfluenced — Influenced sub-line gate (third tier)', () => {
+	it( 'is true only when influenced_revenue_minor is a positive number', () => {
+		expect( hasInfluenced( { influenced_revenue_minor: 250000 } ) ).toBe( true );
+	} );
+
+	it( 'is false when there is no match (0), so no misleading £0 renders', () => {
+		expect( hasInfluenced( { influenced_revenue_minor: 0 } ) ).toBe( false );
+	} );
+
+	it( 'is false when the service omitted the field (older build / no match)', () => {
+		expect( hasInfluenced( {} ) ).toBe( false );
+		expect( hasInfluenced( { influenced_revenue_minor: null } ) ).toBe( false );
+	} );
+
+	it( 'renders its amount via the shipped formatRevenue (no new formatter)', () => {
+		// The sub-line uses the SAME formatRevenue as the Revenue cell, keyed on
+		// the separate influenced_currency: JPY has no decimals, USD has two.
+		expect( formatRevenue( 250000, 'INR' ) ).toContain( '2,500' );
+		expect( formatRevenue( 1234, 'JPY' ) ).not.toContain( '.' );
+		expect( formatRevenue( 500, 'USD' ) ).toBe( '$5.00' );
+	} );
+} );
+
+describe( 'influencedOrdersLabel — singular/plural order count', () => {
+	it( 'renders singular for one order', () => {
+		expect( influencedOrdersLabel( { influenced_orders: 1 } ) ).toBe( '1 order' );
+	} );
+
+	it( 'renders plural for several, and zero when absent', () => {
+		expect( influencedOrdersLabel( { influenced_orders: 3 } ) ).toBe( '3 orders' );
+		expect( influencedOrdersLabel( {} ) ).toBe( '0 orders' );
 	} );
 } );
 

--- a/pages/dashboard/components/TopVideosTable.js
+++ b/pages/dashboard/components/TopVideosTable.js
@@ -10,6 +10,7 @@ import { SearchControl, ToggleControl } from '@wordpress/components';
  */
 import { useFetchTopVideosQuery, useLazyFetchTopVideosQuery } from '../redux/api/dashboardAnalyticsApi';
 import DateRangePicker from '../../analytics/components/DateRangePicker';
+import Tooltip from '../../analytics/Tooltip';
 import { formatWatchTime } from '../../utils/formatters';
 import DefaultThumbnail from '../../../assets/src/images/video-thumbnail-default.png';
 import ExportBtn from '../../../assets/src/images/export.svg';
@@ -270,14 +271,94 @@ export default function TopVideosTable( { siteUrl, skip = false, tabSwitcher = n
 				<table className="w-full">
 					<thead>
 						<tr>
-							<th scope="col">{ __( 'Name', 'godam' ) }</th>
-							<th scope="col">{ __( 'Size', 'godam' ) }</th>
-							<th scope="col">{ __( 'Play Rate', 'godam' ) }</th>
-							<th scope="col">{ __( 'Total Plays', 'godam' ) }</th>
-							<th scope="col">{ __( 'Total Watch Time', 'godam' ) }</th>
-							<th scope="col">{ __( 'Average Engagement', 'godam' ) }</th>
-							<th scope="col">{ __( 'Conversion Rate', 'godam' ) }</th>
-							<th scope="col">{ __( 'Placements', 'godam' ) }</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Name', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'The video\'s title. Open it to see this video\'s own analytics.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Size', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'The video file\'s size.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Play Rate', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'The share of people who, after the video loaded, actually pressed play.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Total Plays', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'How many times this video was played.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Total Watch Time', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'The total time everyone spent watching this video.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Average Engagement', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'On average, how much of the video people watch before leaving.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Conversion Rate', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'The share of viewing sessions that acted on an interactive layer: clicked a hotspot or CTA, submitted a form, voted in a poll, or added to cart. Hovers are not counted.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
+							<th scope="col">
+								<span className="inline-flex items-center gap-1">
+									{ __( 'Placements', 'godam' ) }
+									<Tooltip
+										text={ __(
+											'How many different pages this video appears on.',
+											'godam',
+										) }
+									/>
+								</span>
+							</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/pages/dashboard/index.scss
+++ b/pages/dashboard/index.scss
@@ -791,6 +791,7 @@
 // top-level sections use (matches .top-media-container). Scoped to the dashboard so
 // the per-video Analytics page, where the funnel card is a flex-column child, keeps
 // its own gap.
+.dashboard-container > .godam-revenue-card,
 .dashboard-container > .godam-funnel-card,
 .dashboard-container > .godam-placement-funnel-card {
 	margin-top: 1.5rem;

--- a/pages/dashboard/index.scss
+++ b/pages/dashboard/index.scss
@@ -784,3 +784,18 @@
 	text-underline-offset: 2px;
 	cursor: help;
 }
+
+// The Purchase Funnel and Funnel-by-placement cards sit directly in the dashboard
+// flow between the grid above and the Top Videos/Products table below. The base
+// .godam-card has no margin, so give them the same 1.5rem vertical rhythm the other
+// top-level sections use (matches .top-media-container). Scoped to the dashboard so
+// the per-video Analytics page, where the funnel card is a flex-column child, keeps
+// its own gap.
+.dashboard-container > .godam-funnel-card,
+.dashboard-container > .godam-placement-funnel-card {
+	margin-top: 1.5rem;
+}
+
+.dashboard-container > .godam-placement-funnel-card {
+	margin-bottom: 1.5rem;
+}

--- a/pages/dashboard/redux/api/dashboardAnalyticsApi.js
+++ b/pages/dashboard/redux/api/dashboardAnalyticsApi.js
@@ -118,6 +118,9 @@ export const dashboardAnalyticsApi = createApi( {
 		} ),
 		// Fetch Top Products
 		fetchTopProducts: builder.query( {
+			// sortBy/order are accepted by the endpoint and reserved for a later
+			// interactive column-sort feature; the table sends only the default
+			// (product_views, desc) for now.
 			query: ( { siteUrl, page = 1, limit = 10, search = '', sortBy = 'product_views', order = 'desc', startDate, endDate } ) => ( {
 				url: 'godam/v1/analytics/top-products',
 				params: {

--- a/pages/dashboard/redux/api/dashboardAnalyticsApi.js
+++ b/pages/dashboard/redux/api/dashboardAnalyticsApi.js
@@ -52,6 +52,24 @@ export const dashboardAnalyticsApi = createApi( {
 				return response.dashboard_metrics || {};
 			},
 		} ),
+		// Per-placement funnel (the "Funnel by placement" card). Fetched
+		// separately from the main metrics so its heavier per-placement queries
+		// don't block the dashboard load.
+		fetchPlacementFunnels: builder.query( {
+			query: ( { siteUrl, startDate, endDate } ) => ( {
+				url: 'godam/v1/analytics/placement-funnels',
+				params: {
+					site_url: siteUrl,
+					...rangeParams( { startDate, endDate } ),
+				},
+			} ),
+			transformResponse: ( response ) => {
+				if ( response.status === 'error' ) {
+					return { error: true, message: response.message };
+				}
+				return response.placement_funnels || [];
+			},
+		} ),
 		// Fetch Dashboard Metrics History
 		fetchDashboardMetricsHistory: builder.query( {
 			query: ( { siteUrl, days, startDate, endDate } ) => ( {
@@ -134,4 +152,5 @@ export const {
 	useLazyFetchTopVideosQuery,
 	useFetchTopProductsQuery,
 	useLazyFetchTopProductsQuery,
+	useFetchPlacementFunnelsQuery,
 } = dashboardAnalyticsApi;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,6 +139,9 @@ const godamPlayerAnalytics = {
 	...sharedConfig,
 	entry: {
 		'godam-player-analytics': path.resolve( process.cwd(), 'assets', 'src', 'js', 'godam-player', 'analytics.js' ),
+		// Standalone layer-analytics runtime for pages without the video player
+		// (e.g. the GoDAM Image block with product hotspots).
+		'godam-layer-analytics': path.resolve( process.cwd(), 'assets', 'src', 'js', 'godam-player', 'layer-analytics.js' ),
 	},
 };
 


### PR DESCRIPTION
## What

The **single godam (core) secondary PR** for Woo Phase 2 — the dashboard/UI side. Base: `feat/top-products`. Parent: rtCamp/godam-plugin-wp#26. Supersedes the closed per-sub-task PRs #2087/#2088/#2089. Pairs with godam-analytics#262 and godam-for-woo#197.

## What's in it

- **Revenue KPI card (A/B)** — `RevenueCard` on the dashboard Insights row (single store currency, "excluding N orders" sub-line), reused on the **single-video Analytics page** for per-video revenue. `class-analytics.php` forwards `base_currency` to all four proxied endpoints.
- **Per-hotspot Direct revenue (C)** — the layer panel shows each Woo hotspot's revenue; `useVideoLayerData` maps it onto subs and sums to the parent.
- **Influenced revenue (D)** — a separate "Influenced" sub-line in the Top Products Revenue cell, reusing `formatRevenue`.
- **No-data empty state (F FIX 2)** — the Revenue cell shows "No data" (not a bare dash / misleading 0) when the service sends null revenue.
- **Per-placement split (F EASY WIN A)** — a compact "Woo Layer X · Reel Pop Y" breakdown under the Revenue cell, shown only when 2+ placements drove revenue.
- **Comparative tips (F EASY WIN B)** — `RevenueTips` on the per-video page renders only the favourable comparisons (video-vs-store AOV, revenue per viewer).

All money rendering reuses the single shipped `formatRevenue(minor, currency)` — no new formatter.

## Video-to-Purchase + Funnels (Phase 2, added)
- **`PlacementFunnelCard`** — the **Funnel by placement** dashboard card: a Play→Cart→Purchase funnel per placement (Shoppable Video block / Woo hotspot layer / Reel Pop) with each placement's reach, Played/Added/Purchased counts and % of players, and its play-to-purchase rate. Fetches its own data via a new `fetchPlacementFunnels` RTK query (heavier per-placement queries, so they don't block the main dashboard), proxied through a new `placement-funnels` REST route.

- **`VideoToPurchaseCard`** — mirrors `VideoToCartCard`: the count of distinct viewers who played then bought an attributed product, plus `% of viewers`, with the purple Woo badge and the same null-vs-zero guard. Rendered Woo-gated in the per-video **and** dashboard Insights rows (reads the new `video_to_purchase` key). The Insights row now wraps into a grid on large screens (`lg:flex-wrap` + `lg:[&>*]:basis-40`) so the extra card wraps instead of cramping the previously 4-card cap.
- **`PurchaseFunnelCard`** — the **Purchase Funnel** card (the play-to-cart-to-purchase flow): left-aligned bars in a grey track, the Added-to-cart bar split into **Direct** (added in-video, dark blue) + **Assisted** (clicked out then added, light blue), the count + % of players on the right, drop-off annotations ("X% advanced", "N did not add to cart", a red "N abandoned after adding" pill), and a legend. Rendered **account-wide on the Dashboard** and **per-video** on the analytics page (a `scope` prop switches the descriptor). Keeps the "still counting" note.

## Design polish (matching the finalized ticket design)

- **Detailed Revenue card** — `RevenueCard` rebuilt to match the finalized design: headline total, a Direct/Assisted split bar with per-tier amounts, and the account-level **Influenced** figure in its own dashed box (reported separately, never added to the Direct + Assisted total). The per-video card shows the same split without Influenced (a product-page concept). Moved to its own full-width row above the funnel.
- **Trend badges** — a shared `MetricTrend` footer shows the period-over-period % change (green ↗ / red ↘ + "vs prev N days") on Video-to-Cart, Video-to-Purchase and the Revenue card whenever a bounded range is picked; all-time shows the range label instead. The Insights range now drives every card there (VtC/VtP/Revenue/funnels), not just the three KPI tiles.
- **Top Products i-icons** — info tooltips on the Source, Product Views, Add to Cart and Revenue column headers, each explaining the metric in plain words.
- **Per-product Direct/Assisted revenue** — a "X direct · Y assisted" sub-line under each product's revenue (from the new `revenue_direct_minor` / `revenue_assisted_minor` keys), shown only when the service sent the split; the two amounts are added to the CSV export.
- **Copy + layout** — Video-to-Cart/Purchase subtitles read "carts/orders from video, N% of viewers who played"; the funnel card is titled "Purchase Funnel"; VtC and VtP sit together on their own row below the KPI tiles.

## Tests

**Full core jest suite passes.** New/updated: `RevenueCard.test.js`, `MetricTrend.test.js`, `RevenueTips.test.js`, `TopProductsTable.test.js` (revenue, influenced, No-data, placement split, Direct/Assisted tier split), `useVideoLayerData.test.js` (per-hotspot mapping), `VideoToCartCard.test.js` / `VideoToPurchaseCard.test.js` (subtitle + trend), `PurchaseFunnelCard.test.js`. Each sub-task was revert-proofed on its original branch. phpcs: 0 errors on the changed PHP.

## Depends on

godam-analytics#262 to populate the revenue / order / influenced / placement / tips fields; degrades cleanly against an older service build (fields absent → no card / no sub-line).

## Notes

`@since n.e.x.t`; no CHANGELOG/POT during development. New `data-test-id`s on the revenue surfaces for E2E.


## Image-block hotspots (added)

- **Capture.** A small standalone `godam-layer-analytics` bundle (`assets/src/js/godam-player/layer-analytics-runtime.js` + entry) registers `window.GoDAM.addLayerInteraction` and the page-hide flush WITHOUT the video player, since image pages never load `godam-player-analytics`. `render.php` enqueues it when the image has layers and stamps `data-block-source="godam-image"` on the frame; the flush element lookup now also finds `.godam-image__frame` by `data-id`, so the surface tag survives the flush. `video_id` already carries the image's attachment id via `getVideoKey`, so ingest accepts the event unchanged. Folding `analytics.js` onto the shared runtime to drop the remaining duplication is a follow-up.
- **Source labels.** Top Products Source chips now read **Video Woo Layer** (`woo-layer`) and **Image Woo Layer** (`godam-image`) so the two media read apart.

Verified on the dev site: a synthetic image `type=3` event (no play) rolled up as `godam-image` and rendered as the "Image Woo Layer" chip. The bundle is built and served and registers the buffer API; the live in-image interaction path is unit-tested but not yet exercised on a real page (no authored image-hotspot content exists on the dev site).

## Review fixes (adversarial review)

- **Correct funnel share.** The Purchased row's "% of players" showed purchased ÷ carts (the cart→purchase conversion — a large overstatement that contradicted its own bar); it now shows purchased ÷ players, matching the bar and the server stage rate. purchased/carts stays only as the drop-row "advanced" figure.
- **Funnel can't render inverted.** With the backend now guaranteeing purchased ≤ added ≤ played, bar fractions clamp to [0,1] and the "advanced" % clamps to 100 as a defensive guard against a deploy skew.
- **Honest labels.** The Purchased stage drops the false "net of refunds" descriptor (revenue/counts are gross by design) and is labelled "of those who added" (the nested cohort). The layer panel shows the parent layer's revenue **without** an order total — summing per-hotspot distinct counts overcounts an order spanning two hotspots; a single hotspot still shows its exact distinct count.





## Final adversarial review fixes (image-hotspot pass)

- **Image impressions were always 0**: a still image fires no visibility transition, so the parent-layer `viewed` beacon the product rollup reads was never emitted. `render-image-frame.js` now calls `emitLayerVisible()` once per Woo layer on render, and `render.php` makes the layer-analytics runtime a dependency of the renderer so `window.GoDAM` exists before it fires.
- **block_source dropped on mixed pages**: on a page with both a video and an image, `analytics.js`'s flush wins and its `findVideoElementById` had no image fallback, so image events flushed `block_source=''`. Added the `.godam-image__frame[data-id]` fallback there too, matching the standalone runtime.


## Review fixes (elifvish review on godam-plugin-wp#26)

- **Revenue readable without auth (#2):** `/fetch`, `/dashboard-metrics`, `/layer-analytics` and the new `/placement-funnels` were `__return_true` and now return revenue. Gated all four on `current_user_can( 'upload_files' )` (matching `/top-products`/`/top-videos`); only the admin apps call them, never the front-end player. Verified on the dev site: anonymous → `401`, admin dashboard unaffected.
