### PR TITLE
Fix: feature image virtual media

### DIFF
--- a/assets/src/js/media-library/classic-featured-image.js
+++ b/assets/src/js/media-library/classic-featured-image.js
@@ -1,0 +1,112 @@
+/**
+ * Classic editor Featured image support for the GoDAM tab.
+ *
+ * The block editor's Featured image panel routes a pick through `editPost()`, so the
+ * placeholder GoDAM ID it stores can simply be repointed once the real attachment
+ * exists (see replaceVirtualIdInFeaturedImage in godam-media-frame-shared.js).
+ *
+ * The classic editor gives us no such window. `wp.media.featuredImage.frame()` binds
+ * `wp.media.featuredImage.select` to the state's `select` event at frame construction,
+ * so it always runs before our own handler and immediately calls
+ * `wp.media.featuredImage.set()` with whatever ID the selected model carries — the
+ * Central job docname, at that point. That POSTs to `get-post-thumbnail-html`, which
+ * casts the value with `(int)`: `8f7d2a1b` becomes `8`, so the meta box renders an
+ * unrelated attachment and writes its ID into the `_thumbnail_id` hidden field, which
+ * the next post save then persists.
+ *
+ * So instead of repairing the value afterwards, hold it back. `set()` is wrapped to
+ * park a GoDAM pick rather than send it, and resolveClassicFeaturedImage() releases the
+ * real attachment ID through the original setter once create-media-entry has answered.
+ * Nothing bogus ever reaches the meta box or the hidden field.
+ */
+
+/**
+ * The placeholder GoDAM ID held back from `wp.media.featuredImage.set()` while its real
+ * attachment is being created. Null when no pick is in flight.
+ *
+ * @type {string|number|null}
+ */
+let deferredVirtualId = null;
+
+/**
+ * Whether a `set()` call is carrying a GoDAM pick that onGoDAMSelect() is about to turn
+ * into a real attachment.
+ *
+ * Deliberately mirrors onGoDAMSelect()'s own gate — the two must agree, or a pick gets
+ * parked with nothing on the way to release it. The ID comparison is what keeps
+ * `remove()` working: it calls `set( -1 )`, which never matches the selected model, and
+ * the content mode can still read as 'godam' from an earlier session.
+ *
+ * @param {string|number} id The ID handed to `wp.media.featuredImage.set()`.
+ * @return {boolean} True when the value should be parked instead of sent.
+ */
+function isDeferrableGoDAMId( id ) {
+	const frame = window.wp?.media?.frame;
+
+	if ( 'godam' !== frame?.content?.mode?.() ) {
+		return false;
+	}
+
+	const selected = frame.state?.()?.get?.( 'selection' )?.single?.();
+
+	return !! selected && String( selected.id ) === String( id );
+}
+
+/**
+ * Wrap `wp.media.featuredImage.set()` so a GoDAM pick is parked rather than sent.
+ *
+ * Called from GoDAMCreate() rather than at page load: `wp.media.featuredImage` is
+ * defined by media-editor.js, which is not guaranteed to have run by the time this
+ * bundle initializes, and the patch is only ever needed once the GoDAM tab is rendered.
+ * Idempotent, since GoDAMCreate() runs on every tab activation.
+ *
+ * @return {void}
+ */
+export function setupClassicFeaturedImage() {
+	const featuredImage = window.wp?.media?.featuredImage;
+
+	if ( ! featuredImage || featuredImage.godamOriginalSet ) {
+		return;
+	}
+
+	const originalSet = featuredImage.set;
+
+	if ( 'function' !== typeof originalSet ) {
+		return;
+	}
+
+	// Kept for resolveClassicFeaturedImage(): it runs while the modal still reports
+	// 'godam' as its content mode, so releasing through the wrapper would park the real
+	// ID too and the pick would never land.
+	featuredImage.godamOriginalSet = originalSet;
+
+	featuredImage.set = function( id ) {
+		if ( isDeferrableGoDAMId( id ) ) {
+			deferredVirtualId = id;
+			return undefined;
+		}
+
+		deferredVirtualId = null;
+
+		return originalSet.call( this, id );
+	};
+}
+
+/**
+ * Release a parked classic-editor featured image now that its attachment exists.
+ *
+ * @param {string|number} virtualMediaId The GoDAM ID that was parked.
+ * @param {number}        realId         The newly created WP attachment ID.
+ * @return {void}
+ */
+export function resolveClassicFeaturedImage( virtualMediaId, realId ) {
+	if ( null === deferredVirtualId || String( deferredVirtualId ) !== String( virtualMediaId ) ) {
+		return;
+	}
+
+	deferredVirtualId = null;
+
+	const featuredImage = window.wp?.media?.featuredImage;
+
+	featuredImage?.godamOriginalSet?.call( featuredImage, realId );
+}

--- a/assets/src/js/media-library/classic-featured-image.js
+++ b/assets/src/js/media-library/classic-featured-image.js
@@ -21,12 +21,80 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { isSameId } from './ids.js';
+
+/**
  * The placeholder GoDAM ID held back from `wp.media.featuredImage.set()` while its real
  * attachment is being created. Null when no pick is in flight.
  *
  * @type {string|number|null}
  */
 let deferredVirtualId = null;
+
+/**
+ * The meta box markup replaced by the in-flight placeholder, so a pick that never resolves
+ * can put the previous featured image back. Null when nothing is parked.
+ *
+ * @type {string|null}
+ */
+let metaBoxSnapshot = null;
+
+/**
+ * Whether a media frame is the classic editor's Featured image workflow.
+ *
+ * `wp.media.featuredImage.frame()` is the only frame built with a `featured-image` state,
+ * so its presence identifies the one context where a pick can reach
+ * `wp.media.featuredImage.set()`. Everything else — Insert Media, galleries, the Document
+ * block — is left alone.
+ *
+ * @param {Object} frame A media frame.
+ * @return {boolean} True when the frame is the Featured image workflow.
+ */
+function isFeaturedImageFrame( frame ) {
+	return !! frame?.states?.get?.( 'featured-image' );
+}
+
+/**
+ * Show a placeholder in the featured image meta box while a pick is being resolved.
+ *
+ * Core's `set()` replaces the whole of `#postimagediv .inside` when the real ID lands, so
+ * the placeholder is cleaned up for free on the success path; only the failure path has to
+ * restore the snapshot.
+ *
+ * @return {void}
+ */
+function showInFlightPlaceholder() {
+	const inside = document.querySelector( '#postimagediv .inside' );
+
+	if ( ! inside ) {
+		return;
+	}
+
+	metaBoxSnapshot = inside.innerHTML;
+	inside.innerHTML = '<p class="godam-featured-image-pending">' + __( 'Setting featured image…', 'godam' ) + '</p>';
+}
+
+/**
+ * Put the previous featured image markup back after a pick failed to resolve.
+ *
+ * @return {void}
+ */
+function restoreMetaBox() {
+	const inside = document.querySelector( '#postimagediv .inside' );
+
+	if ( inside && null !== metaBoxSnapshot ) {
+		inside.innerHTML = metaBoxSnapshot;
+	}
+
+	metaBoxSnapshot = null;
+}
 
 /**
  * Whether a `set()` call is carrying a GoDAM pick that onGoDAMSelect() is about to turn
@@ -43,13 +111,13 @@ let deferredVirtualId = null;
 function isDeferrableGoDAMId( id ) {
 	const frame = window.wp?.media?.frame;
 
-	if ( 'godam' !== frame?.content?.mode?.() ) {
+	if ( ! isFeaturedImageFrame( frame ) || 'godam' !== frame?.content?.mode?.() ) {
 		return false;
 	}
 
 	const selected = frame.state?.()?.get?.( 'selection' )?.single?.();
 
-	return !! selected && String( selected.id ) === String( id );
+	return !! selected && isSameId( selected.id, id );
 }
 
 /**
@@ -60,12 +128,21 @@ function isDeferrableGoDAMId( id ) {
  * bundle initializes, and the patch is only ever needed once the GoDAM tab is rendered.
  * Idempotent, since GoDAMCreate() runs on every tab activation.
  *
+ * @param {Object} frame The media frame rendering the GoDAM tab.
  * @return {void}
  */
-export function setupClassicFeaturedImage() {
+export function setupClassicFeaturedImage( frame ) {
 	const featuredImage = window.wp?.media?.featuredImage;
 
 	if ( ! featuredImage || featuredImage.godamOriginalSet ) {
+		return;
+	}
+
+	// Only the Featured image workflow can route a pick through `featuredImage.set()`, so
+	// there is no reason to override a core global while the GoDAM tab is being rendered
+	// inside Insert Media or a gallery frame. GoDAMCreate() runs on every tab activation,
+	// so the patch still gets installed the first time a featured-image frame shows the tab.
+	if ( ! isFeaturedImageFrame( frame ) ) {
 		return;
 	}
 
@@ -83,10 +160,12 @@ export function setupClassicFeaturedImage() {
 	featuredImage.set = function( id ) {
 		if ( isDeferrableGoDAMId( id ) ) {
 			deferredVirtualId = id;
+			showInFlightPlaceholder();
 			return undefined;
 		}
 
 		deferredVirtualId = null;
+		metaBoxSnapshot = null;
 
 		return originalSet.call( this, id );
 	};
@@ -100,7 +179,7 @@ export function setupClassicFeaturedImage() {
  * @return {void}
  */
 export function resolveClassicFeaturedImage( virtualMediaId, realId ) {
-	if ( null === deferredVirtualId || String( deferredVirtualId ) !== String( virtualMediaId ) ) {
+	if ( null === deferredVirtualId || ! isSameId( deferredVirtualId, virtualMediaId ) ) {
 		return;
 	}
 
@@ -108,5 +187,39 @@ export function resolveClassicFeaturedImage( virtualMediaId, realId ) {
 
 	const featuredImage = window.wp?.media?.featuredImage;
 
-	featuredImage?.godamOriginalSet?.call( featuredImage, realId );
+	if ( ! featuredImage?.godamOriginalSet ) {
+		// Nothing will repaint the meta box, so undo the placeholder ourselves.
+		restoreMetaBox();
+		return;
+	}
+
+	// Core's set() replaces the meta box markup, placeholder included.
+	metaBoxSnapshot = null;
+
+	featuredImage.godamOriginalSet.call( featuredImage, realId );
+}
+
+/**
+ * Release a parked classic-editor featured image without setting anything.
+ *
+ * Called when create-media-entry fails or answers with `success: false`. Without this the
+ * park would stay held for the rest of the page's life: the original `set()` was
+ * suppressed, so the meta box silently keeps its previous value while the user believes a
+ * featured image was chosen. Clearing at least lets the next pick through.
+ *
+ * ID-matched for the same reason resolveClassicFeaturedImage() is — a slow failure must
+ * not release a pick the user made after it.
+ *
+ * @param {string|number} virtualMediaId The GoDAM ID that was parked.
+ * @return {boolean} True when a park was actually cleared.
+ */
+export function clearDeferredFeaturedImage( virtualMediaId ) {
+	if ( null === deferredVirtualId || ! isSameId( deferredVirtualId, virtualMediaId ) ) {
+		return false;
+	}
+
+	deferredVirtualId = null;
+	restoreMetaBox();
+
+	return true;
 }

--- a/assets/src/js/media-library/classic-featured-image.test.js
+++ b/assets/src/js/media-library/classic-featured-image.test.js
@@ -4,22 +4,26 @@
 import {
 	setupClassicFeaturedImage,
 	resolveClassicFeaturedImage,
+	clearDeferredFeaturedImage,
 } from './classic-featured-image';
 
 /**
  * Build a `wp.media` double with a frame whose content mode and single selection
  * are controllable, plus a spy standing in for the real `featuredImage.set`.
  *
- * @param {Object}      options            Options.
- * @param {string}      options.mode       Content mode the frame reports.
- * @param {string|null} options.selectedId ID of the single selected model, or null.
+ * @param {Object}      options                    Options.
+ * @param {string}      options.mode               Content mode the frame reports.
+ * @param {string|null} options.selectedId         ID of the single selected model, or null.
+ * @param {boolean}     options.featuredImageFrame Whether the frame carries a 'featured-image' state, as only wp.media.featuredImage.frame() does.
  * @return {Object} The spy `set` and the frame double.
  */
-const mockWpMedia = ( { mode = 'godam', selectedId = 'job-abc' } = {} ) => {
+const mockWpMedia = ( { mode = 'godam', selectedId = 'job-abc', featuredImageFrame = true } = {} ) => {
 	const set = jest.fn();
 
 	const frame = {
 		content: { mode: () => mode },
+		// Only wp.media.featuredImage.frame() carries a 'featured-image' state.
+		states: { get: ( id ) => ( featuredImageFrame && 'featured-image' === id ? {} : undefined ) },
 		state: () => ( {
 			get: () => ( {
 				single: () => ( null === selectedId ? undefined : { id: selectedId } ),
@@ -37,25 +41,44 @@ const mockWpMedia = ( { mode = 'godam', selectedId = 'job-abc' } = {} ) => {
 	return { set, frame };
 };
 
+const PARKED_ID = 'job-abc';
+
+/**
+ * Build the classic editor's featured image meta box so the in-flight placeholder has
+ * somewhere to render.
+ *
+ * @param {string} html Markup standing in for the current featured image.
+ * @return {HTMLElement} The `.inside` container core itself repaints.
+ */
+const mockMetaBox = ( html = '<p id="previous">previous image</p>' ) => {
+	document.body.innerHTML = `<div id="postimagediv"><div class="inside">${ html }</div></div>`;
+
+	return document.querySelector( '#postimagediv .inside' );
+};
+
 describe( 'classic editor featured image deferral', () => {
 	afterEach( () => {
+		// The parked ID is module state, so a test that parks a pick would otherwise leak
+		// it into the next one and make the suite order-dependent.
+		clearDeferredFeaturedImage( PARKED_ID );
+		document.body.innerHTML = '';
 		delete window.wp;
 		jest.restoreAllMocks();
 	} );
 
 	it( 'parks a GoDAM pick instead of sending it to the meta box', () => {
-		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( 'job-abc' );
 
 		expect( set ).not.toHaveBeenCalled();
 	} );
 
 	it( 'releases the real attachment ID once the attachment exists', () => {
-		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( 'job-abc' );
 		resolveClassicFeaturedImage( 'job-abc', 4321 );
 
@@ -64,9 +87,9 @@ describe( 'classic editor featured image deferral', () => {
 	} );
 
 	it( 'ignores a release for a different GoDAM item', () => {
-		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( 'job-abc' );
 		resolveClassicFeaturedImage( 'job-other', 4321 );
 
@@ -74,9 +97,9 @@ describe( 'classic editor featured image deferral', () => {
 	} );
 
 	it( 'releases only once, so a repeat call cannot resurrect a stale pick', () => {
-		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( 'job-abc' );
 		resolveClassicFeaturedImage( 'job-abc', 4321 );
 		resolveClassicFeaturedImage( 'job-abc', 4321 );
@@ -85,9 +108,9 @@ describe( 'classic editor featured image deferral', () => {
 	} );
 
 	it( 'passes a pick made outside the GoDAM tab straight through', () => {
-		const { set } = mockWpMedia( { mode: 'browse', selectedId: '77' } );
+		const { set, frame } = mockWpMedia( { mode: 'browse', selectedId: '77' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( 77 );
 
 		expect( set ).toHaveBeenCalledWith( 77 );
@@ -96,9 +119,9 @@ describe( 'classic editor featured image deferral', () => {
 	it( 'lets "Remove featured image" through even while the tab reads as godam', () => {
 		// remove() calls set( -1 ), which never matches the selected model. The content
 		// mode can still read 'godam' from an earlier session in the same frame.
-		const { set } = mockWpMedia( { mode: 'godam', selectedId: 'job-abc' } );
+		const { set, frame } = mockWpMedia( { mode: 'godam', selectedId: 'job-abc' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( -1 );
 
 		expect( set ).toHaveBeenCalledWith( -1 );
@@ -107,7 +130,7 @@ describe( 'classic editor featured image deferral', () => {
 	it( 'clears a parked pick once a later call goes through unparked', () => {
 		const { set, frame } = mockWpMedia( { mode: 'godam', selectedId: 'job-abc' } );
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		window.wp.media.featuredImage.set( 'job-abc' );
 
 		frame.content.mode = () => 'browse';
@@ -119,11 +142,11 @@ describe( 'classic editor featured image deferral', () => {
 	} );
 
 	it( 'wraps set() only once across repeated tab activations', () => {
-		mockWpMedia();
+		const { frame } = mockWpMedia();
 
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 		const wrapped = window.wp.media.featuredImage.set;
-		setupClassicFeaturedImage();
+		setupClassicFeaturedImage( frame );
 
 		expect( window.wp.media.featuredImage.set ).toBe( wrapped );
 	} );
@@ -133,5 +156,83 @@ describe( 'classic editor featured image deferral', () => {
 
 		expect( () => setupClassicFeaturedImage() ).not.toThrow();
 		expect( () => resolveClassicFeaturedImage( 'job-abc', 4321 ) ).not.toThrow();
+	} );
+
+	it( 'clears a park so a failed creation does not swallow the next pick', () => {
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage( frame );
+		window.wp.media.featuredImage.set( 'job-abc' );
+
+		expect( clearDeferredFeaturedImage( 'job-abc' ) ).toBe( true );
+
+		// The failed pick must not land later...
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+		expect( set ).not.toHaveBeenCalled();
+
+		// ...and the next pick must still be parkable and releasable.
+		window.wp.media.featuredImage.set( 'job-abc' );
+		resolveClassicFeaturedImage( 'job-abc', 9999 );
+		expect( set ).toHaveBeenCalledWith( 9999 );
+	} );
+
+	it( 'ignores a clear for an item other than the parked one', () => {
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage( frame );
+		window.wp.media.featuredImage.set( 'job-abc' );
+
+		// A slow failure must not release a pick the user made after it.
+		expect( clearDeferredFeaturedImage( 'job-stale' ) ).toBe( false );
+
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+		expect( set ).toHaveBeenCalledWith( 4321 );
+	} );
+
+	it( 'leaves core alone when the GoDAM tab renders in a non-featured-image frame', () => {
+		const { set, frame } = mockWpMedia( { featuredImageFrame: false } );
+
+		setupClassicFeaturedImage( frame );
+
+		// Insert Media and gallery frames must not get a patched core global at all.
+		expect( window.wp.media.featuredImage.set ).toBe( set );
+		expect( window.wp.media.featuredImage.godamOriginalSet ).toBeUndefined();
+	} );
+
+	it( 'shows an in-flight placeholder while a pick is parked', () => {
+		const { frame } = mockWpMedia( { selectedId: 'job-abc' } );
+		const inside = mockMetaBox();
+
+		setupClassicFeaturedImage( frame );
+		window.wp.media.featuredImage.set( 'job-abc' );
+
+		expect( inside.querySelector( '.godam-featured-image-pending' ) ).not.toBeNull();
+		expect( inside.querySelector( '#previous' ) ).toBeNull();
+	} );
+
+	it( 'restores the previous featured image markup when a pick fails to resolve', () => {
+		const { frame } = mockWpMedia( { selectedId: 'job-abc' } );
+		const inside = mockMetaBox();
+
+		setupClassicFeaturedImage( frame );
+		window.wp.media.featuredImage.set( 'job-abc' );
+		clearDeferredFeaturedImage( 'job-abc' );
+
+		expect( inside.querySelector( '#previous' ) ).not.toBeNull();
+		expect( inside.querySelector( '.godam-featured-image-pending' ) ).toBeNull();
+	} );
+
+	it( 'leaves the placeholder for core to repaint on a successful release', () => {
+		const { set, frame } = mockWpMedia( { selectedId: 'job-abc' } );
+		const inside = mockMetaBox();
+
+		setupClassicFeaturedImage( frame );
+		window.wp.media.featuredImage.set( 'job-abc' );
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+
+		// The real set() is what replaces #postimagediv .inside, so the old markup must not
+		// be restored underneath it.
+		expect( set ).toHaveBeenCalledWith( 4321 );
+		expect( inside.querySelector( '#previous' ) ).toBeNull();
 	} );
 } );

--- a/assets/src/js/media-library/classic-featured-image.test.js
+++ b/assets/src/js/media-library/classic-featured-image.test.js
@@ -1,0 +1,137 @@
+/**
+ * Internal dependencies
+ */
+import {
+	setupClassicFeaturedImage,
+	resolveClassicFeaturedImage,
+} from './classic-featured-image';
+
+/**
+ * Build a `wp.media` double with a frame whose content mode and single selection
+ * are controllable, plus a spy standing in for the real `featuredImage.set`.
+ *
+ * @param {Object}      options            Options.
+ * @param {string}      options.mode       Content mode the frame reports.
+ * @param {string|null} options.selectedId ID of the single selected model, or null.
+ * @return {Object} The spy `set` and the frame double.
+ */
+const mockWpMedia = ( { mode = 'godam', selectedId = 'job-abc' } = {} ) => {
+	const set = jest.fn();
+
+	const frame = {
+		content: { mode: () => mode },
+		state: () => ( {
+			get: () => ( {
+				single: () => ( null === selectedId ? undefined : { id: selectedId } ),
+			} ),
+		} ),
+	};
+
+	window.wp = {
+		media: {
+			frame,
+			featuredImage: { set },
+		},
+	};
+
+	return { set, frame };
+};
+
+describe( 'classic editor featured image deferral', () => {
+	afterEach( () => {
+		delete window.wp;
+		jest.restoreAllMocks();
+	} );
+
+	it( 'parks a GoDAM pick instead of sending it to the meta box', () => {
+		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( 'job-abc' );
+
+		expect( set ).not.toHaveBeenCalled();
+	} );
+
+	it( 'releases the real attachment ID once the attachment exists', () => {
+		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( 'job-abc' );
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+
+		expect( set ).toHaveBeenCalledTimes( 1 );
+		expect( set ).toHaveBeenCalledWith( 4321 );
+	} );
+
+	it( 'ignores a release for a different GoDAM item', () => {
+		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( 'job-abc' );
+		resolveClassicFeaturedImage( 'job-other', 4321 );
+
+		expect( set ).not.toHaveBeenCalled();
+	} );
+
+	it( 'releases only once, so a repeat call cannot resurrect a stale pick', () => {
+		const { set } = mockWpMedia( { selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( 'job-abc' );
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+
+		expect( set ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'passes a pick made outside the GoDAM tab straight through', () => {
+		const { set } = mockWpMedia( { mode: 'browse', selectedId: '77' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( 77 );
+
+		expect( set ).toHaveBeenCalledWith( 77 );
+	} );
+
+	it( 'lets "Remove featured image" through even while the tab reads as godam', () => {
+		// remove() calls set( -1 ), which never matches the selected model. The content
+		// mode can still read 'godam' from an earlier session in the same frame.
+		const { set } = mockWpMedia( { mode: 'godam', selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( -1 );
+
+		expect( set ).toHaveBeenCalledWith( -1 );
+	} );
+
+	it( 'clears a parked pick once a later call goes through unparked', () => {
+		const { set, frame } = mockWpMedia( { mode: 'godam', selectedId: 'job-abc' } );
+
+		setupClassicFeaturedImage();
+		window.wp.media.featuredImage.set( 'job-abc' );
+
+		frame.content.mode = () => 'browse';
+		window.wp.media.featuredImage.set( 88 );
+		resolveClassicFeaturedImage( 'job-abc', 4321 );
+
+		expect( set ).toHaveBeenCalledTimes( 1 );
+		expect( set ).toHaveBeenCalledWith( 88 );
+	} );
+
+	it( 'wraps set() only once across repeated tab activations', () => {
+		mockWpMedia();
+
+		setupClassicFeaturedImage();
+		const wrapped = window.wp.media.featuredImage.set;
+		setupClassicFeaturedImage();
+
+		expect( window.wp.media.featuredImage.set ).toBe( wrapped );
+	} );
+
+	it( 'is a no-op when the classic featured image helper is absent', () => {
+		window.wp = { media: {} };
+
+		expect( () => setupClassicFeaturedImage() ).not.toThrow();
+		expect( () => resolveClassicFeaturedImage( 'job-abc', 4321 ) ).not.toThrow();
+	} );
+} );

--- a/assets/src/js/media-library/ids.js
+++ b/assets/src/js/media-library/ids.js
@@ -1,0 +1,26 @@
+/**
+ * Media ID comparison shared by the GoDAM virtual-to-real ID swaps.
+ *
+ * Deliberately kept out of utility.js: that module imports models/attachments.js, which
+ * reads a bare `wp` global at load time, so anything importing it cannot be unit tested.
+ */
+
+/**
+ * Compare two media IDs across the virtual/real boundary.
+ *
+ * A GoDAM placeholder ID is a Central job docname (a string) while a WordPress attachment
+ * ID is an integer, and the same value arrives as either type depending on whether it came
+ * from a Backbone model, a block attribute or the post entity. Coercing both sides keeps
+ * that one matching rule in a single place.
+ *
+ * @param {string|number|null|undefined} a First ID.
+ * @param {string|number|null|undefined} b Second ID.
+ * @return {boolean} True when both IDs refer to the same media item.
+ */
+export function isSameId( a, b ) {
+	if ( a === undefined || a === null || b === undefined || b === null ) {
+		return false;
+	}
+
+	return String( a ) === String( b );
+}

--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -16,6 +16,7 @@ import { select, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { getQuery } from '../utility.js';
+import { setupClassicFeaturedImage, resolveClassicFeaturedImage } from '../classic-featured-image.js';
 import { ALLOWED_MEDIA_TYPES as DOCUMENT_MIME_TYPES } from '../../../blocks/godam-pdf/constants.js';
 
 const l10n = wp?.media?.view?.l10n;
@@ -116,7 +117,8 @@ function replaceVirtualIdInCoreImageBlocks( virtualMediaId, realId ) {
  *
  * Core sets `featured_media` synchronously from the frame's `select` event, while the
  * attachment is created asynchronously — so by the time this runs the field already
- * holds the virtual ID and can simply be replaced.
+ * holds the virtual ID and can simply be replaced. The classic editor offers no such
+ * window and is handled by classic-featured-image.js instead.
  *
  * @param {string|number} virtualMediaId - The GoDAM item ID used as a placeholder.
  * @param {number}        realId         - The newly created WP attachment ID.
@@ -143,31 +145,6 @@ function replaceVirtualIdInFeaturedImage( virtualMediaId, realId ) {
 }
 
 /**
- * Check if the current frame is a featured image context.
- *
- * Note: This will not cover the media modal opened from the core feature image block.
- *
- * @since 1.4.8
- *
- * @param {wp.media.view.MediaFrame} frame
- * @return {boolean} True if featured image context, false otherwise.
- */
-const checkIfFeatureImage = ( frame ) => {
-	// Check if this is a featured image context.
-	if ( frame && frame.state && frame.state() ) {
-		const state = frame.state();
-		const stateId = state.id || '';
-
-		// Featured image context
-		if ( stateId === 'featured-image' || frame.id === 'featured-image' ) {
-			return true;
-		}
-	}
-
-	return false;
-};
-
-/**
  * Check if the current frame is an analytics context.
  *
  * @since 1.6.0
@@ -189,10 +166,9 @@ const checkIfAnalyticsContext = ( frame ) => {
  */
 const GoDAMMediaFrameShared = {
 	browseRouter( routerView ) {
-		const isFeatureImage = checkIfFeatureImage( this );
 		const isAnalyticsContext = checkIfAnalyticsContext( this );
 
-		if ( window.godamTabCallback && window.godamTabCallback.validAPIKey && ! isFeatureImage && ! isAnalyticsContext ) {
+		if ( window.godamTabCallback && window.godamTabCallback.validAPIKey && ! isAnalyticsContext ) {
 			routerView.set( {
 				upload: {
 					text: l10n.uploadFilesTitle,
@@ -223,6 +199,9 @@ const GoDAMMediaFrameShared = {
 
 	GoDAMCreate() {
 		const state = this.state();
+
+		// Hold back a classic-editor featured image pick until its attachment exists.
+		setupClassicFeaturedImage();
 
 		const mimeTypes = normalizeGoDAMTabType(
 			state.get( 'library' )?.props?.get( 'type' ),
@@ -332,8 +311,10 @@ const GoDAMMediaFrameShared = {
 				replaceVirtualIdInCoreImageBlocks( data.id, attachment.id );
 
 				// The featured image lives on the post entity rather than on block
-				// attributes, so it needs its own swap.
+				// attributes, so it needs its own swap. The classic editor gets no
+				// placeholder at all — its pick was parked, and is released here.
 				replaceVirtualIdInFeaturedImage( data.id, attachment.id );
+				resolveClassicFeaturedImage( data.id, attachment.id );
 
 				// Trigger custom JS event godam-virtual-attachment-created
 				const event = new CustomEvent( 'godam-virtual-attachment-created', {

--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -16,7 +16,8 @@ import { select, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { getQuery } from '../utility.js';
-import { setupClassicFeaturedImage, resolveClassicFeaturedImage } from '../classic-featured-image.js';
+import { isSameId } from '../ids.js';
+import { setupClassicFeaturedImage, resolveClassicFeaturedImage, clearDeferredFeaturedImage } from '../classic-featured-image.js';
 import { ALLOWED_MEDIA_TYPES as DOCUMENT_MIME_TYPES } from '../../../blocks/godam-pdf/constants.js';
 
 const l10n = wp?.media?.view?.l10n;
@@ -97,7 +98,7 @@ function replaceVirtualIdInCoreImageBlocks( virtualMediaId, realId ) {
 			block.name === 'core/image' &&
 			block.attributes?.id !== undefined &&
 			block.attributes?.id !== null &&
-			String( block.attributes.id ) === String( virtualMediaId )
+			isSameId( block.attributes.id, virtualMediaId )
 		) {
 			blockEditorDispatch.updateBlockAttributes( block.clientId, { id: realId } );
 		}
@@ -137,11 +138,33 @@ function replaceVirtualIdInFeaturedImage( virtualMediaId, realId ) {
 		return;
 	}
 
-	if ( String( currentFeaturedMedia ) !== String( virtualMediaId ) ) {
+	if ( ! isSameId( currentFeaturedMedia, virtualMediaId ) ) {
 		return;
 	}
 
-	dispatch( 'core/editor' ).editPost( { featured_media: realId } );
+	try {
+		dispatch( 'core/editor' ).editPost( { featured_media: realId } );
+	} catch {
+		// Guarded like the read above. A throw here would unwind into processGoDAMItem's
+		// swallow-all catch and take out resolveClassicFeaturedImage() along with both
+		// custom events for this item, which other code depends on.
+	}
+}
+
+/**
+ * Release a classic-editor featured image pick whose attachment was never created.
+ *
+ * The pick is lost either way — there is no ID to set — but clearing the park keeps the
+ * failure to this one item instead of jamming every subsequent pick, and the warning
+ * gives the silent drop a trace, since the meta box just keeps its previous value.
+ *
+ * @param {string|number} virtualMediaId The GoDAM item ID whose creation failed.
+ */
+function releaseParkedFeaturedImage( virtualMediaId ) {
+	if ( clearDeferredFeaturedImage( virtualMediaId ) ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'GoDAM: could not create the attachment for the selected featured image, so the featured image was left unchanged.' );
+	}
 }
 
 /**
@@ -201,7 +224,8 @@ const GoDAMMediaFrameShared = {
 		const state = this.state();
 
 		// Hold back a classic-editor featured image pick until its attachment exists.
-		setupClassicFeaturedImage();
+		// Scoped to the Featured image frame; every other frame is left untouched.
+		setupClassicFeaturedImage( this );
 
 		const mimeTypes = normalizeGoDAMTabType(
 			state.get( 'library' )?.props?.get( 'type' ),
@@ -326,9 +350,15 @@ const GoDAMMediaFrameShared = {
 				// Also trigger count refresh for React components
 				const countRefreshEvent = new CustomEvent( 'godam-attachment-browser:changed' );
 				document.dispatchEvent( countRefreshEvent );
+			} else {
+				// There is no attachment to point the pick at, so a parked classic-editor
+				// featured image has to be released — otherwise the park is held for the
+				// life of the page and every later pick is swallowed too.
+				releaseParkedFeaturedImage( data.id );
 			}
 		} catch {
 			// Swallow request failures so one item does not break the rest of the selection flow.
+			releaseParkedFeaturedImage( data.id );
 		}
 	},
 

--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -104,6 +104,45 @@ function replaceVirtualIdInCoreImageBlocks( virtualMediaId, realId ) {
 }
 
 /**
+ * Repoints the post's featured image from the virtual GoDAM ID to the real WP
+ * attachment ID.
+ *
+ * The featured image is not a block attribute — `core/post-featured-image` (and the
+ * document sidebar's Featured image panel) writes it to the post entity's
+ * `featured_media` field. So the block-attribute swap performed by
+ * core-media-blocks-extension.js never reaches it: the field keeps the GoDAM job ID,
+ * `getEntityRecord( 'postType', 'attachment', <job id> )` 404s, and the block renders
+ * an empty placeholder with no preview.
+ *
+ * Core sets `featured_media` synchronously from the frame's `select` event, while the
+ * attachment is created asynchronously — so by the time this runs the field already
+ * holds the virtual ID and can simply be replaced.
+ *
+ * @param {string|number} virtualMediaId - The GoDAM item ID used as a placeholder.
+ * @param {number}        realId         - The newly created WP attachment ID.
+ */
+function replaceVirtualIdInFeaturedImage( virtualMediaId, realId ) {
+	let currentFeaturedMedia;
+
+	try {
+		// Undefined outside the post editor (media library screen, classic editor).
+		currentFeaturedMedia = select( 'core/editor' )?.getEditedPostAttribute?.( 'featured_media' );
+	} catch {
+		return;
+	}
+
+	if ( currentFeaturedMedia === undefined || currentFeaturedMedia === null ) {
+		return;
+	}
+
+	if ( String( currentFeaturedMedia ) !== String( virtualMediaId ) ) {
+		return;
+	}
+
+	dispatch( 'core/editor' ).editPost( { featured_media: realId } );
+}
+
+/**
  * Check if the current frame is a featured image context.
  *
  * Note: This will not cover the media modal opened from the core feature image block.
@@ -291,6 +330,10 @@ const GoDAMMediaFrameShared = {
 				// carry the virtual GoDAM ID. This runs synchronously before the custom event
 				// so that inner blocks are resolved without relying on React effect timing.
 				replaceVirtualIdInCoreImageBlocks( data.id, attachment.id );
+
+				// The featured image lives on the post entity rather than on block
+				// attributes, so it needs its own swap.
+				replaceVirtualIdInFeaturedImage( data.id, attachment.id );
 
 				// Trigger custom JS event godam-virtual-attachment-created
 				const event = new CustomEvent( 'godam-virtual-attachment-created', {


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1977

This pull request introduces robust support for using GoDAM media items as featured images in both the block and classic editors. The main changes ensure that placeholder GoDAM IDs are properly handled and swapped for real WordPress attachment IDs once the media entry is created, preventing issues where invalid IDs could be saved or displayed. The implementation includes new logic for the classic editor, improved handling in the block editor, and comprehensive unit tests.

**Featured image handling improvements:**

* Added `classic-featured-image.js` to intercept and defer setting GoDAM IDs as featured images in the classic editor, only applying the real attachment ID once it exists, and preventing invalid IDs from being saved or displayed.
* Updated `godam-media-frame-shared.js` to invoke the new classic editor logic (`setupClassicFeaturedImage` and `resolveClassicFeaturedImage`) during GoDAM tab activation and after attachment creation. [[1]](diffhunk://#diff-a7878e67888eef229132a39357ea6378cbaf2c7cdc41b7b4bc69f4333e5fd9a4R19) [[2]](diffhunk://#diff-a7878e67888eef229132a39357ea6378cbaf2c7cdc41b7b4bc69f4333e5fd9a4R203-R205) [[3]](diffhunk://#diff-a7878e67888eef229132a39357ea6378cbaf2c7cdc41b7b4bc69f4333e5fd9a4R313-R318)

**Block editor and post entity integration:**

* Replaced the logic for updating the featured image in the block editor: added `replaceVirtualIdInFeaturedImage()` to swap the GoDAM placeholder ID for the real attachment ID on the post entity, ensuring the correct image is displayed and saved.

**Testing and reliability:**

* Added `classic-featured-image.test.js` with comprehensive tests for the new classic editor featured image deferral and resolution logic, covering edge cases and ensuring correct integration.

**Codebase simplification:**

* Removed the now-unnecessary `checkIfFeatureImage()` logic and related conditional checks, as the new approach directly handles both block and classic editor contexts. [[1]](diffhunk://#diff-a7878e67888eef229132a39357ea6378cbaf2c7cdc41b7b4bc69f4333e5fd9a4L107-R145) [[2]](diffhunk://#diff-a7878e67888eef229132a39357ea6378cbaf2c7cdc41b7b4bc69f4333e5fd9a4L153-R171)

## Demo

https://github.com/user-attachments/assets/b115b0a0-8b1d-482a-9ec8-8d0133af5797

