### PR TITLE
Fix the HTML CTA layer overflow issue

### DIFF
--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -272,10 +272,13 @@
 .easydam-layer--cta-html {
 	font-size: 1.375rem; 
 	font-family: Manrope, sans-serif;
-	width: fit-content;
 	margin: 0 auto;
 	padding: 10px 20px;
 	border-radius: 4px;
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+	box-sizing: border-box;
 }
 
 // Only apply default styles to plain buttons without any classes

--- a/assets/src/blocks/godam-player/style.scss
+++ b/assets/src/blocks/godam-player/style.scss
@@ -272,7 +272,6 @@
 .easydam-layer--cta-html {
 	font-size: 1.375rem; 
 	font-family: Manrope, sans-serif;
-	margin: 0 auto;
 	padding: 10px 20px;
 	border-radius: 4px;
 	width: 100%;

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -207,10 +207,13 @@
 .easydam-layer--cta-html {
 	font-size: 1.375rem;
 	font-family: Manrope, sans-serif;
-	width: fit-content;
 	margin: 0 auto;
 	padding: 10px 20px;
 	border-radius: 4px;
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+	box-sizing: border-box;
 }
 
 .poll-container button:hover {

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -207,7 +207,6 @@
 .easydam-layer--cta-html {
 	font-size: 1.375rem;
 	font-family: Manrope, sans-serif;
-	margin: 0 auto;
 	padding: 10px 20px;
 	border-radius: 4px;
 	width: 100%;


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1532

This pull request updates the styling for the `.easydam-layer--cta-html` class in both the `godam-player/style.scss` and `godam-player.scss` files to improve layout consistency and responsiveness. The changes ensure the element now occupies the full width and height of its container and handles overflow appropriately.

**Styling improvements for `.easydam-layer--cta-html`:**

* Set `width` and `height` to `100%` to make the element fill its container, replacing the previous `fit-content` width. [[1]](diffhunk://#diff-89e92fdab13aad2dda8bfe013f74d8961d1e5fad2e34d617cd41a3d29c67c9caL275-R281) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L210-R216)
* Added `overflow: auto` and `box-sizing: border-box` to ensure content is scrollable if it exceeds the container and that padding/borders are included in the element's total size. [[1]](diffhunk://#diff-89e92fdab13aad2dda8bfe013f74d8961d1e5fad2e34d617cd41a3d29c67c9caL275-R281) [[2]](diffhunk://#diff-219690a9913b2b11e68684985e772b86cc8396a1381054dd4b3ad3d9d818fd79L210-R216)

## Demo

https://github.com/user-attachments/assets/5c7d01df-3b41-4b9b-ac53-83e011b69d9e

