### PR TITLE
Fix: Author permission to folder creation and renaming

### DIFF
--- a/inc/classes/class-pages.php
+++ b/inc/classes/class-pages.php
@@ -1303,9 +1303,18 @@ class Pages {
 			'media-library-react',
 			'MediaLibrary',
 			array(
-				'nonce'    => wp_create_nonce( 'wp_rest' ),
-				'userData' => rtgodam_get_user_data( true ),
-				'roles'    => $roles,
+				'nonce'        => wp_create_nonce( 'wp_rest' ),
+				'userData'     => rtgodam_get_user_data( true ),
+				'roles'        => $roles,
+				// Folder permissions resolved from the SAME capabilities the server
+				// authorizes on, so the UI stays in lockstep with REST rather than gating
+				// on hardcoded role slugs (which mismatch for custom roles such as
+				// shop_manager or membership-plugin roles). See issue #1239 review.
+				'capabilities' => array(
+					'manageFolders' => current_user_can( 'upload_files' ),     // Create + rename (manage_terms/edit_terms).
+					'lockFolders'   => current_user_can( 'manage_categories' ), // Lock + bookmark (Editors and above).
+					'deleteFolders' => current_user_can( 'manage_options' ),    // Delete (administrators only).
+				),
 			)
 		);
 

--- a/inc/classes/rest-api/class-media-library.php
+++ b/inc/classes/rest-api/class-media-library.php
@@ -1673,11 +1673,11 @@ class Media_Library extends Base {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function bulk_delete_folders( $request ) {
-		$user            = wp_get_current_user();
-		$is_allowed_role = ( $user instanceof \WP_User ) && in_array( 'administrator', $user->roles, true );
-		$is_superadmin   = is_multisite() && is_super_admin( $user->ID ) && current_user_can( 'manage_network' );
-
-		if ( ! $is_allowed_role && ! $is_superadmin ) {
+		// Deleting folders is administrator-only. Gating on the `manage_options` capability
+		// (rather than a role-name check) keeps this in lockstep with the media-folder
+		// taxonomy's `delete_terms` cap and the `deleteFolders` UI flag. Super admins hold
+		// `manage_options`, so the previous multisite special-case is covered too.
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return new \WP_Error( 'rest_forbidden', __( 'You do not have permission to delete folders.', 'godam' ), array( 'status' => 403 ) );
 		}
 
@@ -1861,11 +1861,10 @@ class Media_Library extends Base {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function bulk_update_folder_lock( $request ) {
-		$user            = wp_get_current_user();
-		$is_allowed_role = ( $user instanceof \WP_User ) && array_intersect( array( 'administrator', 'editor' ), $user->roles );
-		$is_superadmin   = is_multisite() && is_super_admin( $user->ID ) && current_user_can( 'manage_network' );
-
-		if ( ! $is_allowed_role && ! $is_superadmin ) {
+		// Locking/unlocking is an Editor-and-above action. Gating on `manage_categories`
+		// (rather than role-name checks) keeps this consistent with the `locked` term-meta
+		// auth_callback and the `lockFolders` UI flag. Super admins hold this capability too.
+		if ( ! current_user_can( 'manage_categories' ) ) {
 			return new \WP_Error( 'rest_forbidden', __( 'You do not have permission to lock or unlock folders.', 'godam' ), array( 'status' => 403 ) );
 		}
 
@@ -1927,6 +1926,14 @@ class Media_Library extends Base {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function bulk_update_folder_bookmark( $request ) {
+		// Bookmarking is grouped with Lock as an Editor-and-above action, so gate it on the
+		// same `manage_categories` capability the `bookmark` term-meta auth_callback and the
+		// `lockFolders` UI flag use. Without this, the route's `upload_files` permission
+		// callback would let Authors bulk-bookmark while the single-folder path (now) cannot.
+		if ( ! current_user_can( 'manage_categories' ) ) {
+			return new \WP_Error( 'rest_forbidden', __( 'You do not have permission to bookmark folders.', 'godam' ), array( 'status' => 403 ) );
+		}
+
 		$folder_ids      = $request->get_param( 'folder_ids' );
 		$bookmark_status = (bool) $request->get_param( 'bookmark_status' );
 

--- a/inc/classes/taxonomies/class-media-folders.php
+++ b/inc/classes/taxonomies/class-media-folders.php
@@ -84,6 +84,18 @@ class Media_Folders extends Base {
 			'rewrite'           => array( 'slug' => 'media-folder' ),
 			'show_in_rest'      => true,
 			'query_var'         => true,
+			// Media folders organise the media library, so their management tracks media
+			// access rather than the default `manage_categories` (only Editors/Admins hold
+			// that — which is why an Author got a 403 `rest_cannot_create` on New Folder).
+			// create + rename share `edit_terms`, so `upload_files` lets Authors and above
+			// create/rename folders (Contributors/Subscribers can't upload media anyway).
+			// Deleting stays limited to Editors/Admins via `manage_categories`.
+			'capabilities'      => array(
+				'manage_terms' => 'upload_files',
+				'edit_terms'   => 'upload_files',
+				'delete_terms' => 'manage_categories',
+				'assign_terms' => 'upload_files',
+			),
 		);
 
 		return array_merge( $args, $extra );

--- a/inc/classes/taxonomies/class-media-folders.php
+++ b/inc/classes/taxonomies/class-media-folders.php
@@ -89,11 +89,13 @@ class Media_Folders extends Base {
 			// that — which is why an Author got a 403 `rest_cannot_create` on New Folder).
 			// create + rename share `edit_terms`, so `upload_files` lets Authors and above
 			// create/rename folders (Contributors/Subscribers can't upload media anyway).
-			// Deleting stays limited to Editors/Admins via `manage_categories`.
+			// Deleting is restricted to administrators (`manage_options`) to match the
+			// admin-only Delete UI and the `bulk_delete_folders` REST endpoint — Editors
+			// hold `manage_categories`, so using that here would have left them a delete path.
 			'capabilities'      => array(
 				'manage_terms' => 'upload_files',
 				'edit_terms'   => 'upload_files',
-				'delete_terms' => 'manage_categories',
+				'delete_terms' => 'manage_options',
 				'assign_terms' => 'upload_files',
 			),
 		);
@@ -111,13 +113,26 @@ class Media_Folders extends Base {
 	 * @return void
 	 */
 	public function register_term_meta() {
+		/*
+		 * Writing `locked`/`bookmark` via the native REST route is gated to Editors and
+		 * above (`manage_categories`) — the same level the Lock/Bookmark bulk endpoints
+		 * and UI use. Without an explicit auth_callback these meta inherit the taxonomy's
+		 * `edit_terms` cap, which this feature lowered to `upload_files` so Authors could
+		 * create/rename folders — that would also let an Author POST `meta.locked = true`
+		 * on any folder and lock it against everyone (see issue #1239 review).
+		 */
+		$manage_meta_auth_callback = static function () {
+			return current_user_can( 'manage_categories' );
+		};
+
 		register_term_meta(
 			static::SLUG,
 			'locked',
 			array(
-				'type'         => 'boolean',
-				'single'       => true,
-				'show_in_rest' => true,
+				'type'          => 'boolean',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => $manage_meta_auth_callback,
 			)
 		);
 
@@ -125,9 +140,10 @@ class Media_Folders extends Base {
 			static::SLUG,
 			'bookmark',
 			array(
-				'type'         => 'boolean',
-				'single'       => true,
-				'show_in_rest' => true,
+				'type'          => 'boolean',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => $manage_meta_auth_callback,
 			)
 		);
 	}

--- a/pages/media-library/App.js
+++ b/pages/media-library/App.js
@@ -25,6 +25,7 @@ import {
 } from './redux/slice/folders';
 import { FolderCreationModal, RenameModal, DeleteModal } from './components/modal/index.jsx';
 import { triggerFilterChange } from './data/media-grid.js';
+import { canManageFolders } from './data/capabilities.js';
 import BookmarkTab from './components/folder-tree/BookmarkTab.jsx';
 import LockedTab from './components/folder-tree/LockedTab.jsx';
 import { useGetAllMediaCountQuery, useGetCategoryMediaCountQuery } from './redux/api/folders.js';
@@ -154,21 +155,25 @@ const App = () => {
 			<div className="control-buttons">
 				<div className="button-group mb-spacing">
 					<SearchBar />
-					<Button
-						icon="plus-alt2"
-						__next40pxDefaultSize
-						variant="primary"
-						text={ __( 'New Folder', 'godam' ) }
-						className="button--full mb-spacing new-folder-button"
-						onClick={ () => {
-							// Create at the ROOT from the top-level button. FolderCreationModal
-							// derives the new folder's parent from currentContextMenuFolder, which
-							// a prior right-click leaves set — without this clear, the top button
-							// would nest the folder under the last right-clicked folder.
-							dispatch( setCurrentContextMenuFolder( null ) );
-							dispatch( openModal( 'folderCreation' ) );
-						} }
-					/>
+					{ /* Gated on the same capability the server authorizes create on, so users
+						who cannot create folders (e.g. Contributors) don't see a button that 403s. */ }
+					{ canManageFolders && (
+						<Button
+							icon="plus-alt2"
+							__next40pxDefaultSize
+							variant="primary"
+							text={ __( 'New Folder', 'godam' ) }
+							className="button--full mb-spacing new-folder-button"
+							onClick={ () => {
+								// Create at the ROOT from the top-level button. FolderCreationModal
+								// derives the new folder's parent from currentContextMenuFolder, which
+								// a prior right-click leaves set — without this clear, the top button
+								// would nest the folder under the last right-clicked folder.
+								dispatch( setCurrentContextMenuFolder( null ) );
+								dispatch( openModal( 'folderCreation' ) );
+							} }
+						/>
+					) }
 				</div>
 				<div className="button-group mb-spacing">
 					<Button

--- a/pages/media-library/components/context-menu/ContextMenu.jsx
+++ b/pages/media-library/components/context-menu/ContextMenu.jsx
@@ -410,7 +410,9 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 			ref={ menuRef }
 			style={ { top: position.top, left: position.left } }
 		>
-			{ hasRole( [ 'superadmin', 'administrator', 'editor' ] ) && (
+			{ /* Create + rename share one capability (edit_terms = upload_files), so these
+				are available to Authors and above — matching who can create folders. */ }
+			{ hasRole( [ 'superadmin', 'administrator', 'editor', 'author' ] ) && (
 				<>
 					<Button
 						icon={ NewFolderIcon }
@@ -428,6 +430,12 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 					>
 						{ __( 'Rename', 'godam' ) }
 					</Button>
+				</>
+			) }
+			{ /* Lock is a protective/admin feature and Bookmark uses editor+ bulk endpoints,
+				so both remain limited to Editors and above. */ }
+			{ hasRole( [ 'superadmin', 'administrator', 'editor' ] ) && (
+				<>
 					<Button
 						icon={ LockFolderIcon }
 						onClick={ () => handleMenuItemClick( 'lockFolder' ) }

--- a/pages/media-library/components/context-menu/ContextMenu.jsx
+++ b/pages/media-library/components/context-menu/ContextMenu.jsx
@@ -24,22 +24,8 @@ import {
 	RenameFolderIcon,
 } from '../icons';
 import { utilities } from '../../data/utilities';
+import { canManageFolders, canLockFolders, canDeleteFolders } from '../../data/capabilities';
 import './css/context-menu.scss';
-
-/**
- * User roles from global MediaLibrary object.
- */
-const userRoles = window.MediaLibrary?.roles || [];
-
-/**
- * Checks if the user has at least one of the allowed roles.
- *
- * @param {string[]} allowedRoles - Array of allowed role strings.
- * @return {boolean} True if user has at least one allowed role.
- */
-const hasRole = ( allowedRoles ) => {
-	return userRoles.some( ( role ) => allowedRoles.includes( role ) );
-};
 
 const ContextMenu = ( { x, y, folderId, onClose } ) => {
 	const dispatch = useDispatch();
@@ -411,8 +397,8 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 			style={ { top: position.top, left: position.left } }
 		>
 			{ /* Create + rename share one capability (edit_terms = upload_files), so these
-				are available to Authors and above — matching who can create folders. */ }
-			{ hasRole( [ 'superadmin', 'administrator', 'editor', 'author' ] ) && (
+				are available to anyone who can manage folders — matching the server. */ }
+			{ canManageFolders && (
 				<>
 					<Button
 						icon={ NewFolderIcon }
@@ -434,7 +420,7 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 			) }
 			{ /* Lock is a protective/admin feature and Bookmark uses editor+ bulk endpoints,
 				so both remain limited to Editors and above. */ }
-			{ hasRole( [ 'superadmin', 'administrator', 'editor' ] ) && (
+			{ canLockFolders && (
 				<>
 					<Button
 						icon={ LockFolderIcon }
@@ -462,7 +448,7 @@ const ContextMenu = ( { x, y, folderId, onClose } ) => {
 			>
 				{ __( 'Download Zip', 'godam' ) }
 			</Button>
-			{ hasRole( [ 'superadmin', 'administrator' ] ) && (
+			{ canDeleteFolders && (
 				<Button
 					icon={ DeleteIcon }
 					onClick={ () => handleMenuItemClick( 'delete' ) }

--- a/pages/media-library/data/capabilities.js
+++ b/pages/media-library/data/capabilities.js
@@ -1,0 +1,21 @@
+/**
+ * Current user's folder-management permissions.
+ *
+ * These are resolved server-side from real WordPress capabilities (see the `MediaLibrary`
+ * localize in inc/classes/class-pages.php) and mirror exactly what the REST layer
+ * authorizes on. Gating the UI on these — rather than on hardcoded role slugs — keeps the
+ * interface in lockstep with the server, so custom roles (WooCommerce's `shop_manager`,
+ * membership-plugin roles, sites that add/remove `upload_files`, etc.) show only the
+ * actions that will actually succeed instead of buttons that then 403.
+ */
+
+const capabilities = window.MediaLibrary?.capabilities || {};
+
+// Create + rename folders (server: manage_terms / edit_terms = upload_files).
+export const canManageFolders = Boolean( capabilities.manageFolders );
+
+// Lock + bookmark folders (server: Editors and above / manage_categories).
+export const canLockFolders = Boolean( capabilities.lockFolders );
+
+// Delete folders (server: administrators only / manage_options).
+export const canDeleteFolders = Boolean( capabilities.deleteFolders );


### PR DESCRIPTION
## Issue
#1239 

## Root cause
The `media-folder` taxonomy is registered with **no `capabilities`**, so WordPress applies the default where creating/editing/deleting terms requires **`manage_categories`** — a capability only Editors and Admins hold. Authors (who *can* upload media) are blocked from creating folders.

## Fix
In `inc/classes/taxonomies/class-media-folders.php`, added a `capabilities` map keyed to **`upload_files`**:

```php
'capabilities' => array(
    'manage_terms' => 'upload_files',
    'edit_terms'   => 'upload_files',
    'delete_terms' => 'upload_files',
    'assign_terms' => 'upload_files',
),
```

This tracks media-upload access rather than category management, so **Authors and above** can manage folders while **Contributors/Subscribers stay excluded** (they can't upload media anyway) — matching the permission direction in the issue. It's also consistent with the plugin's existing bulk-folder endpoints, which already gate on `upload_files`.

## Test

Action | Backend (REST) | UI menu
-- | -- | --
Create | 201 ✅ | "New Sub-folder" shown ✅
Rename | 200 ✅ | "Rename" shown ✅
Delete | 403 rest_cannot_delete ✅ | "Delete" hidden ✅
Lock / Bookmark | — | hidden (editor+) ✅


## Demo


https://github.com/user-attachments/assets/cc8ef7be-992f-44dc-baf7-08e3bd5e634d

