### PR TITLE
Fix Document block download link for virtual media

### DIFF
--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -1008,7 +1008,11 @@ function rtgodam_get_document_preview_url( $attachment_id = 0, $fallback_src = '
  *
  * wp_get_attachment_url() already resolves virtual GoDAM media to its CDN URL via
  * Media_Library_Ajax::filter_attachment_url_for_virtual_media(), so local and GoDAM-tab
- * attachments are both handled here.
+ * attachments are both handled here — but see the note in the body on the one case where
+ * that resolution silently produces a path nothing serves.
+ *
+ * Attachment access is bracketed by rtgodam_before_attachment_lookup /
+ * rtgodam_after_attachment_lookup, as everywhere else that reads attachment data.
  *
  * @since n.e.x.t
  *
@@ -1021,10 +1025,57 @@ function rtgodam_get_document_download_url( $attachment_id = 0, $fallback_src = 
 	$godam_post_id = rtgodam_normalize_attachment_id( $attachment_id );
 
 	if ( $godam_post_id ) {
-		$attachment_url = wp_get_attachment_url( $godam_post_id ); // godam-coverage-ignore -- rtgodam_get_document_download_url(): covered transitively — sole caller (assets/src/blocks/godam-pdf/render.php) wraps the entire call in try/finally.
+		/**
+		 * Fires before reading this attachment's URL, its virtual-media marker and its
+		 * transcoded-URL meta, so integrations that centralize media on another site can
+		 * switch context first. Wrapped in try/finally because the block below returns from
+		 * several points once it determines which URL to offer.
+		 *
+		 * @since 2.2.0
+		 */
+		do_action( 'rtgodam_before_attachment_lookup' );
+		try {
+			$attachment_url = wp_get_attachment_url( $godam_post_id );
 
-		if ( ! empty( $attachment_url ) ) {
-			return $attachment_url;
+			/*
+			 * Virtual media — a GoDAM tab import, marked by _godam_original_id — has no local
+			 * file at all: `_wp_attached_file` holds a bare filename that stands for nothing
+			 * on disk.
+			 *
+			 * filter_attachment_url_for_virtual_media() normally redirects such an attachment
+			 * to the CDN, but it does so ONLY through the post guid, and returns WordPress's
+			 * own value untouched when that guid is empty. WordPress then joins the bare
+			 * filename onto the uploads base URL, so the caller gets a confident-looking
+			 * /wp-content/uploads/report.docx that 404s.
+			 *
+			 * rtgodam_transcoded_url is written for these attachments at import time and
+			 * points at the same file on the CDN, so it is the right answer whenever the
+			 * resolved URL turns out to be that local dead end. This matters most for a
+			 * document with no preview, where the download link is the only thing the block
+			 * can offer a visitor.
+			 */
+			$godam_original_id = get_post_meta( $godam_post_id, '_godam_original_id', true );
+
+			if ( ! empty( $godam_original_id ) ) {
+				$godam_uploads     = wp_get_upload_dir();
+				$godam_uploads_url = ! empty( $godam_uploads['baseurl'] ) ? $godam_uploads['baseurl'] : '';
+				$godam_is_local    = empty( $attachment_url )
+					|| ( ! empty( $godam_uploads_url ) && 0 === strpos( $attachment_url, $godam_uploads_url ) );
+
+				if ( $godam_is_local ) {
+					$godam_transcoded_url = get_post_meta( $godam_post_id, 'rtgodam_transcoded_url', true );
+
+					if ( ! empty( $godam_transcoded_url ) ) {
+						return $godam_transcoded_url;
+					}
+				}
+			}
+
+			if ( ! empty( $attachment_url ) ) {
+				return $attachment_url;
+			}
+		} finally {
+			do_action( 'rtgodam_after_attachment_lookup' );
 		}
 	}
 

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -968,27 +968,40 @@ function rtgodam_get_document_preview_url( $attachment_id = 0, $fallback_src = '
 	$attachment_id = rtgodam_normalize_attachment_id( $attachment_id );
 
 	if ( $attachment_id ) {
-		$preview_url = get_post_meta( $attachment_id, 'rtgodam_preview_pdf_url', true );
+		/**
+		 * Fires before reading this attachment's preview-PDF, MIME type, transcoded-URL and
+		 * URL, so integrations that centralize media on another site can switch context
+		 * first. Wrapped in try/finally because the block below returns from several points
+		 * once it determines which URL to offer.
+		 *
+		 * @since 2.2.0
+		 */
+		do_action( 'rtgodam_before_attachment_lookup' );
+		try {
+			$preview_url = get_post_meta( $attachment_id, 'rtgodam_preview_pdf_url', true );
 
-		if ( ! empty( $preview_url ) ) {
-			return $preview_url;
-		}
-
-		if ( 'application/pdf' === get_post_mime_type( $attachment_id ) ) {
-			$transcoded_url = get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true );
-
-			if ( ! empty( $transcoded_url ) ) {
-				return $transcoded_url;
+			if ( ! empty( $preview_url ) ) {
+				return $preview_url;
 			}
 
-			$attachment_url = wp_get_attachment_url( $attachment_id );
+			if ( 'application/pdf' === get_post_mime_type( $attachment_id ) ) {
+				$transcoded_url = get_post_meta( $attachment_id, 'rtgodam_transcoded_url', true );
 
-			if ( ! empty( $attachment_url ) ) {
-				return $attachment_url;
+				if ( ! empty( $transcoded_url ) ) {
+					return $transcoded_url;
+				}
+
+				$attachment_url = wp_get_attachment_url( $attachment_id );
+
+				if ( ! empty( $attachment_url ) ) {
+					return $attachment_url;
+				}
 			}
-		}
 
-		return '';
+			return '';
+		} finally {
+			do_action( 'rtgodam_after_attachment_lookup' );
+		}
 	}
 
 	// No local attachment: a URL-only document can only be previewed when it is
@@ -1012,7 +1025,8 @@ function rtgodam_get_document_preview_url( $attachment_id = 0, $fallback_src = '
  * that resolution silently produces a path nothing serves.
  *
  * Attachment access is bracketed by rtgodam_before_attachment_lookup /
- * rtgodam_after_attachment_lookup, as everywhere else that reads attachment data.
+ * rtgodam_after_attachment_lookup, matching rtgodam_get_document_preview_url() above, so
+ * neither resolver depends on its caller having opened the pair.
  *
  * @since n.e.x.t
  *
@@ -1059,8 +1073,28 @@ function rtgodam_get_document_download_url( $attachment_id = 0, $fallback_src = 
 			if ( ! empty( $godam_original_id ) ) {
 				$godam_uploads     = wp_get_upload_dir();
 				$godam_uploads_url = ! empty( $godam_uploads['baseurl'] ) ? $godam_uploads['baseurl'] : '';
-				$godam_is_local    = empty( $attachment_url )
-					|| ( ! empty( $godam_uploads_url ) && 0 === strpos( $attachment_url, $godam_uploads_url ) );
+
+				/*
+				 * Compared with the scheme stripped. SSL and CDN plugins routinely filter
+				 * wp_get_attachment_url() to https:// while wp_get_upload_dir() still reports
+				 * http:// (or the reverse); a raw prefix match fails on those sites, so
+				 * $godam_is_local would come out false and the 404ing local URL would be
+				 * returned — the exact bug this guards against, silently unfixed.
+				 *
+				 * The host is still part of the comparison, so a filter that moves attachment
+				 * URLs onto a different host is treated as NOT local. That is deliberate:
+				 * there is no way to tell a CDN mirror of the uploads directory from a
+				 * genuinely off-site copy, and honouring the URL the site itself advertises is
+				 * the safer of the two guesses.
+				 */
+				$godam_is_local = empty( $attachment_url )
+					|| (
+						! empty( $godam_uploads_url )
+						&& 0 === strpos(
+							preg_replace( '#^https?://#i', '', $attachment_url ),
+							preg_replace( '#^https?://#i', '', $godam_uploads_url )
+						)
+					);
 
 				if ( $godam_is_local ) {
 					$godam_transcoded_url = get_post_meta( $godam_post_id, 'rtgodam_transcoded_url', true );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -104,6 +104,20 @@ if ( ! function_exists( 'wp_get_attachment_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_get_upload_dir' ) ) {
+
+	/**
+	 * @return array Uploads directory info; only `baseurl` is consumed.
+	 */
+	function wp_get_upload_dir() {
+		$baseurl = isset( $GLOBALS['rtgodam_stub']['uploads_baseurl'] )
+			? (string) $GLOBALS['rtgodam_stub']['uploads_baseurl']
+			: 'https://example.com/wp-content/uploads';
+
+		return array( 'baseurl' => $baseurl );
+	}
+}
+
 if ( ! function_exists( 'get_the_title' ) ) {
 
 	/**

--- a/tests/php/DocumentSupportTest.php
+++ b/tests/php/DocumentSupportTest.php
@@ -612,6 +612,84 @@ class DocumentSupportTest extends TestCase {
 	}
 
 	/**
+	 * Virtual media with no usable guid downloads from the CDN, not a local path.
+	 *
+	 * A GoDAM tab import has no file on disk. When its post guid is empty,
+	 * filter_attachment_url_for_virtual_media() leaves WordPress's own value alone and
+	 * WordPress joins the bare `_wp_attached_file` name onto the uploads base URL — a link
+	 * that looks right and 404s. rtgodam_transcoded_url is the same file on the CDN.
+	 *
+	 * @return void
+	 */
+	public function test_download_url_for_virtual_media_prefers_the_transcoded_url() {
+		$this->stub_mime( 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' );
+		$this->stub_meta(
+			array(
+				'_godam_original_id'     => 'md0r9phqa4',
+				'rtgodam_transcoded_url' => 'https://cdn.example.com/md0r9phqa4/report.docx',
+			)
+		);
+		// What WordPress builds for virtual media once the CDN lookup falls through.
+		$this->stub_attachment_url( 'https://example.com/wp-content/uploads/report.docx' );
+
+		$this->assertSame(
+			'https://cdn.example.com/md0r9phqa4/report.docx',
+			rtgodam_get_document_download_url( 90 ),
+			'Virtual media should download from the CDN, not a local uploads path with no file behind it.'
+		);
+
+		// Same attachment, nothing resolved at all.
+		$this->stub_attachment_url( '' );
+
+		$this->assertSame(
+			'https://cdn.example.com/md0r9phqa4/report.docx',
+			rtgodam_get_document_download_url( 90 ),
+			'An unresolved virtual attachment should still fall back to the transcoded URL.'
+		);
+	}
+
+	/**
+	 * A resolved CDN URL is left alone — the fallback must not override a good answer.
+	 *
+	 * @return void
+	 */
+	public function test_download_url_for_virtual_media_keeps_a_resolved_cdn_url() {
+		$this->stub_mime( 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' );
+		$this->stub_meta(
+			array(
+				'_godam_original_id'     => 'md0r9phqa4',
+				// Deliberately different, so preferring the wrong one would show up here.
+				'rtgodam_transcoded_url' => 'https://cdn.example.com/md0r9phqa4/stale.docx',
+			)
+		);
+		$this->stub_attachment_url( 'https://cdn.example.com/md0r9phqa4/report.docx' );
+
+		$this->assertSame(
+			'https://cdn.example.com/md0r9phqa4/report.docx',
+			rtgodam_get_document_download_url( 90 ),
+			'The guid-resolved CDN URL is authoritative when wp_get_attachment_url() supplies one.'
+		);
+	}
+
+	/**
+	 * An ordinary local upload is untouched: its uploads-directory URL is the real file.
+	 *
+	 * @return void
+	 */
+	public function test_download_url_for_local_uploads_is_untouched() {
+		$this->stub_mime( 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' );
+		// No _godam_original_id: transcoded by GoDAM, but the original still lives on disk.
+		$this->stub_meta( array( 'rtgodam_transcoded_url' => 'https://cdn.example.com/job_9/quarterly.xlsx' ) );
+		$this->stub_attachment_url( 'https://example.com/wp-content/uploads/quarterly.xlsx' );
+
+		$this->assertSame(
+			'https://example.com/wp-content/uploads/quarterly.xlsx',
+			rtgodam_get_document_download_url( 91 ),
+			'A real local upload downloads from the local file, transcoded copy or not.'
+		);
+	}
+
+	/**
 	 * With no attachment to resolve, the supplied source URL is used verbatim.
 	 *
 	 * @return void


### PR DESCRIPTION
This pull request improves the handling of document download URLs for virtual media attachments, ensuring users receive working links in all cases. It also adds comprehensive tests to cover these scenarios and introduces a stub for the uploads directory in the test suite.

**Improvements to virtual media download URL resolution:**

* [`inc/helpers/custom-functions.php`](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27L1024-R1079): Updated `rtgodam_get_document_download_url` to check for virtual media attachments that would otherwise return a broken local URL, and to prefer the `rtgodam_transcoded_url` (CDN link) when appropriate. Also added `rtgodam_before_attachment_lookup` and `rtgodam_after_attachment_lookup` hooks around attachment access for better integration support.
* [`inc/helpers/custom-functions.php`](diffhunk://#diff-f29b4cd63502a994cef6926d1eab320b3b83465c4d16dd6920e3d7162bd61f27L1011-R1015): Clarified documentation in `rtgodam_get_document_preview_url` about the edge case where WordPress generates an unserved uploads path for virtual media.

**Test coverage improvements:**

* [`tests/php/DocumentSupportTest.php`](diffhunk://#diff-22e64c575dbb46ed13907379375490e5a56c47e22535ab6b578c1debf7d2e9ecR614-R691): Added new tests to verify that virtual media attachments reliably return CDN URLs, that resolved CDN URLs are not overridden, and that ordinary local uploads are left untouched.

**Test infrastructure:**

* [`tests/bootstrap.php`](diffhunk://#diff-96a82592013e5f4b91e682332583b7a4a6ca1ff0431d267c61179b1a21b167daR107-R120): Added a stub implementation of `wp_get_upload_dir` to provide a testable uploads base URL in the test environment.