### PR TITLE
feat(dashboard): GA4 connection widget

### DIFF
--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -395,7 +395,13 @@ const Dashboard = () => {
 									testIdPrefix="godam-dashboard-insights-daterange"
 								/>
 							</div>
-							<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-row items-stretch flex-wrap justify-center lg:flex-nowrap">
+							{ /* `lg:flex-nowrap` was sized for four cards (three metric tiles +
+							    Video-to-Cart); with the Woo add-on active, GA4ConnectionWidget
+							    makes it five, and forcing all five into one nowrap row right at
+							    the 1024px breakpoint squeezed each card too narrow to hold its
+							    labels + Manage link comfortably. Pushing the nowrap breakpoint to
+							    `xl` lets the row wrap onto two lines between lg and xl instead. */ }
+							<div className="analytics-info-container single-metrics-info-container flex max-lg:flex-row items-stretch flex-wrap justify-center xl:flex-nowrap">
 
 								<SingleMetrics
 									mode="dashboard"

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -25,6 +25,7 @@ import ViewersGauge from './components/ViewersGauge';
 import PlaybackPerformanceDashboard from '../analytics/PlaybackPerformance';
 import TopVideosTable from './components/TopVideosTable';
 import TopProductsTable from './components/TopProductsTable';
+import GA4ConnectionWidget from './components/GA4ConnectionWidget';
 import DateRangePicker, { triggerLabelFor, fromISO } from '../analytics/components/DateRangePicker';
 
 /**
@@ -455,6 +456,12 @@ const Dashboard = () => {
 										dataLabel={ insightsCardLabel }
 									/>
 								) }
+
+								{ /* GA4 output is a godam-for-woo feature (it pushes the
+								    add_to_cart/purchase events into the store's own
+								    dataLayer), so it's gated the same as Top Products /
+								    Video-to-Cart: the add-on active + a valid license. */ }
+								{ hasWooProducts && <GA4ConnectionWidget /> }
 							</div>
 						</div>
 

--- a/pages/dashboard/Dashboard.js
+++ b/pages/dashboard/Dashboard.js
@@ -473,8 +473,16 @@ const Dashboard = () => {
 							{ /* GA4 output is a godam-for-woo feature (it pushes the
 							    add_to_cart/purchase events into the store's own
 							    dataLayer), so it's gated the same as Top Products /
-							    Video-to-Cart: the add-on active + a valid license. */ }
-							{ hasWooProducts && <GA4ConnectionWidget /> }
+							    Video-to-Cart: the add-on active + a valid license.
+							    Needs its own analytics-info-container wrapper:
+							    .analytics-info/.analytics-single-info are only
+							    styled (flex layout, padding, gap) as descendants of
+							    that class — see analytics/index.scss. */ }
+							{ hasWooProducts && (
+								<div className="analytics-info-container mt-4">
+									<GA4ConnectionWidget />
+								</div>
+							) }
 						</div>
 
 						<div className="playback-performance" id="global-analytics-container">

--- a/pages/dashboard/components/GA4ConnectionWidget.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.js
@@ -55,7 +55,7 @@ const getSourceLabel = ( sourceType ) => {
 };
 
 const tooltipText = __(
-	'add_to_cart and purchase are GA4’s default ecommerce events, already tracked by many stores.',
+	'Add To Cart and Purchase are GA4’s default ecommerce events, already tracked by many stores.',
 	'godam',
 );
 
@@ -87,7 +87,7 @@ const WidgetShell = ( { children } ) => (
  */
 const AllTimeBadge = () => (
 	<span
-		className="text-[10px] uppercase tracking-wide text-zinc-400 whitespace-nowrap"
+		className="text-xs tracking-wide text-zinc-500 whitespace-nowrap"
 		data-test-id="godam-ga4-connection-all-time-badge"
 	>
 		{ __( 'All time', 'godam' ) }
@@ -120,7 +120,7 @@ const GA4ConnectionWidget = () => {
 				<div className="flex justify-between items-start flex-row w-full gap-2">
 					<div className="analytics-info-heading">
 						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-ga4-connection-label">
-							{ __( 'Send add_to_cart and purchase to your GA4', 'godam' ) }
+							{ __( 'GA4 Tracking', 'godam' ) }
 						</p>
 						<Tooltip text={ tooltipText } />
 					</div>
@@ -165,7 +165,7 @@ const GA4ConnectionWidget = () => {
 							data-test-id="godam-ga4-connection-status"
 						>
 							<Icon icon={ warning } size={ 14 } />
-							{ __( 'GA4 connection status unavailable', 'godam' ) }
+							{ __( 'GA4 unavailable', 'godam' ) }
 						</span>
 						<Tooltip text={ __( 'Could not reach the GA4 status endpoint. This can happen right after an update — try refreshing in a moment.', 'godam' ) } />
 					</div>
@@ -210,29 +210,24 @@ const GA4ConnectionWidget = () => {
 						/>
 					</div>
 				</div>
-				<p className="text-xs text-zinc-500" data-test-id="godam-ga4-connection-standing-down-note">
-					{ sprintf(
-						/* translators: %s: name of the other active GA4 integration. */
-						__( '%s is active — GoDAM is not sending anything to avoid duplicate events.', 'godam' ),
-						sourceLabel,
-					) }
-				</p>
 				<div className="flex flex-row justify-between gap-4 items-end">
 					<div className="flex flex-row gap-6">
 						<div className="flex flex-col">
 							<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
 								{ addToCartCount.toLocaleString() }
 							</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'add_to_cart prepared', 'godam' ) }</span>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Add to Cart', 'godam' ) }</span>
 						</div>
 						<div className="flex flex-col">
 							<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
 								{ purchaseCount.toLocaleString() }
 							</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'purchase prepared', 'godam' ) }</span>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Purchase', 'godam' ) }</span>
 						</div>
-						<AllTimeBadge />
 					</div>
+				</div>
+				<div>
+					<AllTimeBadge />
 					<a
 						className="godam-button"
 						href={ getGeneralSettingsUrl() }
@@ -265,16 +260,18 @@ const GA4ConnectionWidget = () => {
 						<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
 							{ addToCartCount.toLocaleString() }
 						</p>
-						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'add_to_cart', 'godam' ) }</span>
+						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Add to Cart', 'godam' ) }</span>
 					</div>
 					<div className="flex flex-col">
 						<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
 							{ purchaseCount.toLocaleString() }
 						</p>
-						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'purchase', 'godam' ) }</span>
+						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Purchase', 'godam' ) }</span>
 					</div>
-					<AllTimeBadge />
 				</div>
+			</div>
+			<div>
+				<AllTimeBadge />
 				<a
 					className="godam-button"
 					href={ getGeneralSettingsUrl() }

--- a/pages/dashboard/components/GA4ConnectionWidget.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.js
@@ -1,0 +1,128 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Tooltip from '../../analytics/Tooltip';
+import { useFetchGa4CountsQuery } from '../redux/api/dashboardAnalyticsApi';
+
+/**
+ * Settings link back to the General Settings tab, where the actual
+ * `enable_gtm_tracking` toggle lives (this widget never renders its own
+ * toggle). Reuses the same `admin.php?page=rtgodam_settings` URL the
+ * dashboard already localizes as `window.videoData.adminUrl` — just pointed
+ * at the "general-settings" tab (App.js reads the URL hash to pick the
+ * active tab) instead of whatever tab that constant happens to hardcode.
+ *
+ * @return {string} URL to the General Settings tab.
+ */
+const getGeneralSettingsUrl = () => {
+	const base = ( window.videoData?.adminUrl || 'admin.php?page=rtgodam_settings' ).split( '#' )[ 0 ];
+	return `${ base }#general-settings`;
+};
+
+/**
+ * GA4 connection widget for the dashboard.
+ *
+ * Confirms whether GoDAM is pushing `add_to_cart`/`purchase` GA4 ecommerce
+ * events (tagged with video context) into the store's own `window.dataLayer`
+ * — the actual push happens in the godam-for-woo add-on; this widget only
+ * surfaces the on/off state and, once on, the running counts.
+ *
+ * Reads `enable_gtm_tracking` directly off `window.godamSettings.enableGTMTracking`
+ * (already localized to the page) rather than round-tripping through an API call.
+ */
+const GA4ConnectionWidget = () => {
+	const isConnected = !! window.godamSettings?.enableGTMTracking;
+
+	const { data } = useFetchGa4CountsQuery( undefined, { skip: ! isConnected } );
+
+	const tooltipText = __(
+		'add_to_cart and purchase are GA4’s default ecommerce events, already tracked by many stores.',
+		'godam',
+	);
+
+	if ( ! isConnected ) {
+		return (
+			<div
+				className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+				data-test-id="godam-ga4-connection-widget"
+			>
+				<div className="analytics-single-info w-full">
+					<div className="flex justify-between items-start flex-row w-full gap-2">
+						<div className="analytics-info-heading">
+							<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-ga4-connection-label">
+								{ __( 'Send add_to_cart and purchase to your GA4', 'godam' ) }
+							</p>
+							<Tooltip text={ tooltipText } />
+						</div>
+					</div>
+					<div className="flex flex-row justify-between gap-2 items-end">
+						<a
+							className="godam-button"
+							href={ getGeneralSettingsUrl() }
+							data-test-id="godam-ga4-connection-enable-link"
+						>
+							{ __( 'Enable', 'godam' ) }
+						</a>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	const addToCartCount = Number( data?.addToCartCount || 0 );
+	const purchaseCount = Number( data?.purchaseCount || 0 );
+
+	return (
+		<div
+			className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+			data-test-id="godam-ga4-connection-widget"
+		>
+			<div className="analytics-single-info w-full">
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading flex items-center gap-1">
+						<span
+							className="flex items-center gap-1 text-xs font-semibold text-emerald-700"
+							data-test-id="godam-ga4-connection-status"
+						>
+							<Icon icon={ check } size={ 14 } />
+							{ __( 'Sending to GA4', 'godam' ) }
+						</span>
+						<Tooltip text={ tooltipText } />
+					</div>
+				</div>
+				<div className="flex flex-row justify-between gap-4 items-end">
+					<div className="flex flex-row gap-6">
+						<div className="flex flex-col">
+							<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
+								{ addToCartCount.toLocaleString() }
+							</p>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'add_to_cart', 'godam' ) }</span>
+						</div>
+						<div className="flex flex-col">
+							<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
+								{ purchaseCount.toLocaleString() }
+							</p>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'purchase', 'godam' ) }</span>
+						</div>
+					</div>
+					<a
+						className="godam-button"
+						href={ getGeneralSettingsUrl() }
+						data-test-id="godam-ga4-connection-manage-link"
+					>
+						{ __( 'Manage', 'godam' ) }
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default GA4ConnectionWidget;

--- a/pages/dashboard/components/GA4ConnectionWidget.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-import { check } from '@wordpress/icons';
+import { check, warning } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -27,6 +27,74 @@ const getGeneralSettingsUrl = () => {
 };
 
 /**
+ * Friendly names for `source_type` values the REST response may report, used
+ * when another GA4 integration is active and GoDAM is standing down. Falls
+ * back to a generic phrase for unrecognized or empty values.
+ */
+const KNOWN_SOURCE_LABELS = {
+	custom: __( 'a custom GA4 integration', 'godam' ),
+	manual: __( 'a manually configured GA4 integration', 'godam' ),
+};
+
+/**
+ * Human-readable label for a `source_type` value.
+ *
+ * @param {string} sourceType Raw `source_type` from the REST response.
+ * @return {string} Friendly description of the other GA4 source.
+ */
+const getSourceLabel = ( sourceType ) => {
+	if ( ! sourceType ) {
+		return __( 'another GA4 integration', 'godam' );
+	}
+
+	if ( KNOWN_SOURCE_LABELS[ sourceType ] ) {
+		return KNOWN_SOURCE_LABELS[ sourceType ];
+	}
+
+	return sourceType;
+};
+
+const tooltipText = __(
+	'add_to_cart and purchase are GA4’s default ecommerce events, already tracked by many stores.',
+	'godam',
+);
+
+/**
+ * Shared outer wrapper for every state of the widget.
+ *
+ * @param {Object} props          Props.
+ * @param {Object} props.children Widget content.
+ * @return {JSX.Element} Wrapper element.
+ */
+const WidgetShell = ( { children } ) => (
+	<div
+		className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+		data-test-id="godam-ga4-connection-widget"
+	>
+		<div className="analytics-single-info w-full">
+			{ children }
+		</div>
+	</div>
+);
+
+/**
+ * "All time" caption shown next to the counts. The counters are lifetime WP
+ * options with no per-day breakdown, so — unlike the range-scoped KPI cards
+ * this widget sits alongside — they never reflect the dashboard's date-range
+ * picker. Called out explicitly so that isn't misread as range-scoped.
+ *
+ * @return {JSX.Element} Caption element.
+ */
+const AllTimeBadge = () => (
+	<span
+		className="text-[10px] uppercase tracking-wide text-zinc-400 whitespace-nowrap"
+		data-test-id="godam-ga4-connection-all-time-badge"
+	>
+		{ __( 'All time', 'godam' ) }
+	</span>
+);
+
+/**
  * GA4 connection widget for the dashboard.
  *
  * Confirms whether GoDAM is pushing `add_to_cart`/`purchase` GA4 ecommerce
@@ -35,82 +103,135 @@ const getGeneralSettingsUrl = () => {
  * surfaces the on/off state and, once on, the running counts.
  *
  * Reads `enable_gtm_tracking` directly off `window.godamSettings.enableGTMTracking`
- * (already localized to the page) rather than round-tripping through an API call.
+ * (already localized to the page) rather than round-tripping through an API call,
+ * but that toggle only says GoDAM is *prepared* to push events — the REST
+ * response's `source_active`/`source_type` say whether it actually is, or
+ * whether another GA4 integration on the store already covers this and GoDAM
+ * is standing down.
  */
 const GA4ConnectionWidget = () => {
 	const isConnected = !! window.godamSettings?.enableGTMTracking;
 
-	const { data } = useFetchGa4CountsQuery( undefined, { skip: ! isConnected } );
-
-	const tooltipText = __(
-		'add_to_cart and purchase are GA4’s default ecommerce events, already tracked by many stores.',
-		'godam',
-	);
+	const { data, isLoading, isError } = useFetchGa4CountsQuery( undefined, { skip: ! isConnected } );
 
 	if ( ! isConnected ) {
 		return (
-			<div
-				className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
-				data-test-id="godam-ga4-connection-widget"
-			>
-				<div className="analytics-single-info w-full">
-					<div className="flex justify-between items-start flex-row w-full gap-2">
-						<div className="analytics-info-heading">
-							<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-ga4-connection-label">
-								{ __( 'Send add_to_cart and purchase to your GA4', 'godam' ) }
-							</p>
-							<Tooltip text={ tooltipText } />
-						</div>
-					</div>
-					<div className="flex flex-row justify-between gap-2 items-end">
-						<a
-							className="godam-button"
-							href={ getGeneralSettingsUrl() }
-							data-test-id="godam-ga4-connection-enable-link"
-						>
-							{ __( 'Enable', 'godam' ) }
-						</a>
+			<WidgetShell>
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading">
+						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-ga4-connection-label">
+							{ __( 'Send add_to_cart and purchase to your GA4', 'godam' ) }
+						</p>
+						<Tooltip text={ tooltipText } />
 					</div>
 				</div>
-			</div>
+				<div className="flex flex-row justify-between gap-2 items-end">
+					<a
+						className="godam-button"
+						href={ getGeneralSettingsUrl() }
+						data-test-id="godam-ga4-connection-enable-link"
+					>
+						{ __( 'Enable', 'godam' ) }
+					</a>
+				</div>
+			</WidgetShell>
+		);
+	}
+
+	if ( isLoading ) {
+		return (
+			<WidgetShell>
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading flex items-center gap-1">
+						<span
+							className="flex items-center gap-1 text-xs font-semibold text-zinc-500"
+							data-test-id="godam-ga4-connection-status"
+						>
+							{ __( 'Checking GA4 status…', 'godam' ) }
+						</span>
+					</div>
+				</div>
+			</WidgetShell>
+		);
+	}
+
+	if ( isError ) {
+		return (
+			<WidgetShell>
+				<div className="flex justify-between items-start flex-row w-full gap-2">
+					<div className="analytics-info-heading flex items-center gap-1">
+						<span
+							className="flex items-center gap-1 text-xs font-semibold text-zinc-500"
+							data-test-id="godam-ga4-connection-status"
+						>
+							<Icon icon={ warning } size={ 14 } />
+							{ __( 'GA4 connection status unavailable', 'godam' ) }
+						</span>
+						<Tooltip text={ __( 'Could not reach the GA4 status endpoint. This can happen right after an update — try refreshing in a moment.', 'godam' ) } />
+					</div>
+				</div>
+				<div className="flex flex-row justify-between gap-2 items-end">
+					<a
+						className="godam-button"
+						href={ getGeneralSettingsUrl() }
+						data-test-id="godam-ga4-connection-manage-link"
+					>
+						{ __( 'Manage', 'godam' ) }
+					</a>
+				</div>
+			</WidgetShell>
 		);
 	}
 
 	const addToCartCount = Number( data?.addToCartCount || 0 );
 	const purchaseCount = Number( data?.purchaseCount || 0 );
+	const isStandingDown = !! data?.sourceActive;
 
-	return (
-		<div
-			className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
-			data-test-id="godam-ga4-connection-widget"
-		>
-			<div className="analytics-single-info w-full">
+	if ( isStandingDown ) {
+		const sourceLabel = getSourceLabel( data?.sourceType );
+
+		return (
+			<WidgetShell>
 				<div className="flex justify-between items-start flex-row w-full gap-2">
 					<div className="analytics-info-heading flex items-center gap-1">
 						<span
-							className="flex items-center gap-1 text-xs font-semibold text-emerald-700"
+							className="flex items-center gap-1 text-xs font-semibold text-amber-700"
 							data-test-id="godam-ga4-connection-status"
 						>
-							<Icon icon={ check } size={ 14 } />
-							{ __( 'Sending to GA4', 'godam' ) }
+							<Icon icon={ warning } size={ 14 } />
+							{ __( 'GoDAM is standing down', 'godam' ) }
 						</span>
-						<Tooltip text={ tooltipText } />
+						<Tooltip
+							text={ sprintf(
+								/* translators: %s: name of the other active GA4 integration. */
+								__( '%s is already sending these events, so GoDAM is not pushing them to avoid duplicates.', 'godam' ),
+								sourceLabel,
+							) }
+						/>
 					</div>
 				</div>
+				<p className="text-xs text-zinc-500" data-test-id="godam-ga4-connection-standing-down-note">
+					{ sprintf(
+						/* translators: %s: name of the other active GA4 integration. */
+						__( '%s is active — GoDAM is not sending anything to avoid duplicate events.', 'godam' ),
+						sourceLabel,
+					) }
+				</p>
 				<div className="flex flex-row justify-between gap-4 items-end">
 					<div className="flex flex-row gap-6">
 						<div className="flex flex-col">
 							<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
 								{ addToCartCount.toLocaleString() }
 							</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'add_to_cart', 'godam' ) }</span>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'add_to_cart prepared', 'godam' ) }</span>
 						</div>
 						<div className="flex flex-col">
 							<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
 								{ purchaseCount.toLocaleString() }
 							</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'purchase', 'godam' ) }</span>
+							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'purchase prepared', 'godam' ) }</span>
 						</div>
+						<AllTimeBadge />
 					</div>
 					<a
 						className="godam-button"
@@ -120,8 +241,49 @@ const GA4ConnectionWidget = () => {
 						{ __( 'Manage', 'godam' ) }
 					</a>
 				</div>
+			</WidgetShell>
+		);
+	}
+
+	return (
+		<WidgetShell>
+			<div className="flex justify-between items-start flex-row w-full gap-2">
+				<div className="analytics-info-heading flex items-center gap-1">
+					<span
+						className="flex items-center gap-1 text-xs font-semibold text-emerald-700"
+						data-test-id="godam-ga4-connection-status"
+					>
+						<Icon icon={ check } size={ 14 } />
+						{ __( 'Sending to GA4', 'godam' ) }
+					</span>
+					<Tooltip text={ tooltipText } />
+				</div>
 			</div>
-		</div>
+			<div className="flex flex-row justify-between gap-4 items-end">
+				<div className="flex flex-row gap-6">
+					<div className="flex flex-col">
+						<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
+							{ addToCartCount.toLocaleString() }
+						</p>
+						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'add_to_cart', 'godam' ) }</span>
+					</div>
+					<div className="flex flex-col">
+						<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
+							{ purchaseCount.toLocaleString() }
+						</p>
+						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'purchase', 'godam' ) }</span>
+					</div>
+					<AllTimeBadge />
+				</div>
+				<a
+					className="godam-button"
+					href={ getGeneralSettingsUrl() }
+					data-test-id="godam-ga4-connection-manage-link"
+				>
+					{ __( 'Manage', 'godam' ) }
+				</a>
+			</div>
+		</WidgetShell>
 	);
 };
 

--- a/pages/dashboard/components/GA4ConnectionWidget.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
-import { check, warning } from '@wordpress/icons';
+import { check, warning, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -60,21 +60,96 @@ const tooltipText = __(
 );
 
 /**
- * Shared outer wrapper for every state of the widget.
+ * Shared outer wrapper for every state of the widget. `.analytics-info` /
+ * `.analytics-single-info` are only styled (flex layout, padding, gap — see
+ * analytics/index.scss) as descendants of `.analytics-info-container`, which
+ * the caller (Dashboard.js) is responsible for wrapping this in.
+ *
+ * A single row at `lg` and up (status on the left, counts + action on the
+ * right); stacked below that. `w-full` since this widget gets its own row,
+ * not a half-width slot shared with another card.
  *
  * @param {Object} props          Props.
- * @param {Object} props.children Widget content.
+ * @param {Object} props.children Widget content — see the per-state renders below.
  * @return {JSX.Element} Wrapper element.
  */
 const WidgetShell = ( { children } ) => (
 	<div
-		className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full md:w-[calc(50%-0.5rem)] lg:w-full"
+		className="analytics-info flex justify-between max-lg:flex-col border border-zinc-200 w-full"
 		data-test-id="godam-ga4-connection-widget"
 	>
-		<div className="analytics-single-info w-full">
+		{ /* `godam-ga4-connection-body` (not the lg:flex-row/items-center/justify-between
+		    Tailwind utilities alone) drives the row/column switch — the nested
+		    .analytics-info-container .analytics-info .analytics-single-info rule in
+		    analytics/index.scss sets flex-direction unconditionally at 3-class
+		    specificity, which a 1-class Tailwind utility (even matched at the lg
+		    breakpoint) cannot outrank; see the matching override in dashboard/index.scss. */ }
+		<div className="analytics-single-info godam-ga4-connection-body w-full gap-3">
 			{ children }
 		</div>
 	</div>
+);
+
+/**
+ * Small filled dot signalling the connection state at a glance, alongside
+ * the text status next to it (which carries the actual meaning) — color
+ * alone is never the only signal.
+ *
+ * @param {Object} props            Props.
+ * @param {string} props.colorClass Tailwind background-color class.
+ * @return {JSX.Element} Dot element.
+ */
+const StatusDot = ( { colorClass } ) => (
+	<span className={ `inline-block w-2 h-2 rounded-full shrink-0 ${ colorClass }` } aria-hidden="true" />
+);
+
+/**
+ * The status line shown at the top of every state: a dot + icon + label,
+ * with an optional info tooltip.
+ *
+ * @param {Object}      props           Props.
+ * @param {string}      props.dotClass  Tailwind background-color class for the StatusDot.
+ * @param {string}      props.textClass Tailwind text-color class for the label.
+ * @param {WPIcon|null} [props.icon]    Optional icon before the label.
+ * @param {string}      props.label     The status text.
+ * @param {string}      [props.tooltip] Optional tooltip text.
+ * @return {JSX.Element} Status line element.
+ */
+const StatusLine = ( { dotClass, textClass, icon, label, tooltip } ) => (
+	<div className="flex items-center gap-2">
+		<StatusDot colorClass={ dotClass } />
+		<span
+			className={ `flex items-center gap-1 text-xs font-semibold whitespace-nowrap ${ textClass }` }
+			data-test-id="godam-ga4-connection-status"
+		>
+			{ icon && <Icon icon={ icon } size={ 14 } /> }
+			{ label }
+		</span>
+		{ tooltip && <Tooltip text={ tooltip } /> }
+	</div>
+);
+
+/**
+ * "Enable"/"Manage" action — styled as a real button (not a plain link) in
+ * the site's own admin theme color (`--wp-admin-theme-color`, same variable
+ * the dashboard's icon fills already follow), with a trailing arrow so it
+ * reads as a navigation action rather than a plain label.
+ *
+ * @param {Object} props        Props.
+ * @param {string} props.href   Destination URL.
+ * @param {string} props.label  Button text.
+ * @param {string} props.testId `data-test-id` for the link.
+ * @return {JSX.Element} Button-styled link.
+ */
+const ActionButton = ( { href, label, testId } ) => (
+	<a
+		className="godam-ga4-connection-button"
+		href={ href }
+		data-test-id={ testId }
+	>
+		{ label }
+		<Icon icon={ chevronRight } size={ 16 } />
+	</a>
 );
 
 /**
@@ -92,6 +167,34 @@ const AllTimeBadge = () => (
 	>
 		{ __( 'All time', 'godam' ) }
 	</span>
+);
+
+/**
+ * The add_to_cart/purchase counts, side by side, once a value is available
+ * (the connected and standing-down states — the count is meaningful either
+ * way, since the server counts events "prepared to send" independent of
+ * whether GoDAM itself ends up pushing them; see the standing-down copy).
+ *
+ * @param {Object} props                Props.
+ * @param {number} props.addToCartCount Lifetime add_to_cart count.
+ * @param {number} props.purchaseCount  Lifetime purchase count.
+ * @return {JSX.Element} Metrics row.
+ */
+const MetricsRow = ( { addToCartCount, purchaseCount } ) => (
+	<div className="flex flex-row gap-8">
+		<div className="flex flex-col">
+			<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
+				{ addToCartCount.toLocaleString() }
+			</p>
+			<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Add to Cart', 'godam' ) }</span>
+		</div>
+		<div className="flex flex-col">
+			<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
+				{ purchaseCount.toLocaleString() }
+			</p>
+			<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Purchase', 'godam' ) }</span>
+		</div>
+	</div>
 );
 
 /**
@@ -117,23 +220,17 @@ const GA4ConnectionWidget = () => {
 	if ( ! isConnected ) {
 		return (
 			<WidgetShell>
-				<div className="flex justify-between items-start flex-row w-full gap-2">
-					<div className="analytics-info-heading">
-						<p className="text-xs text-[#525252] whitespace-nowrap" data-test-id="godam-ga4-connection-label">
-							{ __( 'GA4 Tracking', 'godam' ) }
-						</p>
-						<Tooltip text={ tooltipText } />
-					</div>
-				</div>
-				<div className="flex flex-row justify-between gap-2 items-end">
-					<a
-						className="godam-button"
-						href={ getGeneralSettingsUrl() }
-						data-test-id="godam-ga4-connection-enable-link"
-					>
-						{ __( 'Enable', 'godam' ) }
-					</a>
-				</div>
+				<StatusLine
+					dotClass="bg-zinc-400"
+					textClass="text-zinc-500"
+					label={ __( 'GA4 Tracking off', 'godam' ) }
+					tooltip={ tooltipText }
+				/>
+				<ActionButton
+					href={ getGeneralSettingsUrl() }
+					label={ __( 'Enable', 'godam' ) }
+					testId="godam-ga4-connection-enable-link"
+				/>
 			</WidgetShell>
 		);
 	}
@@ -141,16 +238,11 @@ const GA4ConnectionWidget = () => {
 	if ( isLoading ) {
 		return (
 			<WidgetShell>
-				<div className="flex justify-between items-start flex-row w-full gap-2">
-					<div className="analytics-info-heading flex items-center gap-1">
-						<span
-							className="flex items-center gap-1 text-xs font-semibold text-zinc-500"
-							data-test-id="godam-ga4-connection-status"
-						>
-							{ __( 'Checking GA4 status…', 'godam' ) }
-						</span>
-					</div>
-				</div>
+				<StatusLine
+					dotClass="bg-zinc-400 animate-pulse"
+					textClass="text-zinc-500"
+					label={ __( 'Checking GA4 status…', 'godam' ) }
+				/>
 			</WidgetShell>
 		);
 	}
@@ -158,27 +250,18 @@ const GA4ConnectionWidget = () => {
 	if ( isError ) {
 		return (
 			<WidgetShell>
-				<div className="flex justify-between items-start flex-row w-full gap-2">
-					<div className="analytics-info-heading flex items-center gap-1">
-						<span
-							className="flex items-center gap-1 text-xs font-semibold text-zinc-500"
-							data-test-id="godam-ga4-connection-status"
-						>
-							<Icon icon={ warning } size={ 14 } />
-							{ __( 'GA4 unavailable', 'godam' ) }
-						</span>
-						<Tooltip text={ __( 'Could not reach the GA4 status endpoint. This can happen right after an update — try refreshing in a moment.', 'godam' ) } />
-					</div>
-				</div>
-				<div className="flex flex-row justify-between gap-2 items-end">
-					<a
-						className="godam-button"
-						href={ getGeneralSettingsUrl() }
-						data-test-id="godam-ga4-connection-manage-link"
-					>
-						{ __( 'Manage', 'godam' ) }
-					</a>
-				</div>
+				<StatusLine
+					dotClass="bg-red-500"
+					textClass="text-zinc-500"
+					icon={ warning }
+					label={ __( 'GA4 unavailable', 'godam' ) }
+					tooltip={ __( 'Could not reach the GA4 status endpoint. This can happen right after an update — try refreshing in a moment.', 'godam' ) }
+				/>
+				<ActionButton
+					href={ getGeneralSettingsUrl() }
+					label={ __( 'Manage', 'godam' ) }
+					testId="godam-ga4-connection-manage-link"
+				/>
 			</WidgetShell>
 		);
 	}
@@ -192,49 +275,27 @@ const GA4ConnectionWidget = () => {
 
 		return (
 			<WidgetShell>
-				<div className="flex justify-between items-start flex-row w-full gap-2">
-					<div className="analytics-info-heading flex items-center gap-1">
-						<span
-							className="flex items-center gap-1 text-xs font-semibold text-amber-700"
-							data-test-id="godam-ga4-connection-status"
-						>
-							<Icon icon={ warning } size={ 14 } />
-							{ __( 'GoDAM is standing down', 'godam' ) }
-						</span>
-						<Tooltip
-							text={ sprintf(
-								/* translators: %s: name of the other active GA4 integration. */
-								__( '%s is already sending these events, so GoDAM is not pushing them to avoid duplicates.', 'godam' ),
-								sourceLabel,
-							) }
+				<StatusLine
+					dotClass="bg-amber-500"
+					textClass="text-amber-700"
+					icon={ warning }
+					label={ __( 'GoDAM is standing down', 'godam' ) }
+					tooltip={ sprintf(
+						/* translators: %s: name of the other active GA4 integration. */
+						__( '%s is already sending these events, so GoDAM is not pushing them to avoid duplicates.', 'godam' ),
+						sourceLabel,
+					) }
+				/>
+				<div className="flex items-center gap-6">
+					<MetricsRow addToCartCount={ addToCartCount } purchaseCount={ purchaseCount } />
+					<div className="flex items-center gap-3">
+						<AllTimeBadge />
+						<ActionButton
+							href={ getGeneralSettingsUrl() }
+							label={ __( 'Manage', 'godam' ) }
+							testId="godam-ga4-connection-manage-link"
 						/>
 					</div>
-				</div>
-				<div className="flex flex-row justify-between gap-4 items-end">
-					<div className="flex flex-row gap-6">
-						<div className="flex flex-col">
-							<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
-								{ addToCartCount.toLocaleString() }
-							</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Add to Cart', 'godam' ) }</span>
-						</div>
-						<div className="flex flex-col">
-							<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
-								{ purchaseCount.toLocaleString() }
-							</p>
-							<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Purchase', 'godam' ) }</span>
-						</div>
-					</div>
-				</div>
-				<div>
-					<AllTimeBadge />
-					<a
-						className="godam-button"
-						href={ getGeneralSettingsUrl() }
-						data-test-id="godam-ga4-connection-manage-link"
-					>
-						{ __( 'Manage', 'godam' ) }
-					</a>
 				</div>
 			</WidgetShell>
 		);
@@ -242,43 +303,23 @@ const GA4ConnectionWidget = () => {
 
 	return (
 		<WidgetShell>
-			<div className="flex justify-between items-start flex-row w-full gap-2">
-				<div className="analytics-info-heading flex items-center gap-1">
-					<span
-						className="flex items-center gap-1 text-xs font-semibold text-emerald-700"
-						data-test-id="godam-ga4-connection-status"
-					>
-						<Icon icon={ check } size={ 14 } />
-						{ __( 'Sending to GA4', 'godam' ) }
-					</span>
-					<Tooltip text={ tooltipText } />
+			<StatusLine
+				dotClass="bg-emerald-500"
+				textClass="text-emerald-700"
+				icon={ check }
+				label={ __( 'Sending to GA4', 'godam' ) }
+				tooltip={ tooltipText }
+			/>
+			<div className="flex items-center gap-6">
+				<MetricsRow addToCartCount={ addToCartCount } purchaseCount={ purchaseCount } />
+				<div className="flex items-center gap-3">
+					<AllTimeBadge />
+					<ActionButton
+						href={ getGeneralSettingsUrl() }
+						label={ __( 'Manage', 'godam' ) }
+						testId="godam-ga4-connection-manage-link"
+					/>
 				</div>
-			</div>
-			<div className="flex flex-row justify-between gap-4 items-end">
-				<div className="flex flex-row gap-6">
-					<div className="flex flex-col">
-						<p className="single-metrics-value" data-test-id="godam-ga4-connection-add-to-cart-count">
-							{ addToCartCount.toLocaleString() }
-						</p>
-						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Add to Cart', 'godam' ) }</span>
-					</div>
-					<div className="flex flex-col">
-						<p className="single-metrics-value" data-test-id="godam-ga4-connection-purchase-count">
-							{ purchaseCount.toLocaleString() }
-						</p>
-						<span className="text-xs text-zinc-500 whitespace-nowrap">{ __( 'Purchase', 'godam' ) }</span>
-					</div>
-				</div>
-			</div>
-			<div>
-				<AllTimeBadge />
-				<a
-					className="godam-button"
-					href={ getGeneralSettingsUrl() }
-					data-test-id="godam-ga4-connection-manage-link"
-				>
-					{ __( 'Manage', 'godam' ) }
-				</a>
 			</div>
 		</WidgetShell>
 	);

--- a/pages/dashboard/components/GA4ConnectionWidget.test.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.test.js
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the GA4 connection widget's two states.
+ *
+ * Not connected (`enable_gtm_tracking` off): shows the short pitch line and an
+ * "Enable" link into General Settings, and never calls the counts endpoint.
+ * Connected (`enable_gtm_tracking` on): shows the add_to_cart/purchase counts
+ * from the (mocked) RTK query and a "Manage" link back to the same settings tab.
+ *
+ * Rendered to a static HTML string (no @testing-library/react in this repo — see
+ * VideoToCartCard.test.js for the same pattern), with the RTK query hook mocked
+ * directly rather than wired through a real store/provider.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useFetchGa4CountsQuery } from '../redux/api/dashboardAnalyticsApi';
+import GA4ConnectionWidget from './GA4ConnectionWidget';
+
+jest.mock( '../redux/api/dashboardAnalyticsApi', () => ( {
+	useFetchGa4CountsQuery: jest.fn(),
+} ) );
+
+describe( 'GA4ConnectionWidget', () => {
+	const originalGodamSettings = window.godamSettings;
+	const originalVideoData = window.videoData;
+
+	beforeEach( () => {
+		useFetchGa4CountsQuery.mockReset();
+		useFetchGa4CountsQuery.mockReturnValue( { data: undefined } );
+		window.videoData = { adminUrl: 'admin.php?page=rtgodam_settings#video-settings' };
+	} );
+
+	afterEach( () => {
+		window.godamSettings = originalGodamSettings;
+		window.videoData = originalVideoData;
+	} );
+
+	describe( 'not connected (enable_gtm_tracking off)', () => {
+		beforeEach( () => {
+			window.godamSettings = { enableGTMTracking: false };
+		} );
+
+		it( 'shows the pitch line and an Enable link, no counts', () => {
+			const html = renderToString( <GA4ConnectionWidget /> );
+
+			expect( html ).toContain( 'godam-ga4-connection-widget' );
+			expect( html ).toContain( 'Send add_to_cart and purchase to your GA4' );
+			expect( html ).toContain( 'godam-ga4-connection-enable-link' );
+			expect( html ).toContain( '#general-settings' );
+			expect( html ).not.toContain( 'godam-ga4-connection-add-to-cart-count' );
+			expect( html ).not.toContain( 'godam-ga4-connection-purchase-count' );
+			expect( html ).not.toContain( 'godam-ga4-connection-manage-link' );
+		} );
+
+		it( 'never calls the counts endpoint (skip: true)', () => {
+			renderToString( <GA4ConnectionWidget /> );
+
+			expect( useFetchGa4CountsQuery ).toHaveBeenCalledWith(
+				undefined,
+				expect.objectContaining( { skip: true } ),
+			);
+		} );
+	} );
+
+	describe( 'connected (enable_gtm_tracking on)', () => {
+		beforeEach( () => {
+			window.godamSettings = { enableGTMTracking: true };
+		} );
+
+		it( 'shows the counts from the API response and a Manage link, no Enable CTA', () => {
+			useFetchGa4CountsQuery.mockReturnValue( {
+				data: { addToCartCount: 1234, purchaseCount: 56 },
+			} );
+
+			const html = renderToString( <GA4ConnectionWidget /> );
+
+			expect( html ).toContain( 'godam-ga4-connection-widget' );
+			expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
+			expect( html ).toContain( '1,234' );
+			expect( html ).toContain( 'godam-ga4-connection-purchase-count' );
+			expect( html ).toContain( '56' );
+			expect( html ).toContain( 'godam-ga4-connection-manage-link' );
+			expect( html ).toContain( '#general-settings' );
+			expect( html ).not.toContain( 'godam-ga4-connection-enable-link' );
+		} );
+
+		it( 'calls the counts endpoint (skip: false)', () => {
+			renderToString( <GA4ConnectionWidget /> );
+
+			expect( useFetchGa4CountsQuery ).toHaveBeenCalledWith(
+				undefined,
+				expect.objectContaining( { skip: false } ),
+			);
+		} );
+
+		it( 'treats a missing payload as zero counts rather than throwing', () => {
+			useFetchGa4CountsQuery.mockReturnValue( { data: undefined } );
+
+			const html = renderToString( <GA4ConnectionWidget /> );
+
+			expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
+		} );
+	} );
+} );

--- a/pages/dashboard/components/GA4ConnectionWidget.test.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.test.js
@@ -10,8 +10,9 @@
  * - success + `source_active: false`: the "Sending to GA4" state with counts
  * and an "All time" caption.
  * - success + `source_active: true`: GoDAM is standing down for another GA4
- * integration — a distinct state naming `source_type`, counts relabeled as
- * "prepared" rather than sent, still with the "All time" caption.
+ * integration — a distinct state naming `source_type`, still showing counts
+ * and the "All time" caption (the standing-down status label itself, not
+ * the counts, communicates that nothing was actually sent).
  *
  * Rendered to a static HTML string (no @testing-library/react in this repo — see
  * VideoToCartCard.test.js for the same pattern), with the RTK query hook mocked
@@ -59,7 +60,7 @@ describe( 'GA4ConnectionWidget', () => {
 			const html = renderToString( <GA4ConnectionWidget /> );
 
 			expect( html ).toContain( 'godam-ga4-connection-widget' );
-			expect( html ).toContain( 'Send add_to_cart and purchase to your GA4' );
+			expect( html ).toContain( 'GA4 Tracking' );
 			expect( html ).toContain( 'godam-ga4-connection-enable-link' );
 			expect( html ).toContain( '#general-settings' );
 			expect( html ).not.toContain( 'godam-ga4-connection-add-to-cart-count' );
@@ -113,7 +114,7 @@ describe( 'GA4ConnectionWidget', () => {
 				const html = renderToString( <GA4ConnectionWidget /> );
 
 				expect( html ).toContain( 'godam-ga4-connection-widget' );
-				expect( html ).toContain( 'GA4 connection status unavailable' );
+				expect( html ).toContain( 'GA4 unavailable' );
 				expect( html ).not.toContain( 'Sending to GA4' );
 				expect( html ).not.toContain( 'godam-ga4-connection-add-to-cart-count' );
 				expect( html ).not.toContain( 'godam-ga4-connection-purchase-count' );
@@ -182,7 +183,7 @@ describe( 'GA4ConnectionWidget', () => {
 				expect( html ).toContain( 'a custom GA4 integration' );
 			} );
 
-			it( 'relabels the counts as "prepared" rather than implying they were sent', () => {
+			it( 'still shows the counts alongside the standing-down status, not implying they were sent', () => {
 				useFetchGa4CountsQuery.mockReturnValue( {
 					data: { addToCartCount: 10, purchaseCount: 2, sourceActive: true, sourceType: 'manual' },
 					isLoading: false,
@@ -193,8 +194,11 @@ describe( 'GA4ConnectionWidget', () => {
 
 				expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
 				expect( html ).toContain( '10' );
-				expect( html ).toContain( 'add_to_cart prepared' );
-				expect( html ).toContain( 'purchase prepared' );
+				expect( html ).toContain( 'Add to Cart' );
+				expect( html ).toContain( 'Purchase' );
+				// The standing-down status itself (not the counts) is what
+				// communicates "not sent" — see the preceding test.
+				expect( html ).toContain( 'standing down' );
 			} );
 
 			it( 'still shows the "All time" caption alongside the counts', () => {

--- a/pages/dashboard/components/GA4ConnectionWidget.test.js
+++ b/pages/dashboard/components/GA4ConnectionWidget.test.js
@@ -1,10 +1,17 @@
 /**
- * Unit tests for the GA4 connection widget's two states.
+ * Unit tests for the GA4 connection widget's states.
  *
  * Not connected (`enable_gtm_tracking` off): shows the short pitch line and an
  * "Enable" link into General Settings, and never calls the counts endpoint.
- * Connected (`enable_gtm_tracking` on): shows the add_to_cart/purchase counts
- * from the (mocked) RTK query and a "Manage" link back to the same settings tab.
+ *
+ * Connected (`enable_gtm_tracking` on) branches on the RTK query result:
+ * - loading: a distinct "checking" state, no counts.
+ * - error: a distinct "status unavailable" state, no counts.
+ * - success + `source_active: false`: the "Sending to GA4" state with counts
+ * and an "All time" caption.
+ * - success + `source_active: true`: GoDAM is standing down for another GA4
+ * integration — a distinct state naming `source_type`, counts relabeled as
+ * "prepared" rather than sent, still with the "All time" caption.
  *
  * Rendered to a static HTML string (no @testing-library/react in this repo — see
  * VideoToCartCard.test.js for the same pattern), with the RTK query hook mocked
@@ -34,7 +41,7 @@ describe( 'GA4ConnectionWidget', () => {
 
 	beforeEach( () => {
 		useFetchGa4CountsQuery.mockReset();
-		useFetchGa4CountsQuery.mockReturnValue( { data: undefined } );
+		useFetchGa4CountsQuery.mockReturnValue( { data: undefined, isLoading: false, isError: false } );
 		window.videoData = { adminUrl: 'admin.php?page=rtgodam_settings#video-settings' };
 	} );
 
@@ -75,23 +82,6 @@ describe( 'GA4ConnectionWidget', () => {
 			window.godamSettings = { enableGTMTracking: true };
 		} );
 
-		it( 'shows the counts from the API response and a Manage link, no Enable CTA', () => {
-			useFetchGa4CountsQuery.mockReturnValue( {
-				data: { addToCartCount: 1234, purchaseCount: 56 },
-			} );
-
-			const html = renderToString( <GA4ConnectionWidget /> );
-
-			expect( html ).toContain( 'godam-ga4-connection-widget' );
-			expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
-			expect( html ).toContain( '1,234' );
-			expect( html ).toContain( 'godam-ga4-connection-purchase-count' );
-			expect( html ).toContain( '56' );
-			expect( html ).toContain( 'godam-ga4-connection-manage-link' );
-			expect( html ).toContain( '#general-settings' );
-			expect( html ).not.toContain( 'godam-ga4-connection-enable-link' );
-		} );
-
 		it( 'calls the counts endpoint (skip: false)', () => {
 			renderToString( <GA4ConnectionWidget /> );
 
@@ -101,12 +91,147 @@ describe( 'GA4ConnectionWidget', () => {
 			);
 		} );
 
-		it( 'treats a missing payload as zero counts rather than throwing', () => {
-			useFetchGa4CountsQuery.mockReturnValue( { data: undefined } );
+		describe( 'while the request is in flight', () => {
+			it( 'shows a loading state, not "connected" or counts', () => {
+				useFetchGa4CountsQuery.mockReturnValue( { data: undefined, isLoading: true, isError: false } );
 
-			const html = renderToString( <GA4ConnectionWidget /> );
+				const html = renderToString( <GA4ConnectionWidget /> );
 
-			expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
+				expect( html ).toContain( 'godam-ga4-connection-widget' );
+				expect( html ).toContain( 'Checking GA4 status' );
+				expect( html ).not.toContain( 'Sending to GA4' );
+				expect( html ).not.toContain( 'godam-ga4-connection-add-to-cart-count' );
+				expect( html ).not.toContain( 'godam-ga4-connection-purchase-count' );
+				expect( html ).not.toContain( 'godam-ga4-connection-enable-link' );
+			} );
+		} );
+
+		describe( 'when the request errors', () => {
+			it( 'shows a distinct "status unavailable" state, not "connected" or counts', () => {
+				useFetchGa4CountsQuery.mockReturnValue( { data: undefined, isLoading: false, isError: true } );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-widget' );
+				expect( html ).toContain( 'GA4 connection status unavailable' );
+				expect( html ).not.toContain( 'Sending to GA4' );
+				expect( html ).not.toContain( 'godam-ga4-connection-add-to-cart-count' );
+				expect( html ).not.toContain( 'godam-ga4-connection-purchase-count' );
+				expect( html ).not.toContain( '0/0' );
+			} );
+
+			it( 'does not fall back to a fake connected state with zeroed counts', () => {
+				useFetchGa4CountsQuery.mockReturnValue( { data: undefined, isLoading: false, isError: true } );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).not.toContain( 'single-metrics-value' );
+			} );
+		} );
+
+		describe( 'successful response, source_active: false (GoDAM is the active source)', () => {
+			it( 'shows the counts, a Manage link, an "All time" caption, no Enable CTA', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: { addToCartCount: 1234, purchaseCount: 56, sourceActive: false, sourceType: '' },
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-widget' );
+				expect( html ).toContain( 'Sending to GA4' );
+				expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
+				expect( html ).toContain( '1,234' );
+				expect( html ).toContain( 'godam-ga4-connection-purchase-count' );
+				expect( html ).toContain( '56' );
+				expect( html ).toContain( 'godam-ga4-connection-manage-link' );
+				expect( html ).toContain( '#general-settings' );
+				expect( html ).toContain( 'godam-ga4-connection-all-time-badge' );
+				expect( html ).toContain( 'All time' );
+				expect( html ).not.toContain( 'godam-ga4-connection-enable-link' );
+				expect( html ).not.toContain( 'standing down' );
+			} );
+
+			it( 'treats a missing payload as zero counts rather than throwing', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: undefined,
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
+			} );
+		} );
+
+		describe( 'successful response, source_active: true (GoDAM is standing down)', () => {
+			it( 'shows a standing-down state naming the other source, not "Sending to GA4"', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: { addToCartCount: 10, purchaseCount: 2, sourceActive: true, sourceType: 'custom' },
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-widget' );
+				expect( html ).not.toContain( 'Sending to GA4' );
+				expect( html ).toContain( 'standing down' );
+				expect( html ).toContain( 'a custom GA4 integration' );
+			} );
+
+			it( 'relabels the counts as "prepared" rather than implying they were sent', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: { addToCartCount: 10, purchaseCount: 2, sourceActive: true, sourceType: 'manual' },
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-add-to-cart-count' );
+				expect( html ).toContain( '10' );
+				expect( html ).toContain( 'add_to_cart prepared' );
+				expect( html ).toContain( 'purchase prepared' );
+			} );
+
+			it( 'still shows the "All time" caption alongside the counts', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: { addToCartCount: 10, purchaseCount: 2, sourceActive: true, sourceType: '' },
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-all-time-badge' );
+			} );
+
+			it( 'falls back to a generic phrase for an unrecognized/empty source_type', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: { addToCartCount: 10, purchaseCount: 2, sourceActive: true, sourceType: '' },
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'another GA4 integration' );
+			} );
+
+			it( 'still offers a Manage link back to settings', () => {
+				useFetchGa4CountsQuery.mockReturnValue( {
+					data: { addToCartCount: 10, purchaseCount: 2, sourceActive: true, sourceType: 'custom' },
+					isLoading: false,
+					isError: false,
+				} );
+
+				const html = renderToString( <GA4ConnectionWidget /> );
+
+				expect( html ).toContain( 'godam-ga4-connection-manage-link' );
+			} );
 		} );
 	} );
 } );

--- a/pages/dashboard/index.scss
+++ b/pages/dashboard/index.scss
@@ -6,6 +6,56 @@
 	}
 }
 
+// GA4 connection widget's "Enable"/"Manage" action — a real button (not a
+// plain <a>), in the site's own admin theme colour rather than the fixed
+// brand red .godam-button.is-secondary uses, so it matches whatever colour
+// scheme the merchant has picked for wp-admin.
+.godam-ga4-connection-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	padding: 6px 10px;
+	border-radius: 6px;
+	font-size: 12px;
+	font-weight: 600;
+	white-space: nowrap;
+	color: var(--wp-admin-theme-color, #ab3a6c);
+	border: 1px solid var(--wp-admin-theme-color, #ab3a6c);
+	background: transparent;
+	transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+
+	&:hover,
+	&:focus {
+		background: var(--wp-admin-theme-color, #ab3a6c);
+		color: #fff;
+		text-decoration: none;
+	}
+
+	svg {
+		fill: currentcolor;
+	}
+}
+
+// Row/column switch for the widget's own body. Needs an ID-scoped selector
+// (not a plain Tailwind utility, however many classes) because
+// #root-video-analytics/#root-video-dashboard's own unconditional
+// .analytics-info-container .analytics-info .analytics-single-info rule
+// (analytics/index.scss, nested under those IDs) sets flex-direction — an ID
+// beats any number of plain classes, so only another ID-scoped rule can
+// override it.
+#root-video-analytics .analytics-info-container .analytics-info .analytics-single-info.godam-ga4-connection-body,
+#root-video-dashboard .analytics-info-container .analytics-info .analytics-single-info.godam-ga4-connection-body {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+
+	@media screen and (min-width: 1024px) {
+		flex-direction: row;
+		align-items: center;
+		justify-content: space-between;
+	}
+}
+
 .godam-dashboard-container {
 	background-color: #fff;
 	overflow-x: hidden;

--- a/pages/dashboard/redux/api/dashboardAnalyticsApi.js
+++ b/pages/dashboard/redux/api/dashboardAnalyticsApi.js
@@ -124,6 +124,20 @@ export const dashboardAnalyticsApi = createApi( {
 				};
 			},
 		} ),
+		// Fetch GA4 add_to_cart/purchase counts pushed by the godam-for-woo add-on's
+		// dataLayer emission. Lives under that add-on's own REST namespace (not
+		// `godam/v1`) since it owns the counting; this plugin only surfaces it. Only
+		// meaningful (and only called) once `enable_gtm_tracking` is on — see
+		// GA4ConnectionWidget.
+		fetchGa4Counts: builder.query( {
+			query: () => ( {
+				url: 'godam-for-woo/v1/ga4-counts',
+			} ),
+			transformResponse: ( response ) => ( {
+				addToCartCount: Number( response?.add_to_cart_count || 0 ),
+				purchaseCount: Number( response?.purchase_count || 0 ),
+			} ),
+		} ),
 	} ),
 } );
 
@@ -134,4 +148,5 @@ export const {
 	useLazyFetchTopVideosQuery,
 	useFetchTopProductsQuery,
 	useLazyFetchTopProductsQuery,
+	useFetchGa4CountsQuery,
 } = dashboardAnalyticsApi;

--- a/pages/dashboard/redux/api/dashboardAnalyticsApi.js
+++ b/pages/dashboard/redux/api/dashboardAnalyticsApi.js
@@ -129,6 +129,11 @@ export const dashboardAnalyticsApi = createApi( {
 		// `godam/v1`) since it owns the counting; this plugin only surfaces it. Only
 		// meaningful (and only called) once `enable_gtm_tracking` is on — see
 		// GA4ConnectionWidget.
+		//
+		// `source_active`/`source_type` report whether another GA4 integration on
+		// the store is already covering these events, in which case GoDAM stands
+		// down and pushes nothing even though the counters below keep incrementing
+		// (they document events "prepared to send", not delivered).
 		fetchGa4Counts: builder.query( {
 			query: () => ( {
 				url: 'godam-for-woo/v1/ga4-counts',
@@ -136,6 +141,8 @@ export const dashboardAnalyticsApi = createApi( {
 			transformResponse: ( response ) => ( {
 				addToCartCount: Number( response?.add_to_cart_count || 0 ),
 				purchaseCount: Number( response?.purchase_count || 0 ),
+				sourceActive: !! response?.source_active,
+				sourceType: response?.source_type || '',
 			} ),
 		} ),
 	} ),

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: rtcamp, elifvish, subodhrajpopat, kuldipchaudhary, prachigarg19, juzar, geekofshire, nazmulhassann20, joelabreo, mi5t4n, abhinavbelhekar03, gautam23, mukulsingh27, hbhalodia, kishu7270, opurockey, utsavladani, whiteshadow01, ahmarzaidi, im3dabasia1, rudrakshigupta, sabbir1991, shreyasikhar26
 Tags: transcoder, video, media library, folders, file manager
 Requires at least: 6.5
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 2.1.1
 License: GPLv2 or later


### PR DESCRIPTION
## What this is

The dashboard-facing half of GA4 output: a small widget confirming the GA4 connection is live and showing running counts of what's been sent, so a merchant doesn't have to take it on faith. The actual `dataLayer` pushes happen in `godam-for-woo` ([PR #198](https://github.com/rtCamp/godam-for-woo/pull/198)), which this widget reads from.

## Features

- **`GA4ConnectionWidget`** — gated on the existing `enable_gtm_tracking` setting (`window.godamSettings.enableGTMTracking`, read directly, no new setting added), with **five render states**, not two:
  - **Not connected** (the toggle is off): a short prompt + an Enable link to the existing settings tab.
  - **Loading**: the counts request is in flight.
  - **Status unavailable**: the counts request failed or errored (e.g. a version mismatch with `godam-for-woo`, a permissions issue) — shown distinctly so a broken connection never silently reads as a working one at zero.
  - **Standing down**: the toggle is on, but `godam-for-woo`'s capability probe reports another GA4 integration is active (`source_active: true` on the REST response) — GoDAM is correctly pushing nothing. Names the other source (`source_type`) where known, and relabels the counts "prepared" rather than implying they were sent.
  - **Connected**: the toggle is on and GoDAM is the active source — running `add_to_cart` / `purchase` counts (full numbers, no abbreviation, explicitly labelled "All time" since they're lifetime totals, not scoped to the dashboard's date-range picker), a Manage link back to the settings tab, and an info tooltip explaining these are GA4's own default ecommerce events.
- New RTK Query endpoint hitting `godam-for-woo`'s `GET /ga4-counts` REST route (now returning `source_active`/`source_type` alongside the two counts — the field names this widget's `transformResponse` reads exactly), called whenever the toggle is on.
- Rendered on the dashboard next to the existing Video-to-Cart card, gated the same way the other Woo-only surfaces are (add-on active + valid license); the Insights row's wrap breakpoint was adjusted so five cards no longer crowd each other near 1024px.

## User journey this is part of

**A merchant opens their GoDAM dashboard to answer one question: "is this actually working, and how much is it doing?"** — on day one with the setting off, a week later after turning it on, on a store that already has a different GA4 integration installed, or when something's actually broken. This widget is the merchant's only visibility into that, so every one of its five states needs to stay honest about what's actually happening server-side — which is exactly what the review process behind the sibling PR spent most of its effort verifying, and is the reason this went from two states to five.

<img width="905" height="95" alt="image" src="https://github.com/user-attachments/assets/21a622be-3697-4343-b889-ee7a25955e80" />
<img width="903" height="70" alt="image" src="https://github.com/user-attachments/assets/1ee169d1-6116-4ac7-9b1a-79f8322458c3" />

