### PR TITLE
Update the plugin version, add changelogs, and new contributors props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog #
 
+## v2.2.0 (August 26, 2026) ##
+
+- Feat: The Document block now handles far more than PDFs. You can embed and preview Word, Excel, PowerPoint, OpenDocument, and plain-text files.
+- Feat: Added the same document preview support to the Elementor and WPBakery GoDAM Document widgets.
+- Feat: Show in lightbox — a new option opens a video in a centered lightbox overlay when its poster is clicked, instead of playing it in place. Available in the GoDAM Video block, the Elementor widget, and the WPBakery element.
+- Tweak: The GoDAM media transcoding tool now supports bulk transcoding of all media types supported by GoDAM.
+- Fix: Resolved bugs in the GoDAM Media Library module.
+- Fix: Fixed the transcription source issue for GoDAM videos.
+- Fix: Layer analytics now records a view for each hotspot in its own right, so a hotspot's views, conversion, and "No Action" describe that hotspot rather than the whole layer. This stays correct even as hotspots are added or removed over time.
+
 ## v2.1.1 (August 6, 2026) ##
 
 - Fix: GoDAM no longer fills the debug log with `Function _load_textdomain_just_in_time was called incorrectly` on WordPress 6.7 and later. On sites that display errors, the warning could also appear on the page itself, in the admin and on the front end.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Banner V3](https://github.com/user-attachments/assets/73cfb2c2-0779-44c2-85e7-67e812dd82b6)
 
 # GoDAM - Organize WordPress Media Library & File Manager with Unlimited Folders for Images, Videos & more
-Contributors: [rtcamp](https://profiles.wordpress.org/rtcamp), [elifvish](https://profiles.wordpress.org/elifvish), [subodhrajpopat](https://profiles.wordpress.org/subodhrajpopat), [kuldipchaudhary](https://profiles.wordpress.org/kuldipchaudhary), [prachigarg19](https://profiles.wordpress.org/prachigarg19), [juzar](https://profiles.wordpress.org/juzar), [geekofshire](https://profiles.wordpress.org/geekofshire), [nazmulhassann20](https://profiles.wordpress.org/nazmulhassann20), [mi5t4n](https://profiles.wordpress.org/mi5t4n), [abhinavbelhekar03](https://profiles.wordpress.org/abhinavbelhekar03), [gautam23](https://profiles.wordpress.org/gautam23), [mukulsingh27](https://profiles.wordpress.org/mukulsingh27), [hbhalodia](https://profiles.wordpress.org/hbhalodia), [kishu7270](https://profiles.wordpress.org/kishu7270), [opurockey](https://profiles.wordpress.org/opurockey), [utsavladani](https://profiles.wordpress.org/utsavladani), [whiteshadow01](https://profiles.wordpress.org/whiteshadow01), [ahmarzaidi](https://profiles.wordpress.org/ahmarzaidi), [im3dabasia1](https://profiles.wordpress.org/im3dabasia1)
+Contributors: [rtcamp](https://profiles.wordpress.org/rtcamp), [elifvish](https://profiles.wordpress.org/elifvish), [subodhrajpopat](https://profiles.wordpress.org/subodhrajpopat), [kuldipchaudhary](https://profiles.wordpress.org/kuldipchaudhary), [prachigarg19](https://profiles.wordpress.org/prachigarg19), [juzar](https://profiles.wordpress.org/juzar), [geekofshire](https://profiles.wordpress.org/geekofshire), [nazmulhassann20](https://profiles.wordpress.org/nazmulhassann20), [mi5t4n](https://profiles.wordpress.org/mi5t4n), [abhinavbelhekar03](https://profiles.wordpress.org/abhinavbelhekar03), [gautam23](https://profiles.wordpress.org/gautam23), [mukulsingh27](https://profiles.wordpress.org/mukulsingh27), [hbhalodia](https://profiles.wordpress.org/hbhalodia), [kishu7270](https://profiles.wordpress.org/kishu7270), [opurockey](https://profiles.wordpress.org/opurockey), [utsavladani](https://profiles.wordpress.org/utsavladani), [whiteshadow01](https://profiles.wordpress.org/whiteshadow01), [ahmarzaidi](https://profiles.wordpress.org/ahmarzaidi), [im3dabasia1](https://profiles.wordpress.org/im3dabasia1), [akrocks](https://profiles.wordpress.org/akrocks)
 Tags: transcoder, video, media library, folders, file manager
 
 Requires at least: 6.5
@@ -10,7 +10,7 @@ Tested up to: 7.0
 
 Requires PHP: 7.4
 
-Stable tag: 2.1.1
+Stable tag: 2.2.0
 
 License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/godam.php
+++ b/godam.php
@@ -3,7 +3,7 @@
  * Plugin Name: GoDAM
  * Plugin URI: https://godam.io
  * Description: Seamlessly manage and deliver your media assets directly from the cloud-based media management. Store assets efficiently, stream them via a CDN, and enhance your website's performance and user experience. Featuring adaptive bit rate streaming, adding interactive layers in videos, and taking full advantage of a digital asset management solution within WordPress.
- * Version: 2.1.1
+ * Version: 2.2.0
  * Requires at least: 6.5
  * Requires PHP: 7.4
  * Text Domain: godam
@@ -43,7 +43,7 @@ if ( ! defined( 'RTGODAM_VERSION' ) ) {
 	/**
 	 * The version of the plugin
 	 */
-	define( 'RTGODAM_VERSION', '2.1.1' );
+	define( 'RTGODAM_VERSION', '2.2.0' );
 }
 
 if ( ! defined( 'RTGODAM_API_BASE' ) ) {

--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -168,7 +168,7 @@ class Assets {
 	/**
 	 * Get the guide message to show alongside video thumbnails, for a given screen.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.2.0
 	 *
 	 * @param string $context Where the message will render. One of 'block-editor'
 	 *                        (the godam/video block Inspector's "Video Thumbnail"
@@ -186,7 +186,7 @@ class Assets {
 		 * The message renders in more than one place; switch on `$context` to vary
 		 * the copy, or ignore it to use the same message everywhere.
 		 *
-		 * @since n.e.x.t
+		 * @since 2.2.0
 		 *
 		 * @param string $message Guide message HTML. Default empty string.
 		 * @param string $context Where the message will render: 'block-editor' or

--- a/inc/classes/rest-api/class-transcoding.php
+++ b/inc/classes/rest-api/class-transcoding.php
@@ -26,7 +26,7 @@ class Transcoding extends Base {
 	/**
 	 * Default media type used when none is provided.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.2.0
 	 *
 	 * @var string
 	 */
@@ -54,7 +54,7 @@ class Transcoding extends Base {
 	 * .ogg uploads are stored as `audio/ogg` and matched already; this only reaches the ones a
 	 * migration or custom MIME filter typed as `application/ogg`.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.2.0
 	 *
 	 * @return array<string, string[]> Media type => MIME types (or bare top-level types).
 	 */
@@ -73,7 +73,7 @@ class Transcoding extends Base {
 	/**
 	 * MIME types the Document pipeline covers.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.2.0
 	 *
 	 * @return string[] Document MIME types.
 	 */
@@ -612,7 +612,7 @@ class Transcoding extends Base {
 	 * attachment's extension as well as its MIME type, and neither wp_count_attachments() nor
 	 * a meta query can express that.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.2.0
 	 *
 	 * @param string[] $mime_types Document MIME types to scan. Must not be empty.
 	 *

--- a/inc/classes/shortcodes/class-godam-player.php
+++ b/inc/classes/shortcodes/class-godam-player.php
@@ -271,7 +271,7 @@ class GoDAM_Player {
 		 * Use this when a trigger lives somewhere the content sniff cannot see, such
 		 * as a theme template, a sidebar widget or a nav-menu item.
 		 *
-		 * @since n.e.x.t
+		 * @since 2.2.0
 		 *
 		 * @param bool $godam_needs_runtime Whether the runtime is needed.
 		 */

--- a/inc/classes/wpbakery-elements/class-wpb-godam-document.php
+++ b/inc/classes/wpbakery-elements/class-wpb-godam-document.php
@@ -63,7 +63,7 @@ class WPB_GoDAM_Document {
 	 * Editor frame only — a published page is untouched, and still pays for these only when a
 	 * document is actually on it.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.2.0
 	 *
 	 * @return void
 	 */

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -729,7 +729,7 @@ function godam_is_audio_file( $file_path_or_url ) {
  * assets/src/blocks/godam-pdf/constants.js and the two are asserted equal by
  * tests/php/DocumentSupportTest.php.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @return array<string, string> MIME type => primary file extension.
  */
@@ -759,7 +759,7 @@ function rtgodam_get_supported_document_types() {
  * narrower than the MIME list: several extensions share a MIME type, and only the
  * ones named here are recognised when no attachment is available to ask.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @return string[] Lowercase extensions, without the leading dot.
  */
@@ -773,7 +773,7 @@ function rtgodam_get_supported_document_extensions() {
  * Query strings and fragments are dropped first: CDN URLs routinely carry `?v=2` or
  * `#page=3`, and reading the extension off the raw string would see "pdf?v=2".
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param string $path_or_url File path or URL.
  *
@@ -795,7 +795,7 @@ function rtgodam_get_extension_from_path( $path_or_url ) {
  * The stored path is preferred over the URL: it is what the file is called on disk, and it
  * avoids a second query for attachments whose URL is filtered to a CDN.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param int $attachment_id Attachment ID.
  *
@@ -838,7 +838,7 @@ function rtgodam_get_attachment_extension( $attachment_id ) {
  * the MIME type stands on its own rather than rejecting content that still renders.
  *
  * @since 2.1.0
- * @since n.e.x.t Widened beyond PDF to the formats in rtgodam_get_supported_document_types().
+ * @since 2.2.0 Widened beyond PDF to the formats in rtgodam_get_supported_document_types().
  *
  * @param int|string $attachment_id Attachment ID, or a non-numeric GoDAM media id.
  * @param string     $url           Document URL. Used when no local attachment is available.
@@ -888,7 +888,7 @@ function godam_is_supported_document( $attachment_id = 0, $url = '' ) {
  * Anything else returns 0, which callers treat as "no local attachment" and fall back to the
  * URL they were given. That is the safe direction.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param int|string $attachment_id Attachment ID, or a non-numeric GoDAM media id.
  *
@@ -918,7 +918,7 @@ function rtgodam_normalize_attachment_id( $attachment_id ) {
  * Requiring the extension to match as well costs nothing for the real formats, since each
  * one carries its own extension anyway.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param int $attachment_id Attachment ID.
  *
@@ -957,7 +957,7 @@ function rtgodam_is_supported_document_attachment( $attachment_id ) {
  * An empty return means "no preview available" — either transcoding has not finished or
  * the file is password protected, and the caller should show its download-only panel.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param int|string $attachment_id Attachment ID, or a non-numeric GoDAM media id.
  * @param string     $fallback_src  URL to fall back to when there is no local attachment.
@@ -1028,7 +1028,7 @@ function rtgodam_get_document_preview_url( $attachment_id = 0, $fallback_src = '
  * rtgodam_after_attachment_lookup, matching rtgodam_get_document_preview_url() above, so
  * neither resolver depends on its caller having opened the pair.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param int|string $attachment_id Attachment ID, or a non-numeric GoDAM media id.
  * @param string     $fallback_src  URL to fall back to when there is no local attachment.

--- a/languages/godam.pot
+++ b/languages/godam.pot
@@ -2,30 +2,30 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: GoDAM 2.1.1\n"
+"Project-Id-Version: GoDAM 2.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/godam\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-06T10:01:49+00:00\n"
+"POT-Creation-Date: 2026-08-26T12:00:40+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.12.0\n"
+"X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: godam\n"
 
 #. Plugin Name of the plugin
 #: godam.php
-#: assets/build/pages/video-editor.min.js:2
 #: inc/classes/class-elementor-widgets.php:240
 #: inc/classes/class-pages.php:184
 #: inc/classes/class-pages.php:185
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:68
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:68
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:102
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:68
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:371
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:382
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:401
 #: pages/video-editor/components/forms/CF7.js:22
+#: assets/build/pages/video-editor.min.js:22129
 msgid "GoDAM"
 msgstr ""
 
@@ -49,8138 +49,140 @@ msgstr ""
 msgid "https://rtcamp.com/?utm_source=dashboard&utm_medium=plugin&utm_campaign=godam"
 msgstr ""
 
-#: assets/build/blocks/godam-audio/render.php:150
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/render.php:150
-#: assets/src/blocks/godam-audio/edit.js:686
-msgid "Audio thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:157
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:157
-#: assets/src/blocks/godam-audio/edit.js:692
-#: pages/video-editor/components/audio/AudioCardPreview.js:70
-#: pages/video-editor/VideoEditor.js:649
-msgid "Untitled audio"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:186
-#: assets/src/blocks/godam-audio/render.php:186
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:158
-#: inc/classes/sureforms/class-form-submit.php:377
-#: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:48
-#: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:79
-msgid "Your browser does not support the audio element."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:191
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:191
-#: assets/src/blocks/godam-audio/player.js:50
-#: assets/src/blocks/godam-audio/view.js:254
-#: pages/video-editor/components/audio/AudioCardPreview.js:200
-msgid "Play"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:202
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:202
-#: assets/src/blocks/godam-audio/player.js:72
-#: pages/video-editor/components/audio/AudioCardPreview.js:217
-msgid "Seek"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:242
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:242
-#: inc/classes/elementor-widgets/class-godam-video.php:110
-#: assets/src/blocks/godam-audio/tabs.js:136
-#: assets/src/blocks/godam-player/track-uploader.js:32
-#: pages/video-editor/components/audio/AudioCardPreview.js:244
-#: pages/video-editor/components/editor-shell/EditorTabRail.js:21
-msgid "Chapters"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:247
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:247
-#: assets/src/blocks/godam-audio/tabs.js:147
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:282
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:349
-#: pages/video-editor/components/audio/AudioCardPreview.js:253
-#: pages/video-editor/components/transcription/Transcription.js:170
-msgid "Transcript"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:251
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:251
-#: assets/src/blocks/godam-audio/tabs.js:155
-#: pages/video-editor/components/audio/AudioCardPreview.js:260
-msgid "Toggle panel"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:277
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:277
-#: assets/src/blocks/godam-audio/tabs.js:167
-#: pages/video-editor/components/audio/AudioCardPreview.js:272
-msgid "No chapters to show"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:285
-#: assets/src/blocks/godam-audio/render.php:285
-msgid "Loading transcript…"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/render.php:287
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/render.php:287
-#: assets/src/blocks/godam-audio/tabs.js:187
-#: assets/src/blocks/godam-audio/view.js:116
-#: pages/video-editor/components/audio/AudioCardPreview.js:297
-msgid "No transcript to show"
-msgstr ""
-
-#. translators: %d: number of pages
-#: assets/build/blocks/godam-pdf/render.php:149
-#: assets/src/blocks/godam-pdf/render.php:149
-#, php-format
-msgid "%d page"
-msgid_plural "%d pages"
-msgstr[0] ""
-msgstr[1] ""
-
-#. translators: %s: PDF download URL
-#: assets/build/blocks/godam-pdf/render.php:196
-#: assets/src/blocks/godam-pdf/render.php:196
-#, php-format
-msgid "Your browser does not support PDFs. <a href=\"%s\">Download the PDF</a>."
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:20
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/src/blocks/sureforms/blocks/recorder/render.php:20
-#: inc/classes/fluentforms/fields/class-recorder-field.php:83
-#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:121
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:165
-msgid "GoDAM Recorder"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:24
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: assets/src/blocks/sureforms/blocks/recorder/render.php:24
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:345
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:508
-#: inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php:25
-#: inc/classes/gravity-forms/class-gf-field-godam-video.php:222
-#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:221
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:153
-#: inc/classes/wpforms/wpforms-field-godam-record-frontend.php:61
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:341
-msgid "Start Recording"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:29
-#: assets/src/blocks/sureforms/blocks/recorder/render.php:29
-#: inc/classes/sureforms/class-form-submit.php:80
-msgid "The field is required"
-msgstr ""
-
-#. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
-#: assets/build/blocks/sureforms/blocks/recorder/render.php:117
-#: assets/src/blocks/sureforms/blocks/recorder/render.php:117
-#, php-format
-msgid "Maximum allowed on this server: %d MB"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/player.js:50
-#: assets/src/blocks/godam-audio/view.js:250
-#: pages/video-editor/components/audio/AudioCardPreview.js:200
-msgid "Pause"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/tabs.js:194
-#: assets/src/blocks/godam-audio/view.js:135
-#: pages/video-editor/components/audio/AudioCardPreview.js:304
-msgid "Copied"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/view.js:1
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/tabs.js:194
-#: assets/src/blocks/godam-audio/view.js:124
-#: assets/src/blocks/godam-audio/view.js:140
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:357
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:359
-#: pages/video-editor/components/audio/AudioCardPreview.js:304
-msgid "Copy transcript"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:158
-msgid "Only audio files are allowed in the GoDAM Audio block."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:252
-msgid "Only image files are allowed for the GoDAM Audio thumbnail."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:373
-msgid "Customize Audio"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:390
-#: assets/src/blocks/godam-audio/edit.js:666
-msgid "Replace audio file"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:406
-#: assets/src/blocks/godam-audio/edit.js:677
-msgid "Remove audio"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: inc/classes/elementor-widgets/class-godam-audio.php:70
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:101
-#: assets/src/blocks/godam-audio/edit.js:416
-msgid "Audio Title"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:417
-msgid "Add a title…"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:83
-#: inc/classes/elementor-widgets/class-godam-document.php:86
-#: inc/classes/elementor-widgets/class-godam-video.php:201
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:115
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:115
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:347
-#: assets/src/blocks/godam-audio/edit.js:425
-#: assets/src/blocks/godam-pdf/edit.js:553
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:264
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:183
-#: pages/video-editor/components/cta/CardCTA.js:445
-msgid "Description"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:426
-msgid "Add a short description…"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:355
-msgid "Add Audio File"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:439
-#: assets/src/blocks/godam-audio/edit.js:498
-msgid "Audio Selection"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:95
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:129
-#: assets/src/blocks/godam-audio/edit.js:503
-#: assets/src/blocks/godam-player/edit.js:1053
-#: pages/video-editor/components/appearance/Appearance.js:241
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:503
-msgid "Thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/edit.js:506
-#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:126
-msgid "Select thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:517
-msgid "Edit or replace the thumbnail."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:523
-msgid "Thumbnail preview"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/js/wpbakery-document-selector-param.min.js:1
-#: assets/build/js/wpbakery-image-selector-param.min.js:1
-#: assets/build/js/wpbakery-video-selector-param.min.js:1
-#: assets/build/pages/godam.min.js:2
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:102
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:141
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:180
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:214
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:286
-#: assets/src/blocks/godam-audio/edit.js:543
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:201
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:246
-#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:63
-#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:49
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:91
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:341
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:112
-msgid "Replace"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:1
-#: assets/src/blocks/godam-audio/edit.js:543
-msgid "Set thumbnail"
-msgstr ""
-
-#. translators: %s: thumbnail image URL.
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:549
-#, js-format
-msgid "The current thumbnail url is %s."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:552
-msgid "There is no thumbnail currently selected."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/js/wpbakery-document-selector-param.min.js:1
-#: assets/build/js/wpbakery-image-selector-param.min.js:1
-#: assets/build/js/wpbakery-video-selector-param.min.js:1
-#: assets/build/pages/godam.min.js:2
-#: inc/classes/elementor-controls/class-godam-media.php:163
-#: inc/classes/elementor-controls/class-godam-media.php:165
-#: inc/classes/elementor-controls/class-godam-media.php:211
-#: inc/classes/elementor-controls/class-godam-media.php:213
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:115
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:154
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:189
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:227
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:297
-#: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:70
-#: assets/src/blocks/godam-audio/edit.js:564
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:216
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:262
-#: assets/src/blocks/godam-gallery-v2/edit.js:247
-#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:87
-#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:67
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:111
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:361
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:122
-msgid "Remove"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/edit.js:576
-#: pages/video-editor/components/editor-shell/EditorTabRail.js:20
-#: pages/video-editor/components/transcription/Transcription.js:176
-msgid "Transcription"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:579
-msgid "Show transcript"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:586
-msgid "Show chapters"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-player/index.js:2
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-audio/edit.js:602
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:233
-#: assets/src/blocks/godam-player/track-uploader.js:57
-#: assets/src/js/godam-player/engagement.js:946
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:553
-msgid "Edit"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: godam.php:108
-#: inc/classes/class-pages.php:242
-#: inc/classes/class-pages.php:243
-#: assets/src/blocks/godam-audio/edit.js:607
-#: pages/video-editor/components/appearance/Appearance.js:124
-#: pages/video-editor/components/editor-shell/EditorTabRail.js:19
-msgid "Settings"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-audio.php:109
-#: inc/classes/elementor-widgets/class-godam-video.php:268
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:143
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:77
-#: assets/src/blocks/godam-audio/edit.js:611
-#: assets/src/blocks/godam-player/edit-common-settings.js:93
-msgid "Autoplay"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-audio.php:112
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:150
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:84
-#: assets/src/blocks/godam-audio/edit.js:134
-#: assets/src/blocks/godam-player/edit-common-settings.js:61
-msgid "Autoplay may cause usability issues for some users."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:122
-#: inc/classes/elementor-widgets/class-godam-video.php:280
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:159
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:93
-#: assets/src/blocks/godam-audio/edit.js:620
-msgid "Loop"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:628
-msgctxt "noun; Audio block parameter"
-msgid "Preload"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:178
-#: assets/src/blocks/godam-audio/edit.js:635
-msgid "Browser default"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:141
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:181
-#: assets/src/blocks/godam-audio/edit.js:636
-msgid "Auto"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:142
-#: inc/classes/elementor-widgets/class-godam-video.php:111
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:179
-#: assets/src/blocks/godam-audio/edit.js:637
-#: assets/src/blocks/godam-player/track-uploader.js:33
-msgid "Metadata"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:143
-#: assets/src/blocks/godam-audio/edit.js:638
-msgctxt "Preload value"
-msgid "None"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:650
-msgid "The audio file for this block was deleted from the Media Library. Replace it with another file or remove the block."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: inc/classes/elementor-widgets/class-godam-audio.php:263
-#: assets/src/blocks/godam-audio/edit.js:447
-msgid "Add an audio file"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:450
-msgid "Upload an audio file to embed a player on your page or post."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/index.js:2
-#: assets/src/blocks/godam-audio/edit.js:465
-msgid "+ Upload Audio"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:78
-#: assets/src/blocks/godam-gallery-v2/edit.js:598
-msgid "Only video files can be added to the gallery."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:95
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:125
-msgid "This video is already in the gallery."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: inc/templates/godam-video-gallery.php:251
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:163
-#: assets/src/blocks/godam-gallery-v2/edit.js:716
-#: pages/analytics/Analytics.js:567
-#: pages/video-editor/VideoEditor.js:651
-msgid "Untitled video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/build/js/wpbakery-video-selector-param.min.js:1
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:66
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:271
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:82
-msgid "Select Video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/index.js:1
-#: assets/src/blocks/godam-gallery-v2-item/edit.js:330
-msgid "Choose a video to add this gallery item."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:62
-msgid "Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:63
-msgid "For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/pages/media-library.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-gallery-v2/edit.js:207
-#: pages/media-library/components/folder-tree/FolderTree.jsx:387
-#: pages/media-library/components/folder-tree/FolderTree.jsx:430
-#: pages/video-editor/components/cta/CardCTA.js:369
-msgid "Loading…"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:299
-#: assets/src/blocks/godam-gallery-v2/edit.js:301
-msgid "Add New Video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:606
-#: assets/src/blocks/godam-gallery-v2/edit.js:645
-msgid "Duplicate videos were skipped."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:742
-msgid "Start date cannot be later than end date."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:747
-msgid "End date cannot be earlier than start date."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:767
-msgid "Source"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:774
-msgid "Gallery Source"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:785
-msgid "Handpicked"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:789
-msgid "Query"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-gallery-v2/edit.js:797
-#: assets/src/blocks/godam-player/edit.js:1012
-msgid "Video Selection"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:802
-msgid "Videos play on mute by default"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:850
-#: assets/src/blocks/godam-gallery-v2/edit.js:1281
-msgid "+ Add Video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:56
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:71
-#: assets/src/blocks/godam-gallery-v2/edit.js:860
-msgid "Gallery Settings"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:5
-#: inc/classes/elementor-widgets/class-godam-gallery.php:297
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:240
-#: assets/src/blocks/godam-gallery-v2/edit.js:867
-#: assets/src/blocks/godam-player/edit.js:1020
-msgid "Layout"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:303
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:244
-#: assets/src/blocks/godam-gallery-v2/edit.js:889
-msgid "Carousel"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:301
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:243
-#: assets/src/blocks/godam-gallery-v2/edit.js:894
-msgid "Grid"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:302
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:245
-#: assets/src/blocks/godam-gallery-v2/edit.js:899
-msgid "List"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:325
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:266
-#: assets/src/blocks/godam-gallery-v2/edit.js:907
-msgid "View Ratio"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:924
-msgid "Item Size"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:930
-msgid "Size of each gallery item."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:932
-msgid "S"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:933
-msgid "M"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:934
-msgid "L"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:939
-#: assets/src/blocks/godam-gallery-v2/edit.js:941
-msgid "Info Display"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:946
-msgid "Only Image"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:950
-msgid "Show Video Title and Date"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:350
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:290
-#: assets/src/blocks/godam-gallery-v2/edit.js:962
-#: assets/src/blocks/godam-gallery-v2/edit.js:966
-msgid "Interaction"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:355
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:294
-#: assets/src/blocks/godam-gallery-v2/edit.js:971
-msgid "Autoplay all videos"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:973
-msgid "Visible videos autoplay one at a time and continue through the full video."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:354
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:293
-#: assets/src/blocks/godam-gallery-v2/edit.js:976
-msgid "Play on hover"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:978
-msgid "Videos will play when hovered over"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:992
-msgid "Show play button"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:997
-msgid "Play button overlay is visible on each tile."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:998
-msgid "Play button overlay is hidden."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/src/blocks/godam-gallery-v2/edit.js:1004
-#: assets/src/blocks/godam-gallery-v2/edit.js:1008
-#: assets/src/blocks/godam-player/edit.js:1036
-#: pages/analytics/PlaybackPerformance.js:343
-msgid "Performance"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:274
-#: inc/classes/elementor-widgets/class-godam-video.php:325
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:228
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:145
-#: assets/src/blocks/godam-gallery-v2/edit.js:1018
-#: assets/src/blocks/godam-player/edit-common-settings.js:213
-msgid "Priority"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:273
-#: inc/classes/elementor-widgets/class-godam-video.php:324
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:227
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:144
-#: assets/src/blocks/godam-gallery-v2/edit.js:1022
-#: assets/src/blocks/godam-player/edit-common-settings.js:214
-msgid "Balanced"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1030
-msgid "Engagement"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:349
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:219
-#: assets/src/blocks/godam-gallery-v2/edit.js:1032
-#: assets/src/blocks/godam-player/edit-common-settings.js:236
-msgid "Enable Likes & Comments"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:226
-#: assets/src/blocks/godam-gallery-v2/edit.js:1035
-#: assets/src/blocks/godam-player/edit-common-settings.js:239
-msgid "Engagement will only be visible for transcoded videos"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1046
-msgid "Query Settings"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:115
-#: assets/src/blocks/godam-gallery-v2/edit.js:1051
-msgid "Number of videos"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1061
-msgid "Order by"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:141
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:126
-#: assets/src/blocks/godam-gallery-v2/edit.js:1064
-msgid "Date"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:142
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:127
-#: assets/src/blocks/godam-gallery-v2/edit.js:1065
-#: pages/dashboard/components/TopVideosTable.js:192
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:117
-msgid "Title"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:155
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:141
-#: assets/src/blocks/godam-gallery-v2/edit.js:1074
-msgid "Order"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:159
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:144
-#: assets/src/blocks/godam-gallery-v2/edit.js:1078
-msgid "Descending"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:160
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:145
-#: assets/src/blocks/godam-gallery-v2/edit.js:1082
-msgid "Ascending"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:184
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:157
-#: assets/src/blocks/godam-gallery-v2/edit.js:1093
-msgid "Media Folder"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1097
-msgid "Search and select media folders"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:206
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:170
-#: assets/src/blocks/godam-gallery-v2/edit.js:1103
-msgid "Author"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1107
-msgid "Search and select authors"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:220
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:183
-#: assets/src/blocks/godam-gallery-v2/edit.js:1112
-#: pages/analytics/components/DateRangePicker/index.js:381
-msgid "Date Range"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:224
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:186
-#: assets/src/blocks/godam-gallery-v2/edit.js:1115
-#: pages/analytics/components/DateRangePicker/index.js:88
-#: pages/analytics/components/DateRangePicker/index.js:89
-msgid "All Time"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:225
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:187
-#: assets/src/blocks/godam-gallery-v2/edit.js:1116
-msgid "Last 7 Days"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:226
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:188
-#: assets/src/blocks/godam-gallery-v2/edit.js:1117
-msgid "Last 30 Days"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:227
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:189
-#: assets/src/blocks/godam-gallery-v2/edit.js:1118
-msgid "Last 90 Days"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:228
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:190
-#: assets/src/blocks/godam-gallery-v2/edit.js:1120
-msgid "Custom Range"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:239
-#: assets/src/blocks/godam-gallery-v2/edit.js:1143
-msgid "Start Date"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1153
-msgid "Select Start Date"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:254
-#: assets/src/blocks/godam-gallery-v2/edit.js:1173
-msgid "End Date"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1183
-msgid "Select End Date"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:377
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:315
-#: assets/src/blocks/godam-gallery-v2/edit.js:1206
-msgid "Enable More Items"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:389
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:327
-#: assets/src/blocks/godam-gallery-v2/edit.js:1213
-msgid "More Items Behavior"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1217
-msgid "Load More Button"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1221
-msgid "Infinite Scroll"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1228
-msgid "Carousel layout always uses Infinite Scroll when more items are enabled."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1229
-msgid "Choose how visitors load more videos in query galleries."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/classes/elementor-widgets/class-godam-gallery.php:545
-#: assets/src/blocks/godam-gallery-v2/edit.js:1264
-msgid "Create your media gallery"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1267
-msgid "Upload or select videos to add to your gallery."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/src/blocks/godam-gallery-v2/edit.js:1319
-msgid "Loading matching videos…"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/templates/godam-video-gallery.php:395
-#: assets/src/blocks/godam-gallery-v2/edit.js:1326
-msgid "No videos found"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: inc/templates/godam-video-gallery.php:396
-#: assets/src/blocks/godam-gallery-v2/edit.js:1328
-msgid "Try changing the selected folder, author, or dates."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/index.js:1
-#: assets/build/blocks/godam-player/index.js:5
-#: inc/classes/elementor-widgets/class-godam-gallery.php:78
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:103
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:380
-#: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:30
-#: assets/src/blocks/godam-gallery-v2/edit.js:1352
-#: assets/src/blocks/godam-player/edit.js:1127
-msgid "Video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/view.js:1
-#: assets/src/blocks/godam-gallery-v2/view.js:129
-#: assets/src/blocks/godam-gallery-v2/view.js:136
-msgid "Video player"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/view.js:1
-#: assets/build/pages/onboarding.min.js:2
-#: assets/src/blocks/godam-gallery-v2/view.js:142
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:85
-msgid "Close"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/view.js:1
-#: assets/src/blocks/godam-gallery-v2/view.js:149
-msgid "Previous video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/view.js:1
-#: assets/src/blocks/godam-gallery-v2/view.js:156
-msgid "Next video"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:1
-#: assets/build/js/godam-image-layers-frontend.min.js:1
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/managers/layers/hotspotLayerManager.js:707
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:200
-#: pages/video-editor/components/layers/HotspotLayer.js:769
-msgid "Custom Icon"
-msgstr ""
-
-#. translators: %d: hotspot number
-#. translators: %d is the hotspot index
-#: assets/build/blocks/godam-image/index.js:3
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/build/js/godam-image-layers-frontend.min.js:3
-#: assets/build/js/godam-image-layers-frontend.min.js:5
-#: assets/build/js/godam-player-frontend.min.js:3
-#: assets/build/js/godam-player-frontend.min.js:5
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/managers/layers/hotspotLayerManager.js:749
-#: assets/src/js/godam-player/managers/layers/hotspotLayerManager.js:756
-#: pages/video-editor/components/layers/HotspotLayer.js:458
-#, js-format
-msgid "Hotspot %d"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/src/blocks/godam-image/edit.js:84
-msgid "Only image files are allowed in the GoDAM Image block."
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/src/blocks/godam-image/edit.js:182
-msgid "Customize Image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-image/edit.js:197
-#: pages/video-editor/components/cta/CardCTA.js:399
-msgid "Remove image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/src/blocks/godam-image/edit.js:165
-#: assets/src/blocks/godam-image/edit.js:264
-msgid "Add Image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: inc/classes/elementor-widgets/class-godam-image.php:54
-#: assets/src/blocks/godam-image/edit.js:222
-msgid "Image Selection"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/src/blocks/godam-image/edit.js:224
-msgid "Add hotspot and product layers to make your image stand out."
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: inc/classes/elementor-widgets/class-godam-image.php:72
-#: assets/src/blocks/godam-image/edit.js:231
-msgid "Show image layers"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: inc/classes/elementor-widgets/class-godam-image.php:78
-#: assets/src/blocks/godam-image/edit.js:234
-msgid "Overlays the hotspot / product layers authored in the GoDAM image editor."
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: inc/classes/elementor-widgets/class-godam-image.php:157
-#: assets/src/blocks/godam-image/edit.js:246
-msgid "Add Image Here"
-msgstr ""
-
-#: assets/build/blocks/godam-image/index.js:5
-#: assets/src/blocks/godam-image/edit.js:249
-msgid "Upload or select an image from your media library to get started."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-pdf/caption.js:44
-#: assets/src/blocks/godam-pdf/caption.js:48
-#: assets/src/blocks/godam-player/caption.js:50
-#: assets/src/blocks/godam-player/caption.js:56
-msgid "Add caption"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-pdf/caption.js:49
-#: assets/src/blocks/godam-player/caption.js:57
-msgid "Remove caption"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/js/wpbakery-document-selector-param.min.js:1
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:66
-#: assets/src/blocks/godam-pdf/edit.js:198
-#: assets/src/blocks/godam-pdf/edit.js:327
-#: assets/src/blocks/godam-pdf/edit.js:399
-#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:65
-msgid "Document"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:220
-msgid "Only PDF files can be attached to this block. Please select a PDF document."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:334
-#: assets/src/blocks/godam-pdf/edit.js:521
-msgid "Doc Selection"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:336
-#: assets/src/blocks/godam-pdf/edit.js:523
-msgid "Add title, description, and more to make your document stand out."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:351
-msgid "+ Add Document"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:362
-msgid "Attach a document here"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:365
-msgid "Upload a PDF to embed it or display it as a card with a cover image."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:379
-msgid "+ Upload Document"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:257
-#: assets/src/blocks/godam-pdf/edit.js:421
-msgid "Unsupported file format"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:424
-msgid "Only PDF files are supported. Replace this file with a PDF; it will not be shown on your page."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:456
-msgid "page"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:456
-msgid "pages"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:468
-msgid "Document cover"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:533
-msgid "Remove document"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:72
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:101
-#: assets/src/blocks/godam-pdf/edit.js:544
-msgid "Doc Title"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:75
-#: assets/src/blocks/godam-pdf/edit.js:546
-msgid "Add document title"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:555
-msgid "Add document description"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-pdf/edit.js:563
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:286
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:291
-msgid "Preview"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/pages/analytics.min.js:2
-#: inc/classes/elementor-widgets/class-godam-document.php:99
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:129
-#: assets/src/blocks/godam-pdf/edit.js:567
-#: pages/analytics/helper.js:533
-msgid "View"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:103
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:132
-#: assets/src/blocks/godam-pdf/edit.js:575
-msgid "Default View"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:104
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:133
-#: assets/src/blocks/godam-pdf/edit.js:579
-msgid "Card View"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:587
-msgid "Show cover"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:596
-msgid "Cover"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:1
-#: assets/src/blocks/godam-pdf/edit.js:606
-#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:118
-msgid "Auto-generated cover"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:610
-msgid "Auto-generated"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:643
-msgid "Select cover image"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:1
-#: assets/src/blocks/godam-pdf/edit.js:665
-#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:103
-msgid "Remove cover"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:695
-msgid "+ Add Cover"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/src/blocks/godam-pdf/edit.js:701
-msgid "Recommended aspect ratio: 16:9."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-pdf/edit.js:711
-#: assets/src/blocks/godam-player/edit.js:886
-msgid "Height"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/index.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:116
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:147
-#: assets/src/blocks/godam-pdf/edit.js:714
-msgid "Height (px)"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/view.js:1
-#: assets/src/blocks/godam-pdf/view.js:142
-msgid "<strong>Unable to load PDF.</strong> All sources are unavailable."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:68
-msgid "Muted because of Autoplay."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:105
-msgid "Play on loop"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:292
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:109
-#: assets/src/blocks/godam-player/edit-common-settings.js:113
-msgid "Muted"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:308
-#: assets/src/blocks/godam-player/edit-common-settings.js:123
-msgid "Playback controls"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:132
-msgid "Show share button"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:141
-msgid "Show transcription"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:460
-#: assets/src/blocks/godam-player/edit-common-settings.js:149
-msgid "Show caption"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:157
-msgid "No subtitle/transcript file uploaded."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:160
-msgid "Click here to upload subtitles."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:170
-msgid "Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it. Best for overall page performance."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:171
-msgid "For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly - one or two per page."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/edit-common-settings.js:245
-msgid "Likes & Comments"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/caption.js:51
-msgid "Caption text"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:208
-msgid "Video SEO Schema"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:141
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:216
-msgid "Override default SEO"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:220
-msgid "SEO data is customized for this block. Changes to the media library will not affect this block."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:221
-msgid "SEO data is synced from the media library. Enable to customize SEO for this specific block."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:227
-msgid "SEO data is automatically synced from the media library. Any changes made to the video in the media library will be reflected here."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:233
-msgid "You have overridden the default SEO. Changes to this video in the media library will not update the SEO for this block."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:240
-msgid "Reset to media library defaults"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:176
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:248
-msgid "Content URL"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:179
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:251
-msgid "URL of the video content can be MOV, MP4, MPD. Example: https://www.example.com/video.mp4"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:256
-msgid "Headline *"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:193
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:259
-msgid "Title of the video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/js/godam-elementor-frontend.min.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:269
-#: assets/src/js/elementor/widgets/godam-video.js:326
-msgid "Description of the video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/js/godam-elementor-frontend.min.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:268
-#: assets/src/js/elementor/widgets/godam-video.js:323
-msgid "It is recommended to add a description for better video SEO."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:212
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:275
-msgid "Upload Date"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:276
-msgid "ISO 8601 datetime format. Example: 2024–01–15T10:30:00+00:00"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:143
-#: inc/classes/elementor-widgets/class-godam-video.php:228
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:128
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:283
-#: pages/analytics/helper.js:537
-#: pages/video-editor/components/layers/HotspotLayer.js:509
-msgid "Duration"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:230
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:285
-msgid "ISO 8601 format. Example: PT1H30M"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:242
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:291
-msgid "Video Thumbnail URL"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:294
-msgid "URL of the video thumbnail. Example: https://www.example.com/thumbnail.jpg"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:255
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:299
-msgid "Is Family Friendly"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:257
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:302
-msgid "Is the video suitable for all audiences?"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/media-library.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:308
-#: assets/src/js/deactivation-feedback.js:36
-#: assets/src/js/godam-player/engagement.js:744
-#: pages/godam/components/ConfirmModal.jsx:38
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:191
-#: pages/media-library/App.js:178
-#: pages/media-library/components/modal/DeleteModal.jsx:121
-#: pages/media-library/components/modal/FolderCreationModal.jsx:132
-#: pages/media-library/components/modal/RenameModal.jsx:104
-#: pages/video-editor/components/chapters/ChapterForm.js:124
-#: pages/video-editor/components/layers/LayersHeader.js:105
-#: pages/video-editor/components/transcription/Transcription.js:295
-msgid "Cancel"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-player/components/VideoSEOModal.js:311
-#: assets/src/js/godam-player/engagement.js:1115
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:134
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:140
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:360
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:493
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:130
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:191
-msgid "Save"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/js/media-library.min.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:426
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:158
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:135
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:411
-msgid "Video Thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/blocks/godam-player/index.js:2
-#: assets/build/js/media-library.min.js:1
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:149
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:222
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:317
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:318
-msgid "Upload Custom Thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:156
-#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:158
-msgid "Upload custom thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:172
-msgid "Custom uploaded thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:174
-msgid "Select custom thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:177
-msgid "Custom thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:183
-#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:139
-msgid "Remove custom thumbnail"
-msgstr ""
-
-#. translators: %s: thumbnail URL
-#: assets/build/blocks/godam-player/index.js:2
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:202
-#, js-format
-msgid "Select thumbnail: %s"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:2
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:208
-msgid "Auto-generated from video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/src/blocks/godam-player/components/ThumbnailPanel.js:245
-#: pages/tools/components/tabs/RetranscodeTab.jsx:553
-msgid "Reset"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:2
-#: assets/src/blocks/godam-player/edit.js:86
-msgid "Add a heading…"
-msgstr ""
-
-#. translators: %d: Label of the video text track e.g: "French subtitles".
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:364
-#, js-format
-msgctxt "video caption"
-msgid "Failed to load video data with id: %d"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:499
-msgid "Only video files are allowed in the GoDAM Video block."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:790
-msgid "Add subtitles, layers, and more to make your video stand out."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:817
-msgid "Customize Video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-player/edit.js:835
-#: pages/video-editor/components/ads/CustomAdSettings.js:219
-msgid "Remove video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:803
-#: assets/src/blocks/godam-player/edit.js:1116
-msgid "Add Video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:855
-msgid "Hover option is disabled when autoplay is on."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:178
-#: assets/src/blocks/godam-player/edit.js:856
-msgid "Choose the action to perform on video hover."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:858
-msgid "Show player"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: inc/classes/elementor-widgets/class-godam-video.php:342
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:175
-#: assets/src/blocks/godam-player/edit.js:859
-msgid "Start Preview"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: inc/classes/elementor-widgets/class-godam-video.php:396
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:187
-#: assets/src/blocks/godam-player/edit.js:868
-msgid "Aspect Ratio"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: inc/classes/elementor-widgets/class-godam-video.php:403
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:194
-#: assets/src/blocks/godam-player/edit.js:872
-msgid "Choose the aspect ratio for the video player."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: inc/classes/elementor-widgets/class-godam-video.php:400
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:190
-#: assets/src/blocks/godam-player/edit.js:874
-msgid "Original"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: inc/classes/elementor-widgets/class-godam-gallery.php:329
-#: assets/src/blocks/godam-player/edit.js:875
-msgid "16:9"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:890
-msgid "Set the video height. Width is auto-calculated from the aspect ratio."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:894
-msgid "Show overlay blocks"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:897
-msgid "Display blocks on top of the video player."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:903
-msgid "Vertical alignment"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:907
-msgid "Top"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:908
-msgid "Center"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:909
-msgid "Bottom"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:912
-msgid "Choose where to position the overlay blocks vertically."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:3
-#: assets/src/blocks/godam-player/edit.js:915
-msgid "Time range"
-msgstr ""
-
-#. translators: %s: formatted time
-#: assets/build/blocks/godam-player/index.js:4
-#: assets/src/blocks/godam-player/edit.js:924
-#, js-format
-msgid "Overlay will be visible for %s from the start of the video."
-msgstr ""
-
-#. translators: %s: formatted time
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:932
-#, js-format
-msgid "Video duration: %s"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/build/js/media-library.min.js:1
-#: inc/templates/video-preview.php:86
-#: assets/src/blocks/godam-player/edit.js:952
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:765
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:773
-msgid "Edit Video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:962
-msgid "Video SEO"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:966
-msgid "SEO"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/build/pages/godam.min.js:2
-#: inc/templates/video-preview.php:139
-#: assets/src/blocks/godam-player/edit.js:993
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:310
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:55
-msgid "Upgrade to Pro"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:997
-msgid "You don't have an active plan to use this feature. Upgrade now to use unlimited features as part of GoDAM suite."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/blocks/godam-player/edit.js:1007
-#: pages/godam/components/TrialCountdownBanner.jsx:78
-msgid "Upgrade Now"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:125
-#: assets/src/blocks/godam-player/edit.js:1028
-msgid "Playback Controls"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:1044
-msgid "Hover Options"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: inc/classes/elementor-widgets/class-godam-video.php:674
-#: assets/src/blocks/godam-player/edit.js:1100
-msgid "Add Video Here"
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:1103
-msgid "Upload or select a video from your media library to get started."
-msgstr ""
-
-#: assets/build/blocks/godam-player/index.js:5
-#: assets/src/blocks/godam-player/edit.js:1193
-msgid "Video caption text"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:33
-msgid "Default (HH:MM:SS)"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:34
-#: assets/src/blocks/godam-video-duration/edit.js:63
-msgid "00:00:00"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:38
-msgid "Minutes only (MM:SS)"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:39
-msgid "00:00"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:43
-msgid "Total Seconds"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:44
-msgid "0s"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:51
-msgid "Duration Settings"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/index.js:1
-#: assets/src/blocks/godam-video-duration/edit.js:53
-msgid "Duration Format"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:39
-msgid "Thumbnail Settings"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:42
-msgid "Show play button overlay"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:46
-msgid "Play button will be displayed."
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:47
-msgid "No play button will be displayed."
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:53
-msgid "Link to post"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:57
-msgid "Thumbnail will link to the video page."
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:58
-msgid "Thumbnail will not be linked."
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:65
-msgid "Open in new tab"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:69
-msgid "Link will open in a new tab."
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:70
-msgid "Link will open in the same tab."
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/index.js:1
-#: assets/src/blocks/godam-video-thumbnail/edit.js:82
-msgid "GoDAM Video Thumbnail"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: inc/classes/elementor-widgets/class-godam-video.php:90
-#: assets/src/blocks/godam-player/track-uploader.js:77
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:167
-msgid "Label"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:168
-msgid "Enter label for the field"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:181
-msgid "Enter description"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:184
-msgid "Enter description for the field"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:435
-#: inc/classes/fluentforms/fields/class-recorder-field.php:246
-#: inc/classes/gravity-forms/class-init.php:172
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:197
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:198
-msgid "Choose file selector"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: inc/classes/fluentforms/fields/class-recorder-field.php:250
-#: inc/classes/gravity-forms/class-init.php:181
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:214
-msgid "Local files"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:443
-#: inc/classes/fluentforms/fields/class-recorder-field.php:254
-#: inc/classes/gravity-forms/class-init.php:188
-#: inc/classes/ninja-forms/config/field-settings.php:52
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:205
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:221
-msgid "Webcam"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:444
-#: inc/classes/fluentforms/fields/class-recorder-field.php:258
-#: inc/classes/gravity-forms/class-init.php:195
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:206
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:228
-msgid "Screencast"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:445
-#: inc/classes/gravity-forms/class-init.php:202
-#: inc/classes/ninja-forms/config/field-settings.php:60
-#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:66
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:207
-#: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:30
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:235
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:73
-msgid "Audio"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:249
-msgid "100 MB"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:1
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:250
-msgid "Maximum file size (in MB)"
-msgstr ""
-
-#. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php:76
-#: inc/classes/fluentforms/fields/class-recorder-field.php:431
-#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:259
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:254
-#, js-format,php-format
-msgid "Maximum allowed on this server: %s MB"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:273
-msgid "Is recorder field required?"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:283
-msgid "Enter error message"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:287
-msgid "Enter the required error message"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:303
-msgid "Field settings"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:4
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:310
-#: pages/analytics/charts.js:179
-msgid "Untitled"
-msgstr ""
-
-#. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
-#: assets/build/blocks/sureforms/blocks/recorder/index.js:7
-#: assets/src/blocks/sureforms/blocks/recorder/edit.js:353
-#, js-format
-msgid "Maximum allowed size: %s MB"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:22
-msgid "Select a reason"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:23
-msgid "I found a better plugin"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:24
-msgid "The plugin is not working as expected"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:25
-msgid "I was just testing"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:26
-msgid "Other"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:28
-msgid "Additional details…"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:32
-msgid "Skip & Deactivate"
-msgstr ""
-
-#: assets/build/js/deactivation-feedback.min.js:1
-#: assets/src/js/deactivation-feedback.js:37
-msgid "Submit & Deactivate"
-msgstr ""
-
-#. translators: %d: Maximum allowed file size in MB.
-#: assets/build/js/everestforms.min.js:4
-#: assets/src/js/everestforms/index.js:61
-#, js-format
-msgid "File size exceeds the maximum limit of %d MB."
-msgstr ""
-
-#: assets/build/js/everestforms.min.js:4
-#: assets/build/js/fluentforms.min.js:1
-#: assets/build/js/ninja-forms.min.js:1
-#: assets/src/js/everestforms/index.js:231
-#: assets/src/js/fluentforms/index.js:245
-#: assets/src/js/ninja-forms/index.js:216
-msgid "File upload in progress…"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:725
-msgid "Add timestamp"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:731
-msgid "Add emoji"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:739
-#: assets/src/js/godam-player/engagement.js:928
-#: assets/src/js/godam-player/engagement.js:968
-msgid "Reply"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:739
-msgid "Comment"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: inc/helpers/custom-functions.php:1009
-#: assets/src/js/godam-player/engagement.js:899
-#: assets/src/js/godam-player/engagement.js:906
-msgid "Anonymous"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:915
-msgid "This comment has been deleted"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/media-library.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/engagement.js:938
-#: pages/media-library/components/context-menu/ContextMenu.jsx:464
-#: pages/media-library/components/modal/DeleteModal.jsx:114
-#: pages/video-editor/components/SidebarLayers.js:750
-#: pages/video-editor/components/transcription/Transcription.js:304
-msgid "Delete"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:968
-msgid "Replies"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1020
-msgid "No comments yet. Be the first to comment!"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1081
-msgid "Register"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1081
-msgid "Login"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1081
-msgid "to comment"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/onboarding.min.js:2
-#: assets/src/js/godam-player/engagement.js:1088
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:58
-#: pages/onboarding/components/screens/LoginScreen.jsx:54
-#: pages/onboarding/components/screens/SignupScreen.jsx:77
-msgid "Email"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1092
-msgid "Enter your email"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1151
-msgid "GoDAM Video"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1262
-msgid "Comments"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/engagement.js:1267
-msgid "Hide Comments"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/managers/chaptersManager.js:71
-msgid "Chapter"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/managers/controlsManager.js:84
-msgid "Custom Fullscreen"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/managers/controlsManager.js:165
-msgid "Exit Fullscreen"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/managers/controlsManager.js:377
-#: pages/video-editor/VideoJSPlayer.js:195
-msgid "Custom Play Button"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/godam.min.js:2
-#: assets/src/js/godam-player/managers/controlsManager.js:421
-#: assets/src/js/godam-player/managers/controlsManager.js:438
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:429
-msgid "Branding"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:320
-#: pages/video-editor/components/layers/CTALayer.js:265
-msgid "Done"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:324
-msgid "Skip Form"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:325
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:329
-#: pages/godam/components/WooUnlockedNotice.jsx:202
-#: pages/video-editor/components/forms/FormPreview.js:86
-#: pages/video-editor/components/layers/CTALayer.js:265
-msgid "Skip"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:326
-msgid "Skip Poll"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:1
-#: assets/build/pages/onboarding.min.js:2
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:413
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:416
-#: assets/src/js/godam-player/managers/layers/formLayerManager.js:507
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
-msgid "Continue"
-msgstr ""
-
-#. translators: %d: number of seconds to seek backward
-#. translators: %d: number of seconds to seek forward
-#: assets/build/js/godam-player-frontend.min.js:7
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/playerManager.js:440
-#: assets/src/js/godam-player/managers/playerManager.js:456
-#, js-format
-msgid "%ds"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:278
-msgid "Check out this video!"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:312
-msgid "Share Media"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:321
-msgid "Page Link"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/godam-player/managers/shareManager.js:322
-#: pages/godam/components/GoDAMHeader.jsx:107
-msgid "GoDAM Central"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:323
-msgid "Embed"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:332
-msgid "Start at"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:336
-msgid "mm:ss"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/shareManager.js:643
-msgid "copy icon"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:280
-msgid "Toggle transcript"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:366
-#: assets/src/js/godam-player/managers/transcriptPanelManager.js:368
-msgid "Close transcript"
-msgstr ""
-
-#: assets/build/js/godam-player-frontend.min.js:9
-#: assets/build/pages/godam.min.js:2
-#: assets/src/js/godam-player/masterSettings.js:264
-msgid "Invalid item"
-msgstr ""
-
-#. translators: %d: Maximum allowed duration in seconds
-#: assets/build/js/godam-recorder.min.js:2
-#: assets/src/js/godam-recorder/index.js:271
-#, js-format
-msgid "Maximum allowed duration is %d seconds. Please upload or record a shorter file."
-msgstr ""
-
-#: assets/build/js/godam-recorder.min.js:2
-#: assets/src/js/godam-recorder/index.js:370
-#: assets/src/js/godam-recorder/index.js:373
-msgid "Remove recording"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: admin/godam-transcoder-functions.php:354
-#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:190
-msgid "Transcoding failed, please try again."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:209
-msgid "Not started"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:229
-msgid "Media is transcoded"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/transcoding-status/list-view-transcoding-status.js:265
-msgid "Transcoding…"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/build/pages/whats-new.min.js:2
-#: admin/class-rtgodam-transcoder-admin.php:192
-#: admin/class-rtgodam-transcoder-admin.php:336
-#: admin/godam-transcoder-functions.php:328
-#: inc/classes/class-media-library-ajax.php:1245
-#: inc/templates/video-preview.php:63
-#: assets/src/js/media-library/views/attachment.js:178
-#: pages/godam/components/GoDAMHeader.jsx:74
-#: pages/whats-new/components/Header.js:19
-msgid "GoDAM Logo"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:108
-msgid "No thumbnails found"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:265
-msgid "Select Custom Thumbnail"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:266
-msgid "Use this image"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:278
-msgid "Please select a valid image file (JPEG, PNG, GIF, etc.)."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:314
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:315
-msgid "Only 3 custom thumbnails allowed"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:362
-msgid "Custom Video Thumbnail"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:369
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:373
-msgid "Remove Image"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:588
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:1192
-msgid "Video Thumbnails"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: inc/templates/video-preview.php:82
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:748
-msgid "Edit Image"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/class-pages.php:219
-#: inc/classes/class-pages.php:220
-#: inc/templates/video-preview.php:74
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:767
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:774
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:320
-msgid "Analytics"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: inc/templates/video-preview.php:84
-#: assets/src/js/media-library/views/attachment-detail-two-column.js:801
-msgid "Edit Audio"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-details.js:145
-msgid "oEmbed Video URL"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/views/attachment-details.js:147
-msgid "The oEmbed URL can be used to embed the video in other platforms that support oEmbed."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: admin/godam-transcoder-actions.php:73
-#: assets/src/js/media-library/views/attachment-details.js:157
-msgid "Transcoded CDN URL (MPD)"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: admin/godam-transcoder-actions.php:87
-#: assets/src/js/media-library/views/attachment-details.js:159
-msgid "The URL of the transcoded file is generated automatically and cannot be edited."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: admin/godam-transcoder-actions.php:95
-#: assets/src/js/media-library/views/attachment-details.js:169
-msgid "Transcoded CDN URL (HLS)"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: admin/godam-transcoder-actions.php:104
-#: assets/src/js/media-library/views/attachment-details.js:171
-msgid "The HLS URL of the transcoded file is generated automatically and cannot be edited."
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: assets/src/js/media-library/utility.js:79
-#: pages/godam/components/GoDAMHeader.jsx:102
-msgid "Manage Media"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/utility.js:84
-msgid "Premium Feature"
-msgstr ""
-
-#: assets/build/js/media-library.min.js:1
-#: assets/src/js/media-library/index.js:187
-msgid "Search Media"
-msgstr ""
-
-#: assets/build/js/ninja-forms.min.js:1
-#: assets/src/js/ninja-forms/index.js:280
-msgid "Upload failed. Please try again."
-msgstr ""
-
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:1
-#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:122
-msgid "Custom cover"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:1
-#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:157
-msgid "Select Cover Image"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-cover-selector-param.min.js:1
-#: assets/src/js/wpbakery/wpbakery-document-cover-selector-param.js:158
-msgid "Use image"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-selector-param.min.js:1
-#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:32
-msgid "Select or Upload Document"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-selector-param.min.js:1
-#: inc/classes/elementor-widgets/class-godam-document.php:57
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:75
-#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:34
-msgid "Select Document"
-msgstr ""
-
-#: assets/build/js/wpbakery-document-selector-param.min.js:1
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:214
-#: assets/src/js/wpbakery/wpbakery-document-selector-param.js:125
-msgid "Select document"
-msgstr ""
-
-#: assets/build/js/wpbakery-image-selector-param.min.js:1
-#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:28
-msgid "Select or Upload Image"
-msgstr ""
-
-#: assets/build/js/wpbakery-image-selector-param.min.js:1
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:180
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:267
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:286
-#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:30
-#: assets/src/js/wpbakery/wpbakery-image-selector-param.js:107
-msgid "Select image"
-msgstr ""
-
-#: assets/build/js/wpbakery-video-selector-param.min.js:1
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:81
-msgid "Select or Upload Video"
-msgstr ""
-
-#: assets/build/js/wpbakery-video-selector-param.min.js:1
-#: assets/build/pages/analytics.min.js:2
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:102
-#: assets/src/js/wpbakery/wpbakery-video-selector-param.js:136
-#: pages/analytics/index.js:37
-msgid "Select video"
-msgstr ""
-
-#: assets/build/js/wpforms-godam-recorder-editor.min.js:1
-#: assets/src/js/wpforms-godam-recorder-editor.js:15
-msgid "Select or Upload Video Of Your Choice"
-msgstr ""
-
-#: assets/build/js/wpforms-godam-recorder-editor.min.js:1
-#: assets/src/js/wpforms-godam-recorder-editor.js:20
-msgid "Use this video"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/godam/utils/index.js:77
-msgid "Your API key has expired."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/godam/utils/index.js:78
-msgid "Please renew your subscription from your Account to continue."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/godam/utils/index.js:86
-msgid "Unable to verify API key."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/godam/utils/index.js:87
-msgid "This may be a temporary issue. Please try again later."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/godam/utils/index.js:95
-msgid "API key issue detected."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/godam/utils/index.js:96
-msgid "Please check your API key settings."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/ProUpgradeNotice.jsx:111
-msgid "You are now a pro member"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/ProUpgradeNotice.jsx:113
-msgid "With a paid plan, you get fixed storage, bandwidth that resets monthly, and unlimited sites."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/ProUpgradeNotice.jsx:117
-msgid "Got it"
-msgstr ""
-
-#. translators: %s: trial end date.
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/TrialCountdownBanner.jsx:68
-#, js-format
-msgid "Free trial ends on %s"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:69
-msgid "Interactive product hotspots"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:70
-msgid "Tag products directly on your videos so viewers can buy in a click."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:75
-msgid "Shoppable video"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:76
-msgid "Turn any product video into a storefront that drives conversions."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:81
-msgid "Reel Pops"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:82
-msgid "Surface short, shoppable product reels across your store."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:87
-msgid "Enhanced product page"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:88
-msgid "Showcase your videos right on the WooCommerce product page."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:179
-msgid "You have unlocked Woo features"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:183
-msgid "You've Unlocked Woo Features"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/onboarding.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:185
-#: pages/onboarding/components/screens/EntryScreen.jsx:38
-msgid "Turn your product videos into interactive shopping experiences, focused video content for WooCommerce."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:205
-#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:66
-msgid "Get Started"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/WooUnlockedNotice.jsx:226
-msgid "Feature preview slides"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/GoDAMHeader.jsx:92
-msgid "Need help?"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/GoDAMHeader.jsx:107
-msgid "Premium feature"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/GoDAMHeader.jsx:118
-msgid "Upgrade plan"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/GoDAMHeader.jsx:130
-msgid "Get GoDAM"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/helper.js:141
-msgid "Views by Location"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/helper.js:152
-msgid "Views by location will show up here"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:70
-msgid "7 Days"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:71
-msgid "Last 7 days"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:76
-msgid "15 Days"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:77
-msgid "Last 15 days"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:82
-msgid "1 Month"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:83
-msgid "Last 1 month"
-msgstr ""
-
-#. translators: 1: range start (e.g. "Nov 7"), 2: range end (e.g. "Nov 13").
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:129
-#, js-format
-msgid "%1$s - %2$s"
-msgstr ""
-
-#. translators: %s: range start date, e.g. "Nov 7".
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:137
-#, js-format
-msgid "From %s"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:168
-msgid "Su"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:169
-msgid "Mo"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:170
-msgid "Tu"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:171
-msgid "We"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:172
-msgid "Th"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:173
-msgid "Fr"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:174
-msgid "Sa"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:289
-msgid "Previous month"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:305
-msgid "Next month"
-msgstr ""
-
-#. translators: %s: the selected range label.
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/shared-components.min.js:2
-#: pages/analytics/components/DateRangePicker/index.js:195
-#, js-format
-msgid "Date range: %s"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/SingleMetrics.js:126
-msgid "vs prev period"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/PlaysVsViewers.js:127
-#: pages/analytics/SingleMetrics.js:127
-msgid "vs prev 7 days"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:103
-#: pages/analytics/SingleMetrics.js:157
-#: pages/dashboard/Dashboard.js:224
-msgid "All time"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/PlaysVsViewers.js:91
-msgid "Plays / Unique viewers"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:229
-#: pages/analytics/PlaysVsViewers.js:115
-msgid "Plays"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/PlaysVsViewers.js:116
-#: pages/dashboard/components/ViewersGauge.js:89
-msgid "Unique viewers"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/PlaysVsViewers.js:134
-msgid "Sessions per user:"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/PlaybackPerformance.js:418
-#: pages/analytics/PlaybackPerformance.js:525
-#: pages/dashboard/components/TopVideosTable.js:198
-#: pages/dashboard/Dashboard.js:410
-msgid "Engagement Rate"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:613
-#: pages/analytics/Analytics.js:902
-#: pages/analytics/components/Placements/index.js:230
-#: pages/analytics/PlaybackPerformance.js:425
-#: pages/analytics/PlaybackPerformance.js:524
-#: pages/dashboard/components/TopVideosTable.js:195
-#: pages/dashboard/components/TopVideosTable.js:272
-msgid "Play Rate"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/PlaybackPerformance.js:520
-msgid "Playback Performance"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/analytics/constants/layerTypes.js:129
-#: pages/video-editor/components/SidebarLayers.js:38
-#: pages/video-editor/components/SidebarLayers.js:41
-#: pages/video-editor/components/SidebarLayers.js:462
-#: pages/video-editor/utils/layerTypes.js:71
-msgid "CTA"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/analytics/constants/layerTypes.js:139
-#: pages/video-editor/components/forms/FormFields.js:49
-#: pages/video-editor/components/SidebarLayers.js:481
-msgid "Form"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/analytics/constants/layerTypes.js:147
-#: pages/video-editor/components/SidebarLayers.js:44
-#: pages/video-editor/components/SidebarLayers.js:47
-#: pages/video-editor/components/SidebarLayers.js:463
-#: pages/video-editor/utils/layerTypes.js:76
-msgid "Hotspot"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/analytics/constants/layerTypes.js:157
-#: pages/video-editor/components/layers/PollLayer.js:39
-#: pages/video-editor/components/SidebarLayers.js:124
-#: pages/video-editor/components/SidebarLayers.js:127
-#: pages/video-editor/components/SidebarLayers.js:498
-#: pages/video-editor/utils/layerTypes.js:86
-msgid "Poll"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:165
-msgid "Woo Hotspot"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:228
-msgid "Viewed"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:229
-msgid "Clicked"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:230
-msgid "Submitted"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:231
-msgid "Hovered"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:232
-msgid "Skipped"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:233
-msgid "Voted"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:234
-msgid "Added to Cart"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/constants/layerTypes.js:235
-msgid "No Action"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/hooks/useVideoLayerData.js:190
-msgid "Layer"
-msgstr ""
-
-#. translators: 1: layer type label (e.g. "CTA"), 2: position in the video in seconds.
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/hooks/useVideoLayerData.js:197
-#, js-format
-msgid "%1$s layer at %2$ss"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerTimelineMarker.js:137
-msgid "Conversion rate — share of viewers who saw this layer and interacted with it."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerTimelineMarker.js:155
-#: pages/analytics/timeline/SubHotspotRail.js:222
-msgid "Removed"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerTimelineStrip.js:192
-msgid "Interactive layers on the video timeline"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerTimelineStrip.js:197
-msgid "Nothing to show yet"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerTimelineStrip.js:200
-msgid "Layer analytics appear after the video is played on the front end and the activity is processed. A layer you just added won't have data until viewers interact with it."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/InfoTooltip.js:49
-msgid "Info"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerInteractionFunnel.js:159
-msgid "Interaction Outcomes"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerInteractionFunnel.js:162
-msgid "Of everyone who saw this layer (Viewed = 100%), the share who took each action. \"No action\" saw the layer but never interacted. A viewer can appear in more than one action, so the bars need not add up to 100%."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerInteractionFunnel.js:169
-msgid "Out of all viewers who saw this layer"
-msgstr ""
-
-#. translators: %1$s value, %2$s percentage
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerInteractionFunnel.js:221
-#, js-format
-msgid "%1$s viewers (%2$s%%) saw this layer but didn't interact with it."
-msgstr ""
-
-#. translators: %1$s action name, %2$s value, %3$s percentage
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerInteractionFunnel.js:228
-#, js-format
-msgid "%1$s: %2$s viewers (%3$s%%)."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerInteractionFunnel.js:278
-msgid "of viewers"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:60
-msgid "Products in this layer"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:61
-msgid "Hotspots in this layer"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:66
-msgid "Each row is one product hotspot inside this layer. Select a row to see its individual funnel; \"All Products (Cumulative)\" counts sessions that converted on any product."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:70
-msgid "Each row is one hotspot inside this layer. Select a row to see its individual funnel; \"All Hotspots (Cumulative)\" counts sessions that converted on any hotspot."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:79
-msgid "Conversion"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:85
-msgid "Share of sessions that saw the product and converted — clicked through to it or added it to the cart. Each session counts once, so this never exceeds 100%."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:89
-msgid "Share of sessions that saw the hotspot and clicked it. Each session counts once, so this never exceeds 100%."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:122
-msgid "All Products (Cumulative)"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:123
-msgid "All Hotspots (Cumulative)"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:139
-msgid "A session counts as converted here when it converts on any one product in this layer — clicks it or adds it to the cart. Each session counts once, so this can read higher than every single product's rate."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/SubHotspotRail.js:143
-msgid "A session counts as converted here when it clicks any one hotspot in this layer. Each session counts once, so this can read higher than every single hotspot's rate."
-msgstr ""
-
-#. translators: 1: first position, 2: second position.
-#. translators: 1: comma-separated positions, 2: last position.
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerModifiedNotice.js:63
-#: pages/analytics/timeline/LayerModifiedNotice.js:71
-#, js-format
-msgid "%1$s and %2$s"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerModifiedNotice.js:162
-msgid "This layer has been modified."
-msgstr ""
-
-#. translators: %s is a comma-separated list of timestamps like "0:01 and 0:03".
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerModifiedNotice.js:166
-#, js-format
-msgid "It was previously at %s. Analytics shown here are cumulative across all changes."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerModifiedNotice.js:174
-msgid "Dismiss notice"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:138
-msgid "Untitled layer"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:142
-msgid "Appeared at"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:164
-msgid "View this poll’s results"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:165
-msgid "View this form’s entries"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:168
-msgid "View Poll results"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:169
-msgid "View Form entries"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:177
-msgid "Edit this layer in the video editor"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:179
-msgid "Edit Layer"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:186
-msgid "This layer is no longer in the video. Historical analytics preserved."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/LayerDetailPanel.js:188
-msgid "Removed from video"
-msgstr ""
-
-#. translators: %d is the count of removed layers.
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/HistoricalLayersDrawer.js:55
-#, js-format
-msgid "Removed layers (%d)"
-msgid_plural "Removed layers (%d)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/timeline/HistoricalLayersDrawer.js:70
-msgid "No longer in the video; historical analytics preserved."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:35
-msgid "Add an interactive layer in the video editor to start tracking performance."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:45
-msgid "Click on any hotspot on the left to see its performance."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:50
-msgid "Click on any layer above to view its performance details."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:162
-msgid "Video Layer Timeline"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:166
-msgid "Each marker represents an interactive layer in this video. Click a marker to see how viewers interacted with it."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:173
-msgid "See when interactive layers appeared in your video and how they performed."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:189
-msgid "Video conversion"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:193
-msgid "Share of plays where the viewer converted on any layer (clicked a CTA, submitted a form, voted in a poll, or added a product to cart). A play counts once even if the viewer converts on several layers, so this never exceeds 100%."
-msgstr ""
-
-#. translators: 1: converting sessions, 2: total plays.
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:206
-#, js-format
-msgid "%1$s of %2$s plays"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/VideoLayerTimeline.js:222
-msgid "Unable to load layer analytics. Please try again."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:32
-msgid "Video Block"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:369
-#: pages/analytics/components/Placements/index.js:33
-msgid "Video Gallery"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:34
-msgid "Shoppable Video"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:35
-msgid "WooCommerce Product Gallery"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:36
-msgid "Product Reels"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:37
-msgid "Reel Pop"
-msgstr ""
-
-#. translators: %d: WordPress post ID.
-#: assets/build/pages/analytics.min.js:2
-#: inc/classes/rest-api/class-analytics.php:474
-#: pages/analytics/components/Placements/index.js:173
-#, js-format,php-format
-msgid "Post #%d"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:174
-msgid "Unknown page"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:874
-#: pages/analytics/components/Placements/index.js:228
-msgid "Views"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:232
-msgid "Avg Watch Time"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:238
-msgid "<1s"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:266
-msgid "Displayed on:"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: inc/classes/rest-api/class-analytics.php:475
-#: inc/classes/rest-api/class-analytics.php:536
-#: pages/analytics/components/Placements/index.js:273
-msgid "Deleted page"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:287
-msgid "Edit Page"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/components/Placements/index.js:372
-#: pages/dashboard/components/TopVideosTable.js:200
-#: pages/dashboard/components/TopVideosTable.js:277
-msgid "Placements"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:384
-msgid "Unable to load placement analytics. Please try again."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:396
-msgid "No placements in this date range"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:399
-msgid "This video had no placement activity in the selected range."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:411
-msgid "View all time"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:416
-msgid "No placement data for this video yet"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/components/Placements/index.js:474
-msgid "Placement breakdown reflects activity since v2.1.0. Totals above include the video's full history."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/shared/AnalyticsUnavailableNotice.jsx:24
-msgid "Analytics is temporarily unavailable."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/shared/AnalyticsUnavailableNotice.jsx:25
-msgid "We couldn’t reach the GoDAM analytics service. This is usually temporary. Please refresh in a few minutes."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/helper.js:726
-msgid "retention"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/helper.js:729
-msgid "viewers"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:408
-msgid "Select Video to Perform Performance Comparison Testing"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:410
-msgid "Use this Video"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:517
-msgid "This media doesn't exist."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:519
-msgid "Go to Dashboard"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:531
-msgid "Single Video Analytics"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:532
-msgid "Back to Media Editor"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:541
-#: pages/dashboard/Dashboard.js:312
-msgid "Heads up: analytics update periodically, so new activity may take up to 30 minutes to show here."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:555
-#: pages/dashboard/components/TopVideosTable.js:302
-#: pages/dashboard/components/TopVideosTable.js:314
-msgid "Video thumbnail"
-msgstr ""
-
-#. translators: %d: number of interactive layers on the video.
-#. translators: %d is the number of layers.
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/analytics/Analytics.js:575
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:233
-#, js-format
-msgid "%d layer"
-msgid_plural "%d layers"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:591
-#: pages/dashboard/Dashboard.js:354
-msgid "Insights"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:601
-#: pages/analytics/Analytics.js:886
-#: pages/dashboard/components/TopVideosTable.js:275
-msgid "Average Engagement"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:602
-msgid "Video engagement rate is the percentage of video watched. Average Engagement = Total time played / (Total plays x Video length)"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:614
-#: pages/dashboard/Dashboard.js:383
-msgid "Play rate is the percentage of page visitors who clicked play. Play Rate = Total plays / Page loads"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:625
-#: pages/dashboard/components/TopVideosTable.js:197
-#: pages/dashboard/Dashboard.js:396
-msgid "Watch Time"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: pages/analytics/Analytics.js:626
-#: pages/dashboard/Dashboard.js:397
-msgid "Total time the video has been watched, aggregated across all plays"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:652
-msgid "Viewer Retention Curve"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:666
-msgid "Viewer retention will appear here once this video receives views."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:714
-msgid "Views by Source"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:725
-msgid "Performance Comparison"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:746
-msgid "The test is complete! Review results to identify the best-performing video."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:736
-msgid "In Progress"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:741
-msgid "Initiate the test comparison to generate analytical insights."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:758
-msgid "Start Test"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: inc/classes/elementor-controls/class-godam-media.php:140
-#: pages/analytics/Analytics.js:777
-msgid "Choose Video"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:789
-msgid "Test this video against others to see which performs better."
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:798
-msgid "Upload or Replace CTA Image"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:803
-msgid "Choose"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: assets/build/pages/dashboard.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/analytics/Analytics.js:893
-#: pages/dashboard/components/TopVideosTable.js:196
-#: pages/dashboard/components/TopVideosTable.js:273
-#: pages/dashboard/components/ViewersGauge.js:95
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:105
-msgid "Total Plays"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:914
-msgid "Page Loads"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:928
-msgid "Play Time"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/Analytics.js:942
-msgid "Video Length"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/index.js:79
-msgid "No video is selected"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/index.js:39
-msgid "View analytics"
-msgstr ""
-
-#: assets/build/pages/analytics.min.js:2
-#: pages/analytics/index.js:89
-msgid "Select Video to Edit"
-msgstr ""
-
-#. translators: %s: total plays count.
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/ViewersGauge.js:55
-#, js-format
-msgid "Unique viewers unavailable for the selected range; %s total plays"
-msgstr ""
-
-#. translators: 1: unique viewers count, 2: total plays count.
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/ViewersGauge.js:60
-#, js-format
-msgid "%1$s unique viewers of %2$s total plays"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/ViewersGauge.js:100
-msgid "Unique Viewers"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:225
-msgid "Top Videos"
-msgstr ""
-
-#. translators: %s: number of videos (already locale-formatted).
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:230
-#, js-format
-msgid "%s video"
-msgid_plural "%s videos"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:243
-#: pages/dashboard/components/TopVideosTable.js:244
-msgid "Search videos"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:250
-msgid "Show deleted videos"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:193
-msgid "Media ID"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:144
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:129
-#: pages/dashboard/components/TopVideosTable.js:194
-#: pages/dashboard/components/TopVideosTable.js:271
-msgid "Size"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:199
-#: pages/dashboard/components/TopVideosTable.js:276
-msgid "Conversion Rate"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:261
-msgid "Exporting…"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:261
-msgid "Export"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:270
-msgid "Name"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:274
-msgid "Total Watch Time"
-msgstr ""
-
-#. translators: 1: converting sessions, 2: total plays.
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:335
-#, js-format
-msgid "%1$s of %2$s sessions converted"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:339
-msgid "No layer conversions in this period"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:357
-msgid "No videos match your search"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:358
-msgid "No video plays yet"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:362
-msgid "Try a different title, or clear the search to see all videos."
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:363
-msgid "Once your videos start getting views, your top performers will show up here."
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:374
-msgid "Top videos pagination"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:380
-msgid "Previous page"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/components/TopVideosTable.js:406
-msgid "Next page"
-msgstr ""
-
-#. translators: %d: number of days in the compared previous window.
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:221
-#, js-format
-msgid "vs prev %d days"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: inc/classes/class-pages.php:199
-#: inc/classes/class-pages.php:200
-#: pages/dashboard/Dashboard.js:307
-msgid "Dashboard"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:323
-msgid "See Reel Pop Analytics"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:333
-msgid "Total Plays / Unique Viewers"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:366
-msgid "Active Videos"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:367
-msgid "Number of unique videos that received user interactions each day, such as views or plays."
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:382
-msgid "Avg. Play Rate"
-msgstr ""
-
-#: assets/build/pages/dashboard.min.js:2
-#: pages/dashboard/Dashboard.js:411
-msgid "Average share of each video that viewers watched, across all plays."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/App.js:35
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:101
-msgid "API Key"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: pages/godam/App.js:44
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:101
-#: pages/help/App.js:55
-msgid "General Settings"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: pages/godam/App.js:50
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:101
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:110
-#: pages/help/App.js:59
-msgid "Video Settings"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/App.js:56
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:408
-msgid "Video Player"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/App.js:65
-msgid "Video Ads"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/App.js:74
-msgid "Integrations Settings"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:19
-msgid "Support"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:23
-msgid "Docs"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:27
-msgid "Newsletter"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: inc/classes/class-pages.php:268
-#: inc/classes/class-pages.php:269
-#: pages/dashboard/components/MarketingCarousel.jsx:94
-#: pages/godam/components/GoDAMFooter.jsx:31
-msgid "What's New"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:39
-msgid "Twitter X"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:44
-msgid "Facebook"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:49
-msgid "Linkedin"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:54
-msgid "Instagram"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:59
-msgid "Youtube"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:64
-msgid "WordPress.org"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:67
-msgid "Rate us on WordPress.org"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/tools.min.js:2
-#: pages/godam/components/GoDAMFooter.jsx:77
-msgid "Made with ♥ by the GoDAM Team"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:168
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:42
-msgid "Account"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:70
-msgid "API key verified"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:80
-msgid "Your API Key has expired. You can renew it from your"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:91
-msgid "Unable to verify API key. Please click \"Refresh Status\" to try again."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:60
-msgid "Your API key is required to access the features. You can get your active API key from"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:105
-msgid "Enter your API key here"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/ConfirmModal.jsx:37
-msgid "Confirm"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:63
-msgctxt "gigabyte"
-msgid "GB"
-msgstr ""
-
-#. translators: %s: total plan size in gigabytes
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:68
-#, js-format
-msgid "of %s GB available"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:90
-msgid "Plan Usage"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/onboarding.min.js:2
-#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:93
-#: pages/onboarding/components/SidePanel.jsx:22
-msgid "Bandwidth"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/onboarding.min.js:2
-#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:98
-#: pages/onboarding/components/SidePanel.jsx:25
-msgid "Storage"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:104
-msgid "API Settings"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:125
-msgid "Remove API key"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:50
-msgid "The API key you’ve entered is incorrect. Please enter a valid key"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:39
-msgid "Please enter a valid API key"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:134
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:140
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:360
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:493
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:141
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:130
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:302
-msgid "Saving…"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:141
-msgid "Save API Key"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:84
-msgid "API key status refreshed!"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:94
-msgid "Failed to refresh API key status"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
-msgid "Refreshing…"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: admin/class-rtgodam-transcoder-admin.php:562
-#: admin/class-rtgodam-transcoder-admin.php:625
-#: admin/class-rtgodam-transcoder-admin.php:664
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
-msgid "Refresh Status"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:161
-msgid "Access your active API key from"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:173
-msgid "Having any issue?"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:180
-msgid "Contact Support"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:189
-msgid "Remove API Key?"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:190
-msgid "Yes, Remove"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:60
-msgid "API key deactivated successfully!"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:69
-msgid "Failed to deactivate API key"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:198
-msgid "If you remove the API key, your account will be deactivated and you’ll lose access to the platform."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/APIKey/APIKey.jsx:40
-msgid "Ensure Smooth Video Playback"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/APIKey/APIKey.jsx:42
-msgid "Start with GoDAM Free for 60 days, or plans starting from $9/mo."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/APIKey/APIKey.jsx:51
-msgid "Choose GoDAM Plan"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:74
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:82
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:197
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:387
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:81
-#: pages/video-editor/App.js:124
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:206
-#: pages/video-editor/VideoEditor.js:137
-msgid "You have unsaved changes. Are you sure you want to leave?"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:94
-msgid "Video Ads Settings"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:99
-msgid "Enable Global Video Ads"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:100
-msgid "Enable or disable video ads on all videos across the site"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:111
-#: pages/video-editor/components/appearance/Appearance.js:224
-msgid "Ad Tag URL"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:114
-msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:115
-#: pages/video-editor/components/appearance/Appearance.js:233
-msgid "Learn more."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:59
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:67
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:182
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:98
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:66
-msgid "Settings saved successfully."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:62
-#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:65
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:70
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:73
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:185
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:188
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:101
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:104
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:69
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:72
-msgid "Failed to save settings."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:89
-msgid "Brand Logo"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:96
-msgid "The brand logo will not be applied to the player skin."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:101
-msgid "Shown beside player controls. Can be overridden per video."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:36
-msgid "Select Brand Image"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:38
-msgid "Use this brand image"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:53
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:59
-#: pages/video-editor/components/cta/CardCTA.js:188
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:100
-msgid "Only Image files are allowed"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: inc/classes/elementor-controls/class-godam-media.php:215
-#: inc/classes/elementor-controls/class-godam-media.php:217
-#: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:65
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:112
-msgid "Upload"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:131
-msgid "Selected custom brand"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:106
-msgid "Enable folder organization in media library."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:109
-msgid "This setting is managed by your site administrator and can’t be changed here."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:110
-msgid "Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:121
-msgid "Enable GTM Tracking"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:122
-msgid "Enable Google Tag Manager video tracking for analytics and conversion tracking."
-msgstr ""
-
-#. translators: %s: Integration name, e.g. "WooCommerce".
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:36
-#, js-format
-msgid "Enable %s Integration"
-msgstr ""
-
-#. translators: %s: Integration name, e.g. "WooCommerce".
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:64
-#, js-format
-msgid "Enable or disable the %s integration."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:302
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:47
-msgid "This is a Pro feature."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:314
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:59
-msgid "to use this integration."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:60
-msgid "Installing…"
-msgstr ""
-
-#. translators: %s: Add-on plugin name, e.g. "GoDAM for Woo".
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:65
-#, js-format
-msgid "Install %s"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: admin/class-rtgodam-transcoder-admin.php:221
-#: admin/class-rtgodam-transcoder-admin.php:559
-#: admin/class-rtgodam-transcoder-admin.php:622
-#: admin/class-rtgodam-transcoder-admin.php:661
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:82
-msgid "Learn More"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:95
-msgid "Upgrade Plan"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:22
-#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:26
-msgid "WooCommerce"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:23
-msgid "GoDAM for Woo"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:28
-msgid "Pro"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:223
-msgid "Integration Settings"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:148
-msgid "Add-on installed successfully! Reloading…"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:156
-msgid "Installation failed."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:263
-msgid "Installation failed. Please download the ZIP and install it like any other WordPress plugin."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:272
-msgid "Download ZIP"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:282
-msgid "View Installation Guide"
-msgstr ""
-
-#. translators: %s: Integration name, e.g. "WooCommerce".
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:293
-#, js-format
-msgid "The %s add-on plugin is not installed. Please install it to enable this integration."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:110
-msgid "Integration status updated successfully."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:119
-msgid "Failed to toggle add-on."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/CustomVideoPlayerCSS.jsx:50
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:473
-msgid "Custom CSS"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-video.php:64
-#: inc/classes/elementor-widgets/class-godam-video.php:126
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:29
-#: pages/video-editor/components/forms/CF7.js:26
-msgid "Default"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:30
-msgid "Classic"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:31
-msgid "Minimal"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:32
-msgid "Pills"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:33
-msgid "Bubble"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:414
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:420
-msgid "Player Skin"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:435
-msgid "Brand color"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:447
-msgid "Clear"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:456
-msgid "The brand color will not be applied to the player skin."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:461
-msgid "Applied to the video block. Can be overridden per video."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:478
-msgid "Any custom CSS you add will be applied to all player skins. It's global and not tied to a specific skin style."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:13
-msgid "Highest quality (100%)"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:14
-msgid "Higher quality (80%)"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:15
-msgid "Medium quality (60%)"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:16
-msgid "Lower quality (40%)"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:17
-msgid "Lowest quality (20%)"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:28
-msgid "Video Quality"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:34
-msgid "Select the video quality."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:48
-msgid "Number of video thumbnails generated"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:59
-msgid "This field specifies the number of video thumbnails that will be generated by the GoDAM. To choose from the generated thumbnails for a video, go to Media > Edit > Video Thumbnails. Thumbnails are only generated when the video is first uploaded. Please enter a value between 1 and 10"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:86
-msgid "Enable video watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:93
-msgid "If enabled, GoDAM will add a watermark to the transcoded video"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:100
-msgid "Use image watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:108
-msgid "If enabled, Transcoder will use an image instead of text as the watermark for the transcoded video"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:110
-msgid "(Recommended dimensions: 200 px width × 70 px height)"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:45
-msgid "Select a Watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:47
-msgid "Use this watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:125
-msgid "Change Watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:126
-msgid "Select Watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:138
-msgid "Remove Watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:146
-msgid "Selected watermark"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:166
-msgid "Watermark Text"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:174
-msgid "Enter watermark text"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:175
-msgid "Specify the watermark text that will be added to transcoded videos"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:28
-msgid "Enable video engagement globally"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:32
-msgid "If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:39
-msgid "Enable video share globally"
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:43
-msgid "If disabled, sharing options (such as social sharing buttons) will not be available for GoDAM videos. If enabled, it can be overridden in the block settings panel."
-msgstr ""
-
-#: assets/build/pages/godam.min.js:2
-#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:104
-msgid "Connect your GoDAM API key from the API Key tab to configure video settings."
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:63
-msgid "Configuring the Video Block"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:73
-msgid "Appearance Customisation"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:77
-msgid "Call To Actions"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:81
-msgid "Hotspots"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/help/App.js:85
-#: pages/video-editor/components/SidebarLayers.js:50
-msgid "Forms"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:89
-msgid "ADs"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:99
-msgid "Interface"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:103
-msgid "How Tos"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:131
-msgid "Hi, How can we help?"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:132
-msgid "Welcome to the GoDAM Help Center!"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:134
-msgid "Click on the documentation links below to find step-by-step guides, FAQs, and troubleshooting tips for the features you need help with."
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:148
-#: pages/help/App.js:150
-msgid "Search using keywords"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:214
-msgid "Help us improve GoDAM"
-msgstr ""
-
-#: assets/build/pages/help.min.js:2
-#: pages/help/App.js:217
-msgid "Allows the GoDAM plugin to track anonymous events for analytics purposes. This helps us improve the product experience."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/TreeItem.jsx:97
-msgid "Collapse folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/TreeItem.jsx:97
-msgid "Expand folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:260
-msgid "Currently opened folder is locked and cannot be modified"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:271
-msgid "This folder is locked and cannot be modified"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:285
-msgid "Items assigned successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:305
-msgid "Failed to assign items"
-msgstr ""
-
-#. translators: %s is the error message
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:392
-#, js-format
-msgid "Error: %s"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:125
-msgid "The parent folder is locked, so this folder cannot be moved."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/FolderTree.jsx:155
-msgid "The destination folder is locked and cannot be modified"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: inc/templates/godam-video-gallery.php:460
-#: inc/templates/godam-video-gallery.php:471
-#: pages/media-library/components/folder-tree/FolderTree.jsx:430
-#: pages/media-library/components/search-bar/SearchBar.jsx:213
-msgid "Load More"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:210
-msgid "Preparing ZIP file…"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:218
-msgid "Failed to create ZIP file"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:224
-msgid "Invalid response: missing ZIP URL"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:242
-msgid "Failed to download folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:201
-msgid "Folder ID is missing for download."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:267
-msgid "Invalid folder for bookmark."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:290
-msgid "Bookmark removed successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:291
-msgid "Bookmark added successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:301
-msgid "Bookmarks added successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:307
-msgid "Failed to update bookmark status"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:323
-msgid "Invalid folder to lock."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:339
-msgid "Folder unlocked successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:340
-msgid "Folder locked successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:362
-msgid "Folders locked successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:369
-msgid "Failed to update folder lock status"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:421
-msgid "New Sub-folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:429
-#: pages/media-library/components/modal/RenameModal.jsx:98
-msgid "Rename"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:437
-msgid "Lock Folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:437
-msgid "Unlock Folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:445
-msgid "Add Bookmark"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:445
-msgid "Remove Bookmark"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/context-menu/ContextMenu.jsx:455
-msgid "Download Zip"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/FolderCreationModal.jsx:71
-msgid "Folder created successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/FolderCreationModal.jsx:83
-msgid "Folder with that name already exists."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/FolderCreationModal.jsx:90
-msgid "Failed to create folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/FolderCreationModal.jsx:110
-msgid "Create a new folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/FolderCreationModal.jsx:118
-#: pages/media-library/components/modal/RenameModal.jsx:88
-msgid "Folder Name"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/FolderCreationModal.jsx:126
-msgid "Create"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/RenameModal.jsx:57
-msgid "Folder renamed successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/RenameModal.jsx:64
-msgid "Failed to rename folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/RenameModal.jsx:83
-msgid "Rename folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:63
-msgid "Folders deleted successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:63
-msgid "Folder deleted successfully"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:72
-msgid "Failed to delete folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:91
-msgid "Confirm Delete"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:98
-msgid "Deleting"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:98
-msgid "these"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:98
-msgid "folders"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:98
-msgid "will remove them and all its subfolders, but"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:98
-msgid "media associated with them will not be deleted"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:102
-msgid "Deleting the folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:102
-msgid "will remove it and all its subfolders, but"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:102
-msgid "media associated with it will not be deleted"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/modal/DeleteModal.jsx:107
-msgid "Are you sure you want to proceed? This action cannot be undone."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/BookmarkTab.jsx:56
-#: pages/media-library/components/folder-tree/BookmarkTab.jsx:76
-msgid "Bookmarks"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/BookmarkTab.jsx:64
-msgid "No bookmarks yet"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/LockedTab.jsx:65
-#: pages/media-library/components/folder-tree/LockedTab.jsx:85
-msgid "Locked"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/folder-tree/LockedTab.jsx:73
-msgid "No locked folders yet"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/search-bar/SearchBar.jsx:173
-msgid "Search folder"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/search-bar/SearchBar.jsx:190
-msgid "No folders found."
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/search-bar/SearchBar.jsx:220
-msgid "Searching…"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/search-bar/SearchBar.jsx:220
-msgid "Loading more results…"
-msgstr ""
-
-#: assets/build/pages/media-library.min.js:2
-#: pages/media-library/components/search-bar/SearchBar.jsx:221
-msgid "Error fetching results."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:21
-msgid "Sites"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:21
-msgid "Use GoDAM on unlimited WordPress sites."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:22
-msgid "Generous bandwidth that resets every month."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:23
-msgid "Teams"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:23
-msgid "Invite unlimited editors and contributors."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:24
-msgid "Security"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:24
-msgid "Enterprise-grade encryption."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:25
-msgid "A one-time storage allocation that stays yours."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:26
-msgid "Global CDN"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:26
-msgid "Media served from 100+ locations."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:30
-msgid "No credit card required"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:31
-msgid "Drive conversions with AI-powered tools"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:32
-msgid "Set up in minutes on your existing site"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/SidePanel.jsx:39
-msgid "Used by forward thinking teams"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/OnboardingModal.jsx:71
-msgid "GoDAM onboarding"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/use-connect.js:37
-msgid "Could not load your workspaces. Please try again."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/use-google-signin.js:50
-#: pages/onboarding/utils/use-google-signin.js:114
-msgid "Google sign-in failed."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/use-google-signin.js:61
-msgid "Google sign-in is unavailable right now. Please use another sign-in method."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/use-google-signin.js:67
-msgid "Popup blocked. Allow popups for this site and try again."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/use-google-signin.js:125
-msgid "Google sign-in was cancelled."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/use-google-signin.js:138
-msgid "Could not start Google sign-in."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/BackButton.jsx:19
-msgid "BACK"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:34
-msgid "You have unlocked GoDAM for Woo"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:34
-#: pages/onboarding/components/screens/WelcomeScreen.jsx:19
-msgid "Welcome to GoDAM Pro!"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:39
-msgid "A scalable digital asset management platform for WordPress, optimized for conversion-driven video content."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:43
-msgid "New here? Start your 60-day free trial now."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:46
-msgid "Enjoy a 60-day free trial. After that, continue for $9/month or cancel anytime. No credit card or payment required today."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: assets/build/pages/video-editor.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:49
-#: pages/onboarding/components/screens/SignupScreen.jsx:70
-#: pages/video-editor/components/transcription/Transcription.js:254
-msgid "OR"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:52
-msgid "Login with Email"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:55
-#: pages/onboarding/components/screens/SignupScreen.jsx:67
-msgid "Continue with Google"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/EntryScreen.jsx:58
-msgid "Already have a License key?"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:64
-msgid "Create your account"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:74
-msgid "First Name"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:75
-msgid "Last Name"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:55
-#: pages/onboarding/components/screens/SignupScreen.jsx:78
-msgid "Password"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:78
-msgid "Enter password"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:79
-msgid "Confirm Password"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:55
-#: pages/onboarding/components/screens/SignupScreen.jsx:79
-msgid "Enter Password"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:82
-msgid "I agree to"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:82
-msgid "Terms and Conditions, Privacy Policy, Refund Policy"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:83
-msgid "Email me product updates and release news."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/validators.js:58
-msgid "First name is required."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:34
-#: pages/onboarding/utils/validators.js:61
-msgid "Enter a valid email address."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/validators.js:64
-msgid "Password must be at least 8 characters."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/validators.js:67
-msgid "Passwords do not match."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/utils/validators.js:70
-msgid "Please accept the Terms to continue."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:57
-msgid "Could not create your account. Please try again."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:87
-msgid "Creating…"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:87
-msgid "Sign Up"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/SignupScreen.jsx:90
-msgid "Already have an account?"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:82
-#: pages/onboarding/components/screens/LoginScreen.jsx:62
-#: pages/onboarding/components/screens/SignupScreen.jsx:91
-msgid "Sign in"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:39
-msgid "Verify your email"
-msgstr ""
-
-#. translators: %s: user email address.
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:42
-#, js-format
-msgid "We sent a verification link to %s. Click it to activate your account, then sign in."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:43
-msgid "We sent you a verification link. Click it to activate your account, then sign in."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:47
-msgid "I've verified, sign in"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:31
-msgid "Verification email re-sent."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:33
-msgid "Could not resend the email."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:50
-msgid "Resending…"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:50
-msgid "Resend email"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:51
-msgid "Sign in to your account"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:57
-msgid "Forgot Password?"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:44
-msgid "Invalid email or password."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:36
-msgid "Enter a valid email and password."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:62
-msgid "Signing in…"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:66
-msgid "Don't have an account?"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:67
-msgid "Sign up"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:70
-msgid "Got a licence key?"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LoginScreen.jsx:71
-msgid "Login with key"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:48
-msgid "Reset your password"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:52
-msgid "If that account exists, we've emailed a link to set a new password. Open it to finish resetting, then come back and sign in."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:56
-msgid "Confirm your email and we'll send you a link to set up a new password."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:41
-msgid "Could not send the reset link."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:61
-msgid "Sending…"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:61
-msgid "Reset Password"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:67
-msgid "Go back to sign in"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:50
-msgid "Sign in with license key"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:57
-msgid "License key"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:58
-msgid "Enter your license key"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:67
-msgid "Hide license key"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:67
-msgid "Show license key"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:43
-msgid "That license key could not be verified."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:36
-msgid "Please enter your license key."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:74
-msgid "Verifying…"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:74
-msgid "Verify to Sign in"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:78
-msgid "Lost your key? Find it on your GoDAM app"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:81
-msgid "Login with email instead?"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:64
-msgid "No workspaces yet"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:67
-msgid "This account has no workspaces. <a>Create one in the GoDAM app</a>, then come back."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:82
-msgid "Select a workspace"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:83
-msgid "Choose a workspace to start working!"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:89
-msgid "Select a Workspace"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:118
-msgid "Please note that you won't be able to switch to another workspace after logging in."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:54
-msgid "Could not get the workspace key."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
-msgid "Connecting…"
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WelcomeScreen.jsx:20
-msgid "You're all set. Upload videos to your WordPress Media Library and GoDAM auto-syncs them here."
-msgstr ""
-
-#: assets/build/pages/onboarding.min.js:2
-#: pages/onboarding/components/screens/WelcomeScreen.jsx:28
-msgid "Go to dashboard"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:133
-msgid "WordPress core video migration failed. Please try again."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:130
-msgid "WordPress core video migration completed successfully 🎉"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:165
-msgid "Core video Migration"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:167
-msgid "This tool replaces WordPress core video blocks with GoDAM video blocks. It does not replace videos added in the WordPress Classic Editor."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:186
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:222
-msgid "Abort"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:36
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:40
-msgid "Starting…"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:54
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:69
-msgid "Something went wrong while starting migration."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
-msgid "Restart Migration"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
-msgid "Start Migration"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:144
-msgid "Vimeo Video Migration failed. Please try again."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:141
-msgid "Vimeo Video Migration has been successfully completed for all posts and pages 🎉"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:176
-msgid "Vimeo video Migration"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:178
-msgid "This tool replaces WordPress Vimeo Embed blocks with GoDAM Video blocks. It does not replace Vimeo videos added in the WordPress Classic Editor."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:183
-msgid "This migrator will only migrate Vimeo videos that are already fetched on GoDAM Central."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:184
-msgid "Open"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:199
-msgid "Vimeo video migration in WordPress can only begin after all Vimeo videos have been successfully migrated to GoDAM Central,"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:201
-msgid "Check here!"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:210
-msgid "Migration is in progress. Please wait…"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: admin/class-rtgodam-retranscodemedia.php:134
-#: admin/class-rtgodam-retranscodemedia.php:263
-#: admin/class-rtgodam-retranscodemedia.php:284
-#: admin/js/godam-retranscode-media.js:6
-#: pages/tools/App.js:22
-#: pages/tools/components/tabs/RetranscodeTab.jsx:353
-msgid "Retranscode Media"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:65
-msgid "The requested operation is not allowed. The nonce provided in the URL is invalid or expired."
-msgstr ""
-
-#. translators: %d is the number of selected media files to be transcoded.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:95
-#: pages/tools/components/tabs/RetranscodeTab.jsx:120
-#, js-format
-msgid "%d selected media file(s) will be transcoded."
-msgstr ""
-
-#. translators: %d is the number of selected media files to be retranscoded.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:105
-#, js-format
-msgid "%d selected media file(s) will be retranscoded."
-msgstr ""
-
-#. translators: %d is the number of virtual media files found.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:286
-#, js-format
-msgid "%d virtual media file(s) found, which need to be retranscoded on GoDAM Central."
-msgstr ""
-
-#. translators: %d is the number of media files retranscoded.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:295
-#, js-format
-msgid "Successfully sent %d media file(s) for retranscoding."
-msgstr ""
-
-#. translators: %d is the number of media files that failed to retranscode.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:310
-#, js-format
-msgid "Failed to send %d media file(s) for retranscoding."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:323
-msgid "Operation completed without any media files to retranscode."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:356
-msgid "This tool allows you to retranscode your media files. You can either retranscode specific files selected from the Media Library, or those that are not yet transcoded."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:363
-msgid "Checking the \"Force retranscode\" option will retranscode all media files regardless of their current state."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:368
-msgid "Note: Transcoding and retranscoding will use your bandwidth allowance. Use the force retranscode option carefully."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:379
-msgid "Storage Limit Exceeded:"
-msgstr ""
-
-#. translators: %s is the storage usage percentage.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:382
-#, js-format
-msgid "Your storage usage has exceeded your plan limit (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:403
-msgid "Force retranscode (even if already transcoded)"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:419
-msgid "Fetching media that require retranscoding…"
-msgstr ""
-
-#. translators: %d is the number of untranscoded media files.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:438
-#, js-format
-msgid "%d untranscoded media file(s) selected"
-msgstr ""
-
-#. translators: %d is the number of transcoded media files.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:447
-#, js-format
-msgid "%d transcoded media file(s) selected"
-msgstr ""
-
-#. translators: 1: number of media files that require retranscoding, 2: total number of media files.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:460
-#, js-format
-msgid "%1$d/%2$d media file(s) require retranscoding."
-msgstr ""
-
-#. translators: 1: number of media files that will be retranscoded regardless of their current state, 2: total number of media files.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:466
-#, js-format
-msgid "%1$d/%2$d media file(s) will be retranscoded regardless of their current state."
-msgstr ""
-
-#. translators: 1: number of media files sent for retranscoding, 2: total number of media files selected.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:479
-#, js-format
-msgid "%1$d/%2$d media files sent for retranscoding…"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:153
-msgid "No media files found for retranscoding. Please ensure you have media files that require retranscoding."
-msgstr ""
-
-#. translators: %s is the error message.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:160
-#, js-format
-msgid "Failed to fetch media for retranscoding: %s"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:517
-msgid "Fetch Media"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:527
-msgid "Restart Transcoding"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:529
-msgid "Restart Retranscoding"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:521
-msgid "Start Transcoding"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:523
-msgid "Start Retranscoding"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:177
-msgid "Aborting operation to send media for retranscoding."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/RetranscodeTab.jsx:542
-msgid "Abort Operation"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/App.js:28
-msgid "Video Migration"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/App.js:34
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:201
-msgid "Media Usage Sync"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:70
-msgid "Media usage sync completed successfully."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:204
-msgid "Scans all existing posts and pages to record which media files are used where. GoDAM starts this scan automatically in the background — use this page to monitor progress or trigger it manually if needed."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:210
-msgid "This sync is completely non-destructive."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:212
-msgid "It will not alter, move, or delete any of your existing media files."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:216
-msgid "Processing runs in small background batches so your site stays fully responsive throughout."
-msgstr ""
-
-#. translators: 1: posts synced so far, 2: total posts to sync.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:167
-#, js-format
-msgid "%1$d of %2$d posts synced…"
-msgstr ""
-
-#. translators: 1: posts synced so far, 2: total posts to sync.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:175
-#, js-format
-msgid "%1$d of %2$d posts synced (stopped)."
-msgstr ""
-
-#. translators: %d: total number of posts synced.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:182
-#, js-format
-msgid "%d posts synced."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:232
-msgid "Only administrators can start or stop the media usage sync."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:102
-msgid "All posts are already synced — nothing to do."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:110
-msgid "Failed to start the sync. Please try again."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:150
-msgid "Syncing…"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:153
-msgid "Resume Sync"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:156
-msgid "Sync Completed"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:158
-msgid "Start Sync"
-msgstr ""
-
-#. translators: 1: posts synced so far, 2: total posts to sync.
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:129
-#, js-format
-msgid "Sync stopped. %1$d of %2$d posts were synced. You can resume at any time."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:139
-msgid "Failed to stop the sync. Please try again."
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:255
-msgid "Stopping…"
-msgstr ""
-
-#: assets/build/pages/tools.min.js:2
-#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:256
-msgid "Stop Sync"
-msgstr ""
-
-#. translators: %d is the chapter number.
-#. translators: %d is the chapter position in the list.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/audio/AudioCardPreview.js:285
-#: pages/video-editor/components/chapters/Chapters.js:129
-#, js-format
-msgid "Chapter %d"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/GravityForm.js:55
-#: pages/video-editor/components/SidebarLayers.js:55
-#: pages/video-editor/utils/layerTypes.js:38
-#: pages/video-editor/utils/layerTypes.js:66
-msgid "Gravity Forms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/WPForm.js:42
-#: pages/video-editor/components/SidebarLayers.js:61
-#: pages/video-editor/utils/layerTypes.js:39
-msgid "WPForms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/CF7.js:57
-#: pages/video-editor/components/SidebarLayers.js:67
-#: pages/video-editor/utils/layerTypes.js:40
-msgid "Contact Form 7"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:73
-#: pages/video-editor/utils/layerTypes.js:41
-msgid "Jetpack Forms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/Sureform.js:42
-#: pages/video-editor/components/SidebarLayers.js:79
-#: pages/video-editor/utils/layerTypes.js:42
-msgid "SureForms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/forminatorForms.js:42
-#: pages/video-editor/components/SidebarLayers.js:85
-#: pages/video-editor/utils/layerTypes.js:43
-msgid "Forminator Forms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/FluentForm.js:44
-#: pages/video-editor/components/SidebarLayers.js:91
-#: pages/video-editor/utils/layerTypes.js:44
-msgid "Fluent Forms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/everest-forms/class-everest-forms-integration.php:196
-#: inc/classes/everest-forms/class-everest-forms-integration.php:244
-#: pages/video-editor/components/forms/EverestForm.js:42
-#: pages/video-editor/components/SidebarLayers.js:97
-#: pages/video-editor/utils/layerTypes.js:45
-msgid "Everest Forms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:541
-#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:591
-#: pages/video-editor/components/forms/NinjaForm.js:43
-#: pages/video-editor/components/SidebarLayers.js:103
-#: pages/video-editor/utils/layerTypes.js:46
-msgid "Ninja Forms"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/MetForm.js:43
-#: pages/video-editor/components/SidebarLayers.js:109
-#: pages/video-editor/utils/layerTypes.js:47
-msgid "MetForm"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:117
-#: pages/video-editor/components/SidebarLayers.js:120
-#: pages/video-editor/components/SidebarLayers.js:510
-#: pages/video-editor/utils/layerTypes.js:81
-msgid "Ad"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/productGuide.js:197
-msgid "Next"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:37
-#: pages/video-editor/onboarding/steps.js:38
-msgid "Start by adding layers to this video to make it interactive."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:37
-msgid "Downloaded a demo video."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:59
-msgid "Select a spot on the timeline where you want to add your layer."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:67
-msgid "Start by selecting a layer from the dropdown to add it here."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:78
-msgid "Start with a CTA — it’s the quickest way to make your video interactive."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:86
-msgid "Use this panel to customize and configure your layer settings."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:95
-msgid "Save the video to use it anywhere on your WordPress site."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/steps.js:103
-msgid "Now copy the video to use it in a page."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:58
-msgid "Gravity Forms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:64
-msgid "WPForms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:70
-msgid "Contact Form 7 plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:76
-msgid "Jetpack plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:82
-msgid "SureForms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:88
-msgid "Forminator Forms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:94
-msgid "Fluent Forms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:100
-msgid "Everest Forms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:106
-msgid "Ninja Forms plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:112
-msgid "MetForm plugin is not active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:121
-msgid "This ad will be overridden by Ad server's ads"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:129
-msgid "Poll plugin is not active"
-msgstr ""
-
-#. translators: %s is the layer type label; e.g. "CTA" produces "CTA Layer".
-#. translators: %s is the layer type label; e.g. "CTA Layer".
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:159
-#: pages/video-editor/components/SidebarLayers.js:713
-#, js-format
-msgid "%s Layer"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:462
-msgid "Add a clickable button"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:463
-msgid "Add an info hotspot"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:482
-msgid "Embed a lead form"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:486
-msgid "No form plugin is active"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:499
-msgid "Create an interactive poll"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:511
-msgid "Insert an advertisement"
-msgstr ""
-
-#. translators: %d is the number of layers.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:544
-#, js-format
-msgid "Layers (%d)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:575
-#: pages/video-editor/components/timeline/Timeline.js:428
-msgid "Add layer"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:632
-msgid "To add a layer, pick a spot on the timeline where you want the layer."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:653
-msgid "No layers yet"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:655
-msgid "Add interactive elements like CTAs, polls, and forms to your video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:728
-msgid "Layer options"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/SidebarLayers.js:740
-msgid "Duplicate"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:67
-msgid "Select Video Thumbnail"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:68
-msgid "Use this thumbnail"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:84
-msgid "Select Custom Logo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:85
-msgid "Use this logo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:93
-msgid "Only image files are allowed"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:290
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:72
-#: pages/video-editor/components/appearance/Appearance.js:129
-msgid "Display Settings"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:132
-msgid "Show volume slider"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:138
-msgid "Display captions"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:144
-msgid "Adjust Skip Duration"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:145
-msgid "Number of seconds the skip-forward / skip-backward buttons jump."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:149
-msgid "5 seconds"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:150
-msgid "10 seconds"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:151
-msgid "30 seconds"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:156
-msgid "Customisation Settings"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:174
-msgid "Replace logo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:176
-#: pages/video-editor/components/appearance/Appearance.js:178
-msgid "Custom logo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:179
-msgid "Click to replace"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:182
-msgid "Remove logo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:165
-msgid "Add Custom logo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:194
-msgid "Player Theme"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:199
-msgid "Player Appearance"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:206
-msgid "Icons hover colour"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:213
-msgid "Ad Server"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:216
-msgid "Use ad server's ad"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:217
-msgid "Enable this option to use ads from the ad server. This option will disable the ads layer"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:231
-msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/appearance/Appearance.js:243
-msgid "Select a default thumbnail for this video. You can also override the default thumbnail for different video placements."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:130
-msgid "Click to edit title"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:192
-msgid "Save Video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:222
-msgid "Back to media library"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:253
-msgid "You can copy the block into one of the two options:"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:255
-msgid "1. Insert as a block in the Block editor."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:257
-msgid "2. Insert as HTML content in the Block editor."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:272
-msgid "Copy"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTopBar.js:308
-msgid "More options"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:107
-msgid "The total number of times this video has been played."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:110
-msgid "Layer CTR"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:112
-msgid "Click-through rate of interactive layers: the share of plays where a viewer interacted with a layer. Layer CTR = Converting sessions / Total plays."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:115
-msgid "Avg. Watch Time"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:117
-msgid "Average time watched per play. Avg. Watch Time = Total watch time / Total plays."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:120
-msgid "Total Impressions"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorStatsRow.js:122
-msgid "How many times the video player loaded on a page, whether or not it was played."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTabRail.js:18
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:601
-msgid "Layers"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorTabRail.js:45
-msgid "Editor sections"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/LayersHeader.js:65
-#: pages/video-editor/components/layers/LayersHeader.js:66
-msgid "Layer name"
-msgstr ""
-
-#. translators: %s is the layer display time in seconds.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/LayersHeader.js:77
-#, js-format
-msgid "%ss"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/LayersHeader.js:90
-#: pages/video-editor/components/layers/LayersHeader.js:96
-#: pages/video-editor/components/layers/LayersHeader.js:113
-msgid "Delete layer"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/FormSelector.js:34
-msgid "Select Form"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/AjaxWarning.js:19
-msgid "AJAX submission is required to prevent the form from reloading the video page on submit."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/AjaxWarning.js:20
-msgid "Make sure it's enabled in your"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/AjaxWarning.js:28
-msgid "form settings"
-msgstr ""
-
-#. translators: %s is the form plugin name, e.g. "Gravity Forms".
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/FormFields.js:58
-#, js-format
-msgid "Please activate the %s plugin to use this feature."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/FormFields.js:74
-msgid "Select Theme"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/FormFields.js:90
-msgid "Edit Form"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/FormPreview.js:49
-#: pages/video-editor/components/forms/JetpackForm.js:190
-#: pages/video-editor/components/forms/MetForm.js:67
-#: pages/video-editor/components/forms/NinjaForm.js:67
-msgid "Loading form…"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/GravityForm.js:22
-msgid "Orbital"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/GravityForm.js:26
-msgid "Gravity"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/JetpackForm.js:164
-msgid "Jetpack"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/JetpackForm.js:197
-msgid "Error loading form. Please check if the form exists."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/JetpackForm.js:204
-msgid "No form selected or form not found."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/JetpackForm.js:216
-msgid "No Jetpack forms found. Please"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/JetpackForm.js:223
-msgid "create a Jetpack contact form"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/forms/JetpackForm.js:225
-msgid "first."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:174
-msgid "Select Custom Background Image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:176
-msgid "Use this Background Image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:268
-#: pages/video-editor/components/cta/CardCTA.js:274
-#: pages/video-editor/components/cta/CardCTA.js:284
-#: pages/video-editor/components/layers/HotspotLayer.js:486
-msgid "Please enter a valid URL (e.g., https://example.com)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:310
-msgid "Image Left, Text Right (Full Height)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:311
-msgid "Text Left, Image Right (Full Height)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:312
-msgid "Image Left, Text Right"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:313
-msgid "Text Left, Image Right"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:314
-msgid "Image Top, Text Bottom"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:315
-msgid "Text Top, Image Bottom"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:316
-msgid "Image Background"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:317
-msgid "Text Only (No Image)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:338
-msgid "Card Layout"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-image.php:61
-#: inc/classes/wpbakery-elements/class-wpb-godam-image.php:66
-#: pages/video-editor/components/cta/CardCTA.js:347
-#: pages/video-editor/components/cta/CardCTA.js:391
-msgid "Image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/wpbakery-elements/class-wpb-godam-image.php:75
-#: pages/video-editor/components/cta/CardCTA.js:357
-msgid "Select Image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:360
-msgid "Recommended size: 100KB"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:376
-msgid "Click to replace image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:381
-msgid "Replace image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:386
-msgid "Selected CTA image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:423
-msgid "Width"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:436
-#: pages/video-editor/components/cta/CardCTA.js:438
-msgid "Card Title"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:441
-msgid "Add title here"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:446
-msgid "Character limit"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:449
-msgid "Your description"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:455
-msgid "Button Settings"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:457
-msgid "Button Title"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/helpers/custom-functions.php:210
-#: pages/video-editor/components/cta/CardCTA.js:460
-#: pages/video-editor/components/layers/CTALayer.js:129
-msgid "Check now"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:464
-msgid "Button Link"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:472
-msgid "Button Colour"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:477
-msgid "Text"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/CardCTA.js:484
-#: pages/video-editor/components/layers/FormLayer.js:147
-#: pages/video-editor/components/layers/HotspotLayer.js:580
-#: pages/video-editor/components/layers/PollLayer.js:72
-msgid "Background"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/cta/HtmlCTA.js:25
-msgid "Custom HTML"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:27
-msgid "Fixed Timestamp"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:28
-msgid "Appears at a set second"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:32
-msgid "Watch Depth"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:33
-msgid "Fires after the user crosses a watch %"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:37
-msgid "On Pause"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:38
-msgid "Shows when the viewer pauses (single CTA only)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:42
-msgid "End of Video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:43
-msgid "Overlays on the final frame when playback ends"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:60
-msgid "CTA Trigger"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:98
-msgid "Another CTA already uses On Pause — only one CTA per video can."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:511
-#: pages/video-editor/components/layers/shared/TriggerSection.jsx:107
-msgid "Start Time"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:85
-msgid "Select or Upload Custom Icon"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:87
-msgid "Use this icon"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:147
-msgid "Search icons…"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:192
-msgid "Add Icon"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:216
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:224
-msgid "Replace icon"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:232
-msgid "Remove icon"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:250
-msgid "Select from library"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:261
-msgid "Add custom"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:63
-msgid "Pulse"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:64
-#: pages/video-editor/components/layers/HotspotLayer.js:573
-msgid "Icon"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:96
-msgid "Select / Upload Ad video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:98
-msgid "Add video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:160
-msgid "Ad video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:169
-msgid "This ad will be overridden by the Ad server's ads."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:175
-msgid "Ad Video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:186
-msgid "Select Ad Video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:189
-msgid "Upload or choose a self-hosted video (MP4 recommended)."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:196
-msgid "Click to replace video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:201
-msgid "Replace ad video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:234
-msgid "Playback"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:237
-msgid "Skippable"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:238
-msgid "Allow viewers to skip the ad"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:249
-msgid "Skip after (seconds)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:250
-msgid "Time in seconds before the skip button appears"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:262
-msgid "Click-through"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:264
-msgid "Click link"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/ads/CustomAdSettings.js:267
-msgid "URL to open when the ad is clicked"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/LayerErrorBoundary.js:46
-msgid "This layer could not be opened. It may be provided by an add-on that needs updating to work with this version of GoDAM."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/LayerErrorBoundary.js:53
-msgid "Back to layers"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/FormLayer.js:128
-#: pages/video-editor/components/layers/HotspotLayer.js:590
-#: pages/video-editor/components/layers/PollLayer.js:54
-msgid "Behaviour"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/FormLayer.js:131
-#: pages/video-editor/components/layers/PollLayer.js:57
-msgid "Allow user to skip"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/FormLayer.js:136
-msgid "If enabled, the user will be able to skip the form submission."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/FormLayer.js:142
-#: pages/video-editor/components/layers/PollLayer.js:67
-msgid "Background Colour"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:56
-msgid "Card Style"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:56
-msgid "Perfect for everyone"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:57
-msgid "HTML"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:57
-msgid "Great for developers"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:206
-msgid "Call To Action"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:226
-msgid "Advanced"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:227
-msgid "Layer Background Colour"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/CTALayer.js:230
-msgid "Layer background color"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/helpers/custom-functions.php:235
-#: pages/video-editor/components/layers/CTALayer.js:108
-msgid "No Image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:224
-msgid "New Hotspot"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:438
-msgid "Add Hotspots"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:442
-msgid "Drag the hotspot in video to reposition it."
-msgstr ""
-
-#. translators: %d is the hotspot index
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:466
-#, js-format
-msgid "Delete Hotspot %d"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:476
-msgid "Tooltip Text"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:477
-msgid "Click Me!"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:483
-msgid "Link"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:502
-msgid "Add Hotspot"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:518
-msgid "Layer Duration (seconds)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:176
-msgid "Layer duration exceeds the remaining video length. Please reduce the duration."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:525
-msgid "Duration (in seconds) this layer will stay visible. Maximum: 10 hours (36000 seconds)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:531
-msgid "Style"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:555
-msgid "Pulse colour"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:593
-msgid "Pause video when hotspot is hovered"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/HotspotLayer.js:596
-msgid "Player will pause the video while the layer is displayed and users hover over the hotspots."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/AdsLayer.js:51
-msgid "Self hosted video Ad"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/PollLayer.js:45
-msgid "Select Poll"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/PollLayer.js:62
-msgid "If enabled, the user will be able to skip the poll."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/Layer.js:86
-msgid "Loading layer…"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/layers/Layer.js:90
-msgid "Error: No layer components registered"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:48
-msgid "Configuration Panel"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:49
-msgid "Selected layer will be displayed here"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:52
-msgid "No layers selected"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:53
-msgid "Select a layer from the left panel to edit its properties"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/editor-shell/EditorSkeleton.js:57
-#: pages/video-editor/components/editor-shell/EditorSkeleton.js:59
-msgid "Loading video editor…"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:63
-msgid "Invalid start time format"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:65
-msgid "Start time cannot be negative"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:67
-msgid "Start time exceeds the video duration"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:72
-msgid "Invalid end time format"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:74
-msgid "End time must be after the start time"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:76
-msgid "End time exceeds the video duration"
-msgstr ""
-
-#. translators: %s is the title of the overlapping chapter.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:87
-#, js-format
-msgid "Overlaps with “%s”"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:90
-msgid "Overlaps with another chapter"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:116
-#: pages/video-editor/components/chapters/Chapters.js:142
-msgid "Edit chapter"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:116
-#: pages/video-editor/components/chapters/ChapterForm.js:165
-msgid "Add chapter"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:131
-msgid "Chapter title"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:132
-msgid "e.g. Introduction"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:140
-msgid "Start time"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:148
-msgid "End time"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:165
-msgid "Save chapter"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:169
-msgid "Read more about timestamp format"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/ChapterForm.js:175
-msgid "here"
-msgstr ""
-
-#. translators: %d is the number of chapters.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/Chapters.js:80
-#, js-format
-msgid "Chapters (%d)"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/chapters/Chapters.js:150
-msgid "Delete chapter"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:74
-msgid "Transcription failed. Please try again."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:134
-msgid "Select a caption file"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:135
-msgid "Use this file"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:150
-msgid "Could not attach the caption file."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:144
-msgid "Please choose a .vtt or .srt caption file."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:199
-msgid "Replace transcription file"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:206
-#: pages/video-editor/components/transcription/Transcription.js:285
-msgid "Delete transcription"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:230
-msgid "No cues found in this caption file."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:240
-msgid "Automatically transcribe the audio using GoDAM's AI engine"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:124
-msgid "Could not start transcription. Please try again."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:250
-msgid "Generate Transcription"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:261
-msgid "Generating transcription…"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:264
-msgid "This usually takes 10–15 minutes. We'll notify you once it's ready"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:276
-msgid "Upload File"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:288
-msgid "Delete this transcription? This cannot be undone."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/transcription/Transcription.js:164
-msgid "Could not remove the transcript."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/timeline/Timeline.js:399
-msgid "Click to add layer"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/timeline/Timeline.js:424
-msgid "Add layer at this time"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:650
-msgid "Untitled image"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:496
-msgid "Please select a form for the layer at timestamp:"
-msgid_plural "Please select a form for the layers at timestamps:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:487
-#: pages/video-editor/VideoEditor.js:546
-msgid "GoDAM block copied to clipboard"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:488
-#: pages/video-editor/VideoEditor.js:549
-msgid "Failed to copy GoDAM block"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:592
-msgid "Edit video metadata"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:594
-msgid "Edit image metadata"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:596
-msgid "Edit audio metadata"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:598
-msgid "Edit metadata"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:624
-msgid "Title updated"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:628
-msgid "Failed to update title"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/VideoEditor.js:711
-msgid "Changes saved successfully"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/elementor-widgets/class-godam-gallery.php:99
-#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:92
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:71
-msgid "Videos"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:72
-msgid "Images"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:87
-msgid "All Videos"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:88
-msgid "All Images"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:89
-msgid "All Audio"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:90
-msgid "All"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:96
-msgid "Edited"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:97
-msgid "Unedited"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:103
-msgid "Transcoded"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:104
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:610
-msgid "Non Transcoded"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:115
-msgid "Newest Uploaded"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:116
-msgid "Oldest Uploaded"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:117
-msgid "Recently Edited"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:118
-msgid "Name A-Z"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:119
-msgid "Name Z-A"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:272
-msgid "Quick actions"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:301
-msgid "Copy block"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:313
-msgid "View Analytics"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:560
-msgid "Sourced from GoDAM Central"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:572
-msgid "Media name"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:581
-msgid "Details"
-msgstr ""
-
-#. translators: %s: human-readable date the video was last edited.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:594
-#, js-format
-msgid "Last edited %s"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: inc/classes/class-pages.php:209
-#: inc/classes/class-pages.php:210
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:648
-msgid "Media Editor"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:650
-msgid "Upload media to the WordPress Media Library, GoDAM auto-syncs it here."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:659
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:138
-msgid "See how it works"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:670
-msgid "Search"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:672
-msgid "Search media"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:678
-msgid "Filter by media type"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:686
-msgid "Filter media"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:694
-msgid "Sort media"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:707
-msgid "You have no media yet!"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:709
-msgid "Upload media to the"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:715
-msgid "WordPress Media Library"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:717
-msgid "and GoDAM will sync them here."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:720
-msgid "You can start selling as soon as you add a product."
-msgstr ""
-
-#. translators: 1: number of loaded media items, 2: total media items.
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:751
-#, js-format
-msgid "Showing %1$d of %2$d media items"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:765
-msgid "Load more"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:28
-msgid "Woo"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:29
-msgid "Turn product videos into sales"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:30
-msgid "Add shoppable galleries and product blocks."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:35
-msgid "Make your videos interactive"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:36
-msgid "Add CTAs or hotspots directly on top of any video."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:79
-msgid "Welcome to GoDAM"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:87
-msgid "Choose what you’d like to explore first."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:90
-msgid "Welcome options"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:129
-#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:57
-msgid "Skip for now"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:37
-msgid "Get Started with GoDAM"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:45
-msgid "Get started by adding interactive layers to your video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:223
-msgid "Do you want to end the product guide?"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:224
-msgid "End guide"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:225
-msgid "Keep going"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:230
-msgid "You can start it anytime using the “See how it works” button on the Media Editor."
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:235
-msgid "Do you want to add it to a page?"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:236
-msgid "Yes, Continue"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:237
-msgid "Not now"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:187
-msgid "GoDAM video"
-msgstr ""
-
-#: assets/build/pages/video-editor.min.js:2
-#: pages/video-editor/onboarding/ProductGuide.jsx:243
-msgid "We’ll open a new draft page and drop the video right in."
-msgstr ""
-
-#: assets/build/pages/whats-new.min.js:2
-#: pages/whats-new/components/Header.js:25
-msgid "What's New in GoDAM"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-audio/block.json
-msgctxt "block title"
-msgid "Audio"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-audio/block.json
-msgctxt "block description"
-msgid "Embed a GoDAM audio player."
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-audio/block.json
-msgctxt "block keyword"
-msgid "music"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-audio/block.json
-msgctxt "block keyword"
-msgid "sound"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-audio/block.json
-msgctxt "block keyword"
-msgid "podcast"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-audio/block.json
-msgctxt "block keyword"
-msgid "recording"
-msgstr ""
-
-#: assets/build/blocks/godam-audio/block.json
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-image/block.json
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/build/blocks/godam-player/block.json
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
-#: assets/src/blocks/godam-audio/block.json
-#: assets/src/blocks/godam-gallery-v2-item/block.json
-#: assets/src/blocks/godam-gallery-v2/block.json
-#: assets/src/blocks/godam-image/block.json
-#: assets/src/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-player/block.json
-#: assets/src/blocks/sureforms/blocks/recorder/block.json
-msgctxt "block keyword"
-msgid "godam"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/src/blocks/godam-gallery-v2-item/block.json
-msgctxt "block title"
-msgid "Gallery V2 Item"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/src/blocks/godam-gallery-v2-item/block.json
-msgctxt "block description"
-msgid "A single video item for the GoDAM Gallery V2 block."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-player/block.json
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-gallery-v2-item/block.json
-#: assets/src/blocks/godam-gallery-v2/block.json
-#: assets/src/blocks/godam-player/block.json
-#: assets/src/blocks/godam-video-duration/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block keyword"
-msgid "video"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-gallery-v2-item/block.json
-#: assets/src/blocks/godam-gallery-v2/block.json
-#: assets/src/blocks/godam-video-duration/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block keyword"
-msgid "gallery"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2-item/block.json
-#: assets/src/blocks/godam-gallery-v2-item/block.json
-msgctxt "block keyword"
-msgid "item"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/src/blocks/godam-gallery-v2/block.json
-msgctxt "block title"
-msgid "Video Gallery"
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/src/blocks/godam-gallery-v2/block.json
-msgctxt "block description"
-msgid "Create a handpicked or query-based GoDAM video gallery."
-msgstr ""
-
-#: assets/build/blocks/godam-gallery-v2/block.json
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-gallery-v2/block.json
-#: assets/src/blocks/godam-video-duration/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block keyword"
-msgid "grid"
-msgstr ""
-
-#: assets/build/blocks/godam-image/block.json
-#: assets/src/blocks/godam-image/block.json
-msgctxt "block title"
-msgid "Image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/block.json
-#: assets/src/blocks/godam-image/block.json
-msgctxt "block description"
-msgid "Display an image with interactive GoDAM hotspot and product layers."
-msgstr ""
-
-#: assets/build/blocks/godam-image/block.json
-#: assets/src/blocks/godam-image/block.json
-msgctxt "block keyword"
-msgid "image"
-msgstr ""
-
-#: assets/build/blocks/godam-image/block.json
-#: assets/src/blocks/godam-image/block.json
-msgctxt "block keyword"
-msgid "hotspot"
-msgstr ""
-
-#: assets/build/blocks/godam-image/block.json
-#: assets/src/blocks/godam-image/block.json
-msgctxt "block keyword"
-msgid "shoppable"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-pdf/block.json
-msgctxt "block title"
-msgid "Document"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-pdf/block.json
-msgctxt "block description"
-msgid "Embed a PDF file with preview."
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-pdf/block.json
-msgctxt "block keyword"
-msgid "document"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-pdf/block.json
-msgctxt "block keyword"
-msgid "pdf"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-pdf/block.json
-msgctxt "block keyword"
-msgid "file"
-msgstr ""
-
-#: assets/build/blocks/godam-pdf/block.json
-#: assets/src/blocks/godam-pdf/block.json
-msgctxt "block keyword"
-msgid "preview"
-msgstr ""
-
-#: assets/build/blocks/godam-player/block.json
-#: assets/src/blocks/godam-player/block.json
-msgctxt "block title"
-msgid "Video"
-msgstr ""
-
-#: assets/build/blocks/godam-player/block.json
-#: assets/src/blocks/godam-player/block.json
-msgctxt "block description"
-msgid "Embed a video from your media library or upload a new one."
-msgstr ""
-
-#: assets/build/blocks/godam-player/block.json
-#: assets/src/blocks/godam-player/block.json
-msgctxt "block keyword"
-msgid "movie"
-msgstr ""
-
-#: assets/build/blocks/godam-player/block.json
-#: assets/src/blocks/godam-player/block.json
-msgctxt "block keyword"
-msgid "player"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/src/blocks/godam-video-duration/block.json
-msgctxt "block title"
-msgid "GoDAM Video Duration"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/src/blocks/godam-video-duration/block.json
-msgctxt "block description"
-msgid "Display GoDAM video's duration"
-msgstr ""
-
-#: assets/build/blocks/godam-video-duration/block.json
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-video-duration/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block keyword"
-msgid "videos"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block title"
-msgid "GoDAM Video Thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block description"
-msgid "Display GoDAM video thumbnail"
-msgstr ""
-
-#: assets/build/blocks/godam-video-thumbnail/block.json
-#: assets/src/blocks/godam-video-thumbnail/block.json
-msgctxt "block keyword"
-msgid "thumbnail"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
-#: assets/src/blocks/sureforms/blocks/recorder/block.json
-msgctxt "block title"
-msgid "GoDAM Recorder"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
-#: assets/src/blocks/sureforms/blocks/recorder/block.json
-msgctxt "block description"
-msgid "Enable audio/video submissions inside forms using the GoDAM Recorder field that supports webcam, screencast, and audio recording"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
-#: assets/src/blocks/sureforms/blocks/recorder/block.json
-msgctxt "block keyword"
-msgid "sureforms"
-msgstr ""
-
-#: assets/build/blocks/sureforms/blocks/recorder/block.json
-#: assets/src/blocks/sureforms/blocks/recorder/block.json
-msgctxt "block keyword"
-msgid "recorder"
-msgstr ""
-
 #: admin/class-rtgodam-retranscodemedia.php:117
 msgid "GoDAM Tools"
 msgstr ""
 
+#: admin/class-rtgodam-retranscodemedia.php:134
+#: admin/class-rtgodam-retranscodemedia.php:291
+#: admin/class-rtgodam-retranscodemedia.php:312
+#: admin/js/godam-retranscode-media.js:6
+#: pages/tools/App.js:22
+#: pages/tools/components/tabs/RetranscodeTab.jsx:455
+#: assets/build/pages/tools.min.js:1634
+#: assets/build/pages/tools.min.js:3051
+msgid "Retranscode Media"
+msgstr ""
+
 #: admin/class-rtgodam-retranscodemedia.php:161
-#: admin/class-rtgodam-retranscodemedia.php:361
+#: admin/class-rtgodam-retranscodemedia.php:389
 msgid "Cheatin&#8217; uh?"
 msgstr ""
 
 #. translators: Link to the media page.
-#: admin/class-rtgodam-retranscodemedia.php:183
-#: admin/class-rtgodam-retranscodemedia.php:395
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:193
+#: admin/class-rtgodam-retranscodemedia.php:436
 msgid "Unable to find any media. Are you sure <a href='%s'>some exist</a>?"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:203
+#: admin/class-rtgodam-retranscodemedia.php:215
 msgid "Stopping..."
 msgstr ""
 
 #. translators: The URL to go back to the previous page.
-#: admin/class-rtgodam-retranscodemedia.php:206
-#: admin/class-rtgodam-retranscodemedia.php:475
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:218
+#: admin/class-rtgodam-retranscodemedia.php:517
 msgid "To go back to the previous page, <a href=\"%s\">click here</a>."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:262
+#: admin/class-rtgodam-retranscodemedia.php:290
 msgid "Retranscode this single media"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:417
+#: admin/class-rtgodam-retranscodemedia.php:459
 msgid "There are no media available to send for transcoding."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:427
+#: admin/class-rtgodam-retranscodemedia.php:469
 msgid "You do not have sufficient bandwidth remaining to perform the transcoding."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:428
+#: admin/class-rtgodam-retranscodemedia.php:470
 msgid "Your remaining bandwidth is : "
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:429
+#: admin/class-rtgodam-retranscodemedia.php:471
 msgid "Required bandwidth is: "
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:433
+#: admin/class-rtgodam-retranscodemedia.php:475
 msgid "You can select the files manually and try again."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:440
-#: admin/class-rtgodam-retranscodemedia.php:454
+#: admin/class-rtgodam-retranscodemedia.php:482
+#: admin/class-rtgodam-retranscodemedia.php:496
 msgid "Proceed with retranscoding"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:468
+#: admin/class-rtgodam-retranscodemedia.php:510
 msgid "Your files are being re-transcoded. Do not navigate away from this page until the process is completed, as doing so will prematurely abort the script. Retranscoding can take a while, especially for larger files. You can view the progress below."
 msgstr ""
 
 #. translators: Count of media which were successfully and media which were failed transcoded with the time in seconds and previout page link.
-#: admin/class-rtgodam-retranscodemedia.php:478
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:520
 msgid "All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were %3$s failure(s). To try transcoding the failed media again, <a href=\"%4$s\">click here</a>. %5$s"
 msgstr ""
 
 #. translators: Count of media which were successfully transcoded with the time in seconds and previout page link.
-#: admin/class-rtgodam-retranscodemedia.php:480
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:522
 msgid "All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were 0 failures. %3$s"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:483
-#: admin/class-rtgodam-retranscodemedia.php:536
+#: admin/class-rtgodam-retranscodemedia.php:525
+#: admin/class-rtgodam-retranscodemedia.php:578
 msgid "You must enable Javascript in order to proceed!"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:489
+#: admin/class-rtgodam-retranscodemedia.php:531
 msgid "Abort the Operation"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:491
+#: admin/class-rtgodam-retranscodemedia.php:533
 msgid "Debugging Information"
 msgstr ""
 
 #. translators: Total count of the media.
-#: admin/class-rtgodam-retranscodemedia.php:496
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:538
 msgid "Total Media: %s"
 msgstr ""
 
 #. translators: Count of media which were successfully sent to the transcoder server.
-#: admin/class-rtgodam-retranscodemedia.php:501
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:543
 msgid "Media Sent for Retranscoding: %s"
 msgstr ""
 
 #. translators: Count of media which were failed while sending to the transcoder server.
-#: admin/class-rtgodam-retranscodemedia.php:506
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:548
 msgid "Failed While Sending: %s"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:521
+#: admin/class-rtgodam-retranscodemedia.php:563
 msgid "This tool will retranscode ALL audio/video media uploaded to your website. This can be handy if you need to transcode media files uploaded in the past."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:523
+#: admin/class-rtgodam-retranscodemedia.php:565
 msgid "Sending your entire media library for retranscoding can consume a lot of your bandwidth allowance, so use this tool with care."
 msgstr ""
 
 #. translators: Placeholder is for admin media section link.
-#: admin/class-rtgodam-retranscodemedia.php:528
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:570
 msgid "You can retranscode specific media files (rather than ALL media) from the <a href='%s'>Media</a> page using Bulk Action via drop down or mouse hover a specific media (audio/video) file."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:532
+#: admin/class-rtgodam-retranscodemedia.php:574
 msgid "To begin, just press the button below."
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:534
+#: admin/class-rtgodam-retranscodemedia.php:576
 msgid "Retranscode All Media"
 msgstr ""
 
 #. translators: Media name, Media ID and message for failed transcode.
-#: admin/class-rtgodam-retranscodemedia.php:555
-#, php-format
+#: admin/class-rtgodam-retranscodemedia.php:612
 msgid "&quot;%1$s&quot; (ID %2$s) failed to send. The error message was: %3$s"
 msgstr ""
 
-#: admin/class-rtgodam-retranscodemedia.php:576
+#: admin/class-rtgodam-retranscodemedia.php:633
 msgid "Insufficient bandwidth!"
 msgstr ""
 
@@ -8188,19 +190,16 @@ msgstr ""
 #: admin/class-rtgodam-transcoder-admin.php:86
 #: admin/class-rtgodam-transcoder-admin.php:148
 #: admin/class-rtgodam-transcoder-admin.php:163
-#, php-format
 msgid "Enjoy using our <strong>DAM and Media Editor</strong> features for free! To unlock Transcoding, Analytics and more, <a href=\"%s\">please activate your API key.</a>"
 msgstr ""
 
 #. translators: %d: Number of days until trial ends
 #: admin/class-rtgodam-transcoder-admin.php:111
-#, php-format
 msgid "Your product is under trial. You will be charged after <strong>%d days</strong>. If you wish to cancel, please visit <a href=\"https://app.godam.io/subscription/my-account\" target=\"_blank\">your subscription settings</a>."
 msgstr ""
 
 #. translators: %d: Number of days until transcoded videos are deleted after subscription ends
 #: admin/class-rtgodam-transcoder-admin.php:135
-#, php-format
 msgid "Your subscription has ended. No further transcoding can be done. Transcoded videos will be removed after <strong>%d days</strong>, and Pro features will not be accessible. After the 30-day grace period, already transcoded videos will no longer be served from the CDN. Renew your subscription to keep it up and running."
 msgstr ""
 
@@ -8213,22 +212,49 @@ msgstr ""
 msgid "Use Media Editor"
 msgstr ""
 
+#: admin/class-rtgodam-transcoder-admin.php:192
+#: admin/class-rtgodam-transcoder-admin.php:336
+#: admin/godam-transcoder-functions.php:381
+#: inc/classes/class-media-library-ajax.php:1421
+#: inc/templates/video-preview.php:71
+#: pages/godam/components/GoDAMHeader.jsx:74
+#: pages/whats-new/components/Header.js:19
+#: assets/build/js/media-library.min.js:3375
+#: assets/build/pages/analytics.min.js:16391
+#: assets/build/pages/dashboard.min.js:4417
+#: assets/build/pages/godam.min.js:10393
+#: assets/build/pages/help.min.js:683
+#: assets/build/pages/tools.min.js:933
+#: assets/build/pages/video-editor.min.js:15912
+#: assets/build/pages/whats-new.min.js:751
+msgid "GoDAM Logo"
+msgstr ""
+
 #: admin/class-rtgodam-transcoder-admin.php:196
 msgid "Welcome to GoDAM! Thank you for using our product."
 msgstr ""
 
+#: admin/class-rtgodam-transcoder-admin.php:221
+#: admin/class-rtgodam-transcoder-admin.php:559
+#: admin/class-rtgodam-transcoder-admin.php:622
+#: admin/class-rtgodam-transcoder-admin.php:661
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:82
+#: assets/build/pages/godam.min.js:11622
+msgid "Learn More"
+msgstr ""
+
 #: admin/class-rtgodam-transcoder-admin.php:276
-#: inc/classes/class-media-library-ajax.php:858
+#: inc/classes/class-media-library-ajax.php:949
 msgid "Claim the GoDAM New Year Sale 2026 offer"
 msgstr ""
 
 #: admin/class-rtgodam-transcoder-admin.php:278
-#: inc/classes/class-media-library-ajax.php:860
+#: inc/classes/class-media-library-ajax.php:951
 msgid "New Year Sale 2026 offer from GoDAM"
 msgstr ""
 
 #: admin/class-rtgodam-transcoder-admin.php:279
-#: inc/classes/class-media-library-ajax.php:861
+#: inc/classes/class-media-library-ajax.php:952
 msgid "Dismiss banner"
 msgstr ""
 
@@ -8242,19 +268,16 @@ msgstr ""
 
 #. translators: %1$s: bandwidth percentage, %2$s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:522
-#, php-format
 msgid "Your bandwidth (%1$s%%) and storage (%2$s%%) usage have exceeded your plan limits."
 msgstr ""
 
 #. translators: %s: bandwidth percentage
 #: admin/class-rtgodam-transcoder-admin.php:529
-#, php-format
 msgid "Your bandwidth usage (%s%%) has exceeded your plan limit."
 msgstr ""
 
 #. translators: %s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:535
-#, php-format
 msgid "Your storage usage (%s%%) has exceeded your plan limit."
 msgstr ""
 
@@ -8271,21 +294,26 @@ msgstr ""
 msgid "Upgrade Your Plan"
 msgstr ""
 
+#: admin/class-rtgodam-transcoder-admin.php:562
+#: admin/class-rtgodam-transcoder-admin.php:625
+#: admin/class-rtgodam-transcoder-admin.php:664
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
+#: assets/build/pages/godam.min.js:12848
+msgid "Refresh Status"
+msgstr ""
+
 #. translators: %1$s: bandwidth percentage, %2$s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:585
-#, php-format
 msgid "Your bandwidth (%1$s%%) and storage (%2$s%%) usage are approaching your plan limits."
 msgstr ""
 
 #. translators: %s: bandwidth percentage
 #: admin/class-rtgodam-transcoder-admin.php:592
-#, php-format
 msgid "Your bandwidth usage (%s%%) is approaching your plan limit."
 msgstr ""
 
 #. translators: %s: storage percentage
 #: admin/class-rtgodam-transcoder-admin.php:598
-#, php-format
 msgid "Your storage usage (%s%%) is approaching your plan limit."
 msgstr ""
 
@@ -8303,7 +331,6 @@ msgstr ""
 
 #. translators: %s: bandwidth percentage
 #: admin/class-rtgodam-transcoder-admin.php:642
-#, php-format
 msgid "Your bandwidth usage (%s%%) has exceeded your plan limit. Videos might not be served from CDN on frontend."
 msgstr ""
 
@@ -8345,7 +372,6 @@ msgstr ""
 
 #. translators: %s: PostHog privacy policy URL
 #: admin/class-rtgodam-transcoder-admin.php:727
-#, php-format
 msgid "We are using PostHog to collect anonymous data. <a href=\"%s\" target=\"_blank\">Learn more</a>. This can be disabled from the settings on the Help page."
 msgstr ""
 
@@ -8359,202 +385,378 @@ msgstr ""
 
 #. translators: %s: URL to settings page
 #: admin/class-rtgodam-transcoder-admin.php:778
-#, php-format
 msgid "Your GoDAM API key has expired. Transcoding and other Pro features are currently disabled. Please <a href=\"%s\">renew your subscription</a> to restore access."
 msgstr ""
 
 #. translators: %s: URL to settings page
 #: admin/class-rtgodam-transcoder-admin.php:783
-#, php-format
 msgid "Temporarily unable to verify your GoDAM API key. Transcoding may not work. Please <a href=\"%s\">check your settings</a> or try refreshing the status."
 msgstr ""
 
 #. translators: %s: URL to settings page
 #: admin/class-rtgodam-transcoder-admin.php:792
-#, php-format
 msgid "There is an issue with your GoDAM API key. Transcoding may not work. Please <a href=\"%s\">check your settings</a>."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
 #: admin/class-rtgodam-transcoder-admin.php:891
-#, php-format
 msgid "<strong>Shoppable video for WooCommerce is live!</strong> %1$sActivate%2$s to start selling directly from your videos."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
 #: admin/class-rtgodam-transcoder-admin.php:899
-#, php-format
 msgid "<strong>GoDAM now supports WooCommerce!</strong> %1$sInstall WooCommerce%2$s to start using shoppable videos with GoDAM."
 msgstr ""
 
 #. translators: 1: opening link tag, 2: closing link tag
 #: admin/class-rtgodam-transcoder-admin.php:907
-#, php-format
 msgid "<strong>Add shoppable videos to your WooCommerce store!</strong> %1$sUpgrade your plan%2$s to unlock this feature."
 msgstr ""
 
 #. translators: %s: storage usage percent
-#: admin/class-rtgodam-transcoder-handler.php:266
-#, php-format
+#: admin/class-rtgodam-transcoder-handler.php:311
 msgid "Storage exceeded (%s%%)."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-handler.php:270
+#: admin/class-rtgodam-transcoder-handler.php:315
 msgid "Please upgrade your plan to continue transcoding."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-handler.php:295
-#: inc/classes/class-media-library-ajax.php:268
+#: admin/class-rtgodam-transcoder-handler.php:340
+#: inc/classes/class-media-library-ajax.php:330
 msgid "HTTP authentication is enabled on your site, preventing transcoding."
 msgstr ""
 
 #. translators: 1: max retry attempts, 2: retry interval in minutes
-#: admin/class-rtgodam-transcoder-handler.php:505
-#, php-format
+#: admin/class-rtgodam-transcoder-handler.php:589
 msgid "GoDAM Central returned a server error. Transcoding will be retried automatically (up to %1$d times, every %2$d minutes)."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-handler.php:609
+#: admin/class-rtgodam-transcoder-handler.php:693
 msgid "You have successfully subscribed."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-handler.php:631
+#: admin/class-rtgodam-transcoder-handler.php:715
 msgid "This API key is invalid."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-handler.php:646
+#: admin/class-rtgodam-transcoder-handler.php:730
 msgid "Transcoding service can not be activated on the localhost"
 msgstr ""
 
 #. translators: Return an error if the value is neither a string nor an array.
-#: admin/class-rtgodam-transcoder-rest-routes.php:198
-#, php-format
+#: admin/class-rtgodam-transcoder-rest-routes.php:247
 msgid "%s must be a valid URL or an array of URLs."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:252
+#: admin/class-rtgodam-transcoder-rest-routes.php:327
 msgid "Transcoding error received and recorded."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:284
+#: admin/class-rtgodam-transcoder-rest-routes.php:459
+msgid "Callback processed successfully."
+msgstr ""
+
+#: admin/class-rtgodam-transcoder-rest-routes.php:504
 msgid "Thumbnail created successfully."
 msgstr ""
 
 #. translators: %s is replaced with the attachment ID for which subsizes generation failed.
-#: admin/class-rtgodam-transcoder-rest-routes.php:327
-#, php-format
+#: admin/class-rtgodam-transcoder-rest-routes.php:575
 msgid "GoDAM: Failed to request image subsizes for attachment ID %s. The transcoded image URL has been saved; subsizes may be retried separately."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:335
+#: admin/class-rtgodam-transcoder-rest-routes.php:583
 msgid "Transcoded image URL saved, but failed to request subsizes."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:352
+#: admin/class-rtgodam-transcoder-rest-routes.php:600
 msgid "Attachment not found; it may have been deleted."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:457
-msgid "Callback processed successfully."
-msgstr ""
-
-#: admin/class-rtgodam-transcoder-rest-routes.php:479
+#: admin/class-rtgodam-transcoder-rest-routes.php:627
 msgid "Job ID is required."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:483
+#: admin/class-rtgodam-transcoder-rest-routes.php:631
 msgid "Transcription status is required."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:487
+#: admin/class-rtgodam-transcoder-rest-routes.php:635
 msgid "Transcript path is required."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:494
+#: admin/class-rtgodam-transcoder-rest-routes.php:653
 msgid "Video attachment not found for the provided job ID."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:506
+#: admin/class-rtgodam-transcoder-rest-routes.php:665
 msgid "Transcript path saved successfully."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:516
+#: admin/class-rtgodam-transcoder-rest-routes.php:675
 msgid "Transcription callback received."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:534
-#: admin/godam-transcoder-functions.php:466
-#: inc/classes/rest-api/class-media-library.php:336
-#: inc/classes/rest-api/class-transcoding.php:335
+#: admin/class-rtgodam-transcoder-rest-routes.php:696
+#: admin/godam-transcoder-functions.php:522
+#: inc/classes/rest-api/class-media-library.php:498
+#: inc/classes/rest-api/class-transcoding.php:438
 msgid "API key is required."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:538
+#: admin/class-rtgodam-transcoder-rest-routes.php:700
 msgid "API key not configured on the site."
 msgstr ""
 
-#: admin/class-rtgodam-transcoder-rest-routes.php:542
-#: inc/classes/rest-api/class-media-library.php:343
+#: admin/class-rtgodam-transcoder-rest-routes.php:704
+#: inc/classes/rest-api/class-media-library.php:505
 #: inc/classes/rest-api/class-settings.php:187
-#: inc/classes/rest-api/class-transcoding.php:341
+#: inc/classes/rest-api/class-transcoding.php:444
 msgid "Invalid API key."
 msgstr ""
 
-#: admin/godam-transcoder-actions.php:58
+#: admin/godam-transcoder-actions.php:72
 msgid "oEmbed URL"
 msgstr ""
 
-#: admin/godam-transcoder-actions.php:67
+#: admin/godam-transcoder-actions.php:81
 msgid "The oEmbed URL of the file is generated automatically and cannot be edited."
 msgstr ""
 
-#: admin/godam-transcoder-actions.php:71
+#: admin/godam-transcoder-actions.php:85
 msgid "Transcoded CDN URL"
 msgstr ""
 
-#: admin/godam-transcoder-actions.php:110
-msgid "Transcoded CDN URL "
+#: admin/godam-transcoder-actions.php:87
+#: assets/build/js/media-library.min.js:2920
+msgid "Transcoded CDN URL (MPD)"
+msgstr ""
+
+#: admin/godam-transcoder-actions.php:101
+#: assets/build/js/media-library.min.js:2922
+msgid "The URL of the transcoded file is generated automatically and cannot be edited."
+msgstr ""
+
+#: admin/godam-transcoder-actions.php:109
+#: assets/build/js/media-library.min.js:2932
+msgid "Transcoded CDN URL (HLS)"
 msgstr ""
 
 #: admin/godam-transcoder-actions.php:118
+#: assets/build/js/media-library.min.js:2934
+msgid "The HLS URL of the transcoded file is generated automatically and cannot be edited."
+msgstr ""
+
+#: admin/godam-transcoder-actions.php:124
+msgid "Transcoded CDN URL "
+msgstr ""
+
+#: admin/godam-transcoder-actions.php:132
 msgid "Available in Premium version"
 msgstr ""
 
 #. translators: %1$s URL to the settings page, %2$s API key label.
-#: admin/godam-transcoder-actions.php:123
-#, php-format
+#: admin/godam-transcoder-actions.php:137
 msgid "Activate the <a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> to enable transcoding and adaptive bitrate streaming."
 msgstr ""
 
-#: admin/godam-transcoder-actions.php:125
+#: admin/godam-transcoder-actions.php:139
 msgid "API key"
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:302
+#: admin/godam-transcoder-functions.php:346
 msgid "Transcode Status"
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:330
-#: admin/godam-transcoder-functions.php:377
-#: inc/classes/rest-api/class-transcoding.php:254
+#: admin/godam-transcoder-functions.php:383
+#: admin/godam-transcoder-functions.php:433
+#: inc/classes/rest-api/class-transcoding.php:354
 msgid "Media is transcoded."
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:475
+#: admin/godam-transcoder-functions.php:410
+#: assets/build/js/media-library.min.js:894
+msgid "Transcoding failed, please try again."
+msgstr ""
+
+#: admin/godam-transcoder-functions.php:531
 msgid "API key verification is blocked for localhost environments. To use production API keys on localhost, please add the following constant to your wp-config.php file: define('RTGODAM_API_KEY', 'your-api-key-here');"
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:484
+#: admin/godam-transcoder-functions.php:540
 msgid "The provided API key does not match the RTGODAM_API_KEY constant defined in wp-config.php."
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:580
+#: admin/godam-transcoder-functions.php:636
 msgid "API key verified and stored successfully!"
 msgstr ""
 
-#: admin/godam-transcoder-functions.php:587
+#: admin/godam-transcoder-functions.php:643
 #: inc/classes/enums/class-api-key-status.php:84
 msgid "Unable to verify API key. Please try again later."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:164
+#: assets/build/blocks/godam-audio/index.js:985
+#: assets/build/blocks/godam-audio/index.js:830
+msgid "Audio thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:171
+#: assets/build/blocks/godam-audio/index.js:992
+#: pages/video-editor/components/audio/AudioCardPreview.js:70
+#: pages/video-editor/VideoEditor.js:649
+#: assets/build/blocks/godam-audio/index.js:836
+#: assets/build/pages/video-editor.min.js:17480
+#: assets/build/pages/video-editor.min.js:19541
+msgid "Untitled audio"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:200
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:158
+#: inc/classes/sureforms/class-form-submit.php:377
+#: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:48
+#: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:79
+msgid "Your browser does not support the audio element."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:205
+#: assets/build/blocks/godam-audio/index.js:1145
+#: assets/build/blocks/godam-audio/view.js:511
+#: pages/video-editor/components/audio/AudioCardPreview.js:200
+#: assets/build/blocks/godam-audio/index.js:940
+#: assets/build/blocks/godam-audio/view.js:456
+#: assets/build/pages/video-editor.min.js:19671
+msgid "Play"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:216
+#: assets/build/blocks/godam-audio/index.js:1175
+#: pages/video-editor/components/audio/AudioCardPreview.js:217
+#: assets/build/blocks/godam-audio/index.js:962
+#: assets/build/pages/video-editor.min.js:19688
+msgid "Seek"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:256
+#: inc/classes/elementor-widgets/class-godam-video.php:110
+#: assets/build/blocks/godam-audio/index.js:1374
+#: pages/video-editor/components/audio/AudioCardPreview.js:244
+#: pages/video-editor/components/editor-shell/EditorTabRail.js:21
+#: assets/build/blocks/godam-audio/index.js:1126
+#: assets/build/pages/video-editor.min.js:19715
+#: assets/build/pages/video-editor.min.js:21609
+msgid "Chapters"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:261
+#: assets/build/blocks/godam-audio/index.js:1381
+#: pages/video-editor/components/audio/AudioCardPreview.js:253
+#: pages/video-editor/components/transcription/Transcription.js:170
+#: assets/build/blocks/godam-audio/index.js:1137
+#: assets/build/pages/video-editor.min.js:19724
+#: assets/build/pages/video-editor.min.js:26289
+msgid "Transcript"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:265
+#: assets/build/blocks/godam-audio/index.js:1387
+#: pages/video-editor/components/audio/AudioCardPreview.js:260
+#: assets/build/blocks/godam-audio/index.js:1145
+#: assets/build/pages/video-editor.min.js:19731
+msgid "Toggle panel"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:291
+#: assets/build/blocks/godam-audio/index.js:1399
+#: pages/video-editor/components/audio/AudioCardPreview.js:272
+#: assets/build/blocks/godam-audio/index.js:1157
+#: assets/build/pages/video-editor.min.js:19743
+msgid "No chapters to show"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:299
+msgid "Loading transcript…"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/render.php:301
+#: assets/build/blocks/godam-audio/index.js:1419
+#: assets/build/blocks/godam-audio/view.js:385
+#: pages/video-editor/components/audio/AudioCardPreview.js:297
+#: assets/build/blocks/godam-audio/index.js:1177
+#: assets/build/blocks/godam-audio/view.js:318
+#: assets/build/pages/video-editor.min.js:19768
+msgid "No transcript to show"
+msgstr ""
+
+#. translators: %d: number of pages
+#: assets/build/blocks/godam-pdf/render.php:163
+msgid "%d page"
+msgid_plural "%d pages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/build/blocks/godam-pdf/render.php:209
+#: assets/build/blocks/godam-pdf/index.js:1027
+#: assets/build/blocks/godam-pdf/index.js:966
+msgid "A preview is not available for this document."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/render.php:218
+#: assets/build/blocks/godam-pdf/index.js:1011
+#: assets/build/blocks/godam-pdf/index.js:1033
+#: assets/build/blocks/godam-pdf/index.js:952
+#: assets/build/blocks/godam-pdf/index.js:975
+msgid "Download original"
+msgstr ""
+
+#. translators: %s: original document download URL
+#: assets/build/blocks/godam-pdf/render.php:249
+msgid "This document cannot be displayed here. <a href=\"%s\">Download it instead</a>."
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/render.php:20
+#: inc/classes/fluentforms/fields/class-recorder-field.php:83
+#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:121
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:178
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:165
+msgid "GoDAM Recorder"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/render.php:24
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:345
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:508
+#: inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php:25
+#: inc/classes/gravity-forms/class-gf-field-godam-video.php:222
+#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:221
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:153
+#: inc/classes/wpforms/wpforms-field-godam-record-frontend.php:61
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:344
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:341
+msgid "Start Recording"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/render.php:29
+#: inc/classes/sureforms/class-form-submit.php:80
+msgid "The field is required"
+msgstr ""
+
+#. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
+#: assets/build/blocks/sureforms/blocks/recorder/render.php:117
+msgid "Maximum allowed on this server: %d MB"
+msgstr ""
+
+#: godam.php:108
+#: inc/classes/class-pages.php:242
+#: inc/classes/class-pages.php:243
+#: assets/build/blocks/godam-audio/index.js:896
+#: pages/video-editor/components/appearance/Appearance.js:124
+#: pages/video-editor/components/editor-shell/EditorTabRail.js:19
+#: assets/build/blocks/godam-audio/index.js:751
+#: assets/build/pages/video-editor.min.js:19170
+#: assets/build/pages/video-editor.min.js:21607
+msgid "Settings"
 msgstr ""
 
 #: inc/classes/addons/class-addon-registry.php:106
@@ -8563,13 +765,11 @@ msgstr ""
 
 #. translators: 1: Add-on name, 2: opening link tag, 3: closing link tag
 #: inc/classes/addons/class-addon-registry.php:142
-#, php-format
 msgid "%1$s is out of date and may not work correctly with this version of GoDAM. %2$sUpdate it to the latest version%3$s."
 msgstr ""
 
 #. translators: 1: Add-on name, 2: Required GoDAM version
 #: inc/classes/addons/class-addon-registry.php:229
-#, php-format
 msgid "%1$s requires GoDAM %2$s or higher. Please update the GoDAM plugin."
 msgstr ""
 
@@ -8607,57 +807,58 @@ msgstr ""
 msgid "Invalid data."
 msgstr ""
 
-#: inc/classes/class-demo-assets.php:170
+#: inc/classes/class-demo-assets.php:193
 msgid "Demo asset request failed."
 msgstr ""
 
-#: inc/classes/class-demo-assets.php:178
+#: inc/classes/class-demo-assets.php:201
 msgid "Demo asset not found."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:724
+#: inc/classes/class-media-library-ajax.php:815
 #: pages/media-library/App.js:214
+#: assets/build/pages/media-library.min.js:5865
 msgid "Uncategorized"
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:728
+#: inc/classes/class-media-library-ajax.php:819
 msgid "All collections"
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:810
+#: inc/classes/class-media-library-ajax.php:901
 msgid "Offer banner dismissed successfully."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:904
+#: inc/classes/class-media-library-ajax.php:995
 msgid "Invalid attachment ID or URL."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:910
-#: inc/classes/rest-api/class-media-library.php:629
+#: inc/classes/class-media-library-ajax.php:1017
+#: inc/classes/rest-api/class-media-library.php:827
 msgid "Invalid attachment ID."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:922
+#: inc/classes/class-media-library-ajax.php:1029
 msgid "Could not initialize WordPress filesystem."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:942
+#: inc/classes/class-media-library-ajax.php:1049
 msgid "Could not move file into uploads directory."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1197
+#: inc/classes/class-media-library-ajax.php:1373
 msgid "Insufficient permissions."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1214
+#: inc/classes/class-media-library-ajax.php:1390
 msgid "HTTP auth status saved."
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1247
+#: inc/classes/class-media-library-ajax.php:1423
 msgid "GoDAM Transcoding Blocked"
 msgstr ""
 
-#: inc/classes/class-media-library-ajax.php:1250
+#: inc/classes/class-media-library-ajax.php:1426
 msgid "HTTP authentication is enabled on your site, which prevents GoDAM from accessing media files for transcoding. Please disable HTTP authentication to enable transcoding."
 msgstr ""
 
@@ -8671,7 +872,6 @@ msgstr ""
 
 #. translators: %1$s is the name of the Transcoder plugin, %2$s is the name of the GoDAM plugin.
 #: inc/classes/class-media-tracker.php:209
-#, php-format
 msgid "Please deactivate the <strong>%1$s</strong> plugin to ensure the <strong>%2$s</strong> plugin functions correctly."
 msgstr ""
 
@@ -8685,7 +885,6 @@ msgstr ""
 
 #. translators: 1: posts scanned so far, 2: total posts to scan
 #: inc/classes/class-media-usage-backfill.php:111
-#, php-format
 msgid "(%1$d of %2$d posts scanned)"
 msgstr ""
 
@@ -8695,6 +894,30 @@ msgstr ""
 
 #: inc/classes/class-media-usage-backfill.php:180
 msgid "Action Scheduler is required to run the GoDAM media usage backfill."
+msgstr ""
+
+#: inc/classes/class-pages.php:199
+#: inc/classes/class-pages.php:200
+#: pages/dashboard/Dashboard.js:307
+#: assets/build/pages/dashboard.min.js:3359
+msgid "Dashboard"
+msgstr ""
+
+#: inc/classes/class-pages.php:209
+#: inc/classes/class-pages.php:210
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:648
+#: assets/build/pages/video-editor.min.js:27206
+msgid "Media Editor"
+msgstr ""
+
+#: inc/classes/class-pages.php:219
+#: inc/classes/class-pages.php:220
+#: inc/templates/video-preview.php:82
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:320
+#: assets/build/js/media-library.min.js:2309
+#: assets/build/js/media-library.min.js:2316
+#: assets/build/pages/video-editor.min.js:21971
+msgid "Analytics"
 msgstr ""
 
 #: inc/classes/class-pages.php:231
@@ -8707,19 +930,29 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: inc/classes/class-pages.php:427
+#: inc/classes/class-pages.php:268
+#: inc/classes/class-pages.php:269
+#: pages/dashboard/components/MarketingCarousel.jsx:94
+#: pages/godam/components/GoDAMFooter.jsx:31
+#: assets/build/pages/godam.min.js:10241
+#: assets/build/pages/help.min.js:531
+#: assets/build/pages/tools.min.js:781
+msgid "What's New"
+msgstr ""
+
+#: inc/classes/class-pages.php:442
 msgid "Sorry, you are not allowed to edit this item."
 msgstr ""
 
-#: inc/classes/class-pages.php:809
+#: inc/classes/class-pages.php:824
 msgid "Your last request is still being processed. Please wait a while ..."
 msgstr ""
 
-#: inc/classes/class-pages.php:810
+#: inc/classes/class-pages.php:825
 msgid "Please choose a valid poll answer."
 msgstr ""
 
-#: inc/classes/class-pages.php:811
+#: inc/classes/class-pages.php:826
 msgid "Maximum number of choices allowed: "
 msgstr ""
 
@@ -8727,25 +960,25 @@ msgstr ""
 msgid "GoDAM video performance settings have been simplified to Balanced and Priority modes. Please review any hero videos that should stay in Priority mode after this update."
 msgstr ""
 
-#: inc/classes/class-virtual-media-registrar.php:152
-#: inc/classes/class-virtual-media-registrar.php:279
+#: inc/classes/class-virtual-media-registrar.php:164
+#: inc/classes/class-virtual-media-registrar.php:310
 msgid "GoDAM API key is not configured on this site."
 msgstr ""
 
-#: inc/classes/class-virtual-media-registrar.php:169
-#: inc/classes/class-virtual-media-registrar.php:283
+#: inc/classes/class-virtual-media-registrar.php:181
+#: inc/classes/class-virtual-media-registrar.php:314
 msgid "RTGODAM_API_BASE is not defined."
 msgstr ""
 
-#: inc/classes/class-virtual-media-registrar.php:189
+#: inc/classes/class-virtual-media-registrar.php:201
 msgid "Failed to connect to GoDAM Central."
 msgstr ""
 
-#: inc/classes/class-virtual-media-registrar.php:202
+#: inc/classes/class-virtual-media-registrar.php:214
 msgid "Failed to register virtual media site with GoDAM Central."
 msgstr ""
 
-#: inc/classes/class-virtual-media-registrar.php:316
+#: inc/classes/class-virtual-media-registrar.php:347
 msgid "Failed to remove virtual media site from GoDAM Central."
 msgstr ""
 
@@ -8754,27 +987,31 @@ msgid "Retranscode Failed Media"
 msgstr ""
 
 #. translators: %d is the maximum number of retry attempts.
-#: inc/classes/cron-jobs/class-retranscode-failed-media.php:120
-#, php-format
+#: inc/classes/cron-jobs/class-retranscode-failed-media.php:129
 msgid "Transcoding failed after %d retry attempts. GoDAM Central returned a server error on each attempt."
 msgstr ""
 
-#: inc/classes/cron-jobs/class-retranscode-failed-media.php:168
+#: inc/classes/cron-jobs/class-retranscode-failed-media.php:194
 msgid "GoDAM: Transcoding server error"
 msgstr ""
 
-#: inc/classes/cron-jobs/class-retranscode-failed-media.php:172
+#: inc/classes/cron-jobs/class-retranscode-failed-media.php:198
 msgid "Media Library"
 msgstr ""
 
 #. translators: 1: number of media items queued, 2: retry interval in minutes, 3: max retries, 4: Media Library link
-#: inc/classes/cron-jobs/class-retranscode-failed-media.php:176
-#, php-format
+#: inc/classes/cron-jobs/class-retranscode-failed-media.php:202
 msgid "%1$d media file(s) could not be sent to the GoDAM transcoding server and have been queued for automatic retry (every %2$d minutes, up to %3$d attempts). Visit the %4$s to see their status."
 msgstr ""
 
 #: inc/classes/elementor-controls/class-godam-media.php:137
 msgid "Choose Image"
+msgstr ""
+
+#: inc/classes/elementor-controls/class-godam-media.php:140
+#: pages/analytics/Analytics.js:777
+#: assets/build/pages/analytics.min.js:9941
+msgid "Choose Video"
 msgstr ""
 
 #: inc/classes/elementor-controls/class-godam-media.php:143
@@ -8785,12 +1022,47 @@ msgstr ""
 msgid "Choose File"
 msgstr ""
 
+#: inc/classes/elementor-controls/class-godam-media.php:163
+#: inc/classes/elementor-controls/class-godam-media.php:165
+#: inc/classes/elementor-controls/class-godam-media.php:211
+#: inc/classes/elementor-controls/class-godam-media.php:213
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:123
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:170
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:205
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:251
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:330
+#: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:70
+#: assets/build/blocks/godam-audio/index.js:860
+#: assets/build/blocks/godam-gallery-v2-item/index.js:342
+#: assets/build/blocks/godam-gallery-v2-item/index.js:384
+#: assets/build/blocks/godam-gallery-v2/index.js:5735
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:122
+#: assets/build/blocks/godam-audio/index.js:708
+#: assets/build/blocks/godam-gallery-v2-item/index.js:258
+#: assets/build/blocks/godam-gallery-v2-item/index.js:304
+#: assets/build/blocks/godam-gallery-v2/index.js:5498
+#: assets/build/js/wpbakery-document-selector-param.min.js:303
+#: assets/build/js/wpbakery-image-selector-param.min.js:67
+#: assets/build/js/wpbakery-video-selector-param.min.js:280
+#: assets/build/js/wpbakery-video-selector-param.min.js:530
+#: assets/build/pages/godam.min.js:11364
+msgid "Remove"
+msgstr ""
+
 #: inc/classes/elementor-controls/class-godam-media.php:186
 msgid "Add"
 msgstr ""
 
 #: inc/classes/elementor-controls/class-godam-media.php:202
 msgid "Click the media icon to upload file"
+msgstr ""
+
+#: inc/classes/elementor-controls/class-godam-media.php:215
+#: inc/classes/elementor-controls/class-godam-media.php:217
+#: inc/classes/wpforms/wpforms-field-godam-record-entry-edit.php:65
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:112
+#: assets/build/pages/godam.min.js:11354
+msgid "Upload"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-base.php:82
@@ -8815,9 +1087,35 @@ msgstr ""
 msgid "Select the audio file"
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-audio.php:70
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:101
+#: assets/build/blocks/godam-audio/index.js:726
+#: assets/build/blocks/godam-audio/index.js:560
+msgid "Audio Title"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-audio.php:73
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:104
 msgid "Title shown in the player. Leave empty to use the attachment title."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:83
+#: inc/classes/elementor-widgets/class-godam-document.php:87
+#: inc/classes/elementor-widgets/class-godam-video.php:201
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:115
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:149
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:366
+#: assets/build/blocks/godam-audio/index.js:735
+#: assets/build/blocks/godam-pdf/index.js:1215
+#: assets/build/blocks/godam-player/index.js:10089
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:195
+#: pages/video-editor/components/cta/CardCTA.js:445
+#: assets/build/blocks/godam-audio/index.js:569
+#: assets/build/blocks/godam-pdf/index.js:1173
+#: assets/build/blocks/godam-player/index.js:9543
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:183
+#: assets/build/pages/video-editor.min.js:21110
+msgid "Description"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:85
@@ -8825,13 +1123,78 @@ msgstr ""
 msgid "Short description shown beneath the title."
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-audio.php:95
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:129
+#: assets/build/blocks/godam-audio/index.js:808
+#: assets/build/blocks/godam-player/index.js:11483
+#: pages/video-editor/components/appearance/Appearance.js:241
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:503
+#: assets/build/blocks/godam-audio/index.js:647
+#: assets/build/blocks/godam-player/index.js:10929
+#: assets/build/pages/video-editor.min.js:19287
+#: assets/build/pages/video-editor.min.js:27061
+msgid "Thumbnail"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-audio.php:99
 msgid "Cover image for the player. Leave empty to use the GoDAM-generated cover."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:109
+#: inc/classes/elementor-widgets/class-godam-video.php:268
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:143
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:77
+#: assets/build/blocks/godam-audio/index.js:903
+#: assets/build/blocks/godam-player/index.js:10265
+#: assets/build/blocks/godam-audio/index.js:755
+#: assets/build/blocks/godam-player/index.js:9690
+msgid "Autoplay"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:112
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:150
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:84
+#: assets/build/blocks/godam-audio/index.js:446
+#: assets/build/blocks/godam-player/index.js:10232
+#: assets/build/blocks/godam-audio/index.js:278
+#: assets/build/blocks/godam-player/index.js:9657
+msgid "Autoplay may cause usability issues for some users."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:122
+#: inc/classes/elementor-widgets/class-godam-video.php:280
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:159
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:93
+#: assets/build/blocks/godam-audio/index.js:912
+#: assets/build/blocks/godam-audio/index.js:764
+msgid "Loop"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:134
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:175
 msgid "Preload"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:141
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:181
+#: assets/build/blocks/godam-audio/index.js:930
+#: assets/build/blocks/godam-audio/index.js:780
+msgid "Auto"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:142
+#: inc/classes/elementor-widgets/class-godam-video.php:111
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:179
+#: assets/build/blocks/godam-audio/index.js:933
+#: assets/build/blocks/godam-audio/index.js:781
+msgid "Metadata"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-audio.php:143
+#: assets/build/blocks/godam-audio/index.js:936
+#: assets/build/blocks/godam-audio/index.js:782
+msgctxt "Preload value"
+msgid "None"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-audio.php:154
@@ -8854,6 +1217,12 @@ msgstr ""
 msgid "Show the chapters panel (when chapters are available)."
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-audio.php:263
+#: assets/build/blocks/godam-audio/index.js:762
+#: assets/build/blocks/godam-audio/index.js:591
+msgid "Add an audio file"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-audio.php:266
 msgid "Select an audio file in the Player Settings panel to embed a player on your page or post."
 msgstr ""
@@ -8867,49 +1236,112 @@ msgstr ""
 msgid "Document Settings"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:65
-msgid "Select a PDF document from the media library."
+#: inc/classes/elementor-widgets/class-godam-document.php:57
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:109
+#: assets/build/js/wpbakery-document-selector-param.min.js:250
+msgid "Select Document"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:66
+msgid "Select a PDF, Word, Excel, PowerPoint, OpenDocument, TXT or CSV file from the media library."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:73
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:135
+#: assets/build/blocks/godam-pdf/index.js:1206
+#: assets/build/blocks/godam-pdf/index.js:1164
+msgid "Doc Title"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-document.php:76
+#: assets/build/blocks/godam-pdf/index.js:1208
+#: assets/build/blocks/godam-pdf/index.js:1166
+msgid "Add document title"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:77
 msgid "Leave empty to use the attachment title."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:89
+#: inc/classes/elementor-widgets/class-godam-document.php:90
 msgid "Shown in card view."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:106
+#: inc/classes/elementor-widgets/class-godam-document.php:100
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:163
+#: assets/build/blocks/godam-pdf/index.js:1231
+#: pages/analytics/helper.js:533
+#: assets/build/blocks/godam-pdf/index.js:1187
+#: assets/build/pages/analytics.min.js:13412
+#: assets/build/pages/dashboard.min.js:2637
+msgid "View"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:104
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:166
+#: assets/build/blocks/godam-pdf/index.js:1240
+#: assets/build/blocks/godam-pdf/index.js:1195
+msgid "Default View"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:105
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:167
+#: assets/build/blocks/godam-pdf/index.js:1243
+#: assets/build/blocks/godam-pdf/index.js:1199
+msgid "Card View"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:107
 msgid "Embedded PDF viewer, or a card with a cover image."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:140
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:161
+#: inc/classes/elementor-widgets/class-godam-document.php:117
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:181
+#: assets/build/blocks/godam-pdf/index.js:1411
+#: assets/build/blocks/godam-pdf/index.js:1334
+msgid "Height (px)"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:141
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:195
 msgid "Show Cover"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:153
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:181
+#: inc/classes/elementor-widgets/class-godam-document.php:154
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:215
 msgid "Cover Image"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:157
+#: inc/classes/elementor-widgets/class-godam-document.php:158
 msgid "Leave empty to use the auto-generated cover. Recommended aspect ratio: 16:9."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:169
-#: inc/classes/elementor-widgets/class-godam-video.php:472
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:195
+#: inc/classes/elementor-widgets/class-godam-document.php:170
+#: inc/classes/elementor-widgets/class-godam-video.php:487
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:229
 msgid "Caption"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-document.php:260
-msgid "Only PDF files are supported. Select a PDF in the Document Settings panel; the current file will not be shown on your page."
+#: inc/classes/elementor-widgets/class-godam-document.php:269
+#: assets/build/blocks/godam-pdf/index.js:977
+#: assets/build/blocks/godam-pdf/index.js:921
+msgid "Unsupported file format"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-document.php:272
+msgid "That file type is not supported. Select a PDF, Word, Excel, PowerPoint, OpenDocument, TXT or CSV file in the Document Settings panel; the current file will not be shown on your page."
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:31
 msgctxt "Widget Title"
 msgid "Video Gallery"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:56
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:71
+#: assets/build/blocks/godam-gallery-v2/index.js:6194
+#: assets/build/blocks/godam-gallery-v2/index.js:6111
+msgid "Gallery Settings"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:63
@@ -8932,12 +1364,38 @@ msgstr ""
 msgid "Query: filter from the media library. Handpicked: choose specific videos in order."
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-gallery.php:78
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:103
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:399
+#: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:30
+#: assets/build/blocks/godam-gallery-v2/index.js:6607
+#: assets/build/blocks/godam-player/index.js:11552
+#: pages/tools/components/tabs/RetranscodeTab.jsx:35
+#: assets/build/blocks/godam-gallery-v2/index.js:6603
+#: assets/build/blocks/godam-player/index.js:11003
+#: assets/build/pages/tools.min.js:2631
+msgid "Video"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-gallery.php:92
 msgid "Only video attachments can be picked. The Add button opens the WordPress media library filtered to videos."
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-gallery.php:99
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:92
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:71
+#: assets/build/pages/video-editor.min.js:26629
+msgid "Videos"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-gallery.php:105
 msgid "Add rows and pick a video for each. Order in the list determines display order. Rows with no video are skipped on the frontend."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:115
+#: assets/build/blocks/godam-gallery-v2/index.js:6373
+#: assets/build/blocks/godam-gallery-v2/index.js:6302
+msgid "Number of videos"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:137
@@ -8945,20 +1403,220 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-gallery.php:141
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:126
+#: assets/build/blocks/godam-gallery-v2/index.js:6389
+#: assets/build/blocks/godam-gallery-v2/index.js:6315
+msgid "Date"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:142
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:127
+#: assets/build/blocks/godam-gallery-v2/index.js:6392
+#: pages/dashboard/components/TopVideosTable.js:192
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:117
+#: assets/build/blocks/godam-gallery-v2/index.js:6316
+#: assets/build/pages/dashboard.min.js:3878
+#: assets/build/pages/video-editor.min.js:21768
+msgid "Title"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:143
+#: inc/classes/elementor-widgets/class-godam-video.php:228
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:128
+#: assets/build/blocks/godam-player/index.js:10103
+#: pages/analytics/helper.js:537
+#: pages/video-editor/components/layers/HotspotLayer.js:509
+#: assets/build/blocks/godam-player/index.js:9562
+#: assets/build/pages/analytics.min.js:13416
+#: assets/build/pages/dashboard.min.js:2641
+#: assets/build/pages/video-editor.min.js:24651
+msgid "Duration"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:144
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:129
+#: pages/dashboard/components/TopVideosTable.js:194
+#: pages/dashboard/components/TopVideosTable.js:271
+#: assets/build/pages/dashboard.min.js:3880
+#: assets/build/pages/dashboard.min.js:3957
+msgid "Size"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:155
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:141
+#: assets/build/blocks/godam-gallery-v2/index.js:6402
+#: assets/build/blocks/godam-gallery-v2/index.js:6325
+msgid "Order"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:159
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:144
+#: assets/build/blocks/godam-gallery-v2/index.js:6405
+#: assets/build/blocks/godam-gallery-v2/index.js:6329
+msgid "Descending"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:160
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:145
+#: assets/build/blocks/godam-gallery-v2/index.js:6408
+#: assets/build/blocks/godam-gallery-v2/index.js:6333
+msgid "Ascending"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:184
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:157
+#: assets/build/blocks/godam-gallery-v2/index.js:6418
+#: assets/build/blocks/godam-gallery-v2/index.js:6344
+msgid "Media Folder"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-gallery.php:189
 msgid "Limit results to the selected media folders."
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-gallery.php:206
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:170
+#: assets/build/blocks/godam-gallery-v2/index.js:6426
+#: assets/build/blocks/godam-gallery-v2/index.js:6354
+msgid "Author"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:220
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:183
+#: assets/build/blocks/godam-gallery-v2/index.js:6433
+#: pages/analytics/components/DateRangePicker/index.js:381
+#: assets/build/blocks/godam-gallery-v2/index.js:6363
+#: assets/build/pages/analytics.min.js:11937
+#: assets/build/pages/dashboard.min.js:1935
+#: assets/build/pages/shared-components.min.js:437
+msgid "Date Range"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:224
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:186
+#: assets/build/blocks/godam-gallery-v2/index.js:6436
+#: pages/analytics/components/DateRangePicker/index.js:88
+#: pages/analytics/components/DateRangePicker/index.js:89
+#: assets/build/blocks/godam-gallery-v2/index.js:6366
+#: assets/build/pages/analytics.min.js:11644
+#: assets/build/pages/analytics.min.js:11645
+#: assets/build/pages/dashboard.min.js:1642
+#: assets/build/pages/dashboard.min.js:1643
+#: assets/build/pages/shared-components.min.js:144
+#: assets/build/pages/shared-components.min.js:145
+msgid "All Time"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:225
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:187
+#: assets/build/blocks/godam-gallery-v2/index.js:6439
+#: assets/build/blocks/godam-gallery-v2/index.js:6367
+msgid "Last 7 Days"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:226
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:188
+#: assets/build/blocks/godam-gallery-v2/index.js:6442
+#: assets/build/blocks/godam-gallery-v2/index.js:6368
+msgid "Last 30 Days"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:227
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:189
+#: assets/build/blocks/godam-gallery-v2/index.js:6445
+#: assets/build/blocks/godam-gallery-v2/index.js:6369
+msgid "Last 90 Days"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:228
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:190
+#: assets/build/blocks/godam-gallery-v2/index.js:6448
+#: assets/build/blocks/godam-gallery-v2/index.js:6371
+msgid "Custom Range"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:239
+#: assets/build/blocks/godam-gallery-v2/index.js:6466
+#: assets/build/blocks/godam-gallery-v2/index.js:6394
+msgid "Start Date"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:254
+#: assets/build/blocks/godam-gallery-v2/index.js:6489
+#: assets/build/blocks/godam-gallery-v2/index.js:6424
+msgid "End Date"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-gallery.php:269
-#: inc/classes/elementor-widgets/class-godam-video.php:320
+#: inc/classes/elementor-widgets/class-godam-video.php:333
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:224
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:141
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:157
 msgid "Performance Mode"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:273
+#: inc/classes/elementor-widgets/class-godam-video.php:337
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:227
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:160
+#: assets/build/blocks/godam-gallery-v2/index.js:6352
+#: assets/build/blocks/godam-player/index.js:10389
+#: assets/build/blocks/godam-gallery-v2/index.js:6273
+#: assets/build/blocks/godam-player/index.js:9820
+msgid "Balanced"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:274
+#: inc/classes/elementor-widgets/class-godam-video.php:338
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:228
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:161
+#: assets/build/blocks/godam-gallery-v2/index.js:6349
+#: assets/build/blocks/godam-player/index.js:10386
+#: assets/build/blocks/godam-gallery-v2/index.js:6269
+#: assets/build/blocks/godam-player/index.js:9819
+msgid "Priority"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:276
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:231
 msgid "Priority preloads leading thumbnails with fetchpriority=\"high\"."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:290
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:72
+#: pages/video-editor/components/appearance/Appearance.js:129
+#: assets/build/pages/video-editor.min.js:19175
+msgid "Display Settings"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:297
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:240
+#: assets/build/blocks/godam-gallery-v2/index.js:6200
+#: assets/build/blocks/godam-player/index.js:11435
+#: assets/build/blocks/godam-gallery-v2/index.js:6118
+#: assets/build/blocks/godam-player/index.js:10896
+msgid "Layout"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:301
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:243
+#: assets/build/blocks/godam-gallery-v2/index.js:6225
+#: assets/build/blocks/godam-gallery-v2/index.js:6145
+msgid "Grid"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:302
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:245
+#: assets/build/blocks/godam-gallery-v2/index.js:6229
+#: assets/build/blocks/godam-gallery-v2/index.js:6150
+msgid "List"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:303
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:244
+#: assets/build/blocks/godam-gallery-v2/index.js:6221
+#: assets/build/blocks/godam-gallery-v2/index.js:6140
+msgid "Carousel"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:311
@@ -8979,6 +1637,19 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-gallery.php:317
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:258
 msgid "Large (320px)"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:325
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:266
+#: assets/build/blocks/godam-gallery-v2/index.js:6235
+#: assets/build/blocks/godam-gallery-v2/index.js:6158
+msgid "View Ratio"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:329
+#: assets/build/blocks/godam-player/index.js:11300
+#: assets/build/blocks/godam-player/index.js:10751
+msgid "16:9"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:330
@@ -9002,6 +1673,29 @@ msgstr ""
 msgid "Show Video Titles and Dates"
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-gallery.php:350
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:290
+#: assets/build/blocks/godam-gallery-v2/index.js:6299
+#: assets/build/blocks/godam-gallery-v2/index.js:6306
+#: assets/build/blocks/godam-gallery-v2/index.js:6213
+#: assets/build/blocks/godam-gallery-v2/index.js:6217
+msgid "Interaction"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:354
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:293
+#: assets/build/blocks/godam-gallery-v2/index.js:6314
+#: assets/build/blocks/godam-gallery-v2/index.js:6227
+msgid "Play on hover"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:355
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:294
+#: assets/build/blocks/godam-gallery-v2/index.js:6310
+#: assets/build/blocks/godam-gallery-v2/index.js:6222
+msgid "Autoplay all videos"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-gallery.php:357
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:297
 msgid "Play on hover: videos play when hovered. Autoplay: visible videos autoplay one at a time."
@@ -9015,6 +1709,20 @@ msgstr ""
 #: inc/classes/elementor-widgets/class-godam-gallery.php:370
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:310
 msgid "Show the play button overlay on each tile."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:377
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:315
+#: assets/build/blocks/godam-gallery-v2/index.js:6512
+#: assets/build/blocks/godam-gallery-v2/index.js:6457
+msgid "Enable More Items"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-gallery.php:389
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:327
+#: assets/build/blocks/godam-gallery-v2/index.js:6517
+#: assets/build/blocks/godam-gallery-v2/index.js:6464
+msgid "More Items Behavior"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-gallery.php:393
@@ -9031,6 +1739,12 @@ msgstr ""
 msgid "Show Engagements"
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-gallery.php:545
+#: assets/build/blocks/godam-gallery-v2/index.js:6548
+#: assets/build/blocks/godam-gallery-v2/index.js:6515
+msgid "Create your media gallery"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-gallery.php:548
 msgid "Add videos under \"Videos\" in the Gallery Settings panel to build your gallery."
 msgstr ""
@@ -9040,11 +1754,42 @@ msgctxt "Widget Title"
 msgid "Image"
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-image.php:54
+#: assets/build/blocks/godam-image/index.js:358
+msgid "Image Selection"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-image.php:61
+#: inc/classes/wpbakery-elements/class-wpb-godam-image.php:66
+#: pages/tools/components/tabs/RetranscodeTab.jsx:38
+#: pages/video-editor/components/cta/CardCTA.js:347
+#: pages/video-editor/components/cta/CardCTA.js:391
+#: assets/build/pages/tools.min.js:2634
+#: assets/build/pages/video-editor.min.js:21012
+#: assets/build/pages/video-editor.min.js:21056
+msgid "Image"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-image.php:65
 msgid "Select an image. Hotspot and product layers authored in the GoDAM image editor are overlaid on the front end."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-image.php:160
+#: inc/classes/elementor-widgets/class-godam-image.php:72
+#: assets/build/blocks/godam-image/index.js:366
+msgid "Show image layers"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-image.php:78
+#: assets/build/blocks/godam-image/index.js:371
+msgid "Overlays the hotspot / product layers authored in the GoDAM image editor."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-image.php:165
+#: assets/build/blocks/godam-image/index.js:384
+msgid "Add Image Here"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-image.php:168
 msgid "Select an image in the Image Selection panel to get started."
 msgstr ""
 
@@ -9062,8 +1807,16 @@ msgid "Select video file"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:62
-#: assets/src/blocks/godam-player/track-uploader.js:149
 msgid "Add Video Caption"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:64
+#: inc/classes/elementor-widgets/class-godam-video.php:126
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:29
+#: pages/video-editor/components/forms/CF7.js:26
+#: assets/build/pages/godam.min.js:12225
+#: assets/build/pages/video-editor.min.js:22133
+msgid "Default"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:65
@@ -9079,8 +1832,13 @@ msgstr ""
 msgid "Text track file"
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-video.php:90
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:180
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:167
+msgid "Label"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-video.php:91
-#: assets/src/blocks/godam-player/track-uploader.js:80
 msgid "Title of track"
 msgstr ""
 
@@ -9089,36 +1847,37 @@ msgid "Source Language"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:98
-#: assets/src/blocks/godam-player/track-uploader.js:87
 msgid "Language tag (en, fr, etc.)"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:104
-#: assets/src/blocks/godam-player/track-uploader.js:91
 msgid "Kind"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:107
-#: assets/src/blocks/godam-player/track-uploader.js:29
 msgid "Subtitles"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:108
-#: assets/src/blocks/godam-player/track-uploader.js:30
 msgid "Captions"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:109
-#: assets/src/blocks/godam-player/track-uploader.js:31
 msgid "Descriptions"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:124
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:325
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:338
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:351
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:368
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:344
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:357
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:370
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:387
 msgid "SEO Settings"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:141
+#: assets/build/blocks/godam-player/index.js:10050
+#: assets/build/blocks/godam-player/index.js:9495
+msgid "Override default SEO"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:143
@@ -9133,80 +1892,202 @@ msgstr ""
 msgid "You have overridden the default SEO. Changes to this video in the media library will not update the SEO for this widget."
 msgstr ""
 
+#: inc/classes/elementor-widgets/class-godam-video.php:176
+#: assets/build/blocks/godam-player/index.js:10075
+#: assets/build/blocks/godam-player/index.js:9527
+msgid "Content URL"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:179
+#: assets/build/blocks/godam-player/index.js:10078
+#: assets/build/blocks/godam-player/index.js:9530
+msgid "URL of the video content can be MOV, MP4, MPD. Example: https://www.example.com/video.mp4"
+msgstr ""
+
 #: inc/classes/elementor-widgets/class-godam-video.php:190
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:334
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:353
 msgid "Headline"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:193
+#: assets/build/blocks/godam-player/index.js:10085
+#: assets/build/blocks/godam-player/index.js:9538
+msgid "Title of the video"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:212
+#: assets/build/blocks/godam-player/index.js:10096
+#: assets/build/blocks/godam-player/index.js:9554
+msgid "Upload Date"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:230
+#: assets/build/blocks/godam-player/index.js:10105
+#: assets/build/blocks/godam-player/index.js:9564
+msgid "ISO 8601 format. Example: PT1H30M"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:242
+#: assets/build/blocks/godam-player/index.js:10110
+#: assets/build/blocks/godam-player/index.js:9570
+msgid "Video Thumbnail URL"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:255
+#: assets/build/blocks/godam-player/index.js:10117
+#: assets/build/blocks/godam-player/index.js:9578
+msgid "Is Family Friendly"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:257
+#: assets/build/blocks/godam-player/index.js:10120
+#: assets/build/blocks/godam-player/index.js:9581
+msgid "Is the video suitable for all audiences?"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:292
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:109
+#: assets/build/blocks/godam-player/index.js:10285
+#: assets/build/blocks/godam-player/index.js:9710
+msgid "Muted"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:295
 msgid "Forced on when Autoplay is enabled — most browsers block autoplay with sound."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:336
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:170
+#: inc/classes/elementor-widgets/class-godam-video.php:308
+#: assets/build/blocks/godam-player/index.js:10295
+#: assets/build/blocks/godam-player/index.js:9720
+msgid "Playback controls"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:320
+#: assets/build/blocks/godam-player/index.js:10303
+#: assets/build/blocks/godam-player/index.js:9728
+msgid "Show in lightbox"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:323
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:148
+#: assets/build/blocks/godam-player/index.js:10306
+#: assets/build/blocks/godam-player/index.js:9731
+msgid "Open the video in a lightbox when clicked."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:349
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:186
 msgid "Hover Option"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:340
+#: inc/classes/elementor-widgets/class-godam-video.php:353
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:180
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:173
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:189
 msgid "None"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:341
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:174
+#: inc/classes/elementor-widgets/class-godam-video.php:354
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:190
 msgid "Show Player Controls"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:344
-msgid "Choose the action to perform on video hover. Disabled when Autoplay is on."
+#: inc/classes/elementor-widgets/class-godam-video.php:355
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:191
+#: assets/build/blocks/godam-player/index.js:11281
+#: assets/build/blocks/godam-player/index.js:10735
+msgid "Start Preview"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:357
-msgid "Show Share Button"
-msgstr ""
-
-#: inc/classes/elementor-widgets/class-godam-video.php:369
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:258
-msgid "Show Transcription"
+msgid "Choose the action to perform on video hover. Disabled when Autoplay or Show in lightbox is on."
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:372
+msgid "Show Share Button"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:384
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:277
+msgid "Show Transcription"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:387
 msgid "Show the transcript panel toggle on the player (when a transcript is available)."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:383
+#: inc/classes/elementor-widgets/class-godam-video.php:398
 msgid "Enable Engagements"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:401
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:191
-msgid "16:9 (Standard)"
+#: inc/classes/elementor-widgets/class-godam-video.php:411
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:206
+#: assets/build/blocks/godam-player/index.js:11288
+#: assets/build/blocks/godam-player/index.js:10744
+msgid "Aspect Ratio"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:413
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:203
-msgid "Player Height"
+#: inc/classes/elementor-widgets/class-godam-video.php:415
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:209
+#: assets/build/blocks/godam-player/index.js:11297
+#: assets/build/blocks/godam-player/index.js:10750
+msgid "Original"
 msgstr ""
 
 #: inc/classes/elementor-widgets/class-godam-video.php:416
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:206
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:210
+msgid "16:9 (Standard)"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:418
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:213
+#: assets/build/blocks/godam-player/index.js:11294
+#: assets/build/blocks/godam-player/index.js:10748
+msgid "Choose the aspect ratio for the video player."
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:428
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:222
+msgid "Player Height"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:431
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:225
 msgid "Constrain player height (e.g. 400px, 50vh). Width is derived from aspect ratio."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:429
+#: inc/classes/elementor-widgets/class-godam-video.php:441
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:174
+#: assets/build/blocks/godam-player/index.js:9708
+#: assets/build/blocks/godam-player/index.js:9155
+#: assets/build/js/media-library.min.js:1937
+msgid "Video Thumbnail"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:444
 msgid "Select the video thumbnail."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:446
+#: inc/classes/elementor-widgets/class-godam-video.php:461
 msgid "Or pick an auto-generated thumbnail"
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:448
+#: inc/classes/elementor-widgets/class-godam-video.php:463
 msgid "No auto-generated thumbnails available for this video."
 msgstr ""
 
-#: inc/classes/elementor-widgets/class-godam-video.php:677
+#: inc/classes/elementor-widgets/class-godam-video.php:475
+#: assets/build/blocks/godam-player/index.js:10328
+#: assets/build/blocks/godam-player/index.js:9755
+msgid "Show caption"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:693
+#: assets/build/blocks/godam-player/index.js:11526
+#: assets/build/blocks/godam-player/index.js:10976
+msgid "Add Video Here"
+msgstr ""
+
+#: inc/classes/elementor-widgets/class-godam-video.php:696
 msgid "Select a video in the Player Settings panel to get started."
 msgstr ""
 
@@ -9253,8 +2134,16 @@ msgstr ""
 
 #. translators: %s is the max file size in MB
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:357
-#, php-format
 msgid "Max file size: %s MB"
+msgstr ""
+
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:435
+#: inc/classes/fluentforms/fields/class-recorder-field.php:246
+#: inc/classes/gravity-forms/class-init.php:172
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:197
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:213
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:198
+msgid "Choose file selector"
 msgstr ""
 
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:436
@@ -9268,6 +2157,40 @@ msgstr ""
 msgid "Local Files"
 msgstr ""
 
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:443
+#: inc/classes/fluentforms/fields/class-recorder-field.php:254
+#: inc/classes/gravity-forms/class-init.php:188
+#: inc/classes/ninja-forms/config/field-settings.php:52
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:205
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:232
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:221
+msgid "Webcam"
+msgstr ""
+
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:444
+#: inc/classes/fluentforms/fields/class-recorder-field.php:258
+#: inc/classes/gravity-forms/class-init.php:195
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:206
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:238
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:228
+msgid "Screencast"
+msgstr ""
+
+#: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:445
+#: inc/classes/gravity-forms/class-init.php:202
+#: inc/classes/ninja-forms/config/field-settings.php:60
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:66
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:207
+#: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:30
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:244
+#: pages/tools/components/tabs/RetranscodeTab.jsx:36
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:73
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:235
+#: assets/build/pages/tools.min.js:2632
+#: assets/build/pages/video-editor.min.js:26631
+msgid "Audio"
+msgstr ""
+
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:494
 msgid "Record Button Text"
 msgstr ""
@@ -9279,6 +2202,17 @@ msgstr ""
 
 #: inc/classes/everest-forms/class-everest-forms-field-godam-video.php:509
 msgid "Button Text"
+msgstr ""
+
+#: inc/classes/everest-forms/class-everest-forms-integration.php:196
+#: inc/classes/everest-forms/class-everest-forms-integration.php:244
+#: pages/video-editor/components/forms/EverestForm.js:42
+#: pages/video-editor/components/SidebarLayers.js:97
+#: pages/video-editor/utils/layerTypes.js:45
+#: assets/build/pages/video-editor.min.js:18095
+#: assets/build/pages/video-editor.min.js:22232
+#: assets/build/pages/video-editor.min.js:30127
+msgid "Everest Forms"
 msgstr ""
 
 #: inc/classes/everest-forms/class-everest-forms-integration.php:270
@@ -9315,6 +2249,15 @@ msgstr ""
 msgid "Invalid form ID."
 msgstr ""
 
+#. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
+#: inc/classes/everest-forms/everest-forms-field-godam-record-frontend.php:76
+#: inc/classes/fluentforms/fields/class-recorder-field.php:431
+#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:259
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:260
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:254
+msgid "Maximum allowed on this server: %s MB"
+msgstr ""
+
 #: inc/classes/fluentforms/class-form-submit.php:65
 #: inc/classes/fluentforms/class-form-submit.php:98
 msgid "Fluentforms"
@@ -9324,6 +2267,13 @@ msgstr ""
 #: inc/classes/fluentforms/fields/class-recorder-field.php:363
 #: inc/classes/ninja-forms/config/field-settings.php:18
 msgid "Record Video"
+msgstr ""
+
+#: inc/classes/fluentforms/fields/class-recorder-field.php:250
+#: inc/classes/gravity-forms/class-init.php:181
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:226
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:214
+msgid "Local files"
 msgstr ""
 
 #: inc/classes/fluentforms/fields/class-recorder-field.php:546
@@ -9373,31 +2323,26 @@ msgstr ""
 
 #. translators: %s is the allowed file types.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:152
-#, php-format
 msgid "Accepted file types: %s"
 msgstr ""
 
 #. translators: %s is the maximum file size allowed.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:158
-#, php-format
 msgid "Max. file size: %s"
 msgstr ""
 
 #. translators: %s is the maximum duration.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:165
-#, php-format
 msgid "Max. duration: %s"
 msgstr ""
 
 #. translators: %s is the maximum number of files allowed.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:175
-#, php-format
 msgid "Max. files: %s"
 msgstr ""
 
 #. translators: %d is the number of files.
 #: inc/classes/gravity-forms/class-gf-field-godam-video.php:264
-#, php-format
 msgid "%d files"
 msgstr ""
 
@@ -9447,7 +2392,7 @@ msgid "Leave empty to allow any duration. Example: 180 = 3 minutes."
 msgstr ""
 
 #: inc/classes/gravity-forms/class-init.php:314
-#: inc/helpers/custom-functions.php:903
+#: inc/helpers/custom-functions.php:1254
 msgid "Gravity forms"
 msgstr ""
 
@@ -9464,7 +2409,7 @@ msgid "Your browser does not support the video tag."
 msgstr ""
 
 #: inc/classes/media-library/class-media-folder-create-zip.php:66
-#: inc/classes/media-library/class-media-folder-utils.php:246
+#: inc/classes/media-library/class-media-folder-utils.php:274
 msgid "Invalid folder ID provided."
 msgstr ""
 
@@ -9477,22 +2422,20 @@ msgid "Failed to create godam directory."
 msgstr ""
 
 #. translators: %d is the error code returned by ZipArchive::open()
-#: inc/classes/media-library/class-media-folder-create-zip.php:175
-#, php-format
+#: inc/classes/media-library/class-media-folder-create-zip.php:178
 msgid "Failed to create ZIP file. Error code: %d"
 msgstr ""
 
-#: inc/classes/media-library/class-media-folder-create-zip.php:246
+#: inc/classes/media-library/class-media-folder-create-zip.php:260
 msgid "No valid files found to add to ZIP."
 msgstr ""
 
 #. translators: %1$d: added files, %2$d: skipped files, %3$d: total attachments
-#: inc/classes/media-library/class-media-folder-create-zip.php:267
-#, php-format
+#: inc/classes/media-library/class-media-folder-create-zip.php:281
 msgid "ZIP file created successfully. %1$d files added, %2$d files skipped out of %3$d total attachments."
 msgstr ""
 
-#: inc/classes/media-library/class-media-folder-utils.php:252
+#: inc/classes/media-library/class-media-folder-utils.php:280
 msgid "Media folder not found."
 msgstr ""
 
@@ -9511,7 +2454,6 @@ msgstr ""
 
 #. translators: %d is the Metform ID
 #: inc/classes/metform/class-metform-rest-api.php:152
-#, php-format
 msgid "Unable to find the Metform with ID:%d"
 msgstr ""
 
@@ -9541,8 +2483,18 @@ msgstr ""
 
 #. Translators: %s: Maximum allowed file size in MB.
 #: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:443
-#, php-format
 msgid "File exceeds maximum file size. File must be under %sMB."
+msgstr ""
+
+#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:541
+#: inc/classes/ninja-forms/class-ninja-forms-field-godam-recorder.php:591
+#: pages/video-editor/components/forms/NinjaForm.js:43
+#: pages/video-editor/components/SidebarLayers.js:103
+#: pages/video-editor/utils/layerTypes.js:46
+#: assets/build/pages/video-editor.min.js:18101
+#: assets/build/pages/video-editor.min.js:23003
+#: assets/build/pages/video-editor.min.js:30128
+msgid "Ninja Forms"
 msgstr ""
 
 #: inc/classes/ninja-forms/class-ninja-forms-rest-api.php:58
@@ -9556,7 +2508,6 @@ msgstr ""
 
 #. translators: %d is the Ninja Form ID
 #: inc/classes/ninja-forms/class-ninja-forms-rest-api.php:130
-#, php-format
 msgid "Unable to find the Ninja Form with ID:%d"
 msgstr ""
 
@@ -9636,8 +2587,8 @@ msgid "The Site URL associated with the video."
 msgstr ""
 
 #: inc/classes/rest-api/class-analytics.php:312
-#: inc/classes/rest-api/class-analytics.php:567
-#: inc/classes/rest-api/class-analytics.php:787
+#: inc/classes/rest-api/class-analytics.php:578
+#: inc/classes/rest-api/class-analytics.php:798
 #: inc/classes/rest-api/class-engagement.php:365
 #: inc/classes/rest-api/class-site.php:169
 msgid "Missing API key."
@@ -9647,37 +2598,49 @@ msgstr ""
 msgid "GoDAM account is not verified. Connect your account in GoDAM settings to view layer analytics."
 msgstr ""
 
-#: inc/classes/rest-api/class-analytics.php:371
-#: inc/classes/rest-api/class-analytics.php:593
-#: inc/classes/rest-api/class-analytics.php:825
+#: inc/classes/rest-api/class-analytics.php:382
+#: inc/classes/rest-api/class-analytics.php:604
+#: inc/classes/rest-api/class-analytics.php:836
 msgid "Unable to reach analytics server."
 msgstr ""
 
-#: inc/classes/rest-api/class-analytics.php:380
-#: inc/classes/rest-api/class-analytics.php:604
-#: inc/classes/rest-api/class-analytics.php:834
+#: inc/classes/rest-api/class-analytics.php:391
+#: inc/classes/rest-api/class-analytics.php:615
+#: inc/classes/rest-api/class-analytics.php:845
 msgid "Unexpected error from analytics server."
 msgstr ""
 
-#: inc/classes/rest-api/class-analytics.php:522
+#. translators: %d: WordPress post ID.
+#: inc/classes/rest-api/class-analytics.php:485
+#: pages/analytics/components/Placements/index.js:173
+#: assets/build/pages/analytics.min.js:12119
+msgid "Post #%d"
+msgstr ""
+
+#: inc/classes/rest-api/class-analytics.php:486
+#: inc/classes/rest-api/class-analytics.php:547
+#: pages/analytics/components/Placements/index.js:273
+#: assets/build/pages/analytics.min.js:12219
+msgid "Deleted page"
+msgstr ""
+
+#: inc/classes/rest-api/class-analytics.php:533
 msgid "Unavailable"
 msgstr ""
 
 #. translators: %d: WordPress post ID.
-#: inc/classes/rest-api/class-analytics.php:535
-#, php-format
+#: inc/classes/rest-api/class-analytics.php:546
 msgid "Post #%d (deleted)"
 msgstr ""
 
-#: inc/classes/rest-api/class-analytics.php:726
-#: inc/classes/rest-api/class-analytics.php:883
-#: inc/classes/rest-api/class-analytics.php:947
+#: inc/classes/rest-api/class-analytics.php:737
+#: inc/classes/rest-api/class-analytics.php:894
+#: inc/classes/rest-api/class-analytics.php:958
 msgid "Invalid or unverified API key."
 msgstr ""
 
 #. translators: %s is the error message from the API response.
-#: inc/classes/rest-api/class-analytics.php:754
-#, php-format
+#: inc/classes/rest-api/class-analytics.php:765
 msgid "Error fetching history data: %s"
 msgstr ""
 
@@ -9694,10 +2657,9 @@ msgid "Contact Form 7 plugin is not active."
 msgstr ""
 
 #. translators: %s: video title.
-#: inc/classes/rest-api/class-dynamic-gallery.php:170
-#: inc/templates/godam-video-gallery.php:421
-#: inc/templates/godam-video-gallery.php:487
-#, php-format
+#: inc/classes/rest-api/class-dynamic-gallery.php:179
+#: inc/templates/godam-video-gallery.php:448
+#: inc/templates/godam-video-gallery.php:514
 msgid "Open video: %s"
 msgstr ""
 
@@ -9777,14 +2739,12 @@ msgid "Guest user email saved successfully."
 msgstr ""
 
 #. translators: 1: Parameter.
-#: inc/classes/rest-api/class-engagement.php:957
-#, php-format
+#: inc/classes/rest-api/class-engagement.php:968
 msgid "%1$s is invalid."
 msgstr ""
 
 #. translators: 1: Parameter.
-#: inc/classes/rest-api/class-engagement.php:967
-#, php-format
+#: inc/classes/rest-api/class-engagement.php:978
 msgid "%1$s is empty."
 msgstr ""
 
@@ -9891,7 +2851,6 @@ msgstr ""
 
 #. translators: %s is the field label.
 #: inc/classes/rest-api/class-jetpack.php:711
-#, php-format
 msgid "Valid %s is required."
 msgstr ""
 
@@ -9905,329 +2864,362 @@ msgstr ""
 
 #. translators: %d is the number of errors, %s is the error text, %s is the list of errors.
 #: inc/classes/rest-api/class-jetpack.php:722
-#, php-format
 msgid "Please make sure all fields are valid. You need to fix %1$d %2$s:<br>%3$s"
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:50
+#: inc/classes/rest-api/class-media-library.php:88
+#: inc/classes/rest-api/class-media-library.php:891
+msgid "This folder is locked and cannot be modified."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:100
+msgid "The destination folder is locked and cannot be modified."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:191
 msgid "Array of attachment IDs to associate."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:55
+#: inc/classes/rest-api/class-media-library.php:196
 msgid "ID of the folder term to associate with the attachments."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:73
+#: inc/classes/rest-api/class-media-library.php:214
 msgid "Attachment ID to get EXIF data for."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:91
+#: inc/classes/rest-api/class-media-library.php:232
 msgid "Attachment ID to set video thumbnail for."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:96
+#: inc/classes/rest-api/class-media-library.php:237
 msgid "Attachment URL to set as the thumbnail."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:101
+#: inc/classes/rest-api/class-media-library.php:242
 msgid "Placeholder (low-quality blur-up) thumbnail URL for this thumbnail."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:119
-#: inc/classes/rest-api/class-media-library.php:137
-#: inc/classes/rest-api/class-media-library.php:160
+#: inc/classes/rest-api/class-media-library.php:260
+#: inc/classes/rest-api/class-media-library.php:278
+#: inc/classes/rest-api/class-media-library.php:301
 msgid "Attachment ID to get video thumbnail for."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:142
+#: inc/classes/rest-api/class-media-library.php:283
 msgid "URL of custom thumbnail."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:165
+#: inc/classes/rest-api/class-media-library.php:306
 msgid "Attachment URL of custom thumbnail."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:183
+#: inc/classes/rest-api/class-media-library.php:327
 msgid "ID of the folder to create a ZIP file for."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:202
+#: inc/classes/rest-api/class-media-library.php:345
+msgid "ID of the ZIP build job to poll."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:364
 msgid "Array of folder IDs to delete."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:221
+#: inc/classes/rest-api/class-media-library.php:383
 msgid "Array of folder IDs to update lock status for."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:226
+#: inc/classes/rest-api/class-media-library.php:388
 msgid "The desired lock status (true for locked, false for unlocked)."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:245
+#: inc/classes/rest-api/class-media-library.php:407
 msgid "Array of folder IDs to update bookmark status for."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:250
+#: inc/classes/rest-api/class-media-library.php:412
 msgid "The desired bookmark status (true for bookmarked, false for unbookmarked)."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:347
-#: inc/classes/rest-api/class-media-library.php:566
+#: inc/classes/rest-api/class-media-library.php:509
+#: inc/classes/rest-api/class-media-library.php:762
 msgid "Invalid event."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:575
+#: inc/classes/rest-api/class-media-library.php:771
 msgid "job_id and resized_images are required."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:581
+#: inc/classes/rest-api/class-media-library.php:777
 msgid "Failed to update attachment metadata."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:587
+#: inc/classes/rest-api/class-media-library.php:783
 msgid "Image subsizes successfully generated."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:609
+#: inc/classes/rest-api/class-media-library.php:805
+msgid "No attachment IDs provided."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:833
+msgid "You are not allowed to modify one or more of these attachments."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:854
+msgid "One or more attachments belong to a locked folder and cannot be moved."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:869
 msgid "Failed to remove folder from the attachments."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:616
+#: inc/classes/rest-api/class-media-library.php:876
 msgid "Attachments successfully removed from the folder."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:624
-#: inc/classes/rest-api/class-media-library.php:1141
+#: inc/classes/rest-api/class-media-library.php:884
+#: inc/classes/rest-api/class-media-library.php:1527
+#: inc/classes/rest-api/class-media-library.php:1610
 msgid "Invalid folder term ID."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:635
+#: inc/classes/rest-api/class-media-library.php:900
 msgid "Failed to associate attachments with the folder."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:642
+#: inc/classes/rest-api/class-media-library.php:907
 msgid "Attachments successfully associated with the folder."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:657
+#: inc/classes/rest-api/class-media-library.php:922
 msgid "Invalid taxonomy."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:685
+#: inc/classes/rest-api/class-media-library.php:959
 msgid "Image file not found."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:692
+#: inc/classes/rest-api/class-media-library.php:966
 msgid "No EXIF data found."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:758
-#: inc/classes/rest-api/class-media-library.php:959
-#: inc/classes/rest-api/class-media-library.php:1016
-#: inc/classes/rest-api/class-media-library.php:1076
+#: inc/classes/rest-api/class-media-library.php:1059
+#: inc/classes/rest-api/class-media-library.php:1288
+#: inc/classes/rest-api/class-media-library.php:1373
+#: inc/classes/rest-api/class-media-library.php:1462
 msgid "Attachment is not a video."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:791
+#: inc/classes/rest-api/class-media-library.php:1092
 msgid "Failed to fetch thumbnails from GoDAM."
 msgstr ""
 
 #. translators: %s is the HTTP status code from the GoDAM API response.
-#: inc/classes/rest-api/class-media-library.php:797
-#: inc/classes/rest-api/class-media-library.php:1504
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1098
+#: inc/classes/rest-api/class-media-library.php:2080
 msgid "GoDAM API returned HTTP status: %s"
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:802
+#: inc/classes/rest-api/class-media-library.php:1103
 msgid "Invalid JSON response from GoDAM API."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:810
-#: inc/classes/rest-api/class-media-library.php:851
+#: inc/classes/rest-api/class-media-library.php:1111
+#: inc/classes/rest-api/class-media-library.php:1152
 msgid "No thumbnails found."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:973
+#: inc/classes/rest-api/class-media-library.php:1302
 msgid "Only 3 custom thumbnails are allowed per video."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1025
+#: inc/classes/rest-api/class-media-library.php:1382
 msgid "Custom thumbnail not found."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1037
-#: inc/classes/rest-api/class-media-library.php:1054
+#: inc/classes/rest-api/class-media-library.php:1394
+#: inc/classes/rest-api/class-media-library.php:1411
 msgid "Custom video thumbnail removed successfully."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1081
+#: inc/classes/rest-api/class-media-library.php:1467
 msgid "Invalid thumbnail URL."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1086
+#: inc/classes/rest-api/class-media-library.php:1472
 msgid "Invalid placeholder thumbnail URL."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1115
+#: inc/classes/rest-api/class-media-library.php:1501
 msgid "Video thumbnail successfully set."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1134
+#: inc/classes/rest-api/class-media-library.php:1520
 msgid "Invalid folder ID."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1153
+#: inc/classes/rest-api/class-media-library.php:1565
+#: pages/media-library/components/context-menu/ContextMenu.jsx:210
+#: assets/build/pages/media-library.min.js:6106
+msgid "Preparing ZIP file…"
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:1627
+#: pages/media-library/components/context-menu/ContextMenu.jsx:237
+#: assets/build/pages/media-library.min.js:6133
 msgid "ZIP file created successfully."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1173
+#: inc/classes/rest-api/class-media-library.php:1645
+msgid "Unknown or expired download job."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:1651
+msgid "You are not allowed to access this download job."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:1681
 msgid "You do not have permission to delete folders."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1179
-#: inc/classes/rest-api/class-media-library.php:1306
-#: inc/classes/rest-api/class-media-library.php:1364
+#: inc/classes/rest-api/class-media-library.php:1687
+#: inc/classes/rest-api/class-media-library.php:1876
+#: inc/classes/rest-api/class-media-library.php:1934
 msgid "No folder IDs provided or invalid format."
 msgstr ""
 
+#: inc/classes/rest-api/class-media-library.php:1696
+msgid "One or more selected folders are locked and cannot be deleted."
+msgstr ""
+
 #. translators: %s is the invalid folder ID.
-#: inc/classes/rest-api/class-media-library.php:1188
-#: inc/classes/rest-api/class-media-library.php:1257
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1708
+#: inc/classes/rest-api/class-media-library.php:1814
 msgid "Invalid folder ID: %s"
 msgstr ""
 
 #. translators: %s is the invalid folder ID.
-#: inc/classes/rest-api/class-media-library.php:1196
-#: inc/classes/rest-api/class-media-library.php:1265
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1716
+#: inc/classes/rest-api/class-media-library.php:1822
 msgid "Folder ID %s not found or invalid."
 msgstr ""
 
 #. translators: %s is the invalid folder ID where delete failed.
-#: inc/classes/rest-api/class-media-library.php:1204
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1724
 msgid "Failed to delete folder %s"
 msgstr ""
 
 #. translators: %s is the ID of folder not found.
-#: inc/classes/rest-api/class-media-library.php:1207
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1727
 msgid "Folder ID %s not found during deletion attempt."
 msgstr ""
 
 #. translators: %s is the invalid folder ID.
-#: inc/classes/rest-api/class-media-library.php:1210
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1730
 msgid "Folder ID %s cannot be deleted (possibly uncategorized or default term)."
 msgstr ""
 
 #. translators: %d is the number of folders deleted.
-#: inc/classes/rest-api/class-media-library.php:1221
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1741
 msgid "%d folder(s) deleted successfully."
 msgstr ""
 
 #. translators: %1$d is the number of folders deleted, %2$s are the errors.
-#: inc/classes/rest-api/class-media-library.php:1229
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1749
 msgid "Error deleting some folders. Deleted: %1$d. Errors: %2$s"
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1236
+#: inc/classes/rest-api/class-media-library.php:1756
 msgid "No folders were deleted."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1299
+#. translators: %s is the folder ID whose meta update failed.
+#: inc/classes/rest-api/class-media-library.php:1842
+msgid "Failed to update folder %s."
+msgstr ""
+
+#: inc/classes/rest-api/class-media-library.php:1869
 msgid "You do not have permission to lock or unlock folders."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1318
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1888
 msgid "%d folder(s) locked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1320
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1890
 msgid "%d folder(s) unlocked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1334
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1904
 msgid "Some folders locked, but issues occurred with others. Locked: %d."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1336
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1906
 msgid "Some folders unlocked, but issues occurred with others. Unlocked: %d."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1347
+#: inc/classes/rest-api/class-media-library.php:1917
 msgid "No folders were updated for lock status."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1376
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1946
 msgid "%d folder(s) bookmarked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1378
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1948
 msgid "%d folder(s) unbookmarked successfully."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1392
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1962
 msgid "Some folders bookmarked, but issues occurred with others. Bookmarked: %d."
 msgstr ""
 
 #. translators: %d number of folders.
-#: inc/classes/rest-api/class-media-library.php:1394
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:1964
 msgid "Some folders unbookmarked, but issues occurred with others. Unbookmarked: %d."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1405
+#: inc/classes/rest-api/class-media-library.php:1975
 msgid "No folders were updated for bookmark status."
 msgstr ""
 
 #. translators: %s is the error message from the GoDAM API request.
-#: inc/classes/rest-api/class-media-library.php:1489
-#, php-format
+#: inc/classes/rest-api/class-media-library.php:2065
 msgid "GoDAM API request failed: %s"
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1517
+#: inc/classes/rest-api/class-media-library.php:2093
 msgid "Unexpected API response format."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1550
+#: inc/classes/rest-api/class-media-library.php:2126
 msgid "Filtered GoDAM files by MIME type."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1580
+#: inc/classes/rest-api/class-media-library.php:2156
 msgid "Required fields are missing."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1588
-#: inc/classes/rest-api/class-media-library.php:1595
-#: inc/classes/rest-api/class-media-library.php:1604
+#: inc/classes/rest-api/class-media-library.php:2164
+#: inc/classes/rest-api/class-media-library.php:2171
+#: inc/classes/rest-api/class-media-library.php:2183
 msgid "Invalid or disallowed MIME type."
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1627
+#: inc/classes/rest-api/class-media-library.php:2218
 msgid "Attachment ready"
 msgstr ""
 
-#: inc/classes/rest-api/class-media-library.php:1890
+#: inc/classes/rest-api/class-media-library.php:2542
 msgid "A Folder ID is required"
 msgstr ""
 
@@ -10282,7 +3274,7 @@ msgstr ""
 
 #: inc/classes/rest-api/class-settings.php:172
 #: inc/classes/rest-api/class-settings.php:179
-#: inc/classes/rest-api/class-video-migration.php:1123
+#: inc/classes/rest-api/class-video-migration.php:1189
 msgid "GoDAM API key is required."
 msgstr ""
 
@@ -10319,127 +3311,128 @@ msgstr ""
 msgid "No Sureforms on the site. Please create one"
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:44
+#: inc/classes/rest-api/class-transcoding.php:102
 msgid "The jobID of transcoding job."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:50
+#: inc/classes/rest-api/class-transcoding.php:108
 msgid "The status of the transcoding job."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:56
+#: inc/classes/rest-api/class-transcoding.php:114
 msgid "The progress of the transcoding job."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:62
+#: inc/classes/rest-api/class-transcoding.php:120
 msgid "The error message of the transcoding job."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:68
+#: inc/classes/rest-api/class-transcoding.php:126
 msgid "The error code of the transcoding job."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:90
+#: inc/classes/rest-api/class-transcoding.php:148
 msgid "The array of attachment IDs."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:133
+#: inc/classes/rest-api/class-transcoding.php:171
+msgid "The type of media to fetch for transcoding."
+msgstr ""
+
+#: inc/classes/rest-api/class-transcoding.php:205
 msgid "The comma-separated string of attachment IDs to check."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:160
+#: inc/classes/rest-api/class-transcoding.php:247
 msgid "Attachment not found."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:178
+#: inc/classes/rest-api/class-transcoding.php:266
 msgid "Transcoding status updated successfully."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:234
+#: inc/classes/rest-api/class-transcoding.php:334
 msgid "Media has not been transcoded."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:241
+#: inc/classes/rest-api/class-transcoding.php:341
 msgid "Transcoding has not started."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:250
+#: inc/classes/rest-api/class-transcoding.php:350
 msgid "Media is queued for transcoding."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:251
+#: inc/classes/rest-api/class-transcoding.php:351
 msgid "Media is downloading for transcoding."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:252
+#: inc/classes/rest-api/class-transcoding.php:352
 msgid "Media is downloaded for transcoding."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:253
+#: inc/classes/rest-api/class-transcoding.php:353
 msgid "Media is transcoding."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:258
+#: inc/classes/rest-api/class-transcoding.php:358
 msgid "Unknown transcoding status."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:276
+#: inc/classes/rest-api/class-transcoding.php:376
 msgid "Transcoding complete, generating thumbnail..."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:338
+#: inc/classes/rest-api/class-transcoding.php:441
 msgid "API key not configured."
 msgstr ""
 
 #. translators: %s is the storage usage percentage.
-#: inc/classes/rest-api/class-transcoding.php:369
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:527
 msgid "Storage limit exceeded (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcoding.php:506
+#: inc/classes/rest-api/class-transcoding.php:755
 msgid "Attachment ID not provided"
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
-#: inc/classes/rest-api/class-transcoding.php:518
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:799
 msgid "%1$s (ID %2$d) transcoding request failed. Transcoding requests are not allowed in the localhost environment."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
-#: inc/classes/rest-api/class-transcoding.php:538
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:819
 msgid "%1$s (ID %2$d) is virtual media from GoDAM Central. Please retranscode this media on GoDAM Central."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
-#: inc/classes/rest-api/class-transcoding.php:558
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:839
 msgid "%1$s (ID %2$d) is migrated Vimeo video. Please retranscode this video on GoDAM Central."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID, 3: storage usage percent.
-#: inc/classes/rest-api/class-transcoding.php:581
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:862
 msgid "%1$s (ID %2$d) cannot be retranscoded. Storage limit exceeded (%3$s%%). Please upgrade your plan to continue transcoding."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
-#: inc/classes/rest-api/class-transcoding.php:602
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:883
 msgid "%1$s (ID %2$d) cannot be transcoded. HTTP authentication is enabled on your site. Please disable it to allow transcoding."
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
-#: inc/classes/rest-api/class-transcoding.php:652
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:920
+msgid "%1$s (ID %2$d) is not a document format GoDAM can convert, so it was skipped."
+msgstr ""
+
+#. translators: 1: Attachment title, 2: Attachment ID.
+#: inc/classes/rest-api/class-transcoding.php:963
 msgid "%1$s (ID %2$d) transcoding request failed. Unknown error"
 msgstr ""
 
 #. translators: 1: Attachment title, 2: Attachment ID.
-#: inc/classes/rest-api/class-transcoding.php:668
-#, php-format
+#: inc/classes/rest-api/class-transcoding.php:979
 msgid "%1$s (ID %2$d) transcoding request was sent successfully"
 msgstr ""
 
@@ -10451,19 +3444,19 @@ msgstr ""
 msgid "URL of the uploaded .vtt / .srt caption file."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcription.php:169
+#: inc/classes/rest-api/class-transcription.php:203
 msgid "This video has not been transcoded yet, so it cannot be transcribed."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcription.php:178
+#: inc/classes/rest-api/class-transcription.php:212
 msgid "Connect your GoDAM account to generate transcriptions."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcription.php:197
+#: inc/classes/rest-api/class-transcription.php:231
 msgid "Could not reach the transcription service. Please try again."
 msgstr ""
 
-#: inc/classes/rest-api/class-transcription.php:251
+#: inc/classes/rest-api/class-transcription.php:295
 msgid "Only .vtt or .srt caption files are supported."
 msgstr ""
 
@@ -10501,7 +3494,7 @@ msgstr ""
 
 #: inc/classes/rest-api/class-video-migration.php:92
 #: inc/classes/rest-api/class-video-migration.php:210
-#: inc/classes/rest-api/class-video-migration.php:1226
+#: inc/classes/rest-api/class-video-migration.php:1305
 msgid "Invalid migration type specified."
 msgstr ""
 
@@ -10515,7 +3508,6 @@ msgstr ""
 
 #. translators: %1$d is the number of posts processed, %2$d is the total number of posts to process and %3$d is the migration name
 #: inc/classes/rest-api/class-video-migration.php:123
-#, php-format
 msgid "Processed %1$d of %2$d posts. %3$s aborted."
 msgstr ""
 
@@ -10541,7 +3533,6 @@ msgstr ""
 
 #. translators: %d is the number of batches scheduled for processing
 #: inc/classes/rest-api/class-video-migration.php:414
-#, php-format
 msgid "Scheduled %d batches for processing"
 msgstr ""
 
@@ -10551,33 +3542,29 @@ msgstr ""
 
 #. translators: %1$d is the number of posts processed, %2$d is the total number of posts, %3$d is the progress percentage
 #: inc/classes/rest-api/class-video-migration.php:541
-#, php-format
 msgid "Processed %1$d/%2$d posts (%3$d%% complete)"
 msgstr ""
 
 #. translators: 1: total posts processed, 2: migrated Vimeo embeds, 3: total Vimeo embeds found
 #: inc/classes/rest-api/class-video-migration.php:554
-#, php-format
 msgid "Migration completed! Processed %1$d posts. Migrated %2$d out of %3$d Vimeo Embed Blocks found."
 msgstr ""
 
 #. translators: %d is the total number of posts processed
 #: inc/classes/rest-api/class-video-migration.php:562
-#, php-format
 msgid "Migration completed! Processed %d posts."
 msgstr ""
 
-#: inc/classes/rest-api/class-video-migration.php:1114
+#: inc/classes/rest-api/class-video-migration.php:1180
 msgid "Vimeo URL is required."
 msgstr ""
 
 #. translators: %s: error message
-#: inc/classes/rest-api/class-video-migration.php:1153
-#, php-format
+#: inc/classes/rest-api/class-video-migration.php:1219
 msgid "Error fetching video info: %s"
 msgstr ""
 
-#: inc/classes/rest-api/class-video-migration.php:1165
+#: inc/classes/rest-api/class-video-migration.php:1231
 msgid "Invalid response from GoDAM Central."
 msgstr ""
 
@@ -10612,8 +3599,8 @@ msgstr ""
 msgid "WPForms plugin is not active."
 msgstr ""
 
-#: inc/classes/shortcodes/class-godam-document.php:75
-msgid "Only PDF files are supported. This file will not be shown on your page."
+#: inc/classes/shortcodes/class-godam-document.php:86
+msgid "That file type is not supported. This file will not be shown on your page."
 msgstr ""
 
 #: inc/classes/sureforms/class-form-submit.php:141
@@ -10687,7 +3674,7 @@ msgid "Enter the audio attachment ID from WordPress Media Library."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:86
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:86
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:120
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:86
 msgid "Source URL"
 msgstr ""
@@ -10702,17 +3689,18 @@ msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:146
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:162
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:164
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:198
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:80
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:96
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:112
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:129
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:222
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:243
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:263
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:144
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:241
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:262
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:282
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:320
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:364
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:301
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:339
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:383
 msgid "No"
 msgstr ""
 
@@ -10720,7 +3708,7 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:163
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:197
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:210
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:165
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:199
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:103
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:283
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:304
@@ -10730,17 +3718,24 @@ msgstr ""
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:97
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:113
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:128
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:223
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:244
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:262
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:145
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:242
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:263
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:281
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:321
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:363
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:300
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:340
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:382
 msgid "Yes"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:166
 msgid "Loop the audio playback continuously."
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:178
+#: assets/build/blocks/godam-audio/index.js:927
+#: assets/build/blocks/godam-audio/index.js:779
+msgid "Browser default"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:184
@@ -10749,59 +3744,78 @@ msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:222
 #: inc/classes/wpbakery-elements/class-wpb-godam-audio.php:224
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:209
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:211
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:243
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:245
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:116
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:118
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:362
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:364
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:309
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:311
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:328
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:330
 msgid "Design Options"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:69
-msgid "Embed a PDF document from GoDAM Media Library"
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:100
+#: assets/build/blocks/godam-pdf/index.js:722
+#: assets/build/blocks/godam-pdf/index.js:876
+#: assets/build/blocks/godam-pdf/index.js:953
+#: pages/tools/components/tabs/RetranscodeTab.jsx:37
+#: assets/build/blocks/godam-pdf/index.js:663
+#: assets/build/blocks/godam-pdf/index.js:827
+#: assets/build/blocks/godam-pdf/index.js:899
+#: assets/build/js/wpbakery-document-selector-param.min.js:281
+#: assets/build/pages/tools.min.js:2633
+msgid "Document"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:78
-msgid "Select a PDF document from the WordPress Media Library."
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:103
+msgid "Embed a document from the GoDAM Media Library"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:90
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:112
+msgid "Select a PDF, Word, Excel, PowerPoint, OpenDocument, TXT or CSV file from the WordPress Media Library."
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:124
 msgid "The source URL for the document file."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:104
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:138
 msgid "Add a title for the document. Leave empty to use the attachment title."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:118
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:152
 msgid "Add a document description (shown in card view)."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:136
-msgid "Choose how the document is displayed: an embedded PDF viewer or a card with a cover image."
-msgstr ""
-
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:150
-msgid "Height of the embedded PDF viewer in pixels."
-msgstr ""
-
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:168
-msgid "Show a cover image on the document card."
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:170
+msgid "Choose how the document is displayed: an embedded viewer or a card with a cover image."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-document.php:184
+msgid "Height of the embedded viewer in pixels."
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:202
+msgid "Show a cover image on the document card."
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:218
 msgid "Leave on the auto-generated cover, or select a custom image. Recommended aspect ratio: 16:9."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:198
+#: inc/classes/wpbakery-elements/class-wpb-godam-document.php:232
 msgid "Add a caption for the document."
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:69
 msgid "Image with interactive GoDAM hotspot & product layers"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-image.php:75
+#: pages/video-editor/components/cta/CardCTA.js:357
+#: assets/build/pages/video-editor.min.js:21022
+msgid "Select Image"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-image.php:78
@@ -10820,8 +3834,48 @@ msgstr ""
 msgid "Display the authored hotspot & product layers over the image."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:141
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:102
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:149
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:196
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:230
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:310
+#: assets/build/blocks/godam-audio/index.js:846
+#: assets/build/blocks/godam-gallery-v2-item/index.js:330
+#: assets/build/blocks/godam-gallery-v2-item/index.js:371
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:112
+#: assets/build/blocks/godam-audio/index.js:687
+#: assets/build/blocks/godam-gallery-v2-item/index.js:243
+#: assets/build/blocks/godam-gallery-v2-item/index.js:288
+#: assets/build/js/wpbakery-document-selector-param.min.js:279
+#: assets/build/js/wpbakery-image-selector-param.min.js:49
+#: assets/build/js/wpbakery-video-selector-param.min.js:260
+#: assets/build/js/wpbakery-video-selector-param.min.js:510
+#: assets/build/pages/godam.min.js:11354
+msgid "Replace"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:102
+#: pages/analytics/index.js:37
+#: assets/build/js/wpbakery-video-selector-param.min.js:305
+#: assets/build/pages/analytics.min.js:103067
+msgid "Select video"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:149
 msgid "Select audio"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:196
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:291
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:310
+#: assets/build/js/wpbakery-image-selector-param.min.js:30
+#: assets/build/js/wpbakery-image-selector-param.min.js:107
+msgid "Select image"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-params.php:230
+#: assets/build/js/wpbakery-document-selector-param.min.js:341
+msgid "Select document"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:94
@@ -10900,8 +3954,23 @@ msgstr ""
 msgid "How additional items appear once the initial set is shown."
 msgstr ""
 
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:349
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:238
+#: assets/build/blocks/godam-gallery-v2/index.js:6361
+#: assets/build/blocks/godam-player/index.js:10416
+#: assets/build/blocks/godam-gallery-v2/index.js:6283
+#: assets/build/blocks/godam-player/index.js:9842
+msgid "Enable Likes & Comments"
+msgstr ""
+
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:353
 msgid "Engagement layers only render for transcoded videos."
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:369
+#: pages/analytics/components/Placements/index.js:33
+#: assets/build/pages/analytics.min.js:11979
+msgid "Video Gallery"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:372
@@ -10914,12 +3983,18 @@ msgstr ""
 
 #. translators: 1: taxonomy term name, 2: term ID.
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:411
-#, php-format
 msgid "%1$s (#%2$d)"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video-gallery.php:434
 msgid "All authors"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:66
+#: assets/build/blocks/godam-gallery-v2-item/index.js:392
+#: assets/build/blocks/godam-gallery-v2-item/index.js:313
+#: assets/build/js/wpbakery-video-selector-param.min.js:251
+msgid "Select Video"
 msgstr ""
 
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:69
@@ -10934,76 +4009,98 @@ msgstr ""
 msgid "Mute the video by default."
 msgstr ""
 
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:125
+#: assets/build/blocks/godam-player/index.js:11444
+#: assets/build/blocks/godam-player/index.js:10904
+msgid "Playback Controls"
+msgstr ""
+
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:132
 msgid "Show video playback controls."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:148
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:141
+msgid "Show in Lightbox"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:164
 msgid "Select the performance mode for the video."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:161
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:177
 msgid "Select a custom thumbnail image for the video."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:240
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:194
+msgid "Choose the action to perform on video hover. Ignored when Show in Lightbox is on."
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:245
+#: assets/build/blocks/godam-gallery-v2/index.js:6366
+#: assets/build/blocks/godam-player/index.js:10419
+#: assets/build/blocks/godam-gallery-v2/index.js:6286
+#: assets/build/blocks/godam-player/index.js:9845
+msgid "Engagement will only be visible for transcoded videos"
+msgstr ""
+
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:259
 msgid "Share Button"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:247
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:266
 msgid "Show share button in the video player."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:261
 #: inc/classes/wpbakery-elements/class-wpb-godam-video.php:280
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:299
 msgid "Default (from media)"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:266
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:285
 msgid "Show the transcript button/panel. \"Default\" follows the media/block setting."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:277
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:296
 msgid "Show Caption"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:285
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:304
 msgid "Show the subtitles/captions button. \"Default\" follows the media caption setting."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:296
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:315
 msgid "Video Caption"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:299
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:318
 msgid "Add a caption for the video."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:317
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:336
 msgid "Override SEO"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:324
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:343
 msgid "When disabled, SEO data is automatically synced from the media library. Enable to override with custom values."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:337
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:356
 msgid "Title of the video for SEO."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:350
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:369
 msgid "Description of the video for SEO. It is recommended to add a description for better video SEO."
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:360
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:379
 msgid "Family Friendly"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:367
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:386
 msgid "Is this video family friendly?"
 msgstr ""
 
-#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:383
+#: inc/classes/wpbakery-elements/class-wpb-godam-video.php:402
 msgid "Embed video from GoDAM Media Library"
 msgstr ""
 
@@ -11021,39 +4118,38 @@ msgstr ""
 
 #. translators: %s : Maximum file upload size in human readable format.
 #: inc/classes/wpforms/class-wpforms-field-godam-video.php:266
-#, php-format
 msgid "Maximum allowed on this server: %s "
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:608
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:619
 msgid "There is no error, the file uploaded with success"
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:609
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:620
 msgid "The uploaded file exceeds the upload_max_filesize directive in php.ini"
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:610
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:621
 msgid "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form"
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:611
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:622
 msgid "The uploaded file was only partially uploaded"
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:612
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:623
 msgid "No file was uploaded"
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:613
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:624
 msgid "Missing a temporary folder"
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:614
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:625
 msgid "Failed to write file to disk."
 msgstr ""
 
-#: inc/classes/wpforms/class-wpforms-field-godam-video.php:615
+#: inc/classes/wpforms/class-wpforms-field-godam-video.php:626
 msgid "A PHP extension stopped the file upload."
 msgstr ""
 
@@ -11068,13 +4164,11 @@ msgstr ""
 
 #. translators: %s: Content type (Audio or Video)
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:50
-#, php-format
 msgid "%s transcoding process has not started."
 msgstr ""
 
 #. translators: %s: Content type (Audio or Video)
 #: inc/classes/wpforms/wpforms-field-godam-record-entry-view.php:57
-#, php-format
 msgid "%s saved and transcoded successfully on GoDAM"
 msgstr ""
 
@@ -11086,199 +4180,2304 @@ msgstr ""
 msgid "Video transcoding process is in-progress."
 msgstr ""
 
-#: inc/helpers/custom-functions.php:228
+#: inc/helpers/custom-functions.php:221
+#: pages/video-editor/components/cta/CardCTA.js:460
+#: pages/video-editor/components/layers/CTALayer.js:129
+#: assets/build/pages/video-editor.min.js:21125
+#: assets/build/pages/video-editor.min.js:23836
+msgid "Check now"
+msgstr ""
+
+#: inc/helpers/custom-functions.php:239
 msgid "CTA Card Image"
 msgstr ""
 
+#: inc/helpers/custom-functions.php:246
+#: pages/video-editor/components/layers/CTALayer.js:108
+#: assets/build/pages/video-editor.min.js:23815
+msgid "No Image"
+msgstr ""
+
 #. translators: %s: storage usage percentage
-#: inc/helpers/custom-functions.php:429
-#, php-format
+#: inc/helpers/custom-functions.php:440
 msgid "Storage limit exceeded (%s%%). Please upgrade your plan to continue."
 msgstr ""
 
 #. translators: %s: bandwidth usage percentage
-#: inc/helpers/custom-functions.php:438
-#, php-format
+#: inc/helpers/custom-functions.php:449
 msgid "Bandwidth limit exceeded (%s%%). Please upgrade your plan to continue."
 msgstr ""
 
-#: inc/helpers/custom-functions.php:506
+#: inc/helpers/custom-functions.php:517
 msgid "API key not found ( try refreshing the page )"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:540
+#: inc/helpers/custom-functions.php:551
 msgid "Error fetching data for storage and bandwidth ( remove and add again the API key to get usage analytics )"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:798
+#: inc/helpers/custom-functions.php:1150
 msgid "Form transcoding has been disabled by the site administrator."
 msgstr ""
 
 #. translators: %s: Entry ID for which transcoding failed
-#: inc/helpers/custom-functions.php:939
-#, php-format
+#: inc/helpers/custom-functions.php:1290
 msgid "Transcoding failed | entry Id: %s"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:975
+#: inc/helpers/custom-functions.php:1326
 msgid "s"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1253
+#: inc/helpers/custom-functions.php:1360
+msgid "Anonymous"
+msgstr ""
+
+#: inc/helpers/custom-functions.php:1643
 msgid "Oops! We could not locate your video"
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1265
+#: inc/helpers/custom-functions.php:1654
 msgid "Note: This is a simple image preview. The image and its layers may display differently when added to a page based on theme styles."
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1267
+#: inc/helpers/custom-functions.php:1656
 msgid "Note: This is a simple audio preview. The player may display differently when added to a page based on theme styles."
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1269
+#: inc/helpers/custom-functions.php:1658
 msgid "Note: This is a simple video preview. The video player may display differently when added to a page based on theme styles."
 msgstr ""
 
-#: inc/helpers/custom-functions.php:1424
+#: inc/helpers/custom-functions.php:1822
 msgid "Video not found"
 msgstr ""
 
+#: inc/templates/godam-video-gallery.php:261
+#: assets/build/blocks/godam-gallery-v2-item/index.js:292
+#: assets/build/blocks/godam-gallery-v2/index.js:6086
+#: pages/analytics/Analytics.js:567
+#: pages/video-editor/VideoEditor.js:651
+#: assets/build/blocks/godam-gallery-v2-item/index.js:205
+#: assets/build/blocks/godam-gallery-v2/index.js:5967
+#: assets/build/pages/analytics.min.js:9731
+#: assets/build/pages/video-editor.min.js:17482
+msgid "Untitled video"
+msgstr ""
+
+#: inc/templates/godam-video-gallery.php:422
+#: assets/build/blocks/godam-gallery-v2/index.js:6591
+#: assets/build/blocks/godam-gallery-v2/index.js:6577
+msgid "No videos found"
+msgstr ""
+
+#: inc/templates/godam-video-gallery.php:423
+#: assets/build/blocks/godam-gallery-v2/index.js:6593
+#: assets/build/blocks/godam-gallery-v2/index.js:6579
+msgid "Try changing the selected folder, author, or dates."
+msgstr ""
+
+#: inc/templates/godam-video-gallery.php:487
+#: inc/templates/godam-video-gallery.php:498
+#: pages/media-library/components/folder-tree/FolderTree.jsx:449
+#: pages/media-library/components/search-bar/SearchBar.jsx:216
+#: assets/build/pages/media-library.min.js:6915
+#: assets/build/pages/media-library.min.js:8071
+msgid "Load More"
+msgstr ""
+
 #. translators: %s: video ID.
-#: inc/templates/video-embed.php:33
+#: inc/templates/video-embed.php:43
 msgid "Video Embed"
 msgstr ""
 
 #. translators: %s: video ID.
-#: inc/templates/video-embed.php:33
-#, php-format
+#: inc/templates/video-embed.php:43
 msgid "Video Embed: Attachment(%s)"
 msgstr ""
 
-#: inc/templates/video-preview.php:26
+#: inc/templates/video-preview.php:34
 msgid "Image Preview"
 msgstr ""
 
-#: inc/templates/video-preview.php:28
+#: inc/templates/video-preview.php:36
 msgid "Audio Preview"
 msgstr ""
 
-#: inc/templates/video-preview.php:30
+#: inc/templates/video-preview.php:38
 msgid "Video Preview"
 msgstr ""
 
 #. translators: 1: media type label (e.g. "Image Preview"), 2: attachment ID.
-#: inc/templates/video-preview.php:41
-#, php-format
+#: inc/templates/video-preview.php:49
 msgid "%1$s: Attachment(%2$s)"
 msgstr ""
 
-#: inc/templates/video-preview.php:104
-msgid "Our Pro Features"
+#: inc/templates/video-preview.php:90
+#: assets/build/js/media-library.min.js:2290
+msgid "Edit Image"
 msgstr ""
 
-#: inc/templates/video-preview.php:108
-msgid "Smart media offloading"
+#: inc/templates/video-preview.php:92
+#: assets/build/js/media-library.min.js:2343
+msgid "Edit Audio"
 msgstr ""
 
-#: inc/templates/video-preview.php:109
-msgid "Global CDN-powered delivery"
-msgstr ""
-
-#: inc/templates/video-preview.php:110
-msgid "Adaptive bitrate video streaming"
-msgstr ""
-
-#: inc/templates/video-preview.php:111
-msgid "Advanced video performance analytics"
+#: inc/templates/video-preview.php:94
+#: assets/build/blocks/godam-player/index.js:11374
+#: assets/build/blocks/godam-player/index.js:10828
+#: assets/build/js/media-library.min.js:2307
+#: assets/build/js/media-library.min.js:2315
+msgid "Edit Video"
 msgstr ""
 
 #: inc/templates/video-preview.php:112
-msgid "Automatic video transcoding"
-msgstr ""
-
-#: inc/templates/video-preview.php:113
-msgid "AI-powered video transcription"
-msgstr ""
-
-#: inc/templates/video-preview.php:114
-msgid "Video watermarking"
-msgstr ""
-
-#: inc/templates/video-preview.php:115
-msgid "Multi-thumbnail generation"
+msgid "Our Pro Features"
 msgstr ""
 
 #: inc/templates/video-preview.php:116
+msgid "Smart media offloading"
+msgstr ""
+
+#: inc/templates/video-preview.php:117
+msgid "Global CDN-powered delivery"
+msgstr ""
+
+#: inc/templates/video-preview.php:118
+msgid "Adaptive bitrate video streaming"
+msgstr ""
+
+#: inc/templates/video-preview.php:119
+msgid "Advanced video performance analytics"
+msgstr ""
+
+#: inc/templates/video-preview.php:120
+msgid "Automatic video transcoding"
+msgstr ""
+
+#: inc/templates/video-preview.php:121
+msgid "AI-powered video transcription"
+msgstr ""
+
+#: inc/templates/video-preview.php:122
+msgid "Video watermarking"
+msgstr ""
+
+#: inc/templates/video-preview.php:123
+msgid "Multi-thumbnail generation"
+msgstr ""
+
+#: inc/templates/video-preview.php:124
 msgid "Unified GoDAM Central media library"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:39
-msgid "Video Captions"
+#: inc/templates/video-preview.php:147
+#: assets/build/blocks/godam-player/index.js:11411
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:310
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:55
+#: assets/build/blocks/godam-player/index.js:10869
+#: assets/build/pages/godam.min.js:11696
+#: assets/build/pages/godam.min.js:12026
+msgid "Upgrade to Pro"
 msgstr ""
 
-#. translators: %s: video caption label.
-#: assets/src/blocks/godam-player/track-uploader.js:53
-#, js-format
+#: assets/build/blocks/godam-audio/index.js:468
+#: assets/build/blocks/godam-audio/index.js:302
+msgid "Only audio files are allowed in the GoDAM Audio block."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:551
+#: assets/build/blocks/godam-audio/index.js:396
+msgid "Only image files are allowed for the GoDAM Audio thumbnail."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:666
+#: assets/build/blocks/godam-audio/index.js:499
+msgid "Add Audio File"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:679
+#: assets/build/blocks/godam-audio/index.js:517
+msgid "Customize Audio"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:696
+#: assets/build/blocks/godam-audio/index.js:965
+#: assets/build/blocks/godam-audio/index.js:534
+#: assets/build/blocks/godam-audio/index.js:810
+msgid "Replace audio file"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:718
+#: assets/build/blocks/godam-audio/index.js:973
+#: assets/build/blocks/godam-audio/index.js:550
+#: assets/build/blocks/godam-audio/index.js:821
+msgid "Remove audio"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:727
+#: assets/build/blocks/godam-audio/index.js:561
+msgid "Add a title…"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:736
+#: assets/build/blocks/godam-audio/index.js:570
+msgid "Add a short description…"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:750
+#: assets/build/blocks/godam-audio/index.js:803
+#: assets/build/blocks/godam-audio/index.js:583
+#: assets/build/blocks/godam-audio/index.js:642
+msgid "Audio Selection"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:765
+#: assets/build/blocks/godam-audio/index.js:594
+msgid "Upload an audio file to embed a player on your page or post."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:779
+#: assets/build/blocks/godam-audio/index.js:609
+msgid "+ Upload Audio"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:813
+#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:126
+#: assets/build/blocks/godam-audio/index.js:650
+#: assets/build/pages/video-editor.min.js:19426
+msgid "Select thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:825
+#: assets/build/blocks/godam-audio/index.js:661
+msgid "Edit or replace the thumbnail."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:830
+#: assets/build/blocks/godam-audio/index.js:667
+msgid "Thumbnail preview"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:846
+#: assets/build/blocks/godam-audio/index.js:687
+msgid "Set thumbnail"
+msgstr ""
+
+#. translators: %s: thumbnail image URL.
+#: assets/build/blocks/godam-audio/index.js:851
+#: assets/build/blocks/godam-audio/index.js:693
+msgid "The current thumbnail url is %s."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:851
+#: assets/build/blocks/godam-audio/index.js:696
+msgid "There is no thumbnail currently selected."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:869
+#: pages/video-editor/components/editor-shell/EditorTabRail.js:20
+#: pages/video-editor/components/transcription/Transcription.js:176
+#: assets/build/blocks/godam-audio/index.js:720
+#: assets/build/pages/video-editor.min.js:21608
+#: assets/build/pages/video-editor.min.js:26295
+msgid "Transcription"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:874
+#: assets/build/blocks/godam-audio/index.js:723
+msgid "Show transcript"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:880
+#: assets/build/blocks/godam-audio/index.js:730
+msgid "Show chapters"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:893
+#: assets/build/blocks/godam-player/index.js:9800
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:553
+#: assets/build/blocks/godam-audio/index.js:746
+#: assets/build/blocks/godam-player/index.js:9261
+#: assets/build/pages/video-editor.min.js:27111
+msgid "Edit"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:919
+#: assets/build/blocks/godam-audio/index.js:772
+msgctxt "noun; Audio block parameter"
+msgid "Preload"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:949
+#: assets/build/blocks/godam-audio/index.js:794
+msgid "The audio file for this block was deleted from the Media Library. Replace it with another file or remove the block."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:1145
+#: assets/build/blocks/godam-audio/view.js:507
+#: pages/video-editor/components/audio/AudioCardPreview.js:200
+#: assets/build/blocks/godam-audio/index.js:940
+#: assets/build/blocks/godam-audio/view.js:452
+#: assets/build/pages/video-editor.min.js:19671
+msgid "Pause"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:1424
+#: assets/build/blocks/godam-audio/view.js:403
+#: pages/video-editor/components/audio/AudioCardPreview.js:304
+#: assets/build/blocks/godam-audio/index.js:1184
+#: assets/build/blocks/godam-audio/view.js:337
+#: assets/build/pages/video-editor.min.js:19775
+msgid "Copied"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/index.js:1424
+#: assets/build/blocks/godam-audio/view.js:392
+#: assets/build/blocks/godam-audio/view.js:408
+#: pages/video-editor/components/audio/AudioCardPreview.js:304
+#: assets/build/blocks/godam-audio/index.js:1184
+#: assets/build/blocks/godam-audio/view.js:326
+#: assets/build/blocks/godam-audio/view.js:342
+#: assets/build/pages/video-editor.min.js:19775
+msgid "Copy transcript"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/index.js:209
+#: assets/build/blocks/godam-gallery-v2/index.js:6000
+#: assets/build/blocks/godam-gallery-v2-item/index.js:120
+#: assets/build/blocks/godam-gallery-v2/index.js:5849
+msgid "Only video files can be added to the gallery."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/index.js:227
+#: assets/build/blocks/godam-gallery-v2-item/index.js:259
+#: assets/build/blocks/godam-gallery-v2-item/index.js:137
+#: assets/build/blocks/godam-gallery-v2-item/index.js:167
+msgid "This video is already in the gallery."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/index.js:452
+#: assets/build/blocks/godam-gallery-v2-item/index.js:372
+msgid "Choose a video to add this gallery item."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:5554
+#: assets/build/blocks/godam-gallery-v2/index.js:5313
+msgid "Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:5555
+#: assets/build/blocks/godam-gallery-v2/index.js:5314
+msgid "For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:5668
+#: pages/media-library/components/folder-tree/FolderTree.jsx:406
+#: pages/media-library/components/folder-tree/FolderTree.jsx:449
+#: pages/video-editor/components/cta/CardCTA.js:369
+#: assets/build/blocks/godam-gallery-v2/index.js:5458
+#: assets/build/pages/media-library.min.js:6872
+#: assets/build/pages/media-library.min.js:6915
+#: assets/build/pages/video-editor.min.js:21034
+msgid "Loading…"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:5793
+#: assets/build/blocks/godam-gallery-v2/index.js:5795
+#: assets/build/blocks/godam-gallery-v2/index.js:5550
+#: assets/build/blocks/godam-gallery-v2/index.js:5552
+msgid "Add New Video"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6006
+#: assets/build/blocks/godam-gallery-v2/index.js:6037
+#: assets/build/blocks/godam-gallery-v2/index.js:5857
+#: assets/build/blocks/godam-gallery-v2/index.js:5896
+msgid "Duplicate videos were skipped."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6107
+#: assets/build/blocks/godam-gallery-v2/index.js:5993
+msgid "Start date cannot be later than end date."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6111
+#: assets/build/blocks/godam-gallery-v2/index.js:5998
+msgid "End date cannot be earlier than start date."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6124
+#: assets/build/blocks/godam-gallery-v2/index.js:6018
+msgid "Source"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6130
+#: assets/build/blocks/godam-gallery-v2/index.js:6025
+msgid "Gallery Source"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6142
+#: assets/build/blocks/godam-gallery-v2/index.js:6036
+msgid "Handpicked"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6145
+#: assets/build/blocks/godam-gallery-v2/index.js:6040
+msgid "Query"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6149
+#: assets/build/blocks/godam-player/index.js:11426
+#: assets/build/blocks/godam-gallery-v2/index.js:6048
+#: assets/build/blocks/godam-player/index.js:10888
+msgid "Video Selection"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6154
+#: assets/build/blocks/godam-gallery-v2/index.js:6053
+msgid "Videos play on mute by default"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6189
+#: assets/build/blocks/godam-gallery-v2/index.js:6564
+#: assets/build/blocks/godam-gallery-v2/index.js:6101
+#: assets/build/blocks/godam-gallery-v2/index.js:6532
+msgid "+ Add Video"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6260
+#: assets/build/blocks/godam-gallery-v2/index.js:6175
+msgid "Item Size"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6266
+#: assets/build/blocks/godam-gallery-v2/index.js:6181
+msgid "Size of each gallery item."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6268
+#: assets/build/blocks/godam-gallery-v2/index.js:6183
+msgid "S"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6271
+#: assets/build/blocks/godam-gallery-v2/index.js:6184
+msgid "M"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6274
+#: assets/build/blocks/godam-gallery-v2/index.js:6185
+msgid "L"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6279
+#: assets/build/blocks/godam-gallery-v2/index.js:6283
+#: assets/build/blocks/godam-gallery-v2/index.js:6190
+#: assets/build/blocks/godam-gallery-v2/index.js:6192
+msgid "Info Display"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6287
+#: assets/build/blocks/godam-gallery-v2/index.js:6197
+msgid "Only Image"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6290
+#: assets/build/blocks/godam-gallery-v2/index.js:6201
+msgid "Show Video Title and Date"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6312
+#: assets/build/blocks/godam-gallery-v2/index.js:6224
+msgid "Visible videos autoplay one at a time and continue through the full video."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6316
+#: assets/build/blocks/godam-gallery-v2/index.js:6229
+msgid "Videos will play when hovered over"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6325
+#: assets/build/blocks/godam-gallery-v2/index.js:6243
+msgid "Show play button"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6331
+#: assets/build/blocks/godam-gallery-v2/index.js:6248
+msgid "Play button overlay is visible on each tile."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6331
+#: assets/build/blocks/godam-gallery-v2/index.js:6249
+msgid "Play button overlay is hidden."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6334
+#: assets/build/blocks/godam-gallery-v2/index.js:6340
+#: assets/build/blocks/godam-player/index.js:11459
+#: pages/analytics/PlaybackPerformance.js:343
+#: assets/build/blocks/godam-gallery-v2/index.js:6255
+#: assets/build/blocks/godam-gallery-v2/index.js:6259
+#: assets/build/blocks/godam-player/index.js:10912
+#: assets/build/pages/analytics.min.js:10467
+#: assets/build/pages/dashboard.min.js:885
+msgid "Performance"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6357
+#: assets/build/blocks/godam-gallery-v2/index.js:6281
+msgid "Engagement"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6369
+#: assets/build/blocks/godam-gallery-v2/index.js:6297
+msgid "Query Settings"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6386
+#: assets/build/blocks/godam-gallery-v2/index.js:6312
+msgid "Order by"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6422
+#: assets/build/blocks/godam-gallery-v2/index.js:6348
+msgid "Search and select media folders"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6430
+#: assets/build/blocks/godam-gallery-v2/index.js:6358
+msgid "Search and select authors"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6472
+#: assets/build/blocks/godam-gallery-v2/index.js:6404
+msgid "Select Start Date"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6495
+#: assets/build/blocks/godam-gallery-v2/index.js:6434
+msgid "Select End Date"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6520
+#: assets/build/blocks/godam-gallery-v2/index.js:6468
+msgid "Load More Button"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6523
+#: assets/build/blocks/godam-gallery-v2/index.js:6472
+msgid "Infinite Scroll"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6527
+#: assets/build/blocks/godam-gallery-v2/index.js:6479
+msgid "Carousel layout always uses Infinite Scroll when more items are enabled."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6527
+#: assets/build/blocks/godam-gallery-v2/index.js:6480
+msgid "Choose how visitors load more videos in query galleries."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6551
+#: assets/build/blocks/godam-gallery-v2/index.js:6518
+msgid "Upload or select videos to add to your gallery."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/index.js:6586
+#: assets/build/blocks/godam-gallery-v2/index.js:6570
+msgid "Loading matching videos…"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/view.js:172
+#: assets/build/blocks/godam-gallery-v2/view.js:178
+#: assets/build/blocks/godam-gallery-v2/view.js:161
+#: assets/build/blocks/godam-gallery-v2/view.js:168
+#: assets/build/js/godam-lightbox.min.js:189
+#: assets/build/js/godam-lightbox.min.js:542
+msgid "Video player"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/view.js:183
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:85
+#: assets/build/blocks/godam-gallery-v2/view.js:174
+#: assets/build/js/godam-lightbox.min.js:195
+#: assets/build/pages/onboarding.min.js:1389
+msgid "Close"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/view.js:189
+#: assets/build/blocks/godam-gallery-v2/view.js:181
+#: assets/build/js/godam-lightbox.min.js:202
+msgid "Previous video"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/view.js:195
+#: assets/build/blocks/godam-gallery-v2/view.js:188
+#: assets/build/js/godam-lightbox.min.js:209
+msgid "Next video"
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:237
+msgid "Only image files are allowed in the GoDAM Image block."
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:313
+#: assets/build/blocks/godam-image/index.js:401
+msgid "Add Image"
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:325
+msgid "Customize Image"
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:338
+#: pages/video-editor/components/cta/CardCTA.js:399
+#: assets/build/pages/video-editor.min.js:21064
+msgid "Remove image"
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:362
+msgid "Add hotspot and product layers to make your image stand out."
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:387
+msgid "Upload or select an image from your media library to get started."
+msgstr ""
+
+#: assets/build/blocks/godam-image/index.js:1677
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:200
+#: pages/video-editor/components/layers/HotspotLayer.js:769
+#: assets/build/pages/video-editor.min.js:23497
+#: assets/build/pages/video-editor.min.js:24911
+msgid "Custom Icon"
+msgstr ""
+
+#. translators: %d: hotspot number
+#. translators: %d is the hotspot index
+#: assets/build/blocks/godam-image/index.js:1718
+#: assets/build/blocks/godam-image/index.js:1724
+#: pages/video-editor/components/layers/HotspotLayer.js:458
+#: assets/build/pages/video-editor.min.js:24600
+msgid "Hotspot %d"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf-viewer.js:312
+#: assets/build/blocks/godam-pdf-viewer.js:305
+msgid "This preview could not be loaded."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf-viewer.js:317
+#: assets/build/blocks/godam-pdf/index.js:1051
+#: assets/build/blocks/godam-pdf/index.js:1080
+#: assets/build/blocks/godam-pdf-viewer.js:311
+#: assets/build/blocks/godam-pdf/index.js:994
+#: assets/build/blocks/godam-pdf/index.js:1024
+msgid "Loading preview…"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf-viewer.js:339
+#: assets/build/blocks/godam-pdf-viewer.js:364
+#: assets/build/blocks/godam-pdf-viewer.js:332
+#: assets/build/blocks/godam-pdf-viewer.js:368
+#: assets/build/js/media-library.min.js:2719
+msgid "Document preview"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:184
+#: assets/build/blocks/godam-pdf/index.js:188
+#: assets/build/blocks/godam-player/index.js:9471
+#: assets/build/blocks/godam-player/index.js:9477
+#: assets/build/blocks/godam-pdf/index.js:107
+#: assets/build/blocks/godam-pdf/index.js:111
+#: assets/build/blocks/godam-player/index.js:8928
+#: assets/build/blocks/godam-player/index.js:8934
+msgid "Add caption"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:189
+#: assets/build/blocks/godam-player/index.js:9478
+#: assets/build/blocks/godam-pdf/index.js:112
+#: assets/build/blocks/godam-player/index.js:8935
+msgid "Remove caption"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:733
+#: assets/build/blocks/godam-pdf/index.js:675
+msgid "That file type is not supported. Choose a PDF, Word, Excel, PowerPoint, OpenDocument, TXT or CSV file."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:883
+#: assets/build/blocks/godam-pdf/index.js:1181
+#: assets/build/blocks/godam-pdf/index.js:834
+#: assets/build/blocks/godam-pdf/index.js:1141
+msgid "Doc Selection"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:887
+#: assets/build/blocks/godam-pdf/index.js:1186
+#: assets/build/blocks/godam-pdf/index.js:836
+#: assets/build/blocks/godam-pdf/index.js:1143
+msgid "Add title, description, and more to make your document stand out."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:901
+#: assets/build/blocks/godam-pdf/index.js:851
+msgid "+ Add Document"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:913
+#: assets/build/blocks/godam-pdf/index.js:862
+msgid "Attach a document here"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:916
+#: assets/build/blocks/godam-pdf/index.js:865
+msgid "Upload a PDF, Word, Excel, PowerPoint, OpenDocument, TXT or CSV file to embed it or display it as a card with a cover image."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:929
+#: assets/build/blocks/godam-pdf/index.js:879
+msgid "+ Upload Document"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:980
+#: assets/build/blocks/godam-pdf/index.js:924
+msgid "Replace this with a PDF, Word, Excel, PowerPoint, OpenDocument, TXT or CSV file; it will not be shown on your page."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:999
+#: assets/build/blocks/godam-pdf/index.js:939
+msgid "Generating preview…"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1002
+#: assets/build/blocks/godam-pdf/index.js:942
+msgid "GoDAM is converting this document so it can be displayed on your page. Until it is ready, visitors are offered the original as a download. Reload this post to check for the finished preview."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1111
+#: assets/build/blocks/godam-pdf/index.js:1062
+msgid "page"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1111
+#: assets/build/blocks/godam-pdf/index.js:1062
+msgid "pages"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1122
+#: assets/build/blocks/godam-pdf/index.js:1074
+msgid "Document cover"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1197
+#: assets/build/blocks/godam-pdf/index.js:1153
+msgid "Remove document"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1217
+#: assets/build/blocks/godam-pdf/index.js:1175
+msgid "Add document description"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1225
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:286
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:291
+#: assets/build/blocks/godam-pdf/index.js:1183
+#: assets/build/pages/video-editor.min.js:21937
+#: assets/build/pages/video-editor.min.js:26849
+msgid "Preview"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1248
+#: assets/build/blocks/godam-pdf/index.js:1207
+msgid "Show cover"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1258
+#: assets/build/blocks/godam-pdf/index.js:1216
+msgid "Cover"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1265
+#: assets/build/blocks/godam-pdf/index.js:1226
+#: assets/build/js/wpbakery-document-cover-selector-param.min.js:118
+msgid "Auto-generated cover"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1269
+#: assets/build/blocks/godam-pdf/index.js:1230
+msgid "Auto-generated"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1315
+#: assets/build/blocks/godam-pdf/index.js:1263
+msgid "Select cover image"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1352
+#: assets/build/blocks/godam-pdf/index.js:1285
+#: assets/build/js/wpbakery-document-cover-selector-param.min.js:103
+msgid "Remove cover"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1396
+#: assets/build/blocks/godam-pdf/index.js:1315
+msgid "+ Add Cover"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1401
+#: assets/build/blocks/godam-pdf/index.js:1321
+msgid "Recommended aspect ratio: 16:9."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/index.js:1406
+#: assets/build/blocks/godam-player/index.js:11308
+#: assets/build/blocks/godam-pdf/index.js:1331
+#: assets/build/blocks/godam-player/index.js:10762
+msgid "Height"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9472
+#: assets/build/blocks/godam-player/index.js:8929
+msgid "Caption text"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9725
+#: assets/build/blocks/godam-player/index.js:9789
+#: assets/build/blocks/godam-player/index.js:9177
+#: assets/build/blocks/godam-player/index.js:9250
+#: assets/build/js/media-library.min.js:1843
+#: assets/build/js/media-library.min.js:1844
+msgid "Upload Custom Thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9733
+#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:158
+#: assets/build/blocks/godam-player/index.js:9184
+#: assets/build/pages/video-editor.min.js:19458
+msgid "Upload custom thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9746
+#: assets/build/blocks/godam-player/index.js:9200
+msgid "Custom uploaded thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9750
+#: assets/build/blocks/godam-player/index.js:9202
+msgid "Select custom thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9754
+#: assets/build/blocks/godam-player/index.js:9205
+msgid "Custom thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9761
+#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:139
+#: assets/build/blocks/godam-player/index.js:9211
+#: assets/build/pages/video-editor.min.js:19439
+msgid "Remove custom thumbnail"
+msgstr ""
+
+#. translators: %s: thumbnail URL
+#: assets/build/blocks/godam-player/index.js:9771
+#: assets/build/blocks/godam-player/index.js:9230
+msgid "Select thumbnail: %s"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9778
+#: assets/build/blocks/godam-player/index.js:9236
+msgid "Auto-generated from video"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:9809
+#: pages/tools/components/tabs/RetranscodeTab.jsx:667
+#: assets/build/blocks/godam-player/index.js:9273
+#: assets/build/pages/tools.min.js:3263
+msgid "Reset"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10043
+#: assets/build/blocks/godam-player/index.js:9487
+msgid "Video SEO Schema"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10053
+#: assets/build/blocks/godam-player/index.js:9499
+msgid "SEO data is customized for this block. Changes to the media library will not affect this block."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10053
+#: assets/build/blocks/godam-player/index.js:9500
+msgid "SEO data is synced from the media library. Enable to customize SEO for this specific block."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10058
+#: assets/build/blocks/godam-player/index.js:9506
+msgid "SEO data is automatically synced from the media library. Any changes made to the video in the media library will be reflected here."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10063
+#: assets/build/blocks/godam-player/index.js:9512
+msgid "You have overridden the default SEO. Changes to this video in the media library will not update the SEO for this block."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10070
+#: assets/build/blocks/godam-player/index.js:9519
+msgid "Reset to media library defaults"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10082
+#: assets/build/blocks/godam-player/index.js:9535
+msgid "Headline *"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10092
+#: assets/build/blocks/godam-player/index.js:9547
+#: assets/build/js/godam-elementor-frontend.min.js:468
+msgid "It is recommended to add a description for better video SEO."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10092
+#: assets/build/blocks/godam-player/index.js:9548
+#: assets/build/js/godam-elementor-frontend.min.js:471
+msgid "Description of the video"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10097
+#: assets/build/blocks/godam-player/index.js:9555
+msgid "ISO 8601 datetime format. Example: 2024–01–15T10:30:00+00:00"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10113
+#: assets/build/blocks/godam-player/index.js:9573
+msgid "URL of the video thumbnail. Example: https://www.example.com/thumbnail.jpg"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10132
+#: pages/godam/components/ConfirmModal.jsx:38
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:191
+#: pages/media-library/App.js:178
+#: pages/media-library/components/modal/DeleteModal.jsx:139
+#: pages/media-library/components/modal/FolderCreationModal.jsx:132
+#: pages/media-library/components/modal/RenameModal.jsx:104
+#: pages/video-editor/components/chapters/ChapterForm.js:124
+#: pages/video-editor/components/layers/LayersHeader.js:105
+#: pages/video-editor/components/transcription/Transcription.js:295
+#: assets/build/blocks/godam-player/index.js:9587
+#: assets/build/js/deactivation-feedback.min.js:92
+#: assets/build/pages/godam.min.js:10162
+#: assets/build/pages/godam.min.js:12888
+#: assets/build/pages/media-library.min.js:5829
+#: assets/build/pages/media-library.min.js:7582
+#: assets/build/pages/media-library.min.js:7725
+#: assets/build/pages/media-library.min.js:7840
+#: assets/build/pages/video-editor.min.js:15790
+#: assets/build/pages/video-editor.min.js:19930
+#: assets/build/pages/video-editor.min.js:25218
+#: assets/build/pages/video-editor.min.js:26414
+msgid "Cancel"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10136
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:134
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:140
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:360
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:493
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:130
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:191
+#: assets/build/blocks/godam-player/index.js:9590
+#: assets/build/pages/godam.min.js:11233
+#: assets/build/pages/godam.min.js:11532
+#: assets/build/pages/godam.min.js:12076
+#: assets/build/pages/godam.min.js:12689
+#: assets/build/pages/godam.min.js:13232
+#: assets/build/pages/video-editor.min.js:21842
+msgid "Save"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10238
+#: assets/build/blocks/godam-player/index.js:9664
+msgid "Muted because of Autoplay."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10277
+#: assets/build/blocks/godam-player/index.js:9702
+msgid "Play on loop"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10312
+#: assets/build/blocks/godam-player/index.js:9738
+msgid "Show share button"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10320
+#: assets/build/blocks/godam-player/index.js:9747
+msgid "Show transcription"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10336
+#: assets/build/blocks/godam-player/index.js:9763
+msgid "No subtitle/transcript file uploaded."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10340
+#: assets/build/blocks/godam-player/index.js:9766
+msgid "Click here to upload subtitles."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10347
+#: assets/build/blocks/godam-player/index.js:9776
+msgid "Recommended for most videos. Loads thumbnails as visitors scroll and prepares the video just before they reach it. Best for overall page performance."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10348
+#: assets/build/blocks/godam-player/index.js:9777
+msgid "For hero videos above the fold. Loads the thumbnail immediately and prepares the video for the fastest possible first play. Use sparingly - one or two per page."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10423
+#: assets/build/blocks/godam-player/index.js:9851
+msgid "Likes & Comments"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:10528
+#: assets/build/blocks/godam-player/index.js:9946
+msgid "Add a heading…"
+msgstr ""
+
+#. translators: %d: Label of the video text track e.g: "French subtitles".
+#: assets/build/blocks/godam-player/index.js:10801
+#: assets/build/blocks/godam-player/index.js:10225
 msgctxt "video caption"
-msgid "Edit %s"
+msgid "Failed to load video data with id: %d"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:71
-msgid "Edit track"
+#: assets/build/blocks/godam-player/index.js:10941
+#: assets/build/blocks/godam-player/index.js:10364
+msgid "Only video files are allowed in the GoDAM Video block."
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:73
-msgid "File"
+#: assets/build/blocks/godam-player/index.js:11209
+#: assets/build/blocks/godam-player/index.js:10655
+msgid "Add subtitles, layers, and more to make your video stand out."
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:84
-msgid "Source language"
+#: assets/build/blocks/godam-player/index.js:11220
+#: assets/build/blocks/godam-player/index.js:11541
+#: assets/build/blocks/godam-player/index.js:10668
+#: assets/build/blocks/godam-player/index.js:10992
+msgid "Add Video"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:104
-msgid "Remove track"
+#: assets/build/blocks/godam-player/index.js:11230
+#: assets/build/blocks/godam-player/index.js:10682
+msgid "Customize Video"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:111
-msgid "English"
+#: assets/build/blocks/godam-player/index.js:11245
+#: pages/video-editor/components/ads/CustomAdSettings.js:219
+#: assets/build/blocks/godam-player/index.js:10700
+#: assets/build/pages/video-editor.min.js:18985
+msgid "Remove video"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:123
-msgid "Apply"
+#: assets/build/blocks/godam-player/index.js:11259
+#: assets/build/blocks/godam-player/index.js:10716
+msgid "Hover option is disabled when autoplay is on."
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:154
-msgid "Manage Video Captions"
+#: assets/build/blocks/godam-player/index.js:11262
+#: assets/build/blocks/godam-player/index.js:10719
+msgid "Hover option is disabled when the video opens in a lightbox."
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:179
-msgid "No captions added yet"
+#: assets/build/blocks/godam-player/index.js:11275
+#: assets/build/blocks/godam-player/index.js:10732
+msgid "Choose the action to perform on video hover."
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:181
-msgid "You can upload subtitle or caption files (.vtt) to improve accessibility."
+#: assets/build/blocks/godam-player/index.js:11278
+#: assets/build/blocks/godam-player/index.js:10734
+msgid "Show player"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:194
-msgid "Add new track"
+#: assets/build/blocks/godam-player/index.js:11314
+#: assets/build/blocks/godam-player/index.js:10766
+msgid "Set the video height. Width is auto-calculated from the aspect ratio."
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:205
-msgid "Open Media Library"
+#: assets/build/blocks/godam-player/index.js:11321
+#: assets/build/blocks/godam-player/index.js:10770
+msgid "Show overlay blocks"
 msgstr ""
 
-#: assets/src/blocks/godam-player/track-uploader.js:228
-msgctxt "verb"
-msgid "Upload"
+#: assets/build/blocks/godam-player/index.js:11326
+#: assets/build/blocks/godam-player/index.js:10773
+msgid "Display blocks on top of the video player."
 msgstr ""
 
-#: assets/src/js/godam-player/engagement.js:1105
-msgid "Back"
+#: assets/build/blocks/godam-player/index.js:11330
+#: assets/build/blocks/godam-player/index.js:10779
+msgid "Vertical alignment"
 msgstr ""
 
-#: assets/src/js/godam-player/engagement.js:1115
-msgid "Continue as Guest"
+#: assets/build/blocks/godam-player/index.js:11334
+#: assets/build/blocks/godam-player/index.js:10783
+msgid "Top"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11337
+#: assets/build/blocks/godam-player/index.js:10784
+msgid "Center"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11340
+#: assets/build/blocks/godam-player/index.js:10785
+msgid "Bottom"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11344
+#: assets/build/blocks/godam-player/index.js:10788
+msgid "Choose where to position the overlay blocks vertically."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11346
+#: assets/build/blocks/godam-player/index.js:10791
+msgid "Time range"
+msgstr ""
+
+#. translators: %s: formatted time
+#: assets/build/blocks/godam-player/index.js:11356
+#: assets/build/blocks/godam-player/index.js:10800
+msgid "Overlay will be visible for %s from the start of the video."
+msgstr ""
+
+#. translators: %s: formatted time
+#: assets/build/blocks/godam-player/index.js:11364
+#: assets/build/blocks/godam-player/index.js:10808
+msgid "Video duration: %s"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11382
+#: assets/build/blocks/godam-player/index.js:10838
+msgid "Video SEO"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11385
+#: assets/build/blocks/godam-player/index.js:10842
+msgid "SEO"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11415
+#: assets/build/blocks/godam-player/index.js:10873
+msgid "You don't have an active plan to use this feature. Upgrade now to use unlimited features as part of GoDAM suite."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11423
+#: pages/godam/components/TrialCountdownBanner.jsx:78
+#: assets/build/blocks/godam-player/index.js:10883
+#: assets/build/pages/analytics.min.js:16665
+#: assets/build/pages/dashboard.min.js:4691
+#: assets/build/pages/godam.min.js:10689
+#: assets/build/pages/help.min.js:957
+#: assets/build/pages/tools.min.js:1207
+#: assets/build/pages/video-editor.min.js:16186
+msgid "Upgrade Now"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11474
+#: assets/build/blocks/godam-player/index.js:10920
+msgid "Hover Options"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11529
+#: assets/build/blocks/godam-player/index.js:10979
+msgid "Upload or select a video from your media library to get started."
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:11625
+#: assets/build/blocks/godam-player/index.js:11069
+msgid "Video caption text"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:12256
+#: pages/godam/components/GoDAMHeader.jsx:102
+#: assets/build/blocks/godam-player/index.js:11611
+#: assets/build/js/media-library.min.js:1204
+#: assets/build/pages/analytics.min.js:16419
+#: assets/build/pages/dashboard.min.js:4445
+#: assets/build/pages/godam.min.js:10421
+#: assets/build/pages/help.min.js:711
+#: assets/build/pages/tools.min.js:961
+#: assets/build/pages/video-editor.min.js:15479
+#: assets/build/pages/video-editor.min.js:15940
+msgid "Manage Media"
+msgstr ""
+
+#: assets/build/blocks/godam-player/index.js:12261
+#: assets/build/blocks/godam-player/index.js:11616
+#: assets/build/js/media-library.min.js:1209
+#: assets/build/pages/video-editor.min.js:15484
+msgid "Premium Feature"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:54
+#: assets/build/blocks/godam-video-duration/index.js:33
+msgid "Default (HH:MM:SS)"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:55
+#: assets/build/blocks/godam-video-duration/index.js:84
+#: assets/build/blocks/godam-video-duration/index.js:34
+#: assets/build/blocks/godam-video-duration/index.js:63
+msgid "00:00:00"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:58
+#: assets/build/blocks/godam-video-duration/index.js:38
+msgid "Minutes only (MM:SS)"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:59
+#: assets/build/blocks/godam-video-duration/index.js:39
+msgid "00:00"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:62
+#: assets/build/blocks/godam-video-duration/index.js:43
+msgid "Total Seconds"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:63
+#: assets/build/blocks/godam-video-duration/index.js:44
+msgid "0s"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:68
+#: assets/build/blocks/godam-video-duration/index.js:51
+msgid "Duration Settings"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/index.js:70
+#: assets/build/blocks/godam-video-duration/index.js:53
+msgid "Duration Format"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:92
+#: assets/build/blocks/godam-video-thumbnail/index.js:53
+msgid "Thumbnail Settings"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:97
+#: assets/build/blocks/godam-video-thumbnail/index.js:56
+msgid "Show play button overlay"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:102
+#: assets/build/blocks/godam-video-thumbnail/index.js:60
+msgid "Play button will be displayed."
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:102
+#: assets/build/blocks/godam-video-thumbnail/index.js:61
+msgid "No play button will be displayed."
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:107
+#: assets/build/blocks/godam-video-thumbnail/index.js:67
+msgid "Link to post"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:112
+#: assets/build/blocks/godam-video-thumbnail/index.js:71
+msgid "Thumbnail will link to the video page."
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:112
+#: assets/build/blocks/godam-video-thumbnail/index.js:72
+msgid "Thumbnail will not be linked."
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:117
+#: assets/build/blocks/godam-video-thumbnail/index.js:79
+msgid "Open in new tab"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:122
+#: assets/build/blocks/godam-video-thumbnail/index.js:83
+msgid "Link will open in a new tab."
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:122
+#: assets/build/blocks/godam-video-thumbnail/index.js:84
+msgid "Link will open in the same tab."
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/index.js:134
+#: assets/build/blocks/godam-video-thumbnail/index.js:96
+msgid "GoDAM Video Thumbnail"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:181
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:168
+msgid "Enter label for the field"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:193
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:181
+msgid "Enter description"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:196
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:184
+msgid "Enter description for the field"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:255
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:249
+msgid "100 MB"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:256
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:250
+msgid "Maximum file size (in MB)"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:277
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:273
+msgid "Is recorder field required?"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:286
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:283
+msgid "Enter error message"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:290
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:287
+msgid "Enter the required error message"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:307
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:303
+msgid "Field settings"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:314
+#: pages/analytics/charts.js:179
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:310
+#: assets/build/pages/analytics.min.js:11458
+#: assets/build/pages/dashboard.min.js:1456
+msgid "Untitled"
+msgstr ""
+
+#. Translators: %s will be replaced with the maximum file upload size allowed on the server (e.g., "300MB").
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:358
+#: assets/build/blocks/sureforms/blocks/recorder/index.js:353
+msgid "Maximum allowed size: %s MB"
+msgstr ""
+
+#: pages/analytics/Analytics.js:103
+#: pages/analytics/SingleMetrics.js:157
+#: pages/dashboard/Dashboard.js:224
+#: assets/build/pages/analytics.min.js:9267
+#: assets/build/pages/analytics.min.js:10972
+#: assets/build/pages/dashboard.min.js:1240
+#: assets/build/pages/dashboard.min.js:3276
+msgid "All time"
+msgstr ""
+
+#: pages/analytics/Analytics.js:408
+#: assets/build/pages/analytics.min.js:9572
+msgid "Select Video to Perform Performance Comparison Testing"
+msgstr ""
+
+#: pages/analytics/Analytics.js:410
+#: assets/build/pages/analytics.min.js:9574
+msgid "Use this Video"
+msgstr ""
+
+#: pages/analytics/Analytics.js:517
+#: assets/build/pages/analytics.min.js:9681
+msgid "This media doesn't exist."
+msgstr ""
+
+#: pages/analytics/Analytics.js:519
+#: assets/build/pages/analytics.min.js:9683
+msgid "Go to Dashboard"
+msgstr ""
+
+#: pages/analytics/Analytics.js:531
+#: assets/build/pages/analytics.min.js:9695
+msgid "Single Video Analytics"
+msgstr ""
+
+#: pages/analytics/Analytics.js:532
+#: assets/build/pages/analytics.min.js:9696
+msgid "Back to Media Editor"
+msgstr ""
+
+#: pages/analytics/Analytics.js:541
+#: pages/dashboard/Dashboard.js:312
+#: assets/build/pages/analytics.min.js:9705
+#: assets/build/pages/dashboard.min.js:3364
+msgid "Heads up: analytics update periodically, so new activity may take up to 30 minutes to show here."
+msgstr ""
+
+#: pages/analytics/Analytics.js:555
+#: pages/dashboard/components/TopVideosTable.js:302
+#: pages/dashboard/components/TopVideosTable.js:314
+#: assets/build/pages/analytics.min.js:9719
+#: assets/build/pages/dashboard.min.js:3988
+#: assets/build/pages/dashboard.min.js:4000
+msgid "Video thumbnail"
+msgstr ""
+
+#. translators: %d: number of interactive layers on the video.
+#. translators: %d is the number of layers.
+#: pages/analytics/Analytics.js:575
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:233
+#: assets/build/pages/analytics.min.js:9739
+#: assets/build/pages/video-editor.min.js:21884
+msgid "%d layer"
+msgid_plural "%d layers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pages/analytics/Analytics.js:591
+#: pages/dashboard/Dashboard.js:354
+#: assets/build/pages/analytics.min.js:9755
+#: assets/build/pages/dashboard.min.js:3406
+msgid "Insights"
+msgstr ""
+
+#: pages/analytics/Analytics.js:601
+#: pages/analytics/Analytics.js:886
+#: pages/dashboard/components/TopVideosTable.js:275
+#: assets/build/pages/analytics.min.js:9765
+#: assets/build/pages/analytics.min.js:10050
+#: assets/build/pages/dashboard.min.js:3961
+msgid "Average Engagement"
+msgstr ""
+
+#: pages/analytics/Analytics.js:602
+#: assets/build/pages/analytics.min.js:9766
+msgid "Video engagement rate is the percentage of video watched. Average Engagement = Total time played / (Total plays x Video length)"
+msgstr ""
+
+#: pages/analytics/Analytics.js:613
+#: pages/analytics/Analytics.js:902
+#: pages/analytics/components/Placements/index.js:230
+#: pages/analytics/PlaybackPerformance.js:425
+#: pages/analytics/PlaybackPerformance.js:524
+#: pages/dashboard/components/TopVideosTable.js:195
+#: pages/dashboard/components/TopVideosTable.js:272
+#: assets/build/pages/analytics.min.js:9777
+#: assets/build/pages/analytics.min.js:10066
+#: assets/build/pages/analytics.min.js:10549
+#: assets/build/pages/analytics.min.js:10648
+#: assets/build/pages/analytics.min.js:12176
+#: assets/build/pages/dashboard.min.js:967
+#: assets/build/pages/dashboard.min.js:1066
+#: assets/build/pages/dashboard.min.js:3881
+#: assets/build/pages/dashboard.min.js:3958
+msgid "Play Rate"
+msgstr ""
+
+#: pages/analytics/Analytics.js:614
+#: pages/dashboard/Dashboard.js:383
+#: assets/build/pages/analytics.min.js:9778
+#: assets/build/pages/dashboard.min.js:3435
+msgid "Play rate is the percentage of page visitors who clicked play. Play Rate = Total plays / Page loads"
+msgstr ""
+
+#: pages/analytics/Analytics.js:625
+#: pages/dashboard/components/TopVideosTable.js:197
+#: pages/dashboard/Dashboard.js:396
+#: assets/build/pages/analytics.min.js:9789
+#: assets/build/pages/dashboard.min.js:3448
+#: assets/build/pages/dashboard.min.js:3883
+msgid "Watch Time"
+msgstr ""
+
+#: pages/analytics/Analytics.js:626
+#: pages/dashboard/Dashboard.js:397
+#: assets/build/pages/analytics.min.js:9790
+#: assets/build/pages/dashboard.min.js:3449
+msgid "Total time the video has been watched, aggregated across all plays"
+msgstr ""
+
+#: pages/analytics/Analytics.js:652
+#: assets/build/pages/analytics.min.js:9816
+msgid "Viewer Retention Curve"
+msgstr ""
+
+#: pages/analytics/Analytics.js:666
+#: assets/build/pages/analytics.min.js:9830
+msgid "Viewer retention will appear here once this video receives views."
+msgstr ""
+
+#: pages/analytics/Analytics.js:714
+#: assets/build/pages/analytics.min.js:9878
+msgid "Views by Source"
+msgstr ""
+
+#: pages/analytics/Analytics.js:725
+#: assets/build/pages/analytics.min.js:9889
+msgid "Performance Comparison"
+msgstr ""
+
+#: pages/analytics/Analytics.js:736
+#: assets/build/pages/analytics.min.js:9900
+msgid "In Progress"
+msgstr ""
+
+#: pages/analytics/Analytics.js:741
+#: assets/build/pages/analytics.min.js:9905
+msgid "Initiate the test comparison to generate analytical insights."
+msgstr ""
+
+#: pages/analytics/Analytics.js:746
+#: assets/build/pages/analytics.min.js:9910
+msgid "The test is complete! Review results to identify the best-performing video."
+msgstr ""
+
+#: pages/analytics/Analytics.js:758
+#: assets/build/pages/analytics.min.js:9922
+msgid "Start Test"
+msgstr ""
+
+#: pages/analytics/Analytics.js:789
+#: assets/build/pages/analytics.min.js:9953
+msgid "Test this video against others to see which performs better."
+msgstr ""
+
+#: pages/analytics/Analytics.js:798
+#: assets/build/pages/analytics.min.js:9962
+msgid "Upload or Replace CTA Image"
+msgstr ""
+
+#: pages/analytics/Analytics.js:803
+#: assets/build/pages/analytics.min.js:9967
+msgid "Choose"
+msgstr ""
+
+#: pages/analytics/Analytics.js:874
+#: pages/analytics/components/Placements/index.js:228
+#: assets/build/pages/analytics.min.js:10038
+#: assets/build/pages/analytics.min.js:12174
+msgid "Views"
+msgstr ""
+
+#: pages/analytics/Analytics.js:893
+#: pages/dashboard/components/TopVideosTable.js:196
+#: pages/dashboard/components/TopVideosTable.js:273
+#: pages/dashboard/components/ViewersGauge.js:95
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:105
+#: assets/build/pages/analytics.min.js:10057
+#: assets/build/pages/dashboard.min.js:3882
+#: assets/build/pages/dashboard.min.js:3959
+#: assets/build/pages/dashboard.min.js:4196
+#: assets/build/pages/video-editor.min.js:21549
+msgid "Total Plays"
+msgstr ""
+
+#: pages/analytics/Analytics.js:914
+#: assets/build/pages/analytics.min.js:10078
+msgid "Page Loads"
+msgstr ""
+
+#: pages/analytics/Analytics.js:928
+#: assets/build/pages/analytics.min.js:10092
+msgid "Play Time"
+msgstr ""
+
+#: pages/analytics/Analytics.js:942
+#: assets/build/pages/analytics.min.js:10106
+msgid "Video Length"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:70
+#: assets/build/pages/analytics.min.js:11626
+#: assets/build/pages/dashboard.min.js:1624
+#: assets/build/pages/shared-components.min.js:126
+msgid "7 Days"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:71
+#: assets/build/pages/analytics.min.js:11627
+#: assets/build/pages/dashboard.min.js:1625
+#: assets/build/pages/shared-components.min.js:127
+msgid "Last 7 days"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:76
+#: assets/build/pages/analytics.min.js:11632
+#: assets/build/pages/dashboard.min.js:1630
+#: assets/build/pages/shared-components.min.js:132
+msgid "15 Days"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:77
+#: assets/build/pages/analytics.min.js:11633
+#: assets/build/pages/dashboard.min.js:1631
+#: assets/build/pages/shared-components.min.js:133
+msgid "Last 15 days"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:82
+#: assets/build/pages/analytics.min.js:11638
+#: assets/build/pages/dashboard.min.js:1636
+#: assets/build/pages/shared-components.min.js:138
+msgid "1 Month"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:83
+#: assets/build/pages/analytics.min.js:11639
+#: assets/build/pages/dashboard.min.js:1637
+#: assets/build/pages/shared-components.min.js:139
+msgid "Last 1 month"
+msgstr ""
+
+#. translators: 1: range start (e.g. "Nov 7"), 2: range end (e.g. "Nov 13").
+#: pages/analytics/components/DateRangePicker/index.js:129
+#: assets/build/pages/analytics.min.js:11685
+#: assets/build/pages/dashboard.min.js:1683
+#: assets/build/pages/shared-components.min.js:185
+msgid "%1$s - %2$s"
+msgstr ""
+
+#. translators: %s: range start date, e.g. "Nov 7".
+#: pages/analytics/components/DateRangePicker/index.js:137
+#: assets/build/pages/analytics.min.js:11693
+#: assets/build/pages/dashboard.min.js:1691
+#: assets/build/pages/shared-components.min.js:193
+msgid "From %s"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:168
+#: assets/build/pages/analytics.min.js:11724
+#: assets/build/pages/dashboard.min.js:1722
+#: assets/build/pages/shared-components.min.js:224
+msgid "Su"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:169
+#: assets/build/pages/analytics.min.js:11725
+#: assets/build/pages/dashboard.min.js:1723
+#: assets/build/pages/shared-components.min.js:225
+msgid "Mo"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:170
+#: assets/build/pages/analytics.min.js:11726
+#: assets/build/pages/dashboard.min.js:1724
+#: assets/build/pages/shared-components.min.js:226
+msgid "Tu"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:171
+#: assets/build/pages/analytics.min.js:11727
+#: assets/build/pages/dashboard.min.js:1725
+#: assets/build/pages/shared-components.min.js:227
+msgid "We"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:172
+#: assets/build/pages/analytics.min.js:11728
+#: assets/build/pages/dashboard.min.js:1726
+#: assets/build/pages/shared-components.min.js:228
+msgid "Th"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:173
+#: assets/build/pages/analytics.min.js:11729
+#: assets/build/pages/dashboard.min.js:1727
+#: assets/build/pages/shared-components.min.js:229
+msgid "Fr"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:174
+#: assets/build/pages/analytics.min.js:11730
+#: assets/build/pages/dashboard.min.js:1728
+#: assets/build/pages/shared-components.min.js:230
+msgid "Sa"
+msgstr ""
+
+#. translators: %s: the selected range label.
+#: pages/analytics/components/DateRangePicker/index.js:195
+#: assets/build/pages/analytics.min.js:11751
+#: assets/build/pages/dashboard.min.js:1749
+#: assets/build/pages/shared-components.min.js:251
+msgid "Date range: %s"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:289
+#: assets/build/pages/analytics.min.js:11845
+#: assets/build/pages/dashboard.min.js:1843
+#: assets/build/pages/shared-components.min.js:345
+msgid "Previous month"
+msgstr ""
+
+#: pages/analytics/components/DateRangePicker/index.js:305
+#: assets/build/pages/analytics.min.js:11861
+#: assets/build/pages/dashboard.min.js:1859
+#: assets/build/pages/shared-components.min.js:361
+msgid "Next month"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:32
+#: assets/build/pages/analytics.min.js:11978
+msgid "Video Block"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:34
+#: assets/build/pages/analytics.min.js:11980
+msgid "Shoppable Video"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:35
+#: assets/build/pages/analytics.min.js:11981
+msgid "WooCommerce Product Gallery"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:36
+#: assets/build/pages/analytics.min.js:11982
+msgid "Product Reels"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:37
+#: assets/build/pages/analytics.min.js:11983
+msgid "Reel Pop"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:174
+#: assets/build/pages/analytics.min.js:12120
+msgid "Unknown page"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:229
+#: pages/analytics/PlaysVsViewers.js:115
+#: assets/build/pages/analytics.min.js:10780
+#: assets/build/pages/analytics.min.js:12175
+msgid "Plays"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:232
+#: assets/build/pages/analytics.min.js:12178
+msgid "Avg Watch Time"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:238
+#: assets/build/pages/analytics.min.js:12184
+msgid "<1s"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:266
+#: assets/build/pages/analytics.min.js:12212
+msgid "Displayed on:"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:287
+#: assets/build/pages/analytics.min.js:12233
+msgid "Edit Page"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:372
+#: pages/dashboard/components/TopVideosTable.js:200
+#: pages/dashboard/components/TopVideosTable.js:277
+#: assets/build/pages/analytics.min.js:12318
+#: assets/build/pages/dashboard.min.js:3886
+#: assets/build/pages/dashboard.min.js:3963
+msgid "Placements"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:384
+#: assets/build/pages/analytics.min.js:12330
+msgid "Unable to load placement analytics. Please try again."
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:396
+#: assets/build/pages/analytics.min.js:12342
+msgid "No placements in this date range"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:399
+#: assets/build/pages/analytics.min.js:12345
+msgid "This video had no placement activity in the selected range."
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:411
+#: assets/build/pages/analytics.min.js:12357
+msgid "View all time"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:416
+#: assets/build/pages/analytics.min.js:12362
+msgid "No placement data for this video yet"
+msgstr ""
+
+#: pages/analytics/components/Placements/index.js:474
+#: assets/build/pages/analytics.min.js:12420
+msgid "Placement breakdown reflects activity since v2.1.0. Totals above include the video's full history."
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:129
+#: pages/video-editor/components/SidebarLayers.js:38
+#: pages/video-editor/components/SidebarLayers.js:41
+#: pages/video-editor/components/SidebarLayers.js:462
+#: pages/video-editor/utils/layerTypes.js:71
+#: assets/build/pages/analytics.min.js:12560
+#: assets/build/pages/video-editor.min.js:18036
+#: assets/build/pages/video-editor.min.js:18039
+#: assets/build/pages/video-editor.min.js:18460
+#: assets/build/pages/video-editor.min.js:30153
+msgid "CTA"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:139
+#: pages/video-editor/components/forms/FormFields.js:49
+#: pages/video-editor/components/SidebarLayers.js:481
+#: assets/build/pages/analytics.min.js:12570
+#: assets/build/pages/video-editor.min.js:18479
+#: assets/build/pages/video-editor.min.js:22366
+msgid "Form"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:147
+#: pages/video-editor/components/SidebarLayers.js:44
+#: pages/video-editor/components/SidebarLayers.js:47
+#: pages/video-editor/components/SidebarLayers.js:463
+#: pages/video-editor/utils/layerTypes.js:76
+#: assets/build/pages/analytics.min.js:12578
+#: assets/build/pages/video-editor.min.js:18042
+#: assets/build/pages/video-editor.min.js:18045
+#: assets/build/pages/video-editor.min.js:18461
+#: assets/build/pages/video-editor.min.js:30158
+msgid "Hotspot"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:157
+#: pages/video-editor/components/layers/PollLayer.js:39
+#: pages/video-editor/components/SidebarLayers.js:124
+#: pages/video-editor/components/SidebarLayers.js:127
+#: pages/video-editor/components/SidebarLayers.js:498
+#: pages/video-editor/utils/layerTypes.js:86
+#: assets/build/pages/analytics.min.js:12588
+#: assets/build/pages/video-editor.min.js:18122
+#: assets/build/pages/video-editor.min.js:18125
+#: assets/build/pages/video-editor.min.js:18496
+#: assets/build/pages/video-editor.min.js:25276
+#: assets/build/pages/video-editor.min.js:30168
+msgid "Poll"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:165
+#: assets/build/pages/analytics.min.js:12596
+msgid "Woo Hotspot"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:228
+#: assets/build/pages/analytics.min.js:12659
+msgid "Viewed"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:229
+#: assets/build/pages/analytics.min.js:12660
+msgid "Clicked"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:230
+#: assets/build/pages/analytics.min.js:12661
+msgid "Submitted"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:231
+#: assets/build/pages/analytics.min.js:12662
+msgid "Hovered"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:232
+#: assets/build/pages/analytics.min.js:12663
+msgid "Skipped"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:233
+#: assets/build/pages/analytics.min.js:12664
+msgid "Voted"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:234
+#: assets/build/pages/analytics.min.js:12665
+msgid "Added to Cart"
+msgstr ""
+
+#: pages/analytics/constants/layerTypes.js:235
+#: assets/build/pages/analytics.min.js:12666
+msgid "No Action"
+msgstr ""
+
+#: pages/analytics/helper.js:141
+#: assets/build/pages/analytics.min.js:13020
+#: assets/build/pages/dashboard.min.js:2245
+msgid "Views by Location"
+msgstr ""
+
+#: pages/analytics/helper.js:152
+#: assets/build/pages/analytics.min.js:13031
+#: assets/build/pages/dashboard.min.js:2256
+msgid "Views by location will show up here"
+msgstr ""
+
+#: pages/analytics/helper.js:726
+#: assets/build/pages/analytics.min.js:13605
+#: assets/build/pages/dashboard.min.js:2830
+msgid "retention"
+msgstr ""
+
+#: pages/analytics/helper.js:729
+#: assets/build/pages/analytics.min.js:13608
+#: assets/build/pages/dashboard.min.js:2833
+msgid "viewers"
+msgstr ""
+
+#: pages/analytics/hooks/useVideoLayerData.js:201
+#: assets/build/pages/analytics.min.js:13884
+msgid "Layer"
+msgstr ""
+
+#. translators: 1: layer type label (e.g. "CTA"), 2: position in the video in seconds.
+#: pages/analytics/hooks/useVideoLayerData.js:208
+#: assets/build/pages/analytics.min.js:13891
+msgid "%1$s layer at %2$ss"
+msgstr ""
+
+#: pages/analytics/index.js:39
+#: assets/build/pages/analytics.min.js:103069
+msgid "View analytics"
+msgstr ""
+
+#: pages/analytics/index.js:79
+#: assets/build/pages/analytics.min.js:103109
+msgid "No video is selected"
+msgstr ""
+
+#: pages/analytics/index.js:89
+#: assets/build/pages/analytics.min.js:103119
+msgid "Select Video to Edit"
+msgstr ""
+
+#: pages/analytics/PlaybackPerformance.js:418
+#: pages/analytics/PlaybackPerformance.js:525
+#: pages/dashboard/components/TopVideosTable.js:198
+#: pages/dashboard/Dashboard.js:410
+#: assets/build/pages/analytics.min.js:10542
+#: assets/build/pages/analytics.min.js:10649
+#: assets/build/pages/dashboard.min.js:960
+#: assets/build/pages/dashboard.min.js:1067
+#: assets/build/pages/dashboard.min.js:3462
+#: assets/build/pages/dashboard.min.js:3884
+msgid "Engagement Rate"
+msgstr ""
+
+#: pages/analytics/PlaybackPerformance.js:520
+#: assets/build/pages/analytics.min.js:10644
+#: assets/build/pages/dashboard.min.js:1062
+msgid "Playback Performance"
+msgstr ""
+
+#: pages/analytics/PlaysVsViewers.js:91
+#: assets/build/pages/analytics.min.js:10756
+msgid "Plays / Unique viewers"
+msgstr ""
+
+#: pages/analytics/PlaysVsViewers.js:116
+#: pages/dashboard/components/ViewersGauge.js:89
+#: assets/build/pages/analytics.min.js:10781
+#: assets/build/pages/dashboard.min.js:4190
+msgid "Unique viewers"
+msgstr ""
+
+#: pages/analytics/PlaysVsViewers.js:127
+#: pages/analytics/SingleMetrics.js:127
+#: assets/build/pages/analytics.min.js:10792
+#: assets/build/pages/analytics.min.js:10942
+#: assets/build/pages/dashboard.min.js:1210
+msgid "vs prev 7 days"
+msgstr ""
+
+#: pages/analytics/PlaysVsViewers.js:134
+#: assets/build/pages/analytics.min.js:10799
+msgid "Sessions per user:"
+msgstr ""
+
+#: pages/analytics/SingleMetrics.js:126
+#: assets/build/pages/analytics.min.js:10941
+#: assets/build/pages/dashboard.min.js:1209
+msgid "vs prev period"
+msgstr ""
+
+#. translators: %d is the count of removed layers.
+#: pages/analytics/timeline/HistoricalLayersDrawer.js:55
+#: assets/build/pages/analytics.min.js:14603
+msgid "Removed layers (%d)"
+msgid_plural "Removed layers (%d)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pages/analytics/timeline/HistoricalLayersDrawer.js:70
+#: assets/build/pages/analytics.min.js:14618
+msgid "No longer in the video; historical analytics preserved."
+msgstr ""
+
+#: pages/analytics/timeline/InfoTooltip.js:49
+#: assets/build/pages/analytics.min.js:14689
+msgid "Info"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:138
+#: assets/build/pages/analytics.min.js:14838
+msgid "Untitled layer"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:142
+#: assets/build/pages/analytics.min.js:14842
+msgid "Appeared at"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:164
+#: assets/build/pages/analytics.min.js:14864
+msgid "View this poll’s results"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:165
+#: assets/build/pages/analytics.min.js:14865
+msgid "View this form’s entries"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:168
+#: assets/build/pages/analytics.min.js:14868
+msgid "View Poll results"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:169
+#: assets/build/pages/analytics.min.js:14869
+msgid "View Form entries"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:177
+#: assets/build/pages/analytics.min.js:14877
+msgid "Edit this layer in the video editor"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:179
+#: assets/build/pages/analytics.min.js:14879
+msgid "Edit Layer"
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:186
+#: assets/build/pages/analytics.min.js:14886
+msgid "This layer is no longer in the video. Historical analytics preserved."
+msgstr ""
+
+#: pages/analytics/timeline/LayerDetailPanel.js:188
+#: assets/build/pages/analytics.min.js:14888
+msgid "Removed from video"
+msgstr ""
+
+#: pages/analytics/timeline/LayerInteractionFunnel.js:164
+#: assets/build/pages/analytics.min.js:15184
+msgid "Interaction Outcomes"
+msgstr ""
+
+#: pages/analytics/timeline/LayerInteractionFunnel.js:167
+#: assets/build/pages/analytics.min.js:15187
+msgid "Of everyone who saw this layer (Viewed = 100%), the share who took each action. \"No action\" saw the layer but never interacted. A viewer can appear in more than one action, so the bars need not add up to 100%."
+msgstr ""
+
+#: pages/analytics/timeline/LayerInteractionFunnel.js:174
+#: assets/build/pages/analytics.min.js:15194
+msgid "Out of all viewers who saw this layer"
+msgstr ""
+
+#. translators: %1$s value, %2$s percentage
+#: pages/analytics/timeline/LayerInteractionFunnel.js:226
+#: assets/build/pages/analytics.min.js:15246
+msgid "%1$s viewers (%2$s%%) saw this layer but didn't interact with it."
+msgstr ""
+
+#. translators: %1$s action name, %2$s value, %3$s percentage
+#: pages/analytics/timeline/LayerInteractionFunnel.js:233
+#: assets/build/pages/analytics.min.js:15253
+msgid "%1$s: %2$s viewers (%3$s%%)."
+msgstr ""
+
+#: pages/analytics/timeline/LayerInteractionFunnel.js:283
+#: assets/build/pages/analytics.min.js:15303
+msgid "of viewers"
+msgstr ""
+
+#. translators: 1: first position, 2: second position.
+#. translators: 1: comma-separated positions, 2: last position.
+#: pages/analytics/timeline/LayerModifiedNotice.js:63
+#: pages/analytics/timeline/LayerModifiedNotice.js:71
+#: assets/build/pages/analytics.min.js:15379
+#: assets/build/pages/analytics.min.js:15387
+msgid "%1$s and %2$s"
+msgstr ""
+
+#: pages/analytics/timeline/LayerModifiedNotice.js:162
+#: assets/build/pages/analytics.min.js:15478
+msgid "This layer has been modified."
+msgstr ""
+
+#. translators: %s is a comma-separated list of timestamps like "0:01 and 0:03".
+#: pages/analytics/timeline/LayerModifiedNotice.js:166
+#: assets/build/pages/analytics.min.js:15482
+msgid "It was previously at %s. Analytics shown here are cumulative across all changes."
+msgstr ""
+
+#: pages/analytics/timeline/LayerModifiedNotice.js:174
+#: assets/build/pages/analytics.min.js:15490
+msgid "Dismiss notice"
+msgstr ""
+
+#: pages/analytics/timeline/LayerTimelineMarker.js:137
+#: assets/build/pages/analytics.min.js:15638
+msgid "Conversion rate — share of viewers who saw this layer and interacted with it."
+msgstr ""
+
+#: pages/analytics/timeline/LayerTimelineMarker.js:155
+#: pages/analytics/timeline/SubHotspotRail.js:222
+#: assets/build/pages/analytics.min.js:15656
+#: assets/build/pages/analytics.min.js:16127
+msgid "Removed"
+msgstr ""
+
+#: pages/analytics/timeline/LayerTimelineStrip.js:192
+#: assets/build/pages/analytics.min.js:15856
+msgid "Interactive layers on the video timeline"
+msgstr ""
+
+#: pages/analytics/timeline/LayerTimelineStrip.js:197
+#: assets/build/pages/analytics.min.js:15861
+msgid "Nothing to show yet"
+msgstr ""
+
+#: pages/analytics/timeline/LayerTimelineStrip.js:200
+#: assets/build/pages/analytics.min.js:15864
+msgid "Layer analytics appear after the video is played on the front end and the activity is processed. A layer you just added won't have data until viewers interact with it."
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:60
+#: assets/build/pages/analytics.min.js:15965
+msgid "Products in this layer"
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:61
+#: assets/build/pages/analytics.min.js:15966
+msgid "Hotspots in this layer"
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:66
+#: assets/build/pages/analytics.min.js:15971
+msgid "Each row is one product hotspot inside this layer. Select a row to see its individual funnel; \"All Products (Cumulative)\" counts sessions that converted on any product."
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:70
+#: assets/build/pages/analytics.min.js:15975
+msgid "Each row is one hotspot inside this layer. Select a row to see its individual funnel; \"All Hotspots (Cumulative)\" counts sessions that converted on any hotspot."
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:79
+#: assets/build/pages/analytics.min.js:15984
+msgid "Conversion"
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:85
+#: assets/build/pages/analytics.min.js:15990
+msgid "Share of sessions that saw the product and converted — clicked through to it or added it to the cart. Each session counts once, so this never exceeds 100%."
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:89
+#: assets/build/pages/analytics.min.js:15994
+msgid "Share of sessions that saw the hotspot and clicked it. Each session counts once, so this never exceeds 100%."
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:122
+#: assets/build/pages/analytics.min.js:16027
+msgid "All Products (Cumulative)"
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:123
+#: assets/build/pages/analytics.min.js:16028
+msgid "All Hotspots (Cumulative)"
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:139
+#: assets/build/pages/analytics.min.js:16044
+msgid "A session counts as converted here when it converts on any one product in this layer — clicks it or adds it to the cart. Each session counts once, so this can read higher than every single product's rate."
+msgstr ""
+
+#: pages/analytics/timeline/SubHotspotRail.js:143
+#: assets/build/pages/analytics.min.js:16048
+msgid "A session counts as converted here when it clicks any one hotspot in this layer. Each session counts once, so this can read higher than every single hotspot's rate."
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:35
+#: assets/build/pages/analytics.min.js:11044
+msgid "Add an interactive layer in the video editor to start tracking performance."
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:45
+#: assets/build/pages/analytics.min.js:11054
+msgid "Click on any hotspot on the left to see its performance."
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:50
+#: assets/build/pages/analytics.min.js:11059
+msgid "Click on any layer above to view its performance details."
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:162
+#: assets/build/pages/analytics.min.js:11171
+msgid "Video Layer Timeline"
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:166
+#: assets/build/pages/analytics.min.js:11175
+msgid "Each marker represents an interactive layer in this video. Click a marker to see how viewers interacted with it."
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:173
+#: assets/build/pages/analytics.min.js:11182
+msgid "See when interactive layers appeared in your video and how they performed."
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:189
+#: assets/build/pages/analytics.min.js:11198
+msgid "Video conversion"
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:193
+#: assets/build/pages/analytics.min.js:11202
+msgid "Share of plays where the viewer converted on any layer (clicked a CTA, submitted a form, voted in a poll, or added a product to cart). A play counts once even if the viewer converts on several layers, so this never exceeds 100%."
+msgstr ""
+
+#. translators: 1: converting sessions, 2: total plays.
+#: pages/analytics/VideoLayerTimeline.js:206
+#: assets/build/pages/analytics.min.js:11215
+msgid "%1$s of %2$s plays"
+msgstr ""
+
+#: pages/analytics/VideoLayerTimeline.js:222
+#: assets/build/pages/analytics.min.js:11231
+msgid "Unable to load layer analytics. Please try again."
 msgstr ""
 
 #: pages/dashboard/components/MarketingCarousel.jsx:101
@@ -11289,22 +6488,4719 @@ msgstr ""
 msgid "Feature Screenshot"
 msgstr ""
 
-#: pages/media-library/App.js:167
+#: pages/dashboard/components/TopVideosTable.js:193
+#: assets/build/pages/dashboard.min.js:3879
+msgid "Media ID"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:199
+#: pages/dashboard/components/TopVideosTable.js:276
+#: assets/build/pages/dashboard.min.js:3885
+#: assets/build/pages/dashboard.min.js:3962
+msgid "Conversion Rate"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:225
+#: assets/build/pages/dashboard.min.js:3911
+msgid "Top Videos"
+msgstr ""
+
+#. translators: %s: number of videos (already locale-formatted).
+#: pages/dashboard/components/TopVideosTable.js:230
+#: assets/build/pages/dashboard.min.js:3916
+msgid "%s video"
+msgid_plural "%s videos"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pages/dashboard/components/TopVideosTable.js:243
+#: pages/dashboard/components/TopVideosTable.js:244
+#: assets/build/pages/dashboard.min.js:3929
+#: assets/build/pages/dashboard.min.js:3930
+msgid "Search videos"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:250
+#: assets/build/pages/dashboard.min.js:3936
+msgid "Show deleted videos"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:261
+#: assets/build/pages/dashboard.min.js:3947
+msgid "Exporting…"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:261
+#: assets/build/pages/dashboard.min.js:3947
+msgid "Export"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:270
+#: assets/build/pages/dashboard.min.js:3956
+msgid "Name"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:274
+#: assets/build/pages/dashboard.min.js:3960
+msgid "Total Watch Time"
+msgstr ""
+
+#. translators: 1: converting sessions, 2: total plays.
+#: pages/dashboard/components/TopVideosTable.js:335
+#: assets/build/pages/dashboard.min.js:4021
+msgid "%1$s of %2$s sessions converted"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:339
+#: assets/build/pages/dashboard.min.js:4025
+msgid "No layer conversions in this period"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:357
+#: assets/build/pages/dashboard.min.js:4043
+msgid "No videos match your search"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:358
+#: assets/build/pages/dashboard.min.js:4044
+msgid "No video plays yet"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:362
+#: assets/build/pages/dashboard.min.js:4048
+msgid "Try a different title, or clear the search to see all videos."
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:363
+#: assets/build/pages/dashboard.min.js:4049
+msgid "Once your videos start getting views, your top performers will show up here."
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:374
+#: assets/build/pages/dashboard.min.js:4060
+msgid "Top videos pagination"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:380
+#: assets/build/pages/dashboard.min.js:4066
+msgid "Previous page"
+msgstr ""
+
+#: pages/dashboard/components/TopVideosTable.js:406
+#: assets/build/pages/dashboard.min.js:4092
+msgid "Next page"
+msgstr ""
+
+#. translators: %s: total plays count.
+#: pages/dashboard/components/ViewersGauge.js:55
+#: assets/build/pages/dashboard.min.js:4156
+msgid "Unique viewers unavailable for the selected range; %s total plays"
+msgstr ""
+
+#. translators: 1: unique viewers count, 2: total plays count.
+#: pages/dashboard/components/ViewersGauge.js:60
+#: assets/build/pages/dashboard.min.js:4161
+msgid "%1$s unique viewers of %2$s total plays"
+msgstr ""
+
+#: pages/dashboard/components/ViewersGauge.js:100
+#: assets/build/pages/dashboard.min.js:4201
+msgid "Unique Viewers"
+msgstr ""
+
+#. translators: %d: number of days in the compared previous window.
+#: pages/dashboard/Dashboard.js:221
+#: assets/build/pages/dashboard.min.js:3273
+msgid "vs prev %d days"
+msgstr ""
+
+#: pages/dashboard/Dashboard.js:323
+#: assets/build/pages/dashboard.min.js:3375
+msgid "See Reel Pop Analytics"
+msgstr ""
+
+#: pages/dashboard/Dashboard.js:333
+#: assets/build/pages/dashboard.min.js:3385
+msgid "Total Plays / Unique Viewers"
+msgstr ""
+
+#: pages/dashboard/Dashboard.js:366
+#: assets/build/pages/dashboard.min.js:3418
+msgid "Active Videos"
+msgstr ""
+
+#: pages/dashboard/Dashboard.js:367
+#: assets/build/pages/dashboard.min.js:3419
+msgid "Number of unique videos that received user interactions each day, such as views or plays."
+msgstr ""
+
+#: pages/dashboard/Dashboard.js:382
+#: assets/build/pages/dashboard.min.js:3434
+msgid "Avg. Play Rate"
+msgstr ""
+
+#: pages/dashboard/Dashboard.js:411
+#: assets/build/pages/dashboard.min.js:3463
+msgid "Average share of each video that viewers watched, across all plays."
+msgstr ""
+
+#: pages/godam/App.js:35
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:101
+#: assets/build/pages/godam.min.js:9985
+#: assets/build/pages/godam.min.js:13595
+msgid "API Key"
+msgstr ""
+
+#: pages/godam/App.js:44
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:101
+#: pages/help/App.js:55
+#: assets/build/pages/godam.min.js:9994
+#: assets/build/pages/godam.min.js:11493
+#: assets/build/pages/help.min.js:1692
+msgid "General Settings"
+msgstr ""
+
+#: pages/godam/App.js:50
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:101
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:110
+#: pages/help/App.js:59
+#: assets/build/pages/godam.min.js:10000
+#: assets/build/pages/godam.min.js:13203
+#: assets/build/pages/godam.min.js:13212
+#: assets/build/pages/help.min.js:1696
+msgid "Video Settings"
+msgstr ""
+
+#: pages/godam/App.js:56
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:408
+#: assets/build/pages/godam.min.js:10006
+#: assets/build/pages/godam.min.js:12604
+msgid "Video Player"
+msgstr ""
+
+#: pages/godam/App.js:65
+#: assets/build/pages/godam.min.js:10015
+msgid "Video Ads"
+msgstr ""
+
+#: pages/godam/App.js:74
+#: assets/build/pages/godam.min.js:10024
+msgid "Integrations Settings"
+msgstr ""
+
+#: pages/godam/components/ConfirmModal.jsx:37
+#: assets/build/pages/godam.min.js:10161
+#: assets/build/pages/video-editor.min.js:15789
+msgid "Confirm"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:19
+#: assets/build/pages/godam.min.js:10229
+#: assets/build/pages/help.min.js:519
+#: assets/build/pages/tools.min.js:769
+msgid "Support"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:23
+#: assets/build/pages/godam.min.js:10233
+#: assets/build/pages/help.min.js:523
+#: assets/build/pages/tools.min.js:773
+msgid "Docs"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:27
+#: assets/build/pages/godam.min.js:10237
+#: assets/build/pages/help.min.js:527
+#: assets/build/pages/tools.min.js:777
+msgid "Newsletter"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:39
+#: assets/build/pages/godam.min.js:10249
+#: assets/build/pages/help.min.js:539
+#: assets/build/pages/tools.min.js:789
+msgid "Twitter X"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:44
+#: assets/build/pages/godam.min.js:10254
+#: assets/build/pages/help.min.js:544
+#: assets/build/pages/tools.min.js:794
+msgid "Facebook"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:49
+#: assets/build/pages/godam.min.js:10259
+#: assets/build/pages/help.min.js:549
+#: assets/build/pages/tools.min.js:799
+msgid "Linkedin"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:54
+#: assets/build/pages/godam.min.js:10264
+#: assets/build/pages/help.min.js:554
+#: assets/build/pages/tools.min.js:804
+msgid "Instagram"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:59
+#: assets/build/pages/godam.min.js:10269
+#: assets/build/pages/help.min.js:559
+#: assets/build/pages/tools.min.js:809
+msgid "Youtube"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:64
+#: assets/build/pages/godam.min.js:10274
+#: assets/build/pages/help.min.js:564
+#: assets/build/pages/tools.min.js:814
+msgid "WordPress.org"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:67
+#: assets/build/pages/godam.min.js:10277
+#: assets/build/pages/help.min.js:567
+#: assets/build/pages/tools.min.js:817
+msgid "Rate us on WordPress.org"
+msgstr ""
+
+#: pages/godam/components/GoDAMFooter.jsx:77
+#: assets/build/pages/godam.min.js:10287
+#: assets/build/pages/help.min.js:577
+#: assets/build/pages/tools.min.js:827
+msgid "Made with ♥ by the GoDAM Team"
+msgstr ""
+
+#: pages/godam/components/GoDAMHeader.jsx:92
+#: assets/build/pages/analytics.min.js:16409
+#: assets/build/pages/dashboard.min.js:4435
+#: assets/build/pages/godam.min.js:10411
+#: assets/build/pages/help.min.js:701
+#: assets/build/pages/tools.min.js:951
+#: assets/build/pages/video-editor.min.js:15930
+msgid "Need help?"
+msgstr ""
+
+#: pages/godam/components/GoDAMHeader.jsx:107
+#: assets/build/pages/analytics.min.js:16424
+#: assets/build/pages/dashboard.min.js:4450
+#: assets/build/pages/godam.min.js:10426
+#: assets/build/pages/help.min.js:716
+#: assets/build/pages/tools.min.js:966
+#: assets/build/pages/video-editor.min.js:15945
+msgid "Premium feature"
+msgstr ""
+
+#: pages/godam/components/GoDAMHeader.jsx:107
+#: assets/build/pages/analytics.min.js:16424
+#: assets/build/pages/dashboard.min.js:4450
+#: assets/build/pages/godam.min.js:10426
+#: assets/build/pages/help.min.js:716
+#: assets/build/pages/tools.min.js:966
+#: assets/build/pages/video-editor.min.js:15945
+msgid "GoDAM Central"
+msgstr ""
+
+#: pages/godam/components/GoDAMHeader.jsx:118
+#: assets/build/pages/analytics.min.js:16435
+#: assets/build/pages/dashboard.min.js:4461
+#: assets/build/pages/godam.min.js:10437
+#: assets/build/pages/help.min.js:727
+#: assets/build/pages/tools.min.js:977
+#: assets/build/pages/video-editor.min.js:15956
+msgid "Upgrade plan"
+msgstr ""
+
+#: pages/godam/components/GoDAMHeader.jsx:130
+#: assets/build/pages/analytics.min.js:16447
+#: assets/build/pages/dashboard.min.js:4473
+#: assets/build/pages/godam.min.js:10449
+#: assets/build/pages/help.min.js:739
+#: assets/build/pages/tools.min.js:989
+#: assets/build/pages/video-editor.min.js:15968
+msgid "Get GoDAM"
+msgstr ""
+
+#: pages/godam/components/ProUpgradeNotice.jsx:111
+#: assets/build/pages/analytics.min.js:16572
+#: assets/build/pages/dashboard.min.js:4598
+#: assets/build/pages/godam.min.js:10574
+#: assets/build/pages/help.min.js:864
+#: assets/build/pages/tools.min.js:1114
+#: assets/build/pages/video-editor.min.js:16093
+msgid "You are now a pro member"
+msgstr ""
+
+#: pages/godam/components/ProUpgradeNotice.jsx:113
+#: assets/build/pages/analytics.min.js:16574
+#: assets/build/pages/dashboard.min.js:4600
+#: assets/build/pages/godam.min.js:10576
+#: assets/build/pages/help.min.js:866
+#: assets/build/pages/tools.min.js:1116
+#: assets/build/pages/video-editor.min.js:16095
+msgid "With a paid plan, you get fixed storage, bandwidth that resets monthly, and unlimited sites."
+msgstr ""
+
+#: pages/godam/components/ProUpgradeNotice.jsx:117
+#: assets/build/pages/analytics.min.js:16578
+#: assets/build/pages/dashboard.min.js:4604
+#: assets/build/pages/godam.min.js:10580
+#: assets/build/pages/help.min.js:870
+#: assets/build/pages/tools.min.js:1120
+#: assets/build/pages/video-editor.min.js:16099
+msgid "Got it"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:59
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:67
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:182
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:98
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:66
+#: assets/build/pages/godam.min.js:11158
+#: assets/build/pages/godam.min.js:11459
+#: assets/build/pages/godam.min.js:11898
+#: assets/build/pages/godam.min.js:12294
+#: assets/build/pages/godam.min.js:13168
+msgid "Settings saved successfully."
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:62
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:65
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:70
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:73
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:185
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:188
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:101
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:104
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:69
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:72
+#: assets/build/pages/godam.min.js:11161
+#: assets/build/pages/godam.min.js:11164
+#: assets/build/pages/godam.min.js:11462
+#: assets/build/pages/godam.min.js:11465
+#: assets/build/pages/godam.min.js:11901
+#: assets/build/pages/godam.min.js:11904
+#: assets/build/pages/godam.min.js:12297
+#: assets/build/pages/godam.min.js:12300
+#: assets/build/pages/godam.min.js:13171
+#: assets/build/pages/godam.min.js:13174
+msgid "Failed to save settings."
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:74
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:82
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:197
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:387
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:81
+#: pages/video-editor/App.js:124
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:206
+#: pages/video-editor/VideoEditor.js:137
+#: assets/build/pages/godam.min.js:11173
+#: assets/build/pages/godam.min.js:11474
+#: assets/build/pages/godam.min.js:11913
+#: assets/build/pages/godam.min.js:12583
+#: assets/build/pages/godam.min.js:13183
+#: assets/build/pages/video-editor.min.js:16756
+#: assets/build/pages/video-editor.min.js:16968
+#: assets/build/pages/video-editor.min.js:21857
+msgid "You have unsaved changes. Are you sure you want to leave?"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:94
+#: assets/build/pages/godam.min.js:11193
+msgid "Video Ads Settings"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:99
+#: assets/build/pages/godam.min.js:11198
+msgid "Enable Global Video Ads"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:100
+#: assets/build/pages/godam.min.js:11199
+msgid "Enable or disable video ads on all videos across the site"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:111
+#: pages/video-editor/components/appearance/Appearance.js:224
+#: assets/build/pages/godam.min.js:11210
+#: assets/build/pages/video-editor.min.js:19270
+msgid "Ad Tag URL"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:114
+#: assets/build/pages/godam.min.js:11213
+msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads"
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:115
+#: pages/video-editor/components/appearance/Appearance.js:233
+#: assets/build/pages/godam.min.js:11214
+#: assets/build/pages/video-editor.min.js:19279
+msgid "Learn more."
+msgstr ""
+
+#: pages/godam/components/tabs/AdsSettings/AdsSettings.jsx:134
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:140
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:360
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:493
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:141
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:130
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:302
+#: assets/build/pages/godam.min.js:11233
+#: assets/build/pages/godam.min.js:11532
+#: assets/build/pages/godam.min.js:12076
+#: assets/build/pages/godam.min.js:12689
+#: assets/build/pages/godam.min.js:12838
+#: assets/build/pages/godam.min.js:13232
+#: assets/build/pages/video-editor.min.js:21953
+msgid "Saving…"
+msgstr ""
+
+#: pages/godam/components/tabs/APIKey/APIKey.jsx:40
+#: assets/build/pages/godam.min.js:11075
+msgid "Ensure Smooth Video Playback"
+msgstr ""
+
+#: pages/godam/components/tabs/APIKey/APIKey.jsx:42
+#: assets/build/pages/godam.min.js:11077
+msgid "Start with GoDAM Free for 60 days, or plans starting from $9/mo."
+msgstr ""
+
+#: pages/godam/components/tabs/APIKey/APIKey.jsx:51
+#: assets/build/pages/godam.min.js:11086
+msgid "Choose GoDAM Plan"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:36
+#: assets/build/pages/godam.min.js:11278
+msgid "Select Brand Image"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:38
+#: assets/build/pages/godam.min.js:11280
+msgid "Use this brand image"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:53
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:59
+#: pages/video-editor/components/cta/CardCTA.js:188
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:100
+#: assets/build/pages/godam.min.js:11295
+#: assets/build/pages/godam.min.js:13367
+#: assets/build/pages/video-editor.min.js:20853
+#: assets/build/pages/video-editor.min.js:23397
+msgid "Only Image files are allowed"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:89
+#: assets/build/pages/godam.min.js:11331
+msgid "Brand Logo"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:96
+#: assets/build/pages/godam.min.js:11338
+msgid "The brand logo will not be applied to the player skin."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:101
+#: assets/build/pages/godam.min.js:11343
+msgid "Shown beside player controls. Can be overridden per video."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/BrandImageSelector.jsx:131
+#: assets/build/pages/godam.min.js:11373
+msgid "Selected custom brand"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:106
+#: assets/build/pages/godam.min.js:11498
+msgid "Enable folder organization in media library."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:109
+#: assets/build/pages/godam.min.js:11501
+msgid "This setting is managed by your site administrator and can’t be changed here."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:110
+#: assets/build/pages/godam.min.js:11502
+msgid "Keep this option enabled to organize media into folders within the media library. Disabling it will remove folder organization."
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:121
+#: assets/build/pages/godam.min.js:11513
+msgid "Enable GTM Tracking"
+msgstr ""
+
+#: pages/godam/components/tabs/GeneralSettings/GeneralSettings.jsx:122
+#: assets/build/pages/godam.min.js:11514
+msgid "Enable Google Tag Manager video tracking for analytics and conversion tracking."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:22
+#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:26
+#: assets/build/pages/godam.min.js:12106
+#: assets/build/pages/godam.min.js:12110
+msgid "WooCommerce"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:23
+#: assets/build/pages/godam.min.js:12107
+msgid "GoDAM for Woo"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/integration-tabs.js:28
+#: assets/build/pages/godam.min.js:12112
+msgid "Pro"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:60
+#: assets/build/pages/godam.min.js:11600
+msgid "Installing…"
+msgstr ""
+
+#. translators: %s: Add-on plugin name, e.g. "GoDAM for Woo".
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:65
+#: assets/build/pages/godam.min.js:11605
+msgid "Install %s"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationActionButton.jsx:95
+#: assets/build/pages/godam.min.js:11635
+msgid "Upgrade Plan"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:110
+#: assets/build/pages/godam.min.js:11826
+msgid "Integration status updated successfully."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:119
+#: assets/build/pages/godam.min.js:11835
+msgid "Failed to toggle add-on."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:148
+#: assets/build/pages/godam.min.js:11864
+msgid "Add-on installed successfully! Reloading…"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:156
+#: assets/build/pages/godam.min.js:11872
+msgid "Installation failed."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:223
+#: assets/build/pages/godam.min.js:11939
+msgid "Integration Settings"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:263
+#: assets/build/pages/godam.min.js:11979
+msgid "Installation failed. Please download the ZIP and install it like any other WordPress plugin."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:272
+#: assets/build/pages/godam.min.js:11988
+msgid "Download ZIP"
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:282
+#: assets/build/pages/godam.min.js:11998
+msgid "View Installation Guide"
+msgstr ""
+
+#. translators: %s: Integration name, e.g. "WooCommerce".
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:293
+#: assets/build/pages/godam.min.js:12009
+msgid "The %s add-on plugin is not installed. Please install it to enable this integration."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:302
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:47
+#: assets/build/pages/godam.min.js:11688
+#: assets/build/pages/godam.min.js:12018
+msgid "This is a Pro feature."
+msgstr ""
+
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationsSettings.jsx:314
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:59
+#: assets/build/pages/godam.min.js:11700
+#: assets/build/pages/godam.min.js:12030
+msgid "to use this integration."
+msgstr ""
+
+#. translators: %s: Integration name, e.g. "WooCommerce".
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:36
+#: assets/build/pages/godam.min.js:11677
+msgid "Enable %s Integration"
+msgstr ""
+
+#. translators: %s: Integration name, e.g. "WooCommerce".
+#: pages/godam/components/tabs/IntegrationsSettings/IntegrationToggle.jsx:64
+#: assets/build/pages/godam.min.js:11705
+msgid "Enable or disable the %s integration."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/CustomVideoPlayerCSS.jsx:50
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:473
+#: assets/build/pages/godam.min.js:12171
+#: assets/build/pages/godam.min.js:12669
+msgid "Custom CSS"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:30
+#: assets/build/pages/godam.min.js:12226
+msgid "Classic"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:31
+#: assets/build/pages/godam.min.js:12227
+msgid "Minimal"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:32
+#: assets/build/pages/godam.min.js:12228
+msgid "Pills"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:33
+#: assets/build/pages/godam.min.js:12229
+msgid "Bubble"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:414
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:420
+#: assets/build/pages/godam.min.js:12610
+#: assets/build/pages/godam.min.js:12616
+msgid "Player Skin"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:429
+#: assets/build/pages/godam.min.js:12625
+msgid "Branding"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:435
+#: assets/build/pages/godam.min.js:12631
+msgid "Brand color"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:447
+#: assets/build/pages/godam.min.js:12643
+msgid "Clear"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:456
+#: assets/build/pages/godam.min.js:12652
+msgid "The brand color will not be applied to the player skin."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:461
+#: assets/build/pages/godam.min.js:12657
+msgid "Applied to the video block. Can be overridden per video."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoPlayer/VideoPlayer.jsx:478
+#: assets/build/pages/godam.min.js:12674
+msgid "Any custom CSS you add will be applied to all player skins. It's global and not tied to a specific skin style."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:39
+#: assets/build/pages/godam.min.js:12736
+msgid "Please enter a valid API key"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:50
+#: assets/build/pages/godam.min.js:12747
+msgid "The API key you’ve entered is incorrect. Please enter a valid key"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:60
+#: assets/build/pages/godam.min.js:12757
+msgid "API key deactivated successfully!"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:69
+#: assets/build/pages/godam.min.js:12766
+msgid "Failed to deactivate API key"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:84
+#: assets/build/pages/godam.min.js:12781
+msgid "API key status refreshed!"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:94
+#: assets/build/pages/godam.min.js:12791
+msgid "Failed to refresh API key status"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:104
+#: assets/build/pages/godam.min.js:12801
+msgid "API Settings"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:125
+#: assets/build/pages/godam.min.js:12822
+msgid "Remove API key"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:141
+#: assets/build/pages/godam.min.js:12838
+msgid "Save API Key"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:151
+#: assets/build/pages/godam.min.js:12848
+msgid "Refreshing…"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:161
+#: assets/build/pages/godam.min.js:12858
+msgid "Access your active API key from"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:168
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:42
+#: assets/build/pages/godam.min.js:12865
+#: assets/build/pages/godam.min.js:13536
+msgid "Account"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:173
+#: assets/build/pages/godam.min.js:12870
+msgid "Having any issue?"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:180
+#: assets/build/pages/godam.min.js:12877
+msgid "Contact Support"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:189
+#: assets/build/pages/godam.min.js:12886
+msgid "Remove API Key?"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:190
+#: assets/build/pages/godam.min.js:12887
+msgid "Yes, Remove"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/APISettings.jsx:198
+#: assets/build/pages/godam.min.js:12895
+msgid "If you remove the API key, your account will be deactivated and you’ll lose access to the platform."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:60
+#: assets/build/pages/godam.min.js:13554
+msgid "Your API key is required to access the features. You can get your active API key from"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:70
+#: assets/build/pages/godam.min.js:13564
+msgid "API key verified"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:80
+#: assets/build/pages/godam.min.js:13574
+msgid "Your API Key has expired. You can renew it from your"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:91
+#: assets/build/pages/godam.min.js:13585
+msgid "Unable to verify API key. Please click \"Refresh Status\" to try again."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/components/PasswordFieldWIthToggle/index.jsx:105
+#: assets/build/pages/godam.min.js:13599
+msgid "Enter your API key here"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:63
+#: assets/build/pages/godam.min.js:12965
+msgctxt "gigabyte"
+msgid "GB"
+msgstr ""
+
+#. translators: %s: total plan size in gigabytes
+#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:68
+#: assets/build/pages/godam.min.js:12970
+msgid "of %s GB available"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:90
+#: assets/build/pages/godam.min.js:12992
+msgid "Plan Usage"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:93
+#: pages/onboarding/components/SidePanel.jsx:22
+#: assets/build/pages/godam.min.js:12995
+#: assets/build/pages/onboarding.min.js:657
+msgid "Bandwidth"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/UsageData.jsx:98
+#: pages/onboarding/components/SidePanel.jsx:25
+#: assets/build/pages/godam.min.js:13000
+#: assets/build/pages/onboarding.min.js:660
+msgid "Storage"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:13
+#: assets/build/pages/godam.min.js:13023
+msgid "Highest quality (100%)"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:14
+#: assets/build/pages/godam.min.js:13024
+msgid "Higher quality (80%)"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:15
+#: assets/build/pages/godam.min.js:13025
+msgid "Medium quality (60%)"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:16
+#: assets/build/pages/godam.min.js:13026
+msgid "Lower quality (40%)"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:17
+#: assets/build/pages/godam.min.js:13027
+msgid "Lowest quality (20%)"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:28
+#: assets/build/pages/godam.min.js:13038
+msgid "Video Quality"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoCompressQuality.jsx:34
+#: assets/build/pages/godam.min.js:13044
+msgid "Select the video quality."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:28
+#: assets/build/pages/godam.min.js:13079
+msgid "Enable video engagement globally"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:32
+#: assets/build/pages/godam.min.js:13083
+msgid "If disabled, Likes and Comments will be disabled globally for all GoDAM Video and GoDAM Video Gallery blocks. If enabled, it can be overridden in the block settings panel."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:39
+#: assets/build/pages/godam.min.js:13090
+msgid "Enable video share globally"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoEngagement.jsx:43
+#: assets/build/pages/godam.min.js:13094
+msgid "If disabled, sharing options (such as social sharing buttons) will not be available for GoDAM videos. If enabled, it can be overridden in the block settings panel."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoSettings.jsx:104
+#: assets/build/pages/godam.min.js:13206
+msgid "Connect your GoDAM API key from the API Key tab to configure video settings."
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:48
+#: assets/build/pages/godam.min.js:13290
+msgid "Number of video thumbnails generated"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoThumbnails.jsx:59
+#: assets/build/pages/godam.min.js:13301
+msgid "This field specifies the number of video thumbnails that will be generated by the GoDAM. To choose from the generated thumbnails for a video, go to Media > Edit > Video Thumbnails. Thumbnails are only generated when the video is first uploaded. Please enter a value between 1 and 10"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:45
+#: assets/build/pages/godam.min.js:13353
+msgid "Select a Watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:47
+#: assets/build/pages/godam.min.js:13355
+msgid "Use this watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:86
+#: assets/build/pages/godam.min.js:13394
+msgid "Enable video watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:93
+#: assets/build/pages/godam.min.js:13401
+msgid "If enabled, GoDAM will add a watermark to the transcoded video"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:100
+#: assets/build/pages/godam.min.js:13408
+msgid "Use image watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:108
+#: assets/build/pages/godam.min.js:13416
+msgid "If enabled, Transcoder will use an image instead of text as the watermark for the transcoded video"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:110
+#: assets/build/pages/godam.min.js:13418
+msgid "(Recommended dimensions: 200 px width × 70 px height)"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:125
+#: assets/build/pages/godam.min.js:13433
+msgid "Change Watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:126
+#: assets/build/pages/godam.min.js:13434
+msgid "Select Watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:138
+#: assets/build/pages/godam.min.js:13446
+msgid "Remove Watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:146
+#: assets/build/pages/godam.min.js:13454
+msgid "Selected watermark"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:166
+#: assets/build/pages/godam.min.js:13474
+msgid "Watermark Text"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:174
+#: assets/build/pages/godam.min.js:13482
+msgid "Enter watermark text"
+msgstr ""
+
+#: pages/godam/components/tabs/VideoSettings/VideoWatermark.jsx:175
+#: assets/build/pages/godam.min.js:13483
+msgid "Specify the watermark text that will be added to transcoded videos"
+msgstr ""
+
+#. translators: %s: trial end date.
+#: pages/godam/components/TrialCountdownBanner.jsx:68
+#: assets/build/pages/analytics.min.js:16655
+#: assets/build/pages/dashboard.min.js:4681
+#: assets/build/pages/godam.min.js:10679
+#: assets/build/pages/help.min.js:947
+#: assets/build/pages/tools.min.js:1197
+#: assets/build/pages/video-editor.min.js:16176
+msgid "Free trial ends on %s"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:69
+#: assets/build/pages/analytics.min.js:16742
+#: assets/build/pages/dashboard.min.js:4768
+#: assets/build/pages/godam.min.js:10858
+#: assets/build/pages/help.min.js:1126
+#: assets/build/pages/tools.min.js:1284
+#: assets/build/pages/video-editor.min.js:16263
+msgid "Interactive product hotspots"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:70
+#: assets/build/pages/analytics.min.js:16743
+#: assets/build/pages/dashboard.min.js:4769
+#: assets/build/pages/godam.min.js:10859
+#: assets/build/pages/help.min.js:1127
+#: assets/build/pages/tools.min.js:1285
+#: assets/build/pages/video-editor.min.js:16264
+msgid "Tag products directly on your videos so viewers can buy in a click."
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:75
+#: assets/build/pages/analytics.min.js:16748
+#: assets/build/pages/dashboard.min.js:4774
+#: assets/build/pages/godam.min.js:10864
+#: assets/build/pages/help.min.js:1132
+#: assets/build/pages/tools.min.js:1290
+#: assets/build/pages/video-editor.min.js:16269
+msgid "Shoppable video"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:76
+#: assets/build/pages/analytics.min.js:16749
+#: assets/build/pages/dashboard.min.js:4775
+#: assets/build/pages/godam.min.js:10865
+#: assets/build/pages/help.min.js:1133
+#: assets/build/pages/tools.min.js:1291
+#: assets/build/pages/video-editor.min.js:16270
+msgid "Turn any product video into a storefront that drives conversions."
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:81
+#: assets/build/pages/analytics.min.js:16754
+#: assets/build/pages/dashboard.min.js:4780
+#: assets/build/pages/godam.min.js:10870
+#: assets/build/pages/help.min.js:1138
+#: assets/build/pages/tools.min.js:1296
+#: assets/build/pages/video-editor.min.js:16275
+msgid "Reel Pops"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:82
+#: assets/build/pages/analytics.min.js:16755
+#: assets/build/pages/dashboard.min.js:4781
+#: assets/build/pages/godam.min.js:10871
+#: assets/build/pages/help.min.js:1139
+#: assets/build/pages/tools.min.js:1297
+#: assets/build/pages/video-editor.min.js:16276
+msgid "Surface short, shoppable product reels across your store."
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:87
+#: assets/build/pages/analytics.min.js:16760
+#: assets/build/pages/dashboard.min.js:4786
+#: assets/build/pages/godam.min.js:10876
+#: assets/build/pages/help.min.js:1144
+#: assets/build/pages/tools.min.js:1302
+#: assets/build/pages/video-editor.min.js:16281
+msgid "Enhanced product page"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:88
+#: assets/build/pages/analytics.min.js:16761
+#: assets/build/pages/dashboard.min.js:4787
+#: assets/build/pages/godam.min.js:10877
+#: assets/build/pages/help.min.js:1145
+#: assets/build/pages/tools.min.js:1303
+#: assets/build/pages/video-editor.min.js:16282
+msgid "Showcase your videos right on the WooCommerce product page."
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:179
+#: assets/build/pages/analytics.min.js:16852
+#: assets/build/pages/dashboard.min.js:4878
+#: assets/build/pages/godam.min.js:10968
+#: assets/build/pages/help.min.js:1236
+#: assets/build/pages/tools.min.js:1394
+#: assets/build/pages/video-editor.min.js:16373
+msgid "You have unlocked Woo features"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:183
+#: assets/build/pages/analytics.min.js:16856
+#: assets/build/pages/dashboard.min.js:4882
+#: assets/build/pages/godam.min.js:10972
+#: assets/build/pages/help.min.js:1240
+#: assets/build/pages/tools.min.js:1398
+#: assets/build/pages/video-editor.min.js:16377
+msgid "You've Unlocked Woo Features"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:185
+#: pages/onboarding/components/screens/EntryScreen.jsx:38
+#: assets/build/pages/analytics.min.js:16858
+#: assets/build/pages/dashboard.min.js:4884
+#: assets/build/pages/godam.min.js:10974
+#: assets/build/pages/help.min.js:1242
+#: assets/build/pages/onboarding.min.js:847
+#: assets/build/pages/tools.min.js:1400
+#: assets/build/pages/video-editor.min.js:16379
+msgid "Turn your product videos into interactive shopping experiences, focused video content for WooCommerce."
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:202
+#: pages/video-editor/components/forms/FormPreview.js:86
+#: pages/video-editor/components/layers/CTALayer.js:265
+#: assets/build/pages/analytics.min.js:16875
+#: assets/build/pages/dashboard.min.js:4901
+#: assets/build/pages/godam.min.js:10991
+#: assets/build/pages/help.min.js:1259
+#: assets/build/pages/tools.min.js:1417
+#: assets/build/pages/video-editor.min.js:16396
+#: assets/build/pages/video-editor.min.js:22504
+#: assets/build/pages/video-editor.min.js:23972
+msgid "Skip"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:205
+#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:66
+#: assets/build/pages/analytics.min.js:16878
+#: assets/build/pages/dashboard.min.js:4904
+#: assets/build/pages/godam.min.js:10994
+#: assets/build/pages/help.min.js:1262
+#: assets/build/pages/tools.min.js:1420
+#: assets/build/pages/video-editor.min.js:16399
+#: assets/build/pages/video-editor.min.js:27947
+msgid "Get Started"
+msgstr ""
+
+#: pages/godam/components/WooUnlockedNotice.jsx:226
+#: assets/build/pages/analytics.min.js:16899
+#: assets/build/pages/dashboard.min.js:4925
+#: assets/build/pages/godam.min.js:11015
+#: assets/build/pages/help.min.js:1283
+#: assets/build/pages/tools.min.js:1441
+#: assets/build/pages/video-editor.min.js:16420
+msgid "Feature preview slides"
+msgstr ""
+
+#: pages/godam/utils/index.js:77
+#: assets/build/js/godam-lifterlms-embed.min.js:77
+#: assets/build/js/lifterLMSEmbed.min.js:77
+#: assets/build/pages/analytics.min.js:16996
+#: assets/build/pages/dashboard.min.js:5022
+#: assets/build/pages/godam.min.js:13935
+#: assets/build/pages/help.min.js:1595
+#: assets/build/pages/tools.min.js:1538
+#: assets/build/pages/video-editor.min.js:16517
+msgid "Your API key has expired."
+msgstr ""
+
+#: pages/godam/utils/index.js:78
+#: assets/build/js/godam-lifterlms-embed.min.js:78
+#: assets/build/js/lifterLMSEmbed.min.js:78
+#: assets/build/pages/analytics.min.js:16997
+#: assets/build/pages/dashboard.min.js:5023
+#: assets/build/pages/godam.min.js:13936
+#: assets/build/pages/help.min.js:1596
+#: assets/build/pages/tools.min.js:1539
+#: assets/build/pages/video-editor.min.js:16518
+msgid "Please renew your subscription from your Account to continue."
+msgstr ""
+
+#: pages/godam/utils/index.js:86
+#: assets/build/js/godam-lifterlms-embed.min.js:86
+#: assets/build/js/lifterLMSEmbed.min.js:86
+#: assets/build/pages/analytics.min.js:17005
+#: assets/build/pages/dashboard.min.js:5031
+#: assets/build/pages/godam.min.js:13944
+#: assets/build/pages/help.min.js:1604
+#: assets/build/pages/tools.min.js:1547
+#: assets/build/pages/video-editor.min.js:16526
+msgid "Unable to verify API key."
+msgstr ""
+
+#: pages/godam/utils/index.js:87
+#: assets/build/js/godam-lifterlms-embed.min.js:87
+#: assets/build/js/lifterLMSEmbed.min.js:87
+#: assets/build/pages/analytics.min.js:17006
+#: assets/build/pages/dashboard.min.js:5032
+#: assets/build/pages/godam.min.js:13945
+#: assets/build/pages/help.min.js:1605
+#: assets/build/pages/tools.min.js:1548
+#: assets/build/pages/video-editor.min.js:16527
+msgid "This may be a temporary issue. Please try again later."
+msgstr ""
+
+#: pages/godam/utils/index.js:95
+#: assets/build/js/godam-lifterlms-embed.min.js:95
+#: assets/build/js/lifterLMSEmbed.min.js:95
+#: assets/build/pages/analytics.min.js:17014
+#: assets/build/pages/dashboard.min.js:5040
+#: assets/build/pages/godam.min.js:13953
+#: assets/build/pages/help.min.js:1613
+#: assets/build/pages/tools.min.js:1556
+#: assets/build/pages/video-editor.min.js:16535
+msgid "API key issue detected."
+msgstr ""
+
+#: pages/godam/utils/index.js:96
+#: assets/build/js/godam-lifterlms-embed.min.js:96
+#: assets/build/js/lifterLMSEmbed.min.js:96
+#: assets/build/pages/analytics.min.js:17015
+#: assets/build/pages/dashboard.min.js:5041
+#: assets/build/pages/godam.min.js:13954
+#: assets/build/pages/help.min.js:1614
+#: assets/build/pages/tools.min.js:1557
+#: assets/build/pages/video-editor.min.js:16536
+msgid "Please check your API key settings."
+msgstr ""
+
+#: pages/help/App.js:63
+#: assets/build/pages/help.min.js:1700
+msgid "Configuring the Video Block"
+msgstr ""
+
+#: pages/help/App.js:73
+#: assets/build/pages/help.min.js:1710
+msgid "Appearance Customisation"
+msgstr ""
+
+#: pages/help/App.js:77
+#: assets/build/pages/help.min.js:1714
+msgid "Call To Actions"
+msgstr ""
+
+#: pages/help/App.js:81
+#: assets/build/pages/help.min.js:1718
+msgid "Hotspots"
+msgstr ""
+
+#: pages/help/App.js:85
+#: pages/video-editor/components/SidebarLayers.js:50
+#: assets/build/pages/help.min.js:1722
+#: assets/build/pages/video-editor.min.js:18048
+msgid "Forms"
+msgstr ""
+
+#: pages/help/App.js:89
+#: assets/build/pages/help.min.js:1726
+msgid "ADs"
+msgstr ""
+
+#: pages/help/App.js:99
+#: assets/build/pages/help.min.js:1736
+msgid "Interface"
+msgstr ""
+
+#: pages/help/App.js:103
+#: assets/build/pages/help.min.js:1740
+msgid "How Tos"
+msgstr ""
+
+#: pages/help/App.js:131
+#: assets/build/pages/help.min.js:1768
+msgid "Hi, How can we help?"
+msgstr ""
+
+#: pages/help/App.js:132
+#: assets/build/pages/help.min.js:1769
+msgid "Welcome to the GoDAM Help Center!"
+msgstr ""
+
+#: pages/help/App.js:134
+#: assets/build/pages/help.min.js:1771
+msgid "Click on the documentation links below to find step-by-step guides, FAQs, and troubleshooting tips for the features you need help with."
+msgstr ""
+
+#: pages/help/App.js:148
+#: pages/help/App.js:150
+#: assets/build/pages/help.min.js:1785
+#: assets/build/pages/help.min.js:1787
+msgid "Search using keywords"
+msgstr ""
+
+#: pages/help/App.js:214
+#: assets/build/pages/help.min.js:1851
+msgid "Help us improve GoDAM"
+msgstr ""
+
+#: pages/help/App.js:217
+#: assets/build/pages/help.min.js:1854
+msgid "Allows the GoDAM plugin to track anonymous events for analytics purposes. This helps us improve the product experience."
+msgstr ""
+
+#: pages/media-library/App.js:161
+#: assets/build/pages/media-library.min.js:5812
 msgid "New Folder"
 msgstr ""
 
 #: pages/media-library/App.js:178
+#: assets/build/pages/media-library.min.js:5829
 msgid "Bulk Select"
 msgstr ""
 
 #: pages/media-library/App.js:186
+#: assets/build/pages/media-library.min.js:5837
 msgid "By Name (A-Z)"
 msgstr ""
 
 #: pages/media-library/App.js:187
+#: assets/build/pages/media-library.min.js:5838
 msgid "By Name (Z-A)"
 msgstr ""
 
 #: pages/media-library/App.js:202
+#: assets/build/pages/media-library.min.js:5853
 msgid "All Media"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:201
+#: assets/build/pages/media-library.min.js:6097
+msgid "Folder ID is missing for download."
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:220
+#: assets/build/pages/media-library.min.js:6116
+msgid "Failed to start ZIP creation"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:226
+#: assets/build/pages/media-library.min.js:6122
+msgid "Failed to create ZIP file"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:242
+#: assets/build/pages/media-library.min.js:6138
+msgid "Failed to download folder"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:267
+#: assets/build/pages/media-library.min.js:6163
+msgid "Invalid folder for bookmark."
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:290
+#: assets/build/pages/media-library.min.js:6186
+msgid "Bookmark removed successfully"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:291
+#: assets/build/pages/media-library.min.js:6187
+msgid "Bookmark added successfully"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:301
+#: assets/build/pages/media-library.min.js:6197
+msgid "Bookmarks added successfully"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:307
+#: assets/build/pages/media-library.min.js:6203
+msgid "Failed to update bookmark status"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:323
+#: assets/build/pages/media-library.min.js:6219
+msgid "Invalid folder to lock."
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:339
+#: assets/build/pages/media-library.min.js:6235
+msgid "Folder unlocked successfully"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:340
+#: assets/build/pages/media-library.min.js:6236
+msgid "Folder locked successfully"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:362
+#: assets/build/pages/media-library.min.js:6258
+msgid "Folders locked successfully"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:369
+#: assets/build/pages/media-library.min.js:6265
+msgid "Failed to update folder lock status"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:421
+#: assets/build/pages/media-library.min.js:6317
+msgid "New Sub-folder"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:429
+#: pages/media-library/components/modal/RenameModal.jsx:98
+#: assets/build/pages/media-library.min.js:6325
+#: assets/build/pages/media-library.min.js:7834
+msgid "Rename"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:437
+#: assets/build/pages/media-library.min.js:6333
+msgid "Lock Folder"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:437
+#: assets/build/pages/media-library.min.js:6333
+msgid "Unlock Folder"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:445
+#: assets/build/pages/media-library.min.js:6341
+msgid "Add Bookmark"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:445
+#: assets/build/pages/media-library.min.js:6341
+msgid "Remove Bookmark"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:455
+#: assets/build/pages/media-library.min.js:6351
+msgid "Download Zip"
+msgstr ""
+
+#: pages/media-library/components/context-menu/ContextMenu.jsx:464
+#: pages/media-library/components/modal/DeleteModal.jsx:132
+#: pages/video-editor/components/SidebarLayers.js:750
+#: pages/video-editor/components/transcription/Transcription.js:304
+#: assets/build/pages/media-library.min.js:6360
+#: assets/build/pages/media-library.min.js:7575
+#: assets/build/pages/video-editor.min.js:18748
+#: assets/build/pages/video-editor.min.js:26423
+msgid "Delete"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/BookmarkTab.jsx:56
+#: pages/media-library/components/folder-tree/BookmarkTab.jsx:76
+#: assets/build/pages/media-library.min.js:6424
+#: assets/build/pages/media-library.min.js:6444
+msgid "Bookmarks"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/BookmarkTab.jsx:64
+#: assets/build/pages/media-library.min.js:6432
+msgid "No bookmarks yet"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:132
+#: assets/build/pages/media-library.min.js:6598
+msgid "The parent folder is locked, so this folder cannot be moved."
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:162
+#: assets/build/pages/media-library.min.js:6628
+msgid "The destination folder is locked and cannot be modified"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:185
+#: assets/build/pages/media-library.min.js:6651
+msgid "Failed to move folder"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:279
+#: assets/build/pages/media-library.min.js:6745
+msgid "Currently opened folder is locked and cannot be modified"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:290
+#: assets/build/pages/media-library.min.js:6756
+msgid "This folder is locked and cannot be modified"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:304
+#: assets/build/pages/media-library.min.js:6770
+msgid "Items assigned successfully"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/FolderTree.jsx:324
+#: assets/build/pages/media-library.min.js:6790
+msgid "Failed to assign items"
+msgstr ""
+
+#. translators: %s is the error message
+#: pages/media-library/components/folder-tree/FolderTree.jsx:411
+#: assets/build/pages/media-library.min.js:6877
+msgid "Error: %s"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/LockedTab.jsx:65
+#: pages/media-library/components/folder-tree/LockedTab.jsx:85
+#: assets/build/pages/media-library.min.js:7003
+#: assets/build/pages/media-library.min.js:7023
+msgid "Locked"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/LockedTab.jsx:73
+#: assets/build/pages/media-library.min.js:7011
+msgid "No locked folders yet"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/TreeItem.jsx:97
+#: assets/build/pages/media-library.min.js:7247
+msgid "Collapse folder"
+msgstr ""
+
+#: pages/media-library/components/folder-tree/TreeItem.jsx:97
+#: assets/build/pages/media-library.min.js:7247
+msgid "Expand folder"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:73
+#: assets/build/pages/media-library.min.js:7516
+msgid "Some folders could not be deleted"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:81
+#: assets/build/pages/media-library.min.js:7524
+msgid "Folders deleted successfully"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:81
+#: assets/build/pages/media-library.min.js:7524
+msgid "Folder deleted successfully"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:90
+#: assets/build/pages/media-library.min.js:7533
+msgid "Failed to delete folder"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:109
+#: assets/build/pages/media-library.min.js:7552
+msgid "Confirm Delete"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:116
+#: assets/build/pages/media-library.min.js:7559
+msgid "Deleting"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:116
+#: assets/build/pages/media-library.min.js:7559
+msgid "these"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:116
+#: assets/build/pages/media-library.min.js:7559
+msgid "folders"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:116
+#: assets/build/pages/media-library.min.js:7559
+msgid "will remove them and all its subfolders, but"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:116
+#: assets/build/pages/media-library.min.js:7559
+msgid "media associated with them will not be deleted"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:120
+#: assets/build/pages/media-library.min.js:7563
+msgid "Deleting the folder"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:120
+#: assets/build/pages/media-library.min.js:7563
+msgid "will remove it and all its subfolders, but"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:120
+#: assets/build/pages/media-library.min.js:7563
+msgid "media associated with it will not be deleted"
+msgstr ""
+
+#: pages/media-library/components/modal/DeleteModal.jsx:125
+#: assets/build/pages/media-library.min.js:7568
+msgid "Are you sure you want to proceed? This action cannot be undone."
+msgstr ""
+
+#: pages/media-library/components/modal/FolderCreationModal.jsx:71
+#: assets/build/pages/media-library.min.js:7664
+msgid "Folder created successfully"
+msgstr ""
+
+#: pages/media-library/components/modal/FolderCreationModal.jsx:83
+#: assets/build/pages/media-library.min.js:7676
+msgid "Folder with that name already exists."
+msgstr ""
+
+#: pages/media-library/components/modal/FolderCreationModal.jsx:90
+#: assets/build/pages/media-library.min.js:7683
+msgid "Failed to create folder"
+msgstr ""
+
+#: pages/media-library/components/modal/FolderCreationModal.jsx:110
+#: assets/build/pages/media-library.min.js:7703
+msgid "Create a new folder"
+msgstr ""
+
+#: pages/media-library/components/modal/FolderCreationModal.jsx:118
+#: pages/media-library/components/modal/RenameModal.jsx:88
+#: assets/build/pages/media-library.min.js:7711
+#: assets/build/pages/media-library.min.js:7824
+msgid "Folder Name"
+msgstr ""
+
+#: pages/media-library/components/modal/FolderCreationModal.jsx:126
+#: assets/build/pages/media-library.min.js:7719
+msgid "Create"
+msgstr ""
+
+#: pages/media-library/components/modal/RenameModal.jsx:57
+#: assets/build/pages/media-library.min.js:7793
+msgid "Folder renamed successfully"
+msgstr ""
+
+#: pages/media-library/components/modal/RenameModal.jsx:64
+#: assets/build/pages/media-library.min.js:7800
+msgid "Failed to rename folder"
+msgstr ""
+
+#: pages/media-library/components/modal/RenameModal.jsx:83
+#: assets/build/pages/media-library.min.js:7819
+msgid "Rename folder"
+msgstr ""
+
+#: pages/media-library/components/search-bar/SearchBar.jsx:176
+#: assets/build/pages/media-library.min.js:8031
+msgid "Search folder"
+msgstr ""
+
+#: pages/media-library/components/search-bar/SearchBar.jsx:193
+#: assets/build/pages/media-library.min.js:8048
+msgid "No folders found."
+msgstr ""
+
+#: pages/media-library/components/search-bar/SearchBar.jsx:223
+#: assets/build/pages/media-library.min.js:8078
+msgid "Searching…"
+msgstr ""
+
+#: pages/media-library/components/search-bar/SearchBar.jsx:223
+#: assets/build/pages/media-library.min.js:8078
+msgid "Loading more results…"
+msgstr ""
+
+#: pages/media-library/components/search-bar/SearchBar.jsx:224
+#: assets/build/pages/media-library.min.js:8079
+msgid "Error fetching results."
+msgstr ""
+
+#: pages/media-library/redux/api/folders.js:46
+#: assets/build/pages/media-library.min.js:8548
+msgid "Failed to prepare the ZIP file."
+msgstr ""
+
+#: pages/media-library/redux/api/folders.js:61
+#: assets/build/pages/media-library.min.js:8563
+msgid "Timed out while preparing the ZIP file."
+msgstr ""
+
+#: pages/onboarding/components/BackButton.jsx:19
+#: assets/build/pages/onboarding.min.js:520
+msgid "BACK"
+msgstr ""
+
+#: pages/onboarding/components/OnboardingModal.jsx:71
+#: assets/build/pages/onboarding.min.js:615
+msgid "GoDAM onboarding"
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:34
+#: assets/build/pages/onboarding.min.js:843
+msgid "You have unlocked GoDAM for Woo"
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:34
+#: pages/onboarding/components/screens/WelcomeScreen.jsx:19
+#: assets/build/pages/onboarding.min.js:843
+#: assets/build/pages/onboarding.min.js:1289
+msgid "Welcome to GoDAM Pro!"
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:39
+#: assets/build/pages/onboarding.min.js:848
+msgid "A scalable digital asset management platform for WordPress, optimized for conversion-driven video content."
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:43
+#: assets/build/pages/onboarding.min.js:852
+msgid "New here? Start your 60-day free trial now."
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:46
+#: assets/build/pages/onboarding.min.js:855
+msgid "Enjoy a 60-day free trial. After that, continue for $9/month or cancel anytime. No credit card or payment required today."
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:49
+#: pages/onboarding/components/screens/SignupScreen.jsx:70
+#: pages/video-editor/components/transcription/Transcription.js:254
+#: assets/build/pages/onboarding.min.js:858
+#: assets/build/pages/onboarding.min.js:1185
+#: assets/build/pages/video-editor.min.js:26373
+msgid "OR"
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:52
+#: assets/build/pages/onboarding.min.js:861
+msgid "Login with Email"
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:55
+#: pages/onboarding/components/screens/SignupScreen.jsx:67
+#: assets/build/pages/onboarding.min.js:864
+#: assets/build/pages/onboarding.min.js:1182
+msgid "Continue with Google"
+msgstr ""
+
+#: pages/onboarding/components/screens/EntryScreen.jsx:58
+#: assets/build/pages/onboarding.min.js:867
+msgid "Already have a License key?"
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:34
+#: pages/onboarding/utils/validators.js:61
+#: assets/build/pages/onboarding.min.js:908
+#: assets/build/pages/onboarding.min.js:1865
+msgid "Enter a valid email address."
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:41
+#: assets/build/pages/onboarding.min.js:915
+msgid "Could not send the reset link."
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:48
+#: assets/build/pages/onboarding.min.js:922
+msgid "Reset your password"
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:52
+#: assets/build/pages/onboarding.min.js:926
+msgid "If that account exists, we've emailed a link to set a new password. Open it to finish resetting, then come back and sign in."
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:56
+#: assets/build/pages/onboarding.min.js:930
+msgid "Confirm your email and we'll send you a link to set up a new password."
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:58
+#: pages/onboarding/components/screens/LoginScreen.jsx:54
+#: pages/onboarding/components/screens/SignupScreen.jsx:77
+#: assets/build/pages/onboarding.min.js:932
+#: assets/build/pages/onboarding.min.js:1091
+#: assets/build/pages/onboarding.min.js:1192
+msgid "Email"
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:61
+#: assets/build/pages/onboarding.min.js:935
+msgid "Sending…"
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:61
+#: assets/build/pages/onboarding.min.js:935
+msgid "Reset Password"
+msgstr ""
+
+#: pages/onboarding/components/screens/ForgotPasswordScreen.jsx:67
+#: assets/build/pages/onboarding.min.js:941
+msgid "Go back to sign in"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:36
+#: assets/build/pages/onboarding.min.js:984
+msgid "Please enter your license key."
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:43
+#: assets/build/pages/onboarding.min.js:991
+msgid "That license key could not be verified."
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:50
+#: assets/build/pages/onboarding.min.js:998
+msgid "Sign in with license key"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:57
+#: assets/build/pages/onboarding.min.js:1005
+msgid "License key"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:58
+#: assets/build/pages/onboarding.min.js:1006
+msgid "Enter your license key"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:67
+#: assets/build/pages/onboarding.min.js:1015
+msgid "Hide license key"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:67
+#: assets/build/pages/onboarding.min.js:1015
+msgid "Show license key"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:74
+#: assets/build/pages/onboarding.min.js:1022
+msgid "Verifying…"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:74
+#: assets/build/pages/onboarding.min.js:1022
+msgid "Verify to Sign in"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:78
+#: assets/build/pages/onboarding.min.js:1026
+msgid "Lost your key? Find it on your GoDAM app"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:81
+#: assets/build/pages/onboarding.min.js:1029
+msgid "Login with email instead?"
+msgstr ""
+
+#: pages/onboarding/components/screens/LicenseKeyScreen.jsx:82
+#: pages/onboarding/components/screens/LoginScreen.jsx:62
+#: pages/onboarding/components/screens/SignupScreen.jsx:91
+#: assets/build/pages/onboarding.min.js:1030
+#: assets/build/pages/onboarding.min.js:1099
+#: assets/build/pages/onboarding.min.js:1206
+msgid "Sign in"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:36
+#: assets/build/pages/onboarding.min.js:1073
+msgid "Enter a valid email and password."
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:44
+#: assets/build/pages/onboarding.min.js:1081
+msgid "Invalid email or password."
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:51
+#: assets/build/pages/onboarding.min.js:1088
+msgid "Sign in to your account"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:55
+#: pages/onboarding/components/screens/SignupScreen.jsx:78
+#: assets/build/pages/onboarding.min.js:1092
+#: assets/build/pages/onboarding.min.js:1193
+msgid "Password"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:55
+#: pages/onboarding/components/screens/SignupScreen.jsx:79
+#: assets/build/pages/onboarding.min.js:1092
+#: assets/build/pages/onboarding.min.js:1194
+msgid "Enter Password"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:57
+#: assets/build/pages/onboarding.min.js:1094
+msgid "Forgot Password?"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:62
+#: assets/build/pages/onboarding.min.js:1099
+msgid "Signing in…"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:66
+#: assets/build/pages/onboarding.min.js:1103
+msgid "Don't have an account?"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:67
+#: assets/build/pages/onboarding.min.js:1104
+msgid "Sign up"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:70
+#: assets/build/pages/onboarding.min.js:1107
+msgid "Got a licence key?"
+msgstr ""
+
+#: pages/onboarding/components/screens/LoginScreen.jsx:71
+#: assets/build/pages/onboarding.min.js:1108
+msgid "Login with key"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:57
+#: assets/build/pages/onboarding.min.js:1172
+msgid "Could not create your account. Please try again."
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:64
+#: assets/build/pages/onboarding.min.js:1179
+msgid "Create your account"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:74
+#: assets/build/pages/onboarding.min.js:1189
+msgid "First Name"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:75
+#: assets/build/pages/onboarding.min.js:1190
+msgid "Last Name"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:78
+#: assets/build/pages/onboarding.min.js:1193
+msgid "Enter password"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:79
+#: assets/build/pages/onboarding.min.js:1194
+msgid "Confirm Password"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:82
+#: assets/build/pages/onboarding.min.js:1197
+msgid "I agree to"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:82
+#: assets/build/pages/onboarding.min.js:1197
+msgid "Terms and Conditions, Privacy Policy, Refund Policy"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:83
+#: assets/build/pages/onboarding.min.js:1198
+msgid "Email me product updates and release news."
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:87
+#: assets/build/pages/onboarding.min.js:1202
+msgid "Creating…"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:87
+#: assets/build/pages/onboarding.min.js:1202
+msgid "Sign Up"
+msgstr ""
+
+#: pages/onboarding/components/screens/SignupScreen.jsx:90
+#: assets/build/pages/onboarding.min.js:1205
+msgid "Already have an account?"
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:31
+#: assets/build/pages/onboarding.min.js:1244
+msgid "Verification email re-sent."
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:33
+#: assets/build/pages/onboarding.min.js:1246
+msgid "Could not resend the email."
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:39
+#: assets/build/pages/onboarding.min.js:1252
+msgid "Verify your email"
+msgstr ""
+
+#. translators: %s: user email address.
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:42
+#: assets/build/pages/onboarding.min.js:1255
+msgid "We sent a verification link to %s. Click it to activate your account, then sign in."
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:43
+#: assets/build/pages/onboarding.min.js:1256
+msgid "We sent you a verification link. Click it to activate your account, then sign in."
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:47
+#: assets/build/pages/onboarding.min.js:1260
+msgid "I've verified, sign in"
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:50
+#: assets/build/pages/onboarding.min.js:1263
+msgid "Resending…"
+msgstr ""
+
+#: pages/onboarding/components/screens/VerifyEmailScreen.jsx:50
+#: assets/build/pages/onboarding.min.js:1263
+msgid "Resend email"
+msgstr ""
+
+#: pages/onboarding/components/screens/WelcomeScreen.jsx:20
+#: assets/build/pages/onboarding.min.js:1290
+msgid "You're all set. Upload videos to your WordPress Media Library and GoDAM auto-syncs them here."
+msgstr ""
+
+#: pages/onboarding/components/screens/WelcomeScreen.jsx:28
+#: assets/build/pages/onboarding.min.js:1298
+msgid "Go to dashboard"
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:54
+#: assets/build/pages/onboarding.min.js:1358
+msgid "Could not get the workspace key."
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:64
+#: assets/build/pages/onboarding.min.js:1368
+msgid "No workspaces yet"
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:67
+#: assets/build/pages/onboarding.min.js:1371
+msgid "This account has no workspaces. <a>Create one in the GoDAM app</a>, then come back."
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:82
+#: assets/build/pages/onboarding.min.js:1386
+msgid "Select a workspace"
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:83
+#: assets/build/pages/onboarding.min.js:1387
+msgid "Choose a workspace to start working!"
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:89
+#: assets/build/pages/onboarding.min.js:1393
+msgid "Select a Workspace"
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:118
+#: assets/build/pages/onboarding.min.js:1422
+msgid "Please note that you won't be able to switch to another workspace after logging in."
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
+#: assets/build/pages/onboarding.min.js:1427
+msgid "Connecting…"
+msgstr ""
+
+#: pages/onboarding/components/screens/WorkspaceScreen.jsx:123
+#: assets/build/pages/onboarding.min.js:1427
+msgid "Continue"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:21
+#: assets/build/pages/onboarding.min.js:656
+msgid "Sites"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:21
+#: assets/build/pages/onboarding.min.js:656
+msgid "Use GoDAM on unlimited WordPress sites."
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:22
+#: assets/build/pages/onboarding.min.js:657
+msgid "Generous bandwidth that resets every month."
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:23
+#: assets/build/pages/onboarding.min.js:658
+msgid "Teams"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:23
+#: assets/build/pages/onboarding.min.js:658
+msgid "Invite unlimited editors and contributors."
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:24
+#: assets/build/pages/onboarding.min.js:659
+msgid "Security"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:24
+#: assets/build/pages/onboarding.min.js:659
+msgid "Enterprise-grade encryption."
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:25
+#: assets/build/pages/onboarding.min.js:660
+msgid "A one-time storage allocation that stays yours."
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:26
+#: assets/build/pages/onboarding.min.js:661
+msgid "Global CDN"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:26
+#: assets/build/pages/onboarding.min.js:661
+msgid "Media served from 100+ locations."
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:30
+#: assets/build/pages/onboarding.min.js:665
+msgid "No credit card required"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:31
+#: assets/build/pages/onboarding.min.js:666
+msgid "Drive conversions with AI-powered tools"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:32
+#: assets/build/pages/onboarding.min.js:667
+msgid "Set up in minutes on your existing site"
+msgstr ""
+
+#: pages/onboarding/components/SidePanel.jsx:39
+#: assets/build/pages/onboarding.min.js:674
+msgid "Used by forward thinking teams"
+msgstr ""
+
+#: pages/onboarding/utils/use-connect.js:37
+#: assets/build/pages/onboarding.min.js:1655
+msgid "Could not load your workspaces. Please try again."
+msgstr ""
+
+#: pages/onboarding/utils/use-google-signin.js:50
+#: pages/onboarding/utils/use-google-signin.js:114
+#: assets/build/pages/onboarding.min.js:1710
+#: assets/build/pages/onboarding.min.js:1774
+msgid "Google sign-in failed."
+msgstr ""
+
+#: pages/onboarding/utils/use-google-signin.js:61
+#: assets/build/pages/onboarding.min.js:1721
+msgid "Google sign-in is unavailable right now. Please use another sign-in method."
+msgstr ""
+
+#: pages/onboarding/utils/use-google-signin.js:67
+#: assets/build/pages/onboarding.min.js:1727
+msgid "Popup blocked. Allow popups for this site and try again."
+msgstr ""
+
+#: pages/onboarding/utils/use-google-signin.js:125
+#: assets/build/pages/onboarding.min.js:1785
+msgid "Google sign-in was cancelled."
+msgstr ""
+
+#: pages/onboarding/utils/use-google-signin.js:138
+#: assets/build/pages/onboarding.min.js:1798
+msgid "Could not start Google sign-in."
+msgstr ""
+
+#: pages/onboarding/utils/validators.js:58
+#: assets/build/pages/onboarding.min.js:1862
+msgid "First name is required."
+msgstr ""
+
+#: pages/onboarding/utils/validators.js:64
+#: assets/build/pages/onboarding.min.js:1868
+msgid "Password must be at least 8 characters."
+msgstr ""
+
+#: pages/onboarding/utils/validators.js:67
+#: assets/build/pages/onboarding.min.js:1871
+msgid "Passwords do not match."
+msgstr ""
+
+#: pages/onboarding/utils/validators.js:70
+#: assets/build/pages/onboarding.min.js:1874
+msgid "Please accept the Terms to continue."
+msgstr ""
+
+#: pages/shared/AnalyticsUnavailableNotice.jsx:24
+#: assets/build/pages/analytics.min.js:17062
+#: assets/build/pages/dashboard.min.js:5088
+msgid "Analytics is temporarily unavailable."
+msgstr ""
+
+#: pages/shared/AnalyticsUnavailableNotice.jsx:25
+#: assets/build/pages/analytics.min.js:17063
+#: assets/build/pages/dashboard.min.js:5089
+msgid "We couldn’t reach the GoDAM analytics service. This is usually temporary. Please refresh in a few minutes."
+msgstr ""
+
+#: pages/tools/App.js:28
+#: assets/build/pages/tools.min.js:1640
+msgid "Video Migration"
+msgstr ""
+
+#: pages/tools/App.js:34
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:201
+#: assets/build/pages/tools.min.js:1646
+#: assets/build/pages/tools.min.js:1974
+msgid "Media Usage Sync"
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:70
+#: assets/build/pages/tools.min.js:1843
+msgid "Media usage sync completed successfully."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:102
+#: assets/build/pages/tools.min.js:1875
+msgid "All posts are already synced — nothing to do."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:110
+#: assets/build/pages/tools.min.js:1883
+msgid "Failed to start the sync. Please try again."
+msgstr ""
+
+#. translators: 1: posts synced so far, 2: total posts to sync.
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:129
+#: assets/build/pages/tools.min.js:1902
+msgid "Sync stopped. %1$d of %2$d posts were synced. You can resume at any time."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:139
+#: assets/build/pages/tools.min.js:1912
+msgid "Failed to stop the sync. Please try again."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:150
+#: assets/build/pages/tools.min.js:1923
+msgid "Syncing…"
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:153
+#: assets/build/pages/tools.min.js:1926
+msgid "Resume Sync"
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:156
+#: assets/build/pages/tools.min.js:1929
+msgid "Sync Completed"
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:158
+#: assets/build/pages/tools.min.js:1931
+msgid "Start Sync"
+msgstr ""
+
+#. translators: 1: posts synced so far, 2: total posts to sync.
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:167
+#: assets/build/pages/tools.min.js:1940
+msgid "%1$d of %2$d posts synced…"
+msgstr ""
+
+#. translators: 1: posts synced so far, 2: total posts to sync.
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:175
+#: assets/build/pages/tools.min.js:1948
+msgid "%1$d of %2$d posts synced (stopped)."
+msgstr ""
+
+#. translators: %d: total number of posts synced.
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:182
+#: assets/build/pages/tools.min.js:1955
+msgid "%d posts synced."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:204
+#: assets/build/pages/tools.min.js:1977
+msgid "Scans all existing posts and pages to record which media files are used where. GoDAM starts this scan automatically in the background — use this page to monitor progress or trigger it manually if needed."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:210
+#: assets/build/pages/tools.min.js:1983
+msgid "This sync is completely non-destructive."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:212
+#: assets/build/pages/tools.min.js:1985
+msgid "It will not alter, move, or delete any of your existing media files."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:216
+#: assets/build/pages/tools.min.js:1989
+msgid "Processing runs in small background batches so your site stays fully responsive throughout."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:232
+#: assets/build/pages/tools.min.js:2005
+msgid "Only administrators can start or stop the media usage sync."
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:255
+#: assets/build/pages/tools.min.js:2028
+msgid "Stopping…"
+msgstr ""
+
+#: pages/tools/components/tabs/MediaUsageSyncTab.jsx:256
+#: assets/build/pages/tools.min.js:2029
+msgid "Stop Sync"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:36
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:40
+#: assets/build/pages/tools.min.js:2077
+#: assets/build/pages/tools.min.js:2395
+msgid "Starting…"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:54
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:69
+#: assets/build/pages/tools.min.js:2095
+#: assets/build/pages/tools.min.js:2424
+msgid "Something went wrong while starting migration."
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:130
+#: assets/build/pages/tools.min.js:2171
+msgid "WordPress core video migration completed successfully 🎉"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:133
+#: assets/build/pages/tools.min.js:2174
+msgid "WordPress core video migration failed. Please try again."
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:165
+#: assets/build/pages/tools.min.js:2206
+msgid "Core video Migration"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:167
+#: assets/build/pages/tools.min.js:2208
+msgid "This tool replaces WordPress core video blocks with GoDAM video blocks. It does not replace videos added in the WordPress Classic Editor."
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:186
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:222
+#: assets/build/pages/tools.min.js:2227
+#: assets/build/pages/tools.min.js:2577
+msgid "Abort"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
+#: assets/build/pages/tools.min.js:2236
+#: assets/build/pages/tools.min.js:2586
+msgid "Restart Migration"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/CoreVideoMigration.jsx:195
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:231
+#: assets/build/pages/tools.min.js:2236
+#: assets/build/pages/tools.min.js:2586
+msgid "Start Migration"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:141
+#: assets/build/pages/tools.min.js:2496
+msgid "Vimeo Video Migration has been successfully completed for all posts and pages 🎉"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:144
+#: assets/build/pages/tools.min.js:2499
+msgid "Vimeo Video Migration failed. Please try again."
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:176
+#: assets/build/pages/tools.min.js:2531
+msgid "Vimeo video Migration"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:178
+#: assets/build/pages/tools.min.js:2533
+msgid "This tool replaces WordPress Vimeo Embed blocks with GoDAM Video blocks. It does not replace Vimeo videos added in the WordPress Classic Editor."
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:183
+#: assets/build/pages/tools.min.js:2538
+msgid "This migrator will only migrate Vimeo videos that are already fetched on GoDAM Central."
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:184
+#: assets/build/pages/tools.min.js:2539
+msgid "Open"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:199
+#: assets/build/pages/tools.min.js:2554
+msgid "Vimeo video migration in WordPress can only begin after all Vimeo videos have been successfully migrated to GoDAM Central,"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:201
+#: assets/build/pages/tools.min.js:2556
+msgid "Check here!"
+msgstr ""
+
+#: pages/tools/components/tabs/Migration/VimeoVideoMigration.jsx:210
+#: assets/build/pages/tools.min.js:2565
+msgid "Migration is in progress. Please wait…"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:34
+#: assets/build/pages/tools.min.js:2630
+msgid "All media"
+msgstr ""
+
+#. translators: %s is a comma-separated list of file extensions, e.g. "PDF, DOCX".
+#: pages/tools/components/tabs/RetranscodeTab.jsx:91
+#: assets/build/pages/tools.min.js:2687
+msgid "Fetches %s files. GoDAM converts each one to a preview PDF."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:94
+#: assets/build/pages/tools.min.js:2690
+msgid "Choose which type of media to fetch for transcoding."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:120
+#: assets/build/pages/tools.min.js:2716
+msgid "The requested operation is not allowed. The nonce provided in the URL is invalid or expired."
+msgstr ""
+
+#. translators: %d is the number of selected media files to be transcoded.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:150
+#: pages/tools/components/tabs/RetranscodeTab.jsx:175
+#: assets/build/pages/tools.min.js:2746
+#: assets/build/pages/tools.min.js:2771
+msgid "%d selected media file(s) will be transcoded."
+msgstr ""
+
+#. translators: %d is the number of selected media files to be retranscoded.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:160
+#: assets/build/pages/tools.min.js:2756
+msgid "%d selected media file(s) will be retranscoded."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:217
+#: assets/build/pages/tools.min.js:2813
+msgid "No media files found for retranscoding. Please ensure you have media files that require retranscoding."
+msgstr ""
+
+#. translators: %s is the selected media type label, e.g. Video.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:222
+#: assets/build/pages/tools.min.js:2818
+msgid "No media files of the selected type (%s) found for retranscoding. Please ensure you have media files of this type that require retranscoding."
+msgstr ""
+
+#. translators: %s is the error message.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:233
+#: assets/build/pages/tools.min.js:2829
+msgid "Failed to fetch media for retranscoding: %s"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:250
+#: assets/build/pages/tools.min.js:2846
+msgid "Aborting operation to send media for retranscoding."
+msgstr ""
+
+#. translators: %d is the number of virtual media files found.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:370
+#: assets/build/pages/tools.min.js:2966
+msgid "%d virtual media file(s) found, which need to be retranscoded on GoDAM Central."
+msgstr ""
+
+#. translators: %d is the number of media files retranscoded.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:379
+#: assets/build/pages/tools.min.js:2975
+msgid "Successfully sent %d media file(s) for retranscoding."
+msgstr ""
+
+#. translators: %d is the number of media files that failed to retranscode.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:394
+#: assets/build/pages/tools.min.js:2990
+msgid "Failed to send %d media file(s) for retranscoding."
+msgstr ""
+
+#. translators: %d is the number of media files that were skipped.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:412
+#: assets/build/pages/tools.min.js:3008
+msgid "%d media file(s) were skipped and not sent for retranscoding."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:425
+#: assets/build/pages/tools.min.js:3021
+msgid "Operation completed without any media files to retranscode."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:458
+#: assets/build/pages/tools.min.js:3054
+msgid "This tool allows you to retranscode your media files. You can either retranscode specific files selected from the Media Library, or pick a media type below and fetch the files of that type that are not yet transcoded."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:465
+#: assets/build/pages/tools.min.js:3061
+msgid "Checking the \"Force retranscode\" option will retranscode all media files regardless of their current state."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:470
+#: assets/build/pages/tools.min.js:3066
+msgid "Note: Transcoding and retranscoding will use your bandwidth allowance. Use the force retranscode option carefully."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:481
+#: assets/build/pages/tools.min.js:3077
+msgid "Storage Limit Exceeded:"
+msgstr ""
+
+#. translators: %s is the storage usage percentage.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:484
+#: assets/build/pages/tools.min.js:3080
+msgid "Your storage usage has exceeded your plan limit (%s%%). Retranscoding is currently blocked. Please upgrade your plan to continue."
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:500
+#: assets/build/pages/tools.min.js:3096
+msgid "Media type"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:517
+#: assets/build/pages/tools.min.js:3113
+msgid "Force retranscode (even if already transcoded)"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:533
+#: assets/build/pages/tools.min.js:3129
+msgid "Fetching media that require retranscoding…"
+msgstr ""
+
+#. translators: %d is the number of untranscoded media files.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:552
+#: assets/build/pages/tools.min.js:3148
+msgid "%d untranscoded media file(s) selected"
+msgstr ""
+
+#. translators: %d is the number of transcoded media files.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:561
+#: assets/build/pages/tools.min.js:3157
+msgid "%d transcoded media file(s) selected"
+msgstr ""
+
+#. translators: 1: number of media files that require retranscoding, 2: total number of media files.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:574
+#: assets/build/pages/tools.min.js:3170
+msgid "%1$d/%2$d media file(s) require retranscoding."
+msgstr ""
+
+#. translators: 1: number of media files that will be retranscoded regardless of their current state, 2: total number of media files.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:580
+#: assets/build/pages/tools.min.js:3176
+msgid "%1$d/%2$d media file(s) will be retranscoded regardless of their current state."
+msgstr ""
+
+#. translators: 1: number of media files sent for retranscoding, 2: total number of media files selected.
+#: pages/tools/components/tabs/RetranscodeTab.jsx:593
+#: assets/build/pages/tools.min.js:3189
+msgid "%1$d/%2$d media files sent for retranscoding…"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:631
+#: assets/build/pages/tools.min.js:3227
+msgid "Fetch Media"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:635
+#: assets/build/pages/tools.min.js:3231
+msgid "Start Transcoding"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:637
+#: assets/build/pages/tools.min.js:3233
+msgid "Start Retranscoding"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:641
+#: assets/build/pages/tools.min.js:3237
+msgid "Restart Transcoding"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:643
+#: assets/build/pages/tools.min.js:3239
+msgid "Restart Retranscoding"
+msgstr ""
+
+#: pages/tools/components/tabs/RetranscodeTab.jsx:656
+#: assets/build/pages/tools.min.js:3252
+msgid "Abort Operation"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:96
+#: assets/build/pages/video-editor.min.js:18862
+msgid "Select / Upload Ad video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:98
+#: assets/build/pages/video-editor.min.js:18864
+msgid "Add video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:160
+#: assets/build/pages/video-editor.min.js:18926
+msgid "Ad video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:169
+#: assets/build/pages/video-editor.min.js:18935
+msgid "This ad will be overridden by the Ad server's ads."
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:175
+#: assets/build/pages/video-editor.min.js:18941
+msgid "Ad Video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:186
+#: assets/build/pages/video-editor.min.js:18952
+msgid "Select Ad Video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:189
+#: assets/build/pages/video-editor.min.js:18955
+msgid "Upload or choose a self-hosted video (MP4 recommended)."
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:196
+#: assets/build/pages/video-editor.min.js:18962
+msgid "Click to replace video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:201
+#: assets/build/pages/video-editor.min.js:18967
+msgid "Replace ad video"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:234
+#: assets/build/pages/video-editor.min.js:19000
+msgid "Playback"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:237
+#: assets/build/pages/video-editor.min.js:19003
+msgid "Skippable"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:238
+#: assets/build/pages/video-editor.min.js:19004
+msgid "Allow viewers to skip the ad"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:249
+#: assets/build/pages/video-editor.min.js:19015
+msgid "Skip after (seconds)"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:250
+#: assets/build/pages/video-editor.min.js:19016
+msgid "Time in seconds before the skip button appears"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:262
+#: assets/build/pages/video-editor.min.js:19028
+msgid "Click-through"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:264
+#: assets/build/pages/video-editor.min.js:19030
+msgid "Click link"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:267
+#: assets/build/pages/video-editor.min.js:19033
+msgid "URL to open when the ad is clicked"
+msgstr ""
+
+#: pages/video-editor/components/ads/CustomAdSettings.js:268
+#: pages/video-editor/components/cta/CardCTA.js:274
+#: pages/video-editor/components/cta/CardCTA.js:284
+#: pages/video-editor/components/layers/HotspotLayer.js:486
+#: assets/build/pages/video-editor.min.js:19034
+#: assets/build/pages/video-editor.min.js:20939
+#: assets/build/pages/video-editor.min.js:20949
+#: assets/build/pages/video-editor.min.js:24628
+msgid "Please enter a valid URL (e.g., https://example.com)"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:84
+#: assets/build/pages/video-editor.min.js:19130
+msgid "Select Custom Logo"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:85
+#: assets/build/pages/video-editor.min.js:19131
+msgid "Use this logo"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:93
+#: assets/build/pages/video-editor.min.js:19139
+msgid "Only image files are allowed"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:132
+#: assets/build/pages/video-editor.min.js:19178
+msgid "Show volume slider"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:138
+#: assets/build/pages/video-editor.min.js:19184
+msgid "Display captions"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:144
+#: assets/build/pages/video-editor.min.js:19190
+msgid "Adjust Skip Duration"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:145
+#: assets/build/pages/video-editor.min.js:19191
+msgid "Number of seconds the skip-forward / skip-backward buttons jump."
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:149
+#: assets/build/pages/video-editor.min.js:19195
+msgid "5 seconds"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:150
+#: assets/build/pages/video-editor.min.js:19196
+msgid "10 seconds"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:151
+#: assets/build/pages/video-editor.min.js:19197
+msgid "30 seconds"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:156
+#: assets/build/pages/video-editor.min.js:19202
+msgid "Customisation Settings"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:165
+#: assets/build/pages/video-editor.min.js:19211
+msgid "Add Custom logo"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:174
+#: assets/build/pages/video-editor.min.js:19220
+msgid "Replace logo"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:176
+#: pages/video-editor/components/appearance/Appearance.js:178
+#: assets/build/pages/video-editor.min.js:19222
+#: assets/build/pages/video-editor.min.js:19224
+msgid "Custom logo"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:179
+#: assets/build/pages/video-editor.min.js:19225
+msgid "Click to replace"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:182
+#: assets/build/pages/video-editor.min.js:19228
+msgid "Remove logo"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:194
+#: assets/build/pages/video-editor.min.js:19240
+msgid "Player Theme"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:199
+#: assets/build/pages/video-editor.min.js:19245
+msgid "Player Appearance"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:206
+#: assets/build/pages/video-editor.min.js:19252
+msgid "Icons hover colour"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:213
+#: assets/build/pages/video-editor.min.js:19259
+msgid "Ad Server"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:216
+#: assets/build/pages/video-editor.min.js:19262
+msgid "Use ad server's ad"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:217
+#: assets/build/pages/video-editor.min.js:19263
+msgid "Enable this option to use ads from the ad server. This option will disable the ads layer"
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:231
+#: assets/build/pages/video-editor.min.js:19277
+msgid "A VAST ad tag URL is used by a player to retrieve video and audio ads."
+msgstr ""
+
+#: pages/video-editor/components/appearance/Appearance.js:243
+#: assets/build/pages/video-editor.min.js:19289
+msgid "Select a default thumbnail for this video. You can also override the default thumbnail for different video placements."
+msgstr ""
+
+#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:67
+#: assets/build/pages/video-editor.min.js:19367
+msgid "Select Video Thumbnail"
+msgstr ""
+
+#: pages/video-editor/components/appearance/ThumbnailSelector.jsx:68
+#: assets/build/pages/video-editor.min.js:19368
+msgid "Use this thumbnail"
+msgstr ""
+
+#. translators: %d is the chapter number.
+#. translators: %d is the chapter position in the list.
+#: pages/video-editor/components/audio/AudioCardPreview.js:285
+#: pages/video-editor/components/chapters/Chapters.js:129
+#: assets/build/pages/video-editor.min.js:19756
+#: assets/build/pages/video-editor.min.js:20118
+msgid "Chapter %d"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:63
+#: assets/build/pages/video-editor.min.js:19869
+msgid "Invalid start time format"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:65
+#: assets/build/pages/video-editor.min.js:19871
+msgid "Start time cannot be negative"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:67
+#: assets/build/pages/video-editor.min.js:19873
+msgid "Start time exceeds the video duration"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:72
+#: assets/build/pages/video-editor.min.js:19878
+msgid "Invalid end time format"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:74
+#: assets/build/pages/video-editor.min.js:19880
+msgid "End time must be after the start time"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:76
+#: assets/build/pages/video-editor.min.js:19882
+msgid "End time exceeds the video duration"
+msgstr ""
+
+#. translators: %s is the title of the overlapping chapter.
+#: pages/video-editor/components/chapters/ChapterForm.js:87
+#: assets/build/pages/video-editor.min.js:19893
+msgid "Overlaps with “%s”"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:90
+#: assets/build/pages/video-editor.min.js:19896
+msgid "Overlaps with another chapter"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:116
+#: pages/video-editor/components/chapters/Chapters.js:142
+#: assets/build/pages/video-editor.min.js:19922
+#: assets/build/pages/video-editor.min.js:20131
+msgid "Edit chapter"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:116
+#: pages/video-editor/components/chapters/ChapterForm.js:165
+#: assets/build/pages/video-editor.min.js:19922
+#: assets/build/pages/video-editor.min.js:19971
+msgid "Add chapter"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:131
+#: assets/build/pages/video-editor.min.js:19937
+msgid "Chapter title"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:132
+#: assets/build/pages/video-editor.min.js:19938
+msgid "e.g. Introduction"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:140
+#: assets/build/pages/video-editor.min.js:19946
+msgid "Start time"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:148
+#: assets/build/pages/video-editor.min.js:19954
+msgid "End time"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:165
+#: assets/build/pages/video-editor.min.js:19971
+msgid "Save chapter"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:169
+#: assets/build/pages/video-editor.min.js:19975
+msgid "Read more about timestamp format"
+msgstr ""
+
+#: pages/video-editor/components/chapters/ChapterForm.js:175
+#: assets/build/pages/video-editor.min.js:19981
+msgid "here"
+msgstr ""
+
+#. translators: %d is the number of chapters.
+#: pages/video-editor/components/chapters/Chapters.js:80
+#: assets/build/pages/video-editor.min.js:20069
+msgid "Chapters (%d)"
+msgstr ""
+
+#: pages/video-editor/components/chapters/Chapters.js:150
+#: assets/build/pages/video-editor.min.js:20139
+msgid "Delete chapter"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:174
+#: assets/build/pages/video-editor.min.js:20839
+msgid "Select Custom Background Image"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:176
+#: assets/build/pages/video-editor.min.js:20841
+msgid "Use this Background Image"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:310
+#: assets/build/pages/video-editor.min.js:20975
+msgid "Image Left, Text Right (Full Height)"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:311
+#: assets/build/pages/video-editor.min.js:20976
+msgid "Text Left, Image Right (Full Height)"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:312
+#: assets/build/pages/video-editor.min.js:20977
+msgid "Image Left, Text Right"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:313
+#: assets/build/pages/video-editor.min.js:20978
+msgid "Text Left, Image Right"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:314
+#: assets/build/pages/video-editor.min.js:20979
+msgid "Image Top, Text Bottom"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:315
+#: assets/build/pages/video-editor.min.js:20980
+msgid "Text Top, Image Bottom"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:316
+#: assets/build/pages/video-editor.min.js:20981
+msgid "Image Background"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:317
+#: assets/build/pages/video-editor.min.js:20982
+msgid "Text Only (No Image)"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:338
+#: assets/build/pages/video-editor.min.js:21003
+msgid "Card Layout"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:360
+#: assets/build/pages/video-editor.min.js:21025
+msgid "Recommended size: 100KB"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:376
+#: assets/build/pages/video-editor.min.js:21041
+msgid "Click to replace image"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:381
+#: assets/build/pages/video-editor.min.js:21046
+msgid "Replace image"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:386
+#: assets/build/pages/video-editor.min.js:21051
+msgid "Selected CTA image"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:423
+#: assets/build/pages/video-editor.min.js:21088
+msgid "Width"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:436
+#: pages/video-editor/components/cta/CardCTA.js:438
+#: assets/build/pages/video-editor.min.js:21101
+#: assets/build/pages/video-editor.min.js:21103
+msgid "Card Title"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:441
+#: assets/build/pages/video-editor.min.js:21106
+msgid "Add title here"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:446
+#: assets/build/pages/video-editor.min.js:21111
+msgid "Character limit"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:449
+#: assets/build/pages/video-editor.min.js:21114
+msgid "Your description"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:455
+#: assets/build/pages/video-editor.min.js:21120
+msgid "Button Settings"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:457
+#: assets/build/pages/video-editor.min.js:21122
+msgid "Button Title"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:464
+#: assets/build/pages/video-editor.min.js:21129
+msgid "Button Link"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:472
+#: assets/build/pages/video-editor.min.js:21137
+msgid "Button Colour"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:477
+#: assets/build/pages/video-editor.min.js:21142
+msgid "Text"
+msgstr ""
+
+#: pages/video-editor/components/cta/CardCTA.js:484
+#: pages/video-editor/components/layers/FormLayer.js:147
+#: pages/video-editor/components/layers/HotspotLayer.js:580
+#: pages/video-editor/components/layers/PollLayer.js:72
+#: assets/build/pages/video-editor.min.js:21149
+#: assets/build/pages/video-editor.min.js:24129
+#: assets/build/pages/video-editor.min.js:24722
+#: assets/build/pages/video-editor.min.js:25309
+msgid "Background"
+msgstr ""
+
+#: pages/video-editor/components/cta/HtmlCTA.js:25
+#: assets/build/pages/video-editor.min.js:21187
+msgid "Custom HTML"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:48
+#: assets/build/pages/video-editor.min.js:21254
+msgid "Configuration Panel"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:49
+#: assets/build/pages/video-editor.min.js:21255
+msgid "Selected layer will be displayed here"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:52
+#: assets/build/pages/video-editor.min.js:21258
+msgid "No layers selected"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/ConfigurationPanel.js:53
+#: assets/build/pages/video-editor.min.js:21259
+msgid "Select a layer from the left panel to edit its properties"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorSkeleton.js:57
+#: pages/video-editor/components/editor-shell/EditorSkeleton.js:59
+#: assets/build/pages/video-editor.min.js:21332
+#: assets/build/pages/video-editor.min.js:21334
+msgid "Loading video editor…"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:107
+#: assets/build/pages/video-editor.min.js:21551
+msgid "The total number of times this video has been played."
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:110
+#: assets/build/pages/video-editor.min.js:21554
+msgid "Layer CTR"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:112
+#: assets/build/pages/video-editor.min.js:21556
+msgid "Click-through rate of interactive layers: the share of plays where a viewer interacted with a layer. Layer CTR = Converting sessions / Total plays."
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:115
+#: assets/build/pages/video-editor.min.js:21559
+msgid "Avg. Watch Time"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:117
+#: assets/build/pages/video-editor.min.js:21561
+msgid "Average time watched per play. Avg. Watch Time = Total watch time / Total plays."
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:120
+#: assets/build/pages/video-editor.min.js:21564
+msgid "Total Impressions"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorStatsRow.js:122
+#: assets/build/pages/video-editor.min.js:21566
+msgid "How many times the video player loaded on a page, whether or not it was played."
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTabRail.js:18
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:601
+#: assets/build/pages/video-editor.min.js:21606
+#: assets/build/pages/video-editor.min.js:27159
+msgid "Layers"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTabRail.js:45
+#: assets/build/pages/video-editor.min.js:21633
+msgid "Editor sections"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:130
+#: assets/build/pages/video-editor.min.js:21781
+msgid "Click to edit title"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:192
+#: assets/build/pages/video-editor.min.js:21843
+msgid "Save Video"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:222
+#: assets/build/pages/video-editor.min.js:21873
+msgid "Back to media library"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:253
+#: assets/build/pages/video-editor.min.js:21904
+msgid "You can copy the block into one of the two options:"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:255
+#: assets/build/pages/video-editor.min.js:21906
+msgid "1. Insert as a block in the Block editor."
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:257
+#: assets/build/pages/video-editor.min.js:21908
+msgid "2. Insert as HTML content in the Block editor."
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:272
+#: assets/build/pages/video-editor.min.js:21923
+msgid "Copy"
+msgstr ""
+
+#: pages/video-editor/components/editor-shell/EditorTopBar.js:308
+#: assets/build/pages/video-editor.min.js:21959
+msgid "More options"
+msgstr ""
+
+#: pages/video-editor/components/forms/AjaxWarning.js:19
+#: assets/build/pages/video-editor.min.js:22090
+msgid "AJAX submission is required to prevent the form from reloading the video page on submit."
+msgstr ""
+
+#: pages/video-editor/components/forms/AjaxWarning.js:20
+#: assets/build/pages/video-editor.min.js:22091
+msgid "Make sure it's enabled in your"
+msgstr ""
+
+#: pages/video-editor/components/forms/AjaxWarning.js:28
+#: assets/build/pages/video-editor.min.js:22099
+msgid "form settings"
+msgstr ""
+
+#: pages/video-editor/components/forms/CF7.js:57
+#: pages/video-editor/components/SidebarLayers.js:67
+#: pages/video-editor/utils/layerTypes.js:40
+#: assets/build/pages/video-editor.min.js:18065
+#: assets/build/pages/video-editor.min.js:22164
+#: assets/build/pages/video-editor.min.js:30122
+msgid "Contact Form 7"
+msgstr ""
+
+#: pages/video-editor/components/forms/FluentForm.js:44
+#: pages/video-editor/components/SidebarLayers.js:91
+#: pages/video-editor/utils/layerTypes.js:44
+#: assets/build/pages/video-editor.min.js:18089
+#: assets/build/pages/video-editor.min.js:22297
+#: assets/build/pages/video-editor.min.js:30126
+msgid "Fluent Forms"
+msgstr ""
+
+#. translators: %s is the form plugin name, e.g. "Gravity Forms".
+#: pages/video-editor/components/forms/FormFields.js:58
+#: assets/build/pages/video-editor.min.js:22375
+msgid "Please activate the %s plugin to use this feature."
+msgstr ""
+
+#: pages/video-editor/components/forms/FormFields.js:74
+#: assets/build/pages/video-editor.min.js:22391
+msgid "Select Theme"
+msgstr ""
+
+#: pages/video-editor/components/forms/FormFields.js:90
+#: assets/build/pages/video-editor.min.js:22407
+msgid "Edit Form"
+msgstr ""
+
+#: pages/video-editor/components/forms/forminatorForms.js:42
+#: pages/video-editor/components/SidebarLayers.js:85
+#: pages/video-editor/utils/layerTypes.js:43
+#: assets/build/pages/video-editor.min.js:18083
+#: assets/build/pages/video-editor.min.js:23277
+#: assets/build/pages/video-editor.min.js:30125
+msgid "Forminator Forms"
+msgstr ""
+
+#: pages/video-editor/components/forms/FormPreview.js:49
+#: pages/video-editor/components/forms/JetpackForm.js:190
+#: pages/video-editor/components/forms/MetForm.js:67
+#: pages/video-editor/components/forms/NinjaForm.js:67
+#: assets/build/pages/video-editor.min.js:22467
+#: assets/build/pages/video-editor.min.js:22838
+#: assets/build/pages/video-editor.min.js:22951
+#: assets/build/pages/video-editor.min.js:23027
+msgid "Loading form…"
+msgstr ""
+
+#: pages/video-editor/components/forms/FormSelector.js:34
+#: assets/build/pages/video-editor.min.js:22547
+msgid "Select Form"
+msgstr ""
+
+#: pages/video-editor/components/forms/GravityForm.js:22
+#: assets/build/pages/video-editor.min.js:22590
+msgid "Orbital"
+msgstr ""
+
+#: pages/video-editor/components/forms/GravityForm.js:26
+#: assets/build/pages/video-editor.min.js:22594
+msgid "Gravity"
+msgstr ""
+
+#: pages/video-editor/components/forms/GravityForm.js:55
+#: pages/video-editor/components/SidebarLayers.js:55
+#: pages/video-editor/utils/layerTypes.js:38
+#: pages/video-editor/utils/layerTypes.js:66
+#: assets/build/pages/video-editor.min.js:18053
+#: assets/build/pages/video-editor.min.js:22623
+#: assets/build/pages/video-editor.min.js:30120
+#: assets/build/pages/video-editor.min.js:30148
+msgid "Gravity Forms"
+msgstr ""
+
+#: pages/video-editor/components/forms/JetpackForm.js:164
+#: assets/build/pages/video-editor.min.js:22812
+msgid "Jetpack"
+msgstr ""
+
+#: pages/video-editor/components/forms/JetpackForm.js:197
+#: assets/build/pages/video-editor.min.js:22845
+msgid "Error loading form. Please check if the form exists."
+msgstr ""
+
+#: pages/video-editor/components/forms/JetpackForm.js:204
+#: assets/build/pages/video-editor.min.js:22852
+msgid "No form selected or form not found."
+msgstr ""
+
+#: pages/video-editor/components/forms/JetpackForm.js:216
+#: assets/build/pages/video-editor.min.js:22864
+msgid "No Jetpack forms found. Please"
+msgstr ""
+
+#: pages/video-editor/components/forms/JetpackForm.js:223
+#: assets/build/pages/video-editor.min.js:22871
+msgid "create a Jetpack contact form"
+msgstr ""
+
+#: pages/video-editor/components/forms/JetpackForm.js:225
+#: assets/build/pages/video-editor.min.js:22873
+msgid "first."
+msgstr ""
+
+#: pages/video-editor/components/forms/MetForm.js:43
+#: pages/video-editor/components/SidebarLayers.js:109
+#: pages/video-editor/utils/layerTypes.js:47
+#: assets/build/pages/video-editor.min.js:18107
+#: assets/build/pages/video-editor.min.js:22927
+#: assets/build/pages/video-editor.min.js:30129
+msgid "MetForm"
+msgstr ""
+
+#: pages/video-editor/components/forms/Sureform.js:42
+#: pages/video-editor/components/SidebarLayers.js:79
+#: pages/video-editor/utils/layerTypes.js:42
+#: assets/build/pages/video-editor.min.js:18077
+#: assets/build/pages/video-editor.min.js:23078
+#: assets/build/pages/video-editor.min.js:30124
+msgid "SureForms"
+msgstr ""
+
+#: pages/video-editor/components/forms/WPForm.js:42
+#: pages/video-editor/components/SidebarLayers.js:61
+#: pages/video-editor/utils/layerTypes.js:39
+#: assets/build/pages/video-editor.min.js:18059
+#: assets/build/pages/video-editor.min.js:23140
+#: assets/build/pages/video-editor.min.js:30121
+msgid "WPForms"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:85
+#: assets/build/pages/video-editor.min.js:23382
+msgid "Select or Upload Custom Icon"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:87
+#: assets/build/pages/video-editor.min.js:23384
+msgid "Use this icon"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:147
+#: assets/build/pages/video-editor.min.js:23444
+msgid "Search icons…"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:192
+#: assets/build/pages/video-editor.min.js:23489
+msgid "Add Icon"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:216
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:224
+#: assets/build/pages/video-editor.min.js:23513
+#: assets/build/pages/video-editor.min.js:23521
+msgid "Replace icon"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:232
+#: assets/build/pages/video-editor.min.js:23529
+msgid "Remove icon"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:250
+#: assets/build/pages/video-editor.min.js:23547
+msgid "Select from library"
+msgstr ""
+
+#: pages/video-editor/components/hotspot/FontAwesomeIconPicker.js:261
+#: assets/build/pages/video-editor.min.js:23558
+msgid "Add custom"
+msgstr ""
+
+#: pages/video-editor/components/layers/AdsLayer.js:51
+#: assets/build/pages/video-editor.min.js:23698
+msgid "Self hosted video Ad"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:56
+#: assets/build/pages/video-editor.min.js:23763
+msgid "Card Style"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:56
+#: assets/build/pages/video-editor.min.js:23763
+msgid "Perfect for everyone"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:57
+#: assets/build/pages/video-editor.min.js:23764
+msgid "HTML"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:57
+#: assets/build/pages/video-editor.min.js:23764
+msgid "Great for developers"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:206
+#: assets/build/pages/video-editor.min.js:23913
+msgid "Call To Action"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:226
+#: assets/build/pages/video-editor.min.js:23933
+msgid "Advanced"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:227
+#: assets/build/pages/video-editor.min.js:23934
+msgid "Layer Background Colour"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:230
+#: assets/build/pages/video-editor.min.js:23937
+msgid "Layer background color"
+msgstr ""
+
+#: pages/video-editor/components/layers/CTALayer.js:265
+#: assets/build/pages/video-editor.min.js:23972
+msgid "Done"
+msgstr ""
+
+#: pages/video-editor/components/layers/FormLayer.js:128
+#: pages/video-editor/components/layers/HotspotLayer.js:590
+#: pages/video-editor/components/layers/PollLayer.js:54
+#: assets/build/pages/video-editor.min.js:24110
+#: assets/build/pages/video-editor.min.js:24732
+#: assets/build/pages/video-editor.min.js:25291
+msgid "Behaviour"
+msgstr ""
+
+#: pages/video-editor/components/layers/FormLayer.js:131
+#: pages/video-editor/components/layers/PollLayer.js:57
+#: assets/build/pages/video-editor.min.js:24113
+#: assets/build/pages/video-editor.min.js:25294
+msgid "Allow user to skip"
+msgstr ""
+
+#: pages/video-editor/components/layers/FormLayer.js:136
+#: assets/build/pages/video-editor.min.js:24118
+msgid "If enabled, the user will be able to skip the form submission."
+msgstr ""
+
+#: pages/video-editor/components/layers/FormLayer.js:142
+#: pages/video-editor/components/layers/PollLayer.js:67
+#: assets/build/pages/video-editor.min.js:24124
+#: assets/build/pages/video-editor.min.js:25304
+msgid "Background Colour"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:63
+#: assets/build/pages/video-editor.min.js:24205
+msgid "Pulse"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:64
+#: pages/video-editor/components/layers/HotspotLayer.js:573
+#: assets/build/pages/video-editor.min.js:24206
+#: assets/build/pages/video-editor.min.js:24715
+msgid "Icon"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:176
+#: assets/build/pages/video-editor.min.js:24318
+msgid "Layer duration exceeds the remaining video length. Please reduce the duration."
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:224
+#: assets/build/pages/video-editor.min.js:24366
+msgid "New Hotspot"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:438
+#: assets/build/pages/video-editor.min.js:24580
+msgid "Add Hotspots"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:442
+#: assets/build/pages/video-editor.min.js:24584
+msgid "Drag the hotspot in video to reposition it."
+msgstr ""
+
+#. translators: %d is the hotspot index
+#: pages/video-editor/components/layers/HotspotLayer.js:466
+#: assets/build/pages/video-editor.min.js:24608
+msgid "Delete Hotspot %d"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:476
+#: assets/build/pages/video-editor.min.js:24618
+msgid "Tooltip Text"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:477
+#: assets/build/pages/video-editor.min.js:24619
+msgid "Click Me!"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:483
+#: assets/build/pages/video-editor.min.js:24625
+msgid "Link"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:502
+#: assets/build/pages/video-editor.min.js:24644
+msgid "Add Hotspot"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:511
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:107
+#: assets/build/pages/video-editor.min.js:24653
+#: assets/build/pages/video-editor.min.js:25432
+msgid "Start Time"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:518
+#: assets/build/pages/video-editor.min.js:24660
+msgid "Layer Duration (seconds)"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:525
+#: assets/build/pages/video-editor.min.js:24667
+msgid "Duration (in seconds) this layer will stay visible. Maximum: 10 hours (36000 seconds)"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:531
+#: assets/build/pages/video-editor.min.js:24673
+msgid "Style"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:555
+#: assets/build/pages/video-editor.min.js:24697
+msgid "Pulse colour"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:593
+#: assets/build/pages/video-editor.min.js:24735
+msgid "Pause video when hotspot is hovered"
+msgstr ""
+
+#: pages/video-editor/components/layers/HotspotLayer.js:596
+#: assets/build/pages/video-editor.min.js:24738
+msgid "Player will pause the video while the layer is displayed and users hover over the hotspots."
+msgstr ""
+
+#: pages/video-editor/components/layers/Layer.js:86
+#: assets/build/pages/video-editor.min.js:25033
+msgid "Loading layer…"
+msgstr ""
+
+#: pages/video-editor/components/layers/Layer.js:90
+#: assets/build/pages/video-editor.min.js:25037
+msgid "Error: No layer components registered"
+msgstr ""
+
+#: pages/video-editor/components/layers/LayerErrorBoundary.js:46
+#: assets/build/pages/video-editor.min.js:25094
+msgid "This layer could not be opened. It may be provided by an add-on that needs updating to work with this version of GoDAM."
+msgstr ""
+
+#: pages/video-editor/components/layers/LayerErrorBoundary.js:53
+#: assets/build/pages/video-editor.min.js:25101
+msgid "Back to layers"
+msgstr ""
+
+#: pages/video-editor/components/layers/LayersHeader.js:65
+#: pages/video-editor/components/layers/LayersHeader.js:66
+#: assets/build/pages/video-editor.min.js:25178
+#: assets/build/pages/video-editor.min.js:25179
+msgid "Layer name"
+msgstr ""
+
+#. translators: %s is the layer display time in seconds.
+#: pages/video-editor/components/layers/LayersHeader.js:77
+#: assets/build/pages/video-editor.min.js:25190
+msgid "%ss"
+msgstr ""
+
+#: pages/video-editor/components/layers/LayersHeader.js:90
+#: pages/video-editor/components/layers/LayersHeader.js:96
+#: pages/video-editor/components/layers/LayersHeader.js:113
+#: assets/build/pages/video-editor.min.js:25203
+#: assets/build/pages/video-editor.min.js:25209
+#: assets/build/pages/video-editor.min.js:25226
+msgid "Delete layer"
+msgstr ""
+
+#: pages/video-editor/components/layers/PollLayer.js:45
+#: assets/build/pages/video-editor.min.js:25282
+msgid "Select Poll"
+msgstr ""
+
+#: pages/video-editor/components/layers/PollLayer.js:62
+#: assets/build/pages/video-editor.min.js:25299
+msgid "If enabled, the user will be able to skip the poll."
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:27
+#: assets/build/pages/video-editor.min.js:25352
+msgid "Fixed Timestamp"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:28
+#: assets/build/pages/video-editor.min.js:25353
+msgid "Appears at a set second"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:32
+#: assets/build/pages/video-editor.min.js:25357
+msgid "Watch Depth"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:33
+#: assets/build/pages/video-editor.min.js:25358
+msgid "Fires after the user crosses a watch %"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:37
+#: assets/build/pages/video-editor.min.js:25362
+msgid "On Pause"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:38
+#: assets/build/pages/video-editor.min.js:25363
+msgid "Shows when the viewer pauses (single CTA only)"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:42
+#: assets/build/pages/video-editor.min.js:25367
+msgid "End of Video"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:43
+#: assets/build/pages/video-editor.min.js:25368
+msgid "Overlays on the final frame when playback ends"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:60
+#: assets/build/pages/video-editor.min.js:25385
+msgid "CTA Trigger"
+msgstr ""
+
+#: pages/video-editor/components/layers/shared/TriggerSection.jsx:98
+#: assets/build/pages/video-editor.min.js:25423
+msgid "Another CTA already uses On Pause — only one CTA per video can."
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:58
+#: assets/build/pages/video-editor.min.js:18056
+msgid "Gravity Forms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:64
+#: assets/build/pages/video-editor.min.js:18062
+msgid "WPForms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:70
+#: assets/build/pages/video-editor.min.js:18068
+msgid "Contact Form 7 plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:73
+#: pages/video-editor/utils/layerTypes.js:41
+#: assets/build/pages/video-editor.min.js:18071
+#: assets/build/pages/video-editor.min.js:30123
+msgid "Jetpack Forms"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:76
+#: assets/build/pages/video-editor.min.js:18074
+msgid "Jetpack plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:82
+#: assets/build/pages/video-editor.min.js:18080
+msgid "SureForms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:88
+#: assets/build/pages/video-editor.min.js:18086
+msgid "Forminator Forms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:94
+#: assets/build/pages/video-editor.min.js:18092
+msgid "Fluent Forms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:100
+#: assets/build/pages/video-editor.min.js:18098
+msgid "Everest Forms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:106
+#: assets/build/pages/video-editor.min.js:18104
+msgid "Ninja Forms plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:112
+#: assets/build/pages/video-editor.min.js:18110
+msgid "MetForm plugin is not active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:117
+#: pages/video-editor/components/SidebarLayers.js:120
+#: pages/video-editor/components/SidebarLayers.js:510
+#: pages/video-editor/utils/layerTypes.js:81
+#: assets/build/pages/video-editor.min.js:18115
+#: assets/build/pages/video-editor.min.js:18118
+#: assets/build/pages/video-editor.min.js:18508
+#: assets/build/pages/video-editor.min.js:30163
+msgid "Ad"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:121
+#: assets/build/pages/video-editor.min.js:18119
+msgid "This ad will be overridden by Ad server's ads"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:129
+#: assets/build/pages/video-editor.min.js:18127
+msgid "Poll plugin is not active"
+msgstr ""
+
+#. translators: %s is the layer type label; e.g. "CTA" produces "CTA Layer".
+#. translators: %s is the layer type label; e.g. "CTA Layer".
+#: pages/video-editor/components/SidebarLayers.js:159
+#: pages/video-editor/components/SidebarLayers.js:713
+#: assets/build/pages/video-editor.min.js:18157
+#: assets/build/pages/video-editor.min.js:18711
+msgid "%s Layer"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:462
+#: assets/build/pages/video-editor.min.js:18460
+msgid "Add a clickable button"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:463
+#: assets/build/pages/video-editor.min.js:18461
+msgid "Add an info hotspot"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:482
+#: assets/build/pages/video-editor.min.js:18480
+msgid "Embed a lead form"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:486
+#: assets/build/pages/video-editor.min.js:18484
+msgid "No form plugin is active"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:499
+#: assets/build/pages/video-editor.min.js:18497
+msgid "Create an interactive poll"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:511
+#: assets/build/pages/video-editor.min.js:18509
+msgid "Insert an advertisement"
+msgstr ""
+
+#. translators: %d is the number of layers.
+#: pages/video-editor/components/SidebarLayers.js:544
+#: assets/build/pages/video-editor.min.js:18542
+msgid "Layers (%d)"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:575
+#: pages/video-editor/components/timeline/Timeline.js:428
+#: assets/build/pages/video-editor.min.js:18573
+#: assets/build/pages/video-editor.min.js:25962
+msgid "Add layer"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:632
+#: assets/build/pages/video-editor.min.js:18630
+msgid "To add a layer, pick a spot on the timeline where you want the layer."
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:653
+#: assets/build/pages/video-editor.min.js:18651
+msgid "No layers yet"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:655
+#: assets/build/pages/video-editor.min.js:18653
+msgid "Add interactive elements like CTAs, polls, and forms to your video"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:728
+#: assets/build/pages/video-editor.min.js:18726
+msgid "Layer options"
+msgstr ""
+
+#: pages/video-editor/components/SidebarLayers.js:740
+#: assets/build/pages/video-editor.min.js:18738
+msgid "Duplicate"
+msgstr ""
+
+#: pages/video-editor/components/timeline/Timeline.js:399
+#: assets/build/pages/video-editor.min.js:25933
+msgid "Click to add layer"
+msgstr ""
+
+#: pages/video-editor/components/timeline/Timeline.js:424
+#: assets/build/pages/video-editor.min.js:25958
+msgid "Add layer at this time"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:74
+#: assets/build/pages/video-editor.min.js:26193
+msgid "Transcription failed. Please try again."
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:124
+#: assets/build/pages/video-editor.min.js:26243
+msgid "Could not start transcription. Please try again."
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:134
+#: assets/build/pages/video-editor.min.js:26253
+msgid "Select a caption file"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:135
+#: assets/build/pages/video-editor.min.js:26254
+msgid "Use this file"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:144
+#: assets/build/pages/video-editor.min.js:26263
+msgid "Please choose a .vtt or .srt caption file."
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:150
+#: assets/build/pages/video-editor.min.js:26269
+msgid "Could not attach the caption file."
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:164
+#: assets/build/pages/video-editor.min.js:26283
+msgid "Could not remove the transcript."
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:199
+#: assets/build/pages/video-editor.min.js:26318
+msgid "Replace transcription file"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:206
+#: pages/video-editor/components/transcription/Transcription.js:285
+#: assets/build/pages/video-editor.min.js:26325
+#: assets/build/pages/video-editor.min.js:26404
+msgid "Delete transcription"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:230
+#: assets/build/pages/video-editor.min.js:26349
+msgid "No cues found in this caption file."
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:240
+#: assets/build/pages/video-editor.min.js:26359
+msgid "Automatically transcribe the audio using GoDAM's AI engine"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:250
+#: assets/build/pages/video-editor.min.js:26369
+msgid "Generate Transcription"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:261
+#: assets/build/pages/video-editor.min.js:26380
+msgid "Generating transcription…"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:264
+#: assets/build/pages/video-editor.min.js:26383
+msgid "This usually takes 10–15 minutes. We'll notify you once it's ready"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:276
+#: assets/build/pages/video-editor.min.js:26395
+msgid "Upload File"
+msgstr ""
+
+#: pages/video-editor/components/transcription/Transcription.js:288
+#: assets/build/pages/video-editor.min.js:26407
+msgid "Delete this transcription? This cannot be undone."
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:72
+#: assets/build/pages/video-editor.min.js:26630
+msgid "Images"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:87
+#: assets/build/pages/video-editor.min.js:26645
+msgid "All Videos"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:88
+#: assets/build/pages/video-editor.min.js:26646
+msgid "All Images"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:89
+#: assets/build/pages/video-editor.min.js:26647
+msgid "All Audio"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:90
+#: assets/build/pages/video-editor.min.js:26648
+msgid "All"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:96
+#: assets/build/pages/video-editor.min.js:26654
+msgid "Edited"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:97
+#: assets/build/pages/video-editor.min.js:26655
+msgid "Unedited"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:103
+#: assets/build/pages/video-editor.min.js:26661
+msgid "Transcoded"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:104
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:610
+#: assets/build/pages/video-editor.min.js:26662
+#: assets/build/pages/video-editor.min.js:27168
+msgid "Non Transcoded"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:115
+#: assets/build/pages/video-editor.min.js:26673
+msgid "Newest Uploaded"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:116
+#: assets/build/pages/video-editor.min.js:26674
+msgid "Oldest Uploaded"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:117
+#: assets/build/pages/video-editor.min.js:26675
+msgid "Recently Edited"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:118
+#: assets/build/pages/video-editor.min.js:26676
+msgid "Name A-Z"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:119
+#: assets/build/pages/video-editor.min.js:26677
+msgid "Name Z-A"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:272
+#: assets/build/pages/video-editor.min.js:26830
+msgid "Quick actions"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:301
+#: assets/build/pages/video-editor.min.js:26859
+msgid "Copy block"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:313
+#: assets/build/pages/video-editor.min.js:26871
+msgid "View Analytics"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:487
+#: pages/video-editor/VideoEditor.js:546
+#: assets/build/pages/video-editor.min.js:17377
+#: assets/build/pages/video-editor.min.js:27045
+msgid "GoDAM block copied to clipboard"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:488
+#: pages/video-editor/VideoEditor.js:549
+#: assets/build/pages/video-editor.min.js:17380
+#: assets/build/pages/video-editor.min.js:27046
+msgid "Failed to copy GoDAM block"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:560
+#: assets/build/pages/video-editor.min.js:27118
+msgid "Sourced from GoDAM Central"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:572
+#: assets/build/pages/video-editor.min.js:27130
+msgid "Media name"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:581
+#: assets/build/pages/video-editor.min.js:27139
+msgid "Details"
+msgstr ""
+
+#. translators: %s: human-readable date the video was last edited.
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:594
+#: assets/build/pages/video-editor.min.js:27152
+msgid "Last edited %s"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:650
+#: assets/build/pages/video-editor.min.js:27208
+msgid "Upload media to the WordPress Media Library, GoDAM auto-syncs it here."
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:659
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:138
+#: assets/build/pages/video-editor.min.js:27217
+#: assets/build/pages/video-editor.min.js:27873
+msgid "See how it works"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:670
+#: assets/build/pages/video-editor.min.js:27228
+msgid "Search"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:672
+#: assets/build/pages/video-editor.min.js:27230
+msgid "Search media"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:678
+#: assets/build/pages/video-editor.min.js:27236
+msgid "Filter by media type"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:686
+#: assets/build/pages/video-editor.min.js:27244
+msgid "Filter media"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:694
+#: assets/build/pages/video-editor.min.js:27252
+msgid "Sort media"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:707
+#: assets/build/pages/video-editor.min.js:27265
+msgid "You have no media yet!"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:709
+#: assets/build/pages/video-editor.min.js:27267
+msgid "Upload media to the"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:715
+#: assets/build/pages/video-editor.min.js:27273
+msgid "WordPress Media Library"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:717
+#: assets/build/pages/video-editor.min.js:27275
+msgid "and GoDAM will sync them here."
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:720
+#: assets/build/pages/video-editor.min.js:27278
+msgid "You can start selling as soon as you add a product."
+msgstr ""
+
+#. translators: 1: number of loaded media items, 2: total media items.
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:751
+#: assets/build/pages/video-editor.min.js:27309
+msgid "Showing %1$d of %2$d media items"
+msgstr ""
+
+#: pages/video-editor/components/video-dataview/VideoEditorDataView.jsx:765
+#: assets/build/pages/video-editor.min.js:27323
+msgid "Load more"
+msgstr ""
+
+#: pages/video-editor/onboarding/productGuide.js:197
+#: assets/build/pages/video-editor.min.js:28152
+msgid "Next"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:187
+#: assets/build/pages/video-editor.min.js:27672
+msgid "GoDAM video"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:223
+#: assets/build/pages/video-editor.min.js:27708
+msgid "Do you want to end the product guide?"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:224
+#: assets/build/pages/video-editor.min.js:27709
+msgid "End guide"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:225
+#: assets/build/pages/video-editor.min.js:27710
+msgid "Keep going"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:230
+#: assets/build/pages/video-editor.min.js:27715
+msgid "You can start it anytime using the “See how it works” button on the Media Editor."
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:235
+#: assets/build/pages/video-editor.min.js:27720
+msgid "Do you want to add it to a page?"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:236
+#: assets/build/pages/video-editor.min.js:27721
+msgid "Yes, Continue"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:237
+#: assets/build/pages/video-editor.min.js:27722
+msgid "Not now"
+msgstr ""
+
+#: pages/video-editor/onboarding/ProductGuide.jsx:243
+#: assets/build/pages/video-editor.min.js:27728
+msgid "We’ll open a new draft page and drop the video right in."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:37
+#: pages/video-editor/onboarding/steps.js:38
+#: assets/build/pages/video-editor.min.js:28419
+#: assets/build/pages/video-editor.min.js:28420
+msgid "Start by adding layers to this video to make it interactive."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:37
+#: assets/build/pages/video-editor.min.js:28419
+msgid "Downloaded a demo video."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:59
+#: assets/build/pages/video-editor.min.js:28441
+msgid "Select a spot on the timeline where you want to add your layer."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:67
+#: assets/build/pages/video-editor.min.js:28449
+msgid "Start by selecting a layer from the dropdown to add it here."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:78
+#: assets/build/pages/video-editor.min.js:28460
+msgid "Start with a CTA — it’s the quickest way to make your video interactive."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:86
+#: assets/build/pages/video-editor.min.js:28468
+msgid "Use this panel to customize and configure your layer settings."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:95
+#: assets/build/pages/video-editor.min.js:28477
+msgid "Save the video to use it anywhere on your WordPress site."
+msgstr ""
+
+#: pages/video-editor/onboarding/steps.js:103
+#: assets/build/pages/video-editor.min.js:28485
+msgid "Now copy the video to use it in a page."
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:28
+#: assets/build/pages/video-editor.min.js:27763
+msgid "Woo"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:29
+#: assets/build/pages/video-editor.min.js:27764
+msgid "Turn product videos into sales"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:30
+#: assets/build/pages/video-editor.min.js:27765
+msgid "Add shoppable galleries and product blocks."
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:35
+#: assets/build/pages/video-editor.min.js:27770
+msgid "Make your videos interactive"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:36
+#: assets/build/pages/video-editor.min.js:27771
+msgid "Add CTAs or hotspots directly on top of any video."
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:79
+#: assets/build/pages/video-editor.min.js:27814
+msgid "Welcome to GoDAM"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:87
+#: assets/build/pages/video-editor.min.js:27822
+msgid "Choose what you’d like to explore first."
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:90
+#: assets/build/pages/video-editor.min.js:27825
+msgid "Welcome options"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeChooserModal.jsx:129
+#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:57
+#: assets/build/pages/video-editor.min.js:27864
+#: assets/build/pages/video-editor.min.js:27938
+msgid "Skip for now"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:37
+#: assets/build/pages/video-editor.min.js:27918
+msgid "Get Started with GoDAM"
+msgstr ""
+
+#: pages/video-editor/onboarding/WelcomeIntroModal.jsx:45
+#: assets/build/pages/video-editor.min.js:27926
+msgid "Get started by adding interactive layers to your video"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:496
+#: assets/build/pages/video-editor.min.js:17327
+msgid "Please select a form for the layer at timestamp:"
+msgid_plural "Please select a form for the layers at timestamps:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pages/video-editor/VideoEditor.js:592
+#: assets/build/pages/video-editor.min.js:17423
+msgid "Edit video metadata"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:594
+#: assets/build/pages/video-editor.min.js:17425
+msgid "Edit image metadata"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:596
+#: assets/build/pages/video-editor.min.js:17427
+msgid "Edit audio metadata"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:598
+#: assets/build/pages/video-editor.min.js:17429
+msgid "Edit metadata"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:624
+#: assets/build/pages/video-editor.min.js:17455
+msgid "Title updated"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:628
+#: assets/build/pages/video-editor.min.js:17459
+msgid "Failed to update title"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:650
+#: assets/build/pages/video-editor.min.js:17481
+msgid "Untitled image"
+msgstr ""
+
+#: pages/video-editor/VideoEditor.js:711
+#: assets/build/pages/video-editor.min.js:17542
+msgid "Changes saved successfully"
+msgstr ""
+
+#: pages/video-editor/VideoJSPlayer.js:195
+#: assets/build/pages/video-editor.min.js:17837
+msgid "Custom Play Button"
+msgstr ""
+
+#: pages/whats-new/components/Header.js:25
+#: assets/build/pages/whats-new.min.js:757
+msgid "What's New in GoDAM"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:78
+msgid "Select a reason"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:79
+msgid "I found a better plugin"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:80
+msgid "The plugin is not working as expected"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:81
+msgid "I was just testing"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:82
+msgid "Other"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:84
+msgid "Additional details…"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:88
+msgid "Skip & Deactivate"
+msgstr ""
+
+#: assets/build/js/deactivation-feedback.min.js:93
+msgid "Submit & Deactivate"
+msgstr ""
+
+#. translators: %d: Maximum allowed file size in MB.
+#: assets/build/js/everestforms.min.js:117
+msgid "File size exceeds the maximum limit of %d MB."
+msgstr ""
+
+#: assets/build/js/everestforms.min.js:287
+#: assets/build/js/fluentforms.min.js:301
+#: assets/build/js/ninja-forms.min.js:272
+msgid "File upload in progress…"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:913
+msgid "Not started"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:933
+msgid "Media is transcoded"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:969
+msgid "Transcoding…"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1634
+msgid "No thumbnails found"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1791
+msgid "Select Custom Thumbnail"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1792
+msgid "Use this image"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1804
+msgid "Please select a valid image file (JPEG, PNG, GIF, etc.)."
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1840
+#: assets/build/js/media-library.min.js:1841
+msgid "Only 3 custom thumbnails allowed"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1888
+msgid "Custom Video Thumbnail"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:1895
+#: assets/build/js/media-library.min.js:1899
+msgid "Remove Image"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:2116
+#: assets/build/js/media-library.min.js:2753
+msgid "Video Thumbnails"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:2908
+msgid "oEmbed Video URL"
+msgstr ""
+
+#: assets/build/js/media-library.min.js:2910
+msgid "The oEmbed URL can be used to embed the video in other platforms that support oEmbed."
+msgstr ""
+
+#: assets/build/js/media-library.min.js:9715
+msgid "Search Media"
+msgstr ""
+
+#: assets/build/js/ninja-forms.min.js:336
+msgid "Upload failed. Please try again."
+msgstr ""
+
+#: assets/build/js/wpbakery-document-cover-selector-param.min.js:122
+msgid "Custom cover"
+msgstr ""
+
+#: assets/build/js/wpbakery-document-cover-selector-param.min.js:157
+msgid "Select Cover Image"
+msgstr ""
+
+#: assets/build/js/wpbakery-document-cover-selector-param.min.js:158
+msgid "Use image"
+msgstr ""
+
+#: assets/build/js/wpbakery-document-selector-param.min.js:248
+msgid "Select or Upload Document"
+msgstr ""
+
+#: assets/build/js/wpbakery-image-selector-param.min.js:28
+msgid "Select or Upload Image"
+msgstr ""
+
+#: assets/build/js/wpbakery-video-selector-param.min.js:250
+msgid "Select or Upload Video"
+msgstr ""
+
+#: assets/build/js/wpforms-godam-recorder-editor.min.js:69932
+msgid "Select or Upload Video Of Your Choice"
+msgstr ""
+
+#: assets/build/js/wpforms-godam-recorder-editor.min.js:69937
+msgid "Use this video"
+msgstr ""
+
+#: assets/build/pages/godam.min.js:9780
+msgid "Invalid item"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+msgctxt "block title"
+msgid "Audio"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+msgctxt "block description"
+msgid "Embed a GoDAM audio player."
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+msgctxt "block keyword"
+msgid "music"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+msgctxt "block keyword"
+msgid "sound"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+msgctxt "block keyword"
+msgid "podcast"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+msgctxt "block keyword"
+msgid "recording"
+msgstr ""
+
+#: assets/build/blocks/godam-audio/block.json
+#: assets/build/blocks/godam-gallery-v2-item/block.json
+#: assets/build/blocks/godam-gallery-v2/block.json
+#: assets/build/blocks/godam-image/block.json
+#: assets/build/blocks/godam-pdf/block.json
+#: assets/build/blocks/godam-player/block.json
+#: assets/build/blocks/sureforms/blocks/recorder/block.json
+msgctxt "block keyword"
+msgid "godam"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/block.json
+msgctxt "block title"
+msgid "Gallery V2 Item"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/block.json
+msgctxt "block description"
+msgid "A single video item for the GoDAM Gallery V2 block."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/block.json
+#: assets/build/blocks/godam-gallery-v2/block.json
+#: assets/build/blocks/godam-player/block.json
+#: assets/build/blocks/godam-video-duration/block.json
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block keyword"
+msgid "video"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/block.json
+#: assets/build/blocks/godam-gallery-v2/block.json
+#: assets/build/blocks/godam-video-duration/block.json
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block keyword"
+msgid "gallery"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2-item/block.json
+msgctxt "block keyword"
+msgid "item"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/block.json
+msgctxt "block title"
+msgid "Video Gallery"
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/block.json
+msgctxt "block description"
+msgid "Create a handpicked or query-based GoDAM video gallery."
+msgstr ""
+
+#: assets/build/blocks/godam-gallery-v2/block.json
+#: assets/build/blocks/godam-video-duration/block.json
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block keyword"
+msgid "grid"
+msgstr ""
+
+#: assets/build/blocks/godam-image/block.json
+msgctxt "block title"
+msgid "Image"
+msgstr ""
+
+#: assets/build/blocks/godam-image/block.json
+msgctxt "block description"
+msgid "Display an image with interactive GoDAM hotspot and product layers."
+msgstr ""
+
+#: assets/build/blocks/godam-image/block.json
+msgctxt "block keyword"
+msgid "image"
+msgstr ""
+
+#: assets/build/blocks/godam-image/block.json
+msgctxt "block keyword"
+msgid "hotspot"
+msgstr ""
+
+#: assets/build/blocks/godam-image/block.json
+msgctxt "block keyword"
+msgid "shoppable"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block title"
+msgid "Document"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block description"
+msgid "Embed a document with a preview. Supports PDF, Word, Excel, PowerPoint, OpenDocument, TXT and CSV."
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "document"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "pdf"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "doc"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "docx"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "word"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "excel"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "xlsx"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "powerpoint"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "pptx"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "spreadsheet"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "csv"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "file"
+msgstr ""
+
+#: assets/build/blocks/godam-pdf/block.json
+msgctxt "block keyword"
+msgid "preview"
+msgstr ""
+
+#: assets/build/blocks/godam-player/block.json
+msgctxt "block title"
+msgid "Video"
+msgstr ""
+
+#: assets/build/blocks/godam-player/block.json
+msgctxt "block description"
+msgid "Embed a video from your media library or upload a new one."
+msgstr ""
+
+#: assets/build/blocks/godam-player/block.json
+msgctxt "block keyword"
+msgid "movie"
+msgstr ""
+
+#: assets/build/blocks/godam-player/block.json
+msgctxt "block keyword"
+msgid "player"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/block.json
+msgctxt "block title"
+msgid "GoDAM Video Duration"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/block.json
+msgctxt "block description"
+msgid "Display GoDAM video's duration"
+msgstr ""
+
+#: assets/build/blocks/godam-video-duration/block.json
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block keyword"
+msgid "videos"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block title"
+msgid "GoDAM Video Thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block description"
+msgid "Display GoDAM video thumbnail"
+msgstr ""
+
+#: assets/build/blocks/godam-video-thumbnail/block.json
+msgctxt "block keyword"
+msgid "thumbnail"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/block.json
+msgctxt "block title"
+msgid "GoDAM Recorder"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/block.json
+msgctxt "block description"
+msgid "Enable audio/video submissions inside forms using the GoDAM Recorder field that supports webcam, screencast, and audio recording"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/block.json
+msgctxt "block keyword"
+msgid "sureforms"
+msgstr ""
+
+#: assets/build/blocks/sureforms/blocks/recorder/block.json
+msgctxt "block keyword"
+msgid "recorder"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "godam",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "godam",
-			"version": "2.1.1",
+			"version": "2.2.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "godam",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"description": "A WordPress plugin to manage digital assets",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === GoDAM - Organize WordPress Media Library & File Manager with Unlimited Folders for Images, Videos & more ===
-Contributors: rtcamp, elifvish, subodhrajpopat, kuldipchaudhary, prachigarg19, juzar, geekofshire, nazmulhassann20, joelabreo, mi5t4n, abhinavbelhekar03, gautam23, mukulsingh27, hbhalodia, kishu7270, opurockey, utsavladani, whiteshadow01, ahmarzaidi, im3dabasia1, rudrakshigupta, sabbir1991, shreyasikhar26
+Contributors: rtcamp, elifvish, subodhrajpopat, kuldipchaudhary, prachigarg19, juzar, geekofshire, nazmulhassann20, joelabreo, mi5t4n, abhinavbelhekar03, gautam23, mukulsingh27, hbhalodia, kishu7270, opurockey, utsavladani, whiteshadow01, ahmarzaidi, im3dabasia1, rudrakshigupta, sabbir1991, shreyasikhar26, akrocks
 Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.1.1
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -224,6 +224,16 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 
 == Changelog ==
 
+= v2.2.0 (August 26, 2026) =
+
+- Feat: The Document block now handles far more than PDFs. You can embed and preview Word, Excel, PowerPoint, OpenDocument, and plain-text files.
+- Feat: Added the same document preview support to the Elementor and WPBakery GoDAM Document widgets.
+- Feat: Show in lightbox — a new option opens a video in a centered lightbox overlay when its poster is clicked, instead of playing it in place. Available in the GoDAM Video block, the Elementor widget, and the WPBakery element.
+- Tweak: The GoDAM media transcoding tool now supports bulk transcoding of all media types supported by GoDAM.
+- Fix: Resolved bugs in the GoDAM Media Library module.
+- Fix: Fixed the transcription source issue for GoDAM videos.
+- Fix: Layer analytics now records a view for each hotspot in its own right, so a hotspot's views, conversion, and "No Action" describe that hotspot rather than the whole layer. This stays correct even as hotspots are added or removed over time.
+
 = v2.1.1 (August 6, 2026) =
 
 - Fix: GoDAM no longer fills the debug log with `Function _load_textdomain_just_in_time was called incorrectly` on WordPress 6.7 and later. On sites that display errors, the warning could also appear on the page itself, in the admin and on the front end.
@@ -245,24 +255,6 @@ A. Yes, GoDAM provides robust analytics tools to track video engagement, includi
 - Fix: Resolved video transcript UI/UX issues.
 - Fix: Fixed the Elementor Select option colour and the media picker popup in Elementor.
 - Chore: Resolved open Dependabot npm security advisories.
-
-= v2.0.0 (July 14, 2026) =
-
-- Feat: GoDAM 2.0 brings a complete visual redesign across the admin and front end, with refreshed branding, new logos, and updated block icons.
-- Feat: Rebuilt the Video Editor with a streamlined layout for managing layers, hotspots, CTAs, and forms.
-- Feat: Added a guided onboarding experience, embedded in the plugin and integrated with GoDAM Central.
-- Feat: Redesigned the analytics dashboard with a cleaner layout, a Layer Timeline range control, and Top Videos improvements.
-- Feat: Redesigned the Video Player, Video Gallery, Audio, and Document blocks.
-- Tweak: The admin UI now follows the WordPress admin colour scheme, and the front end follows the configured brand colour.
-- Tweak: The Video Layer editor now warns before leaving with unsaved changes.
-- Tweak: The WooCommerce integration toggle is disabled when no valid API key is present, as it is a Pro feature.
-- Fix: Various QA fixes across blocks, the video editor, and the media gallery.
-
-= v1.13.0 (June 18, 2026) =
-
-- Feat: Track GoDAM media usage across post content, blocks, shortcodes, Elementor, block widgets, and featured images — recording where each asset is used and notifying GoDAM Central.
-- Feat: Automatically backfill media usage for existing content in the background, via the migration runner in Action Scheduler batches, on upgrade.
-- Tweak: Authenticate GoDAM Central media-usage logging and retry failed notifications with backoff so transient outages do not lose events.
 
 
 [CHECK THE FULL CHANGELOG](https://github.com/rtCamp/godam/blob/main/CHANGELOG.md)


### PR DESCRIPTION
= v2.2.0 (August 26, 2026) =

- Feat: The Document block now handles far more than PDFs. You can embed and preview Word, Excel, PowerPoint, OpenDocument, and plain-text files.
- Feat: Added the same document preview support to the Elementor and WPBakery GoDAM Document widgets.
- Feat: Show in lightbox — a new option opens a video in a centered lightbox overlay when its poster is clicked, instead of playing it in place. Available in the GoDAM Video block, the Elementor widget, and the WPBakery element.
- Tweak: The GoDAM media transcoding tool now supports bulk transcoding of all media types supported by GoDAM.
- Fix: Resolved bugs in the GoDAM Media Library module.
- Fix: Fixed the transcription source issue for GoDAM videos.
- Fix: Layer analytics now records a view for each hotspot in its own right, so a hotspot's views, conversion, and "No Action" describe that hotspot rather than the whole layer. This stays correct even as hotspots are added or removed over time.
