### PR TITLE
refactor: rebuild Help page as docs hub grid

### DIFF
--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -125,10 +125,6 @@ $media-frame-width: calc(300px + 2 * 24px);
 			background-color: #fff;
 		}
 	}
-
-	#root-video-help {
-		margin-left: 20px;
-	}
 }
 
 // Analytics surface (dashboard + per-video analytics) opts back into the WP

--- a/assets/src/css/admin.scss
+++ b/assets/src/css/admin.scss
@@ -125,6 +125,14 @@ $media-frame-width: calc(300px + 2 * 24px);
 			background-color: #fff;
 		}
 	}
+
+	// Safari never receives `.not-safari` (see admin.js), so it stays in normal
+	// flow and keeps the negative margin above. The Help page is full-bleed, so
+	// without this it slides 20px left and under the admin menu. Give the offset
+	// back only in that layout — the fixed `.not-safari` layout must stay flush.
+	&:not(.not-safari) #root-video-help {
+		margin-left: 20px;
+	}
 }
 
 // Analytics surface (dashboard + per-video analytics) opts back into the WP
@@ -164,6 +172,11 @@ $media-frame-width: calc(300px + 2 * 24px);
 
 	.godam-admin-root {
 		margin-left: -10px;
+	}
+
+	// Mirrors the desktop compensation above against the -10px mobile pull.
+	.godam-admin-root:not(.not-safari) #root-video-help {
+		margin-left: 10px;
 	}
 
 	.auto-fold .godam-admin-root.not-safari {

--- a/pages/help/App.js
+++ b/pages/help/App.js
@@ -6,21 +6,19 @@ import { useSelector, useDispatch } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, ToggleControl } from '@wordpress/components';
-import { chevronRight } from '@wordpress/icons';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import Customize from '../../assets/src/images/customize.png';
-import Folder from '../../assets/src/images/folder.png';
-import WebDesign from '../../assets/src/images/web-design.png';
 import GodamHeader from '../godam/components/GoDAMHeader.jsx';
 import GoDAMFooter from '../godam/components/GoDAMFooter.jsx';
 import { useSaveMediaSettingsMutation, useGetMediaSettingsQuery } from '../godam/redux/api/media-settings.js';
 import { updateMediaSetting } from '../godam/redux/slice/media-settings.js';
+import { getHubSections } from './constants';
+import DocsSearch from './components/DocsSearch';
+import HubCard from './components/HubCard';
 
 const App = () => {
 	const dispatch = useDispatch();
@@ -47,173 +45,47 @@ const App = () => {
 		await saveMediaSettings( { settings: updatedSettings } );
 	};
 
-	const content = [
-		{
-			section_name: 'Settings and configuration',
-			articles_list: [
-				{
-					title: __( 'General Settings', 'godam' ),
-					link: 'settings-and-configuration/general-settings/',
-				},
-				{
-					title: __( 'Video Settings', 'godam' ),
-					link: 'settings-and-configuration/video-settings/',
-				},
-				{
-					title: __( 'Configuring the Video Block', 'godam' ),
-					link: 'section/configuring-the-video-block',
-				},
-			],
-			icon: Customize,
-		},
-		{
-			section_name: 'Appearance Settings',
-			articles_list: [
-				{
-					title: __( 'Appearance Customisation', 'godam' ),
-					link: 'appearance-settings/appearance-customization/',
-				},
-				{
-					title: __( 'Call To Actions', 'godam' ),
-					link: 'features/call-to-actions-ctas/',
-				},
-				{
-					title: __( 'Hotspots', 'godam' ),
-					link: 'features/hotspots/',
-				},
-				{
-					title: __( 'Forms', 'godam' ),
-					link: 'features/forms/',
-				},
-				{
-					title: __( 'ADs', 'godam' ),
-					link: 'features/ads/',
-				},
-			],
-			icon: WebDesign,
-		},
-		{
-			section_name: 'DAM',
-			articles_list: [
-				{
-					title: __( 'Interface', 'godam' ),
-					link: 'dam/interface/',
-				},
-				{
-					title: __( 'How Tos', 'godam' ),
-					link: 'dam/how-tos/',
-				},
-			],
-			icon: Folder,
-		},
-	];
+	const sections = getHubSections();
 
-	const colors = [ '#fffacd', '#a2d5f2', '#b2f2bb' ];
-	const [ input, setInput ] = useState( '' );
-
-	const handleSearchSubmit = ( e ) => {
-		e.preventDefault();
-		if ( input.length === 0 ) {
-			return;
-		}
-		const encodedInputValue = encodeURIComponent( input );
-
-		const newUrl = `https://godam.io/?s=${ encodedInputValue }&post_type=docs`;
-
-		window.open( newUrl, '_blank' );
-	};
 	return (
 		<div className="godam-help-container">
 			<GodamHeader />
-			<div className="godam-hero-container max-w-[1260px] mx-auto px-4">
-				<section>
-					<div className="hero-content">
-						<h1 className="hero-text">{ __( 'Hi, How can we help?', 'godam' ) }</h1>
-						<h2>{ __( 'Welcome to the GoDAM Help Center!', 'godam' ) }</h2>
-						<p>
-							{ __(
-								'Click on the documentation links below to find step-by-step guides, FAQs, and troubleshooting tips for the features you need help with.',
-								'godam',
-							) }
-						</p>
-						<div className="search">
-							<form
-								role="search"
-								className="form-field shadow-search rounded w-full p-1 mb-0"
-								onSubmit={ handleSearchSubmit }
-							>
-								<input
-									className="search-field w-full"
-									type="search"
-									placeholder={ __( 'Search using keywords', 'godam' ) }
-									autoComplete="off"
-									aria-label={ __( 'Search using keywords', 'godam' ) }
-									onChange={ ( e ) => setInput( e.target.value ) }
-									value={ input }
-								/>
-							</form>
-							<svg
-								className="search-icon"
-								width="16"
-								height="16"
-								viewBox="0 0 16 16"
-								fill="none"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<path
-									fillRule="evenodd"
-									clipRule="evenodd"
-									d="M2.75 7.33333C2.75 4.80203 4.80203 2.75 7.33333 2.75C9.86464 2.75 11.9167 4.80203 11.9167 7.33333C11.9167 8.56597 11.4301 9.68496 10.6385 10.5087C10.6146 10.5274 10.5916 10.5477 10.5696 10.5697C10.5477 10.5917 10.5273 10.6146 10.5087 10.6385C9.68494 11.4301 8.56596 11.9167 7.33333 11.9167C4.80203 11.9167 2.75 9.86464 2.75 7.33333ZM11.0719 12.1326C10.0405 12.9373 8.74289 13.4167 7.33333 13.4167C3.9736 13.4167 1.25 10.6931 1.25 7.33333C1.25 3.9736 3.9736 1.25 7.33333 1.25C10.6931 1.25 13.4167 3.9736 13.4167 7.33333C13.4167 8.7429 12.9373 10.0405 12.1326 11.072L14.5303 13.4697C14.8232 13.7626 14.8232 14.2374 14.5303 14.5303C14.2374 14.8232 13.7625 14.8232 13.4696 14.5303L11.0719 12.1326Z"
-									style={ { fill: 'var(--wp-admin-theme-color, #ab3a6c)' } }
-								></path>
-							</svg>
-						</div>
-					</div>
-				</section>
-			</div>
-			<div className="flex justify-center flex-wrap gap-8 py-6 max-w-[1260px] mx-auto px-4">
-				{ content && content.map( ( section, index ) => (
-					<div key={ index } className="single-container">
-						<div
-							className="single-container-img"
-							style={ { backgroundColor: colors[ index ] } }
-						>
-							<img
-								src={ section.icon }
-								height={ 50 }
-								width={ 50 }
-								alt={ section.section_name }
-							/>
-						</div>
 
-						<div className="single-container-content">
-							<h3>{ section.section_name }</h3>
-							<ul>
-								{ section.articles_list && section.articles_list.map( ( article ) => (
-									<li key={ article.link }>
-										<Icon className="icon" icon={ chevronRight } />
-										<a
-											target="_blank"
-											href={ `https://godam.io/docs/${ article.link }` }
-											rel="noreferrer"
-										>
-											{ article.title }
-										</a>
-									</li>
-								) ) }
-							</ul>
+			<div className="godam-help-hero">
+				<div className="godam-help-hero__inner">
+					<p className="godam-help-eyebrow">{ __( 'Documentation', 'godam' ) }</p>
+					<h1 className="godam-help-hero__title">
+						{ __( 'What are you building with GoDAM?', 'godam' ) }
+					</h1>
+					<p className="godam-help-hero__subtitle">
+						{ __( 'Pick where you use GoDAM — or search across every hub.', 'godam' ) }
+					</p>
+					<DocsSearch />
+				</div>
+			</div>
+
+			<div className="godam-help-sections">
+				{ sections.map( ( section ) => (
+					<section key={ section.id } className="godam-help-section">
+						<p className="godam-help-eyebrow">{ section.label }</p>
+						<p className="godam-help-section__description">{ section.description }</p>
+
+						<div className="godam-help-grid">
+							{ section.hubs.map( ( hub ) => (
+								<HubCard key={ hub.id } hub={ hub } />
+							) ) }
 						</div>
-					</div>
+					</section>
 				) ) }
 			</div>
 
-			<div className="max-w-[1260px] mx-auto px-4 py-8 border-t border-gray-200 mt-8">
-				<div className="flex items-center justify-between bg-gray-50 p-4 rounded-lg border border-gray-100">
+			<div className="godam-help-tracking">
+				<div className="godam-help-tracking__inner">
 					<div>
-						<h4 className="text-sm font-medium text-gray-900 m-0">
+						<h4 className="godam-help-tracking__title">
 							{ __( 'Help us improve GoDAM', 'godam' ) }
 						</h4>
-						<p className="text-xs text-gray-500 mb-0">
+						<p className="godam-help-tracking__description">
 							{ __( 'Allows the GoDAM plugin to track anonymous events for analytics purposes. This helps us improve the product experience.', 'godam' ) }
 						</p>
 					</div>

--- a/pages/help/App.js
+++ b/pages/help/App.js
@@ -6,6 +6,7 @@ import { useSelector, useDispatch } from 'react-redux';
 /**
  * WordPress dependencies
  */
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
 
@@ -16,9 +17,9 @@ import GodamHeader from '../godam/components/GoDAMHeader.jsx';
 import GoDAMFooter from '../godam/components/GoDAMFooter.jsx';
 import { useSaveMediaSettingsMutation, useGetMediaSettingsQuery } from '../godam/redux/api/media-settings.js';
 import { updateMediaSetting } from '../godam/redux/slice/media-settings.js';
-import { getHubSections } from './constants';
-import DocsSearch from './components/DocsSearch';
-import HubCard from './components/HubCard';
+import { getHubSections } from './constants.js';
+import DocsSearch from './components/DocsSearch.jsx';
+import HubCard from './components/HubCard.jsx';
 
 const App = () => {
 	const dispatch = useDispatch();
@@ -45,7 +46,8 @@ const App = () => {
 		await saveMediaSettings( { settings: updatedSettings } );
 	};
 
-	const sections = getHubSections();
+	// Static data, but it runs a `__()` call per string — build it once.
+	const sections = useMemo( () => getHubSections(), [] );
 
 	return (
 		<div className="godam-help-container">
@@ -58,7 +60,7 @@ const App = () => {
 						{ __( 'What are you building with GoDAM?', 'godam' ) }
 					</h1>
 					<p className="godam-help-hero__subtitle">
-						{ __( 'Pick where you use GoDAM — or search across every hub.', 'godam' ) }
+						{ __( 'Pick where you use GoDAM or search across every hub.', 'godam' ) }
 					</p>
 					<DocsSearch />
 				</div>
@@ -67,7 +69,7 @@ const App = () => {
 			<div className="godam-help-sections">
 				{ sections.map( ( section ) => (
 					<section key={ section.id } className="godam-help-section">
-						<p className="godam-help-eyebrow">{ section.label }</p>
+						<h2 className="godam-help-eyebrow">{ section.label }</h2>
 						<p className="godam-help-section__description">{ section.description }</p>
 
 						<div className="godam-help-grid">

--- a/pages/help/components/DocsSearch.jsx
+++ b/pages/help/components/DocsSearch.jsx
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getDocsSearchUrl } from '../constants';
-import HubIcon from './HubIcon';
+import { getDocsSearchUrl } from '../constants.js';
+import HubIcon from './HubIcon.jsx';
 
 /**
  * Site-wide docs search.

--- a/pages/help/components/DocsSearch.jsx
+++ b/pages/help/components/DocsSearch.jsx
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getDocsSearchUrl } from '../constants';
+import HubIcon from './HubIcon';
+
+/**
+ * Site-wide docs search.
+ *
+ * Submitting hands the query to the GoDAM site search in a new tab, the same
+ * way the docs landing page does.
+ */
+const DocsSearch = () => {
+	const [ query, setQuery ] = useState( '' );
+
+	const handleSubmit = ( event ) => {
+		event.preventDefault();
+
+		const term = query.trim();
+
+		if ( ! term ) {
+			return;
+		}
+
+		window.open( getDocsSearchUrl( term ), '_blank', 'noopener,noreferrer' );
+	};
+
+	const label = __( 'Search the GoDAM documentation', 'godam' );
+
+	return (
+		<form className="godam-help-search" role="search" onSubmit={ handleSubmit }>
+			<input
+				className="godam-help-search__input"
+				type="search"
+				value={ query }
+				onChange={ ( event ) => setQuery( event.target.value ) }
+				placeholder={ __( 'Search the docs — e.g. “image hotspots”, “transcoding”, “shoppable video”', 'godam' ) }
+				aria-label={ label }
+				autoComplete="off"
+			/>
+			<button className="godam-help-search__submit" type="submit" aria-label={ label }>
+				<HubIcon name="search" />
+			</button>
+		</form>
+	);
+};
+
+export default DocsSearch;

--- a/pages/help/components/HubCard.jsx
+++ b/pages/help/components/HubCard.jsx
@@ -6,15 +6,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { GODAM_DOCS_URL } from '../constants';
-import HubIcon from './HubIcon';
+import { GODAM_DOCS_URL } from '../constants.js';
+import HubIcon from './HubIcon.jsx';
 
 /**
  * A single documentation hub card.
  *
- * Hubs without a `slug` have no docs hub published yet — they keep the card
- * layout but render an inert action, so the status badge stays the only claim
- * the card makes.
+ * Hubs without a `slug` have no docs hub published yet, so the card omits the
+ * action entirely and lets the status badge be the only claim it makes. An
+ * "Open docs" button — even a greyed one — would imply docs already exist.
  *
  * @param {Object} props     Component props.
  * @param {Object} props.hub Hub definition from `getHubSections()`.
@@ -29,7 +29,7 @@ const HubCard = ( { hub } ) => {
 				<HubIcon name={ icon } />
 			</span>
 
-			<p className="godam-help-card__eyebrow">{ eyebrow }</p>
+			<p className="godam-help-eyebrow godam-help-card__eyebrow">{ eyebrow }</p>
 			<h3 className="godam-help-card__title">{ title }</h3>
 			<p className="godam-help-card__description">{ description }</p>
 
@@ -39,8 +39,8 @@ const HubCard = ( { hub } ) => {
 				</p>
 			) }
 
-			<div className="godam-help-card__action">
-				{ url ? (
+			{ url && (
+				<div className="godam-help-card__action">
 					<a
 						className="godam-help-button"
 						href={ url }
@@ -52,12 +52,8 @@ const HubCard = ( { hub } ) => {
 							{ __( '(opens in a new tab)', 'godam' ) }
 						</span>
 					</a>
-				) : (
-					<span className="godam-help-button godam-help-button--disabled" aria-disabled="true">
-						{ __( 'Open docs', 'godam' ) }
-					</span>
-				) }
-			</div>
+				</div>
+			) }
 		</article>
 	);
 };

--- a/pages/help/components/HubCard.jsx
+++ b/pages/help/components/HubCard.jsx
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { GODAM_DOCS_URL } from '../constants';
+import HubIcon from './HubIcon';
+
+/**
+ * A single documentation hub card.
+ *
+ * Hubs without a `slug` have no docs hub published yet — they keep the card
+ * layout but render an inert action, so the status badge stays the only claim
+ * the card makes.
+ *
+ * @param {Object} props     Component props.
+ * @param {Object} props.hub Hub definition from `getHubSections()`.
+ */
+const HubCard = ( { hub } ) => {
+	const { icon, eyebrow, title, description, badge, badgeVariant, slug } = hub;
+	const url = slug ? `${ GODAM_DOCS_URL }/${ slug }/` : '';
+
+	return (
+		<article className="godam-help-card">
+			<span className="godam-help-card__icon">
+				<HubIcon name={ icon } />
+			</span>
+
+			<p className="godam-help-card__eyebrow">{ eyebrow }</p>
+			<h3 className="godam-help-card__title">{ title }</h3>
+			<p className="godam-help-card__description">{ description }</p>
+
+			{ badge && (
+				<p className={ `godam-help-badge godam-help-badge--${ badgeVariant || 'accent' }` }>
+					{ badge }
+				</p>
+			) }
+
+			<div className="godam-help-card__action">
+				{ url ? (
+					<a
+						className="godam-help-button"
+						href={ url }
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ __( 'Open docs', 'godam' ) }
+						<span className="screen-reader-text">
+							{ __( '(opens in a new tab)', 'godam' ) }
+						</span>
+					</a>
+				) : (
+					<span className="godam-help-button godam-help-button--disabled" aria-disabled="true">
+						{ __( 'Open docs', 'godam' ) }
+					</span>
+				) }
+			</div>
+		</article>
+	);
+};
+
+export default HubCard;

--- a/pages/help/components/HubIcon.jsx
+++ b/pages/help/components/HubIcon.jsx
@@ -1,0 +1,98 @@
+/**
+ * Line icons used by the documentation hub cards.
+ *
+ * They mirror the icon set on the GoDAM docs landing page: a 24×24 grid,
+ * `currentColor` strokes at 1.6 and round caps/joins, so the colour follows
+ * the admin theme through the surrounding CSS.
+ */
+const ICONS = {
+	wordpress: (
+		<>
+			<rect x="3" y="4" width="18" height="16" rx="2" />
+			<path d="M3 9h18M7 13h6M7 16h9" />
+		</>
+	),
+	woocommerce: (
+		<>
+			<circle cx="9" cy="20" r="1.4" />
+			<circle cx="18" cy="20" r="1.4" />
+			<path d="M2 3h3l2.2 12.3a1.5 1.5 0 0 0 1.5 1.2h8.6a1.5 1.5 0 0 0 1.5-1.2L21.5 7H6" />
+		</>
+	),
+	shopify: (
+		<>
+			<path d="M6 8h12l1 12H5L6 8Z" />
+			<path d="M9 8V6a3 3 0 0 1 6 0v2" />
+		</>
+	),
+	central: (
+		<>
+			<circle cx="12" cy="12" r="2.6" />
+			<circle cx="12" cy="4" r="1.8" />
+			<circle cx="12" cy="20" r="1.8" />
+			<circle cx="4.5" cy="8" r="1.8" />
+			<circle cx="19.5" cy="8" r="1.8" />
+			<path d="M12 6.6v2.8M12 14.6v3.6M9.7 10.8 6 9M14.3 10.8 18 9" />
+		</>
+	),
+	platform: (
+		<>
+			<circle cx="12" cy="12" r="3.2" />
+			<path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9l2.1 2.1M17 17l2.1 2.1M19.1 4.9L17 7M7 17l-2.1 2.1" />
+		</>
+	),
+	chrome: (
+		<>
+			<circle cx="12" cy="12" r="9" />
+			<circle cx="12" cy="12" r="3.2" />
+			<path d="M12 8.8h8.5M8.6 6.5 4.4 13M15.4 13l-4 7.5" />
+		</>
+	),
+	ios: (
+		<>
+			<rect x="7" y="2.5" width="10" height="19" rx="2.5" />
+			<path d="M10.5 18.5h3" />
+		</>
+	),
+	macos: (
+		<>
+			<rect x="4" y="5" width="16" height="11" rx="1.5" />
+			<path d="M2 20h20" />
+		</>
+	),
+	android: (
+		<>
+			<rect x="6" y="8" width="12" height="9" rx="2" />
+			<path d="M9 8V6M15 8V6M9.5 12h.01M14.5 12h.01M4 11v3M20 11v3" />
+		</>
+	),
+	search: <path d="M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14ZM20 20l-4.1-4.1" />,
+};
+
+const HubIcon = ( { name } ) => {
+	const paths = ICONS[ name ];
+
+	if ( ! paths ) {
+		return null;
+	}
+
+	return (
+		<svg
+			className="godam-help-icon"
+			viewBox="0 0 24 24"
+			width="24"
+			height="24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.6"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+			focusable="false"
+		>
+			{ paths }
+		</svg>
+	);
+};
+
+export default HubIcon;

--- a/pages/help/constants.js
+++ b/pages/help/constants.js
@@ -1,0 +1,145 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Base URL of the public GoDAM site.
+ *
+ * The docs hubs and the site-wide search both live here. Change this single
+ * constant to point the Help page at a different environment.
+ */
+export const GODAM_SITE_URL = 'https://godam.io';
+
+/**
+ * Base URL of the documentation hubs.
+ */
+export const GODAM_DOCS_URL = `${ GODAM_SITE_URL }/docs`;
+
+/**
+ * Build the site search URL for a given query.
+ *
+ * Mirrors the docs landing page, which submits a plain `?s=` search against
+ * the site root, so spaces are encoded as `+` rather than `%20`.
+ *
+ * @param {string} query Search term.
+ * @return {string} Absolute search URL.
+ */
+export const getDocsSearchUrl = ( query ) => {
+	const params = new URLSearchParams( { s: query } );
+
+	return `${ GODAM_SITE_URL }/?${ params.toString() }`;
+};
+
+/**
+ * Documentation hubs, grouped the same way as the GoDAM docs landing page.
+ *
+ * Each hub renders as a card. A hub without a `slug` has no docs hub yet, so
+ * its card renders with a disabled action and a status badge instead.
+ *
+ * @return {Array} Sections, each with a label, description and list of hubs.
+ */
+export const getHubSections = () => [
+	{
+		id: 'on-your-site',
+		label: __( 'On your site', 'godam' ),
+		description: __( 'Platform-specific hubs where you install and configure GoDAM.', 'godam' ),
+		hubs: [
+			{
+				id: 'wordpress',
+				icon: 'wordpress',
+				eyebrow: __( 'Core · WordPress', 'godam' ),
+				title: __( 'GoDAM for WordPress', 'godam' ),
+				description: __( 'The WordPress plugin: upload, transcode, blocks, page builders, interactive layers, integrations & analytics.', 'godam' ),
+				badge: __( '70+ articles', 'godam' ),
+				slug: 'wordpress',
+			},
+			{
+				id: 'woocommerce',
+				icon: 'woocommerce',
+				eyebrow: __( 'Add-on · WooCommerce', 'godam' ),
+				title: __( 'GoDAM for WooCommerce', 'godam' ),
+				description: __( 'Make your store shoppable — shoppable video, product reels and product hotspots.', 'godam' ),
+				badge: __( '5 articles', 'godam' ),
+				slug: 'woo',
+			},
+			{
+				id: 'shopify',
+				icon: 'shopify',
+				eyebrow: __( 'Add-on · Shopify', 'godam' ),
+				title: __( 'GoDAM for Shopify', 'godam' ),
+				description: __( 'Shoppable video for Shopify stores — same commerce experience, built for Shopify.', 'godam' ),
+				badge: __( 'Coming soon', 'godam' ),
+				badgeVariant: 'neutral',
+			},
+		],
+	},
+	{
+		id: 'the-cloud-platform',
+		label: __( 'The cloud platform', 'godam' ),
+		description: __( 'Central management and the shared engine behind every product.', 'godam' ),
+		hubs: [
+			{
+				id: 'central',
+				icon: 'central',
+				eyebrow: __( 'SaaS · app.godam', 'godam' ),
+				title: __( 'GoDAM Central', 'godam' ),
+				description: __( 'Your cloud DAM — media, playlists, teams, billing and player settings.', 'godam' ),
+				badge: __( '8 articles', 'godam' ),
+				slug: 'central',
+			},
+			{
+				id: 'platform',
+				icon: 'platform',
+				eyebrow: __( 'Platform · Engine', 'godam' ),
+				title: __( 'How GoDAM works', 'godam' ),
+				description: __( 'The shared engine — transcoding, adaptive streaming, codecs, AI and delivery, documented once.', 'godam' ),
+				badge: __( 'Concepts', 'godam' ),
+				slug: 'platform',
+			},
+		],
+	},
+	{
+		id: 'on-your-devices',
+		label: __( 'On your devices', 'godam' ),
+		description: __( 'Capture tools for browser and mobile.', 'godam' ),
+		hubs: [
+			{
+				id: 'chrome',
+				icon: 'chrome',
+				eyebrow: __( 'Device · Extension', 'godam' ),
+				title: __( 'GoDAM Screen Recorder for Chrome', 'godam' ),
+				description: __( 'Record your screen from Chrome and send it straight to GoDAM.', 'godam' ),
+				badge: __( '2 articles', 'godam' ),
+				slug: 'chrome',
+			},
+			{
+				id: 'ios',
+				icon: 'ios',
+				eyebrow: __( 'Device · iPhone', 'godam' ),
+				title: __( 'GoDAM for iOS', 'godam' ),
+				description: __( 'Capture, record and upload to GoDAM straight from your iPhone.', 'godam' ),
+				badge: __( 'Coming soon', 'godam' ),
+				badgeVariant: 'neutral',
+			},
+			{
+				id: 'macos',
+				icon: 'macos',
+				eyebrow: __( 'Device · Mac', 'godam' ),
+				title: __( 'GoDAM for macOS', 'godam' ),
+				description: __( 'Screen recording on macOS.', 'godam' ),
+				badge: __( 'Planned', 'godam' ),
+				badgeVariant: 'neutral',
+			},
+			{
+				id: 'android',
+				icon: 'android',
+				eyebrow: __( 'Device · Android', 'godam' ),
+				title: __( 'GoDAM for Android', 'godam' ),
+				description: __( 'Capture on Android.', 'godam' ),
+				badge: __( 'Planned', 'godam' ),
+				badgeVariant: 'neutral',
+			},
+		],
+	},
+];

--- a/pages/help/index.scss
+++ b/pages/help/index.scss
@@ -14,11 +14,25 @@
 }
 
 #root-video-help {
-	background-image: url(../../assets/src/images/hero-bg.webp);
-	background-size: cover;
+	background-color: #fff;
 }
 
 .godam-help-container {
+
+	// Mirrors the palette of the GoDAM docs landing page, but keeps the accent
+	// tied to the admin theme colour so the page matches the rest of the plugin.
+	--godam-help-accent: var(--wp-admin-theme-color, #5d31ff);
+	--godam-help-accent-bg: color-mix(in srgb, var(--godam-help-accent) 10%, #fff);
+	--godam-help-accent-border: color-mix(in srgb, var(--godam-help-accent) 24%, #fff);
+	--godam-help-heading: #0a1b22;
+	--godam-help-body: #3b494e;
+	--godam-help-card-bg: #fffefc;
+	--godam-help-card-border: #e2e2d9;
+	--godam-help-tile-bg: #e8f8ff;
+	--godam-help-tile-border: #d8e9f2;
+	--godam-help-max-width: 1260px;
+
+	background-color: #fff;
 
 	.godam-settings-header-content {
 
@@ -36,151 +50,307 @@
 	}
 }
 
-.navbar {
-	position: relative;
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	justify-content: space-between;
-	padding: 1rem 2rem;
+// Small caps label shared by the hero and each section heading.
+.godam-help-eyebrow {
+	margin: 0 0 0.75rem;
+	color: var(--godam-help-accent);
+	font-size: 12px;
+	font-weight: 700;
+	line-height: 1.3;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+}
 
-	h1 {
-		font-style: normal;
-		font-weight: 800;
-		color: var(--wp-admin-theme-color, #ab3a6c);
+.godam-help-hero {
+	padding: 4rem 1.5rem 3rem;
+
+	@media (max-width: 782px) {
+		padding: 2.5rem 1rem 2rem;
+	}
+
+	&__inner {
+		max-width: 880px;
+		margin: 0 auto;
+	}
+
+	&__title {
+		margin: 0 0 0.75rem;
+		color: var(--godam-help-heading);
+		font-size: clamp(2rem, 3.4vw, 2.8rem);
+		font-weight: 500;
+		line-height: 1.15;
+		letter-spacing: -0.02em;
+	}
+
+	&__subtitle {
+		margin: 0 0 1.75rem;
+		color: var(--godam-help-body);
+		font-size: 1.1rem;
+		line-height: 1.6;
 	}
 }
 
-.hero-text {
-	text-align: center;
-	margin: 2rem 0;
-}
-
-.search {
+.godam-help-search {
 	display: flex;
-	flex-direction: row-reverse;
-	align-items: center;
-	justify-content: flex-end;
-	margin: 1.5rem auto;
-	background-color: #fff;
-	border-radius: 2rem;
-	border: 2px solid var(--wp-admin-theme-color, #ab3a6c);
-	cursor: pointer;
-	position: relative;
-	width: 100%;
-	max-width: 400px;
+	align-items: stretch;
+	gap: 0.75rem;
+	max-width: 820px;
 
-	svg {
-		position: absolute;
-		left: 1rem;
-	}
-
-	input[type="search"] {
-		padding-left: 3em;
-		border-style: none;
-		-webkit-appearance: none;
-		appearance: none;
-		outline: none;
+	&__input {
+		flex: 1;
+		min-width: 0;
+		height: 56px;
+		padding: 0 1.25rem;
+		border: 1px solid var(--godam-help-card-border);
+		border-radius: 14px;
 		background-color: #fff;
-		width: 100% !important;
-		border-radius: 2rem;
+		color: var(--godam-help-heading);
+		font-size: 1rem;
+		line-height: 1.5;
+		box-shadow: none;
+
+		&::placeholder {
+			color: #7b8a90;
+		}
+
+		&:focus {
+			border-color: var(--godam-help-accent);
+			outline: none;
+			box-shadow: 0 0 0 1px var(--godam-help-accent);
+		}
 
 		&::-webkit-search-cancel-button {
 			display: none;
 		}
 	}
 
-	textarea:focus,
-	input:focus {
-		outline: none;
-		-webkit-box-shadow: none;
-		box-shadow: none;
-	}
-}
-
-.hero-content {
-	padding: 10px 0;
-	text-align: center;
-	max-width: 600px;
-	margin: 0 auto;
-}
-
-.single-container {
-	background-color: #fff;
-	width: 310px;
-	border-radius: 12px;
-	box-shadow: 3px 4px 4px #d3d3d3;
-
-	h3 {
-		color: #242748;
-		font-weight: 400;
-	}
-}
-
-.single-container-img {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	padding: 1.5rem;
-	min-height: 100px;
-	border-radius: 12px 12px 0 0;
-}
-
-.single-container-content {
-	padding: 0 1.5rem 1.5rem 1.5rem;
-}
-
-.cards-container li {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	margin-bottom: 1rem;
-
-	svg {
-		border: 1px solid var(--wp-admin-theme-color, #ab3a6c);
-		border-radius: 50%;
-		box-shadow: 0 0 3px var(--wp-admin-theme-color, #ab3a6c);
-		padding: 5px;
-		position: relative;
-		top: 0;
+	&__submit {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 74px;
+		height: 56px;
+		padding: 0;
+		border: 0;
+		border-radius: 12px;
+		background-color: var(--godam-help-accent);
+		color: #fff;
 		cursor: pointer;
-		height: 10px;
-		width: 10px;
+		transition: opacity 0.15s ease;
+
+		&:hover,
+		&:focus {
+			opacity: 0.9;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--godam-help-accent);
+			outline-offset: 2px;
+		}
 	}
 }
 
-.single-container ul li {
+.godam-help-sections {
+	max-width: var(--godam-help-max-width);
+	margin: 0 auto;
+	padding: 0 1.5rem;
+
+	@media (max-width: 782px) {
+		padding: 0 1rem;
+	}
+}
+
+.godam-help-section {
+	padding-bottom: 4rem;
+
+	&__description {
+		margin: 0 0 1.75rem;
+		color: var(--godam-help-body);
+		font-size: 0.9rem;
+		line-height: 1.6;
+	}
+}
+
+.godam-help-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 2.5rem;
+
+	@media (max-width: 1180px) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	@media (max-width: 782px) {
+		grid-template-columns: minmax(0, 1fr);
+		gap: 1.5rem;
+	}
+}
+
+.godam-help-card {
 	display: flex;
-	align-items: center;
-	gap: 10px;
-	margin-bottom: 1rem;
-
-	a {
-		color: #000;
-		text-decoration: none;
-	}
-
-	.icon {
-		border-radius: 999px;
-		border: 1px solid var(--wp-admin-theme-color, #ab3a6c);
-	}
+	flex-direction: column;
+	padding: 2rem;
+	border: 1px solid var(--godam-help-card-border);
+	border-radius: 12px;
+	background-color: var(--godam-help-card-bg);
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
 
 	&:hover {
+		border-color: var(--godam-help-accent-border);
+		box-shadow: 0 6px 18px rgba(10, 27, 34, 0.06);
+	}
 
-		svg {
-			background-color: var(--wp-admin-theme-color, #ab3a6c);
-			border-radius: 999px;
-			left: 2px;
+	&__icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 46px;
+		height: 46px;
+		margin-bottom: 1.75rem;
+		border: 1px solid var(--godam-help-tile-border);
+		border-radius: 11px;
+		background-color: var(--godam-help-tile-bg);
+		color: var(--godam-help-accent);
+	}
 
-			path {
-				fill: #fff;
-			}
+	&__eyebrow {
+		margin: 0 0 0.5rem;
+		color: var(--godam-help-accent);
+		font-size: 12px;
+		font-weight: 700;
+		line-height: 1.3;
+		letter-spacing: 0.09em;
+		text-transform: uppercase;
+	}
+
+	&__title {
+		margin: 0 0 0.5rem;
+		color: var(--godam-help-heading);
+		font-size: 1.18rem;
+		font-weight: 500;
+		line-height: 1.35;
+		letter-spacing: -0.01em;
+	}
+
+	&__description {
+		margin: 0 0 1rem;
+		color: var(--godam-help-body);
+		font-size: 0.9rem;
+		line-height: 1.6;
+	}
+
+	&__action {
+		margin-top: auto;
+		padding-top: 1.5rem;
+	}
+}
+
+.godam-help-badge {
+	display: inline-block;
+
+	// The card is a flex column, so the pill has to opt out of the default
+	// `stretch` alignment or it spans the full card width.
+	align-self: flex-start;
+	margin: 0;
+	padding: 3px 10px;
+	border: 1px solid transparent;
+	border-radius: 999px;
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1.4;
+
+	&--accent {
+		border-color: var(--godam-help-accent-border);
+		background-color: var(--godam-help-accent-bg);
+		color: var(--godam-help-accent);
+	}
+
+	&--neutral {
+		border-color: var(--godam-help-card-border);
+		background-color: var(--godam-help-tile-bg);
+		color: var(--godam-help-body);
+	}
+}
+
+.godam-help-button {
+	display: inline-block;
+	padding: 8px 16px;
+	border-radius: 8px;
+	background-color: var(--godam-help-accent);
+	color: #fff;
+	font-size: 0.85rem;
+	font-weight: 600;
+	line-height: 1.4;
+	text-decoration: none;
+	transition: opacity 0.15s ease;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: #fff;
+		opacity: 0.9;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--godam-help-accent);
+		outline-offset: 2px;
+	}
+
+	&--disabled {
+		background-color: #ececeb;
+		color: #8a9599;
+		cursor: not-allowed;
+		opacity: 1;
+
+		&:hover,
+		&:focus {
+			color: #8a9599;
+			opacity: 1;
 		}
+	}
+}
 
-		li {
-			color: var(--wp-admin-theme-color, #ab3a6c);
-			font-weight: 600;
-		}
+.godam-help-tracking {
+	max-width: var(--godam-help-max-width);
+	margin: 0 auto;
+	padding: 0 1.5rem 3rem;
+
+	@media (max-width: 782px) {
+		padding: 0 1rem 2rem;
+	}
+
+	&__inner {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: 1.25rem 1.5rem;
+		border: 1px solid var(--godam-help-card-border);
+		border-radius: 12px;
+		background-color: var(--godam-help-card-bg);
+	}
+
+	&__title {
+		margin: 0 0 0.25rem;
+		color: var(--godam-help-heading);
+		font-size: 0.95rem;
+		font-weight: 600;
+	}
+
+	&__description {
+		margin: 0;
+		max-width: 68ch;
+		color: var(--godam-help-body);
+		font-size: 0.8rem;
+		line-height: 1.6;
+	}
+}
+
+.godam-toggle-small {
+
+	.components-form-toggle {
+		transform: scale(0.8);
+		margin-right: 0;
 	}
 }
 
@@ -188,13 +358,5 @@
 
 	#wpcontent {
 		padding-left: 0 !important;
-	}
-}
-
-.godam-toggle-small {
-	
-	.components-form-toggle {
-		transform: scale(0.8);
-		margin-right: 0;
 	}
 }

--- a/pages/help/index.scss
+++ b/pages/help/index.scss
@@ -71,6 +71,10 @@
 	&__inner {
 		max-width: 880px;
 		margin: 0 auto;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
 	}
 
 	&__title {
@@ -95,6 +99,7 @@
 	align-items: stretch;
 	gap: 0.75rem;
 	max-width: 820px;
+	width: 100%;
 
 	&__input {
 		flex: 1;
@@ -213,14 +218,10 @@
 		color: var(--godam-help-accent);
 	}
 
+	// Everything else comes from the shared `.godam-help-eyebrow`, which the
+	// card applies alongside this class; only the spacing differs here.
 	&__eyebrow {
-		margin: 0 0 0.5rem;
-		color: var(--godam-help-accent);
-		font-size: 12px;
-		font-weight: 700;
-		line-height: 1.3;
-		letter-spacing: 0.09em;
-		text-transform: uppercase;
+		margin-bottom: 0.5rem;
 	}
 
 	&__title {
@@ -294,19 +295,6 @@
 	&:focus-visible {
 		outline: 2px solid var(--godam-help-accent);
 		outline-offset: 2px;
-	}
-
-	&--disabled {
-		background-color: #ececeb;
-		color: #8a9599;
-		cursor: not-allowed;
-		opacity: 1;
-
-		&:hover,
-		&:focus {
-			color: #8a9599;
-			opacity: 1;
-		}
 	}
 }
 


### PR DESCRIPTION
Mirror the godam.io/docs landing page: hero with site search, three sections of hub cards (On your site / The cloud platform / On your devices). Search opens godam.io/?s=<query> in a new tab.

Hub copy, badges and slugs move to pages/help/constants.js so the docs base URL is a single constant. Cards without a published hub render an inert action instead of linking out.

## Demo

https://github.com/user-attachments/assets/f7c4ae09-15a8-4381-b73a-f57d42613ac8

