### PR TITLE
Fix: render FontAwesome icons on Woo hotspots in the image block editor

### DIFF
--- a/assets/src/js/godam-image-layers/render-image-frame.js
+++ b/assets/src/js/godam-image-layers/render-image-frame.js
@@ -259,6 +259,23 @@ export function initImageFrame( frame ) {
 			// empty boxes; on the front end this is a harmless idempotent pass.
 			if ( hasHotspotsWithIcons( layers ) ) {
 				renderFontAwesomeIcons( frame );
+
+				// Woo markers are appended asynchronously (createProductHotspots
+				// resolves the products over REST first), so the pass above runs
+				// before their `<i class="fa-solid ...">` nodes even exist. On the
+				// front end FontAwesome's own dom.watch() observer catches them
+				// late; inside the editor iframe it never does, leaving Woo product
+				// hotspots as empty circles. Watch the overlay and re-run the
+				// conversion whenever unconverted icons show up. i2svg replaces the
+				// `<i>` with an `<svg>`, so the resulting mutation finds nothing
+				// left to convert and the loop settles immediately.
+				const iconObserver = new MutationObserver( () => {
+					if ( sharedEl.querySelector( 'i[class*="fa-"]' ) ) {
+						renderFontAwesomeIcons( frame );
+					}
+				} );
+				iconObserver.observe( sharedEl, { childList: true, subtree: true } );
+				cleanups.push( () => iconObserver.disconnect() );
 			}
 
 			// Mark rendered only after a fully successful pass. If any manager setup


### PR DESCRIPTION
<img width="1470" height="728" alt="Screenshot 2026-08-25 at 5 37 55 PM" src="https://github.com/user-attachments/assets/0510a133-5a89-4141-bf5f-36b02ed42dc7" />

This pull request improves the handling of FontAwesome icons for Woo product hotspots in the image frame editor. It ensures that icons loaded asynchronously are properly rendered, addressing an issue where they previously appeared as empty circles inside the editor iframe.

**FontAwesome Icon Rendering Improvements:**

* Added a `MutationObserver` to monitor the overlay (`sharedEl`) for newly added FontAwesome icon elements and trigger `renderFontAwesomeIcons` as needed, ensuring Woo product hotspots display correctly even when loaded asynchronously.