### PR TITLE
fix(player): don't fire layers during hover Start video preview on hover

### DIFF
--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -709,13 +709,19 @@
 	background-color: var(--rtgodam-control-bar-color, #3858e9) !important;
 	border: 0;
 	border-radius: 50%;
+	// Hidden until a preview is playing. `visibility`/`pointer-events` (not just
+	// opacity) so the invisible button cannot swallow a click meant to start the
+	// video, and is not tab-reachable or announced while off screen.
 	opacity: 0;
-	// Interactive – must receive clicks even though the stripe does not.
-	pointer-events: auto;
-	transition: opacity 0.15s ease, filter 0.15s ease;
+	visibility: hidden;
+	pointer-events: none;
+	transition: opacity 0.15s ease, filter 0.15s ease, visibility 0s linear 0.15s;
 
 	&.is-visible {
 		opacity: 1;
+		visibility: visible;
+		pointer-events: auto;
+		transition: opacity 0.15s ease, filter 0.15s ease;
 	}
 
 	&:hover,

--- a/assets/src/css/godam-player.scss
+++ b/assets/src/css/godam-player.scss
@@ -642,6 +642,118 @@
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Hover-preview reel chrome
+// Lightweight overlays shown only while a "start-preview" hover preview is
+// playing: a thin reel-style progress stripe along the bottom and a
+// mute/unmute toggle in the top-right corner. Both are appended to the player
+// root by HoverManager and toggled via `.is-visible`.
+// ---------------------------------------------------------------------------
+
+// While a hover preview is playing, hide the overlay share / transcript
+// buttons (they sit on the container, outside the control bar that the preview
+// already hides). Bubble skin routes them into the control bar instead, so they
+// are hidden with it and need no rule here.
+.easydam-video-container.godam-hover-preview-active {
+
+	.godam-share-button,
+	.godam-transcript-button {
+		display: none !important;
+	}
+}
+
+.godam-preview-progress {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 3;
+	height: 3px;
+	background-color: rgba(255, 255, 255, 0.25);
+	opacity: 0;
+	// Presentational only – clicks fall through to the video (commit playback).
+	pointer-events: none;
+	transition: opacity 0.15s ease;
+
+	&.is-visible {
+		opacity: 1;
+	}
+
+	&__fill {
+		width: 0;
+		height: 100%;
+		background-color: var(--rtgodam-control-bar-color, #3858e9);
+		transition: width 0.1s linear;
+	}
+}
+
+// The toggle reuses Video.js's `vjs-mute-control vjs-control vjs-button`
+// markup so each skin paints its own volume glyph; these rules only lift it
+// out of the (hidden) control bar and into the top-right corner. The doubled
+// class raises specificity enough to win over the base `.vjs-control` sizing.
+.godam-preview-mute.vjs-control.vjs-button {
+	position: absolute;
+	top: 12px;
+	right: 12px;
+	z-index: 4;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 3em;
+	height: 3em;
+	padding: 0;
+	margin: 0;
+	color: #fff;
+	cursor: pointer;
+	// Match the player's primary (control bar) colour.
+	background-color: var(--rtgodam-control-bar-color, #3858e9) !important;
+	border: 0;
+	border-radius: 50%;
+	opacity: 0;
+	// Interactive – must receive clicks even though the stripe does not.
+	pointer-events: auto;
+	transition: opacity 0.15s ease, filter 0.15s ease;
+
+	&.is-visible {
+		opacity: 1;
+	}
+
+	&:hover,
+	&:focus-visible {
+		filter: brightness(1.1);
+	}
+
+	.vjs-icon-placeholder::before {
+		position: static;
+		width: auto;
+		font-size: 1.5em;
+		line-height: 1;
+	}
+}
+
+// Classic skin overrides the mute glyph with SVGs scoped to `.vjs-control-bar`;
+// the preview toggle lives outside it, so mirror those SVGs here (only the
+// muted / full-volume states the toggle uses) to match the control bar.
+.godam-classic-skin .video-js .godam-preview-mute {
+
+	/* stylelint-disable-next-line no-descending-specificity -- overlay copy of the classic mute glyph; the control-bar rule keeps its own icon. */
+	&.vjs-vol-0 .vjs-icon-placeholder::before {
+		width: 21px;
+		height: 21px;
+		background: url(../images/classic-mute-icon.svg) no-repeat;
+		background-size: contain;
+		content: '' !important; /* Hide default icon */
+	}
+
+	&.vjs-vol-3 .vjs-icon-placeholder::before {
+		width: 21px;
+		height: 21px;
+		background: url(../images/classic-volume-3-icon.svg) no-repeat;
+		background-size: contain;
+		content: '' !important; /* Hide default icon */
+	}
+}
+
 // CSS to override the elementor image CSS in editor.
 .elementor .vjs-poster img {
 	height: 100% !important;

--- a/assets/src/js/godam-player/managers/hoverManager.js
+++ b/assets/src/js/godam-player/managers/hoverManager.js
@@ -32,6 +32,10 @@ class HoverManager {
 		this.hoverSelect = videoElement.dataset.hoverSelect || 'none';
 		this.isVideoClicked = false;
 		this.isHovered = false;
+		// True while an uncommitted hover preview is running. Interactive layers
+		// are suppressed for its duration – a preview is a playback teaser, not
+		// a place to show forms/CTAs/hotspots.
+		this.isPreviewPlaying = false;
 		this.options = options;
 
 		this.init();
@@ -64,6 +68,16 @@ class HoverManager {
 		this.videoElement.addEventListener( 'mouseenter', this.handleMouseEnter.bind( this ) );
 		this.videoElement.addEventListener( 'mouseleave', this.handleMouseLeave.bind( this ) );
 		this.videoElement.addEventListener( 'click', this.handleVideoClick.bind( this ) );
+
+		// Playback that starts while the pointer is away from the video is real
+		// playback, not a preview – e.g. the big play button or the control bar,
+		// whose clicks never reach the <video> element and so never run
+		// `handleVideoClick`. Clear the preview flag so layers resume working.
+		this.player.on( 'play', () => {
+			if ( ! this.isHovered ) {
+				this.isPreviewPlaying = false;
+			}
+		} );
 	}
 
 	/**
@@ -115,6 +129,7 @@ class HoverManager {
 
 		if ( this.isHovered ) {
 			this.isVideoClicked = true;
+			this.isPreviewPlaying = false;
 
 			this.player.volume( 1 );
 			this.player.play();
@@ -130,6 +145,8 @@ class HoverManager {
 	 * Starts the video preview by playing the video muted and hiding controls.
 	 */
 	startPreview() {
+		this.isPreviewPlaying = true;
+
 		this.player.volume( 0 );
 		this.player.currentTime( 0 );
 
@@ -147,6 +164,21 @@ class HoverManager {
 	stopPreview() {
 		this.player.pause();
 		this.player.currentTime( 0 );
+	}
+
+	/**
+	 * Whether an uncommitted hover preview is in progress.
+	 *
+	 * Deliberately keyed off the live preview flag rather than `hoverSelect`, so
+	 * autoplay players (where `init()` bails out) and `show-player-controls`
+	 * mode can never report a preview. The flag is intentionally NOT cleared by
+	 * `stopPreview()`: `pause()` emits its event asynchronously, so clearing it
+	 * there would let an `on_pause` CTA slip through as the pointer leaves.
+	 *
+	 * @return {boolean} True while a hover preview is active.
+	 */
+	isPreviewActive() {
+		return this.isPreviewPlaying;
 	}
 }
 

--- a/assets/src/js/godam-player/managers/hoverManager.js
+++ b/assets/src/js/godam-player/managers/hoverManager.js
@@ -126,7 +126,13 @@ class HoverManager {
 				this.isPreviewInitiatedPlay = false;
 				return;
 			}
+			// Real, committed playback. Lift suppression and mark the player as
+			// committed so a later hover cannot restart a preview over it – the
+			// big play button / control bar never reach `handleVideoClick`, so
+			// `isVideoClicked` would otherwise stay false and re-enable preview.
 			this.isPreviewPlaying = false;
+			this.isVideoClicked = true;
+			this.togglePreviewOverlays( false );
 		} );
 	}
 

--- a/assets/src/js/godam-player/managers/hoverManager.js
+++ b/assets/src/js/godam-player/managers/hoverManager.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * HoverManager
  *
  * A utility class for managing hover-based video interactions using Video.js.
@@ -67,6 +72,10 @@ class HoverManager {
 		// `play` event that signals real, committed playback. Consumed once in the
 		// `play` handler.
 		this.isPreviewInitiatedPlay = false;
+		// True once the viewer has interacted with THIS player (clicked it or its
+		// mute toggle). A cross-preview unmute is only re-applied to players with
+		// a gesture, since browsers pause media unmuted without one.
+		this.hasUserGesture = false;
 		this.options = options;
 
 		this.init();
@@ -109,6 +118,11 @@ class HoverManager {
 		// Advance the reel progress stripe as the preview plays.
 		this.player.on( 'timeupdate', this.updatePreviewProgress.bind( this ) );
 
+		// The preview now starts on a timer; cancel it if the player is disposed
+		// inside the delay window (block-editor re-render, gallery removal, SPA
+		// nav) so the callback never runs against a torn-down player.
+		this.player.on( 'dispose', () => this.clearPreviewTimer() );
+
 		// Any `play` event other than the preview's own means real, committed
 		// playback has begun – e.g. the big play button, the control bar, the
 		// spacebar/keyboard handler, or a programmatic `player.play()`, none of
@@ -126,13 +140,14 @@ class HoverManager {
 				this.isPreviewInitiatedPlay = false;
 				return;
 			}
-			// Real, committed playback. Lift suppression and mark the player as
-			// committed so a later hover cannot restart a preview over it – the
-			// big play button / control bar never reach `handleVideoClick`, so
-			// `isVideoClicked` would otherwise stay false and re-enable preview.
+			// Real, committed playback (big play button, control bar, keyboard,
+			// programmatic). Mark the player committed so a later hover cannot
+			// restart a preview over it, then fully restore anything a preceding
+			// `startPreview()` changed – otherwise this path can leave the player
+			// muted, control-less and stuck behind its own poster.
 			this.isPreviewPlaying = false;
 			this.isVideoClicked = true;
-			this.togglePreviewOverlays( false );
+			this.exitPreviewToPlayback();
 		} );
 	}
 
@@ -175,6 +190,7 @@ class HoverManager {
 		this.previewMuteButton = document.createElement( 'button' );
 		this.previewMuteButton.type = 'button';
 		this.previewMuteButton.className = 'godam-preview-mute vjs-mute-control vjs-control vjs-button';
+		this.previewMuteButton.setAttribute( 'data-test-id', 'godam-preview-mute-toggle' );
 		this.previewMuteButton.innerHTML =
 			'<span class="vjs-icon-placeholder" aria-hidden="true"></span>' +
 			'<span class="vjs-control-text" aria-live="polite"></span>';
@@ -226,32 +242,47 @@ class HoverManager {
 	}
 
 	/**
-	 * Applies the session mute preference to the player and syncs the button
-	 * icon. Kept separate from `player.muted()` so preview start (always muted
-	 * for autoplay) and the viewer's stored choice stay in one place.
+	 * The mute state to actually apply to this preview. Honours the shared
+	 * session preference, but only carries a cross-preview *unmute* onto a
+	 * player the viewer has interacted with – browsers pause media that becomes
+	 * unmuted without a user gesture, so an ungestured player stays muted.
+	 *
+	 * @return {boolean} True if this preview should be muted.
 	 */
-	applyPreviewMute() {
-		this.player.muted( previewSessionMuted );
-		this.updateMuteButton();
+	getEffectiveMuted() {
+		return previewSessionMuted || ! this.hasUserGesture;
 	}
 
 	/**
-	 * Reflects the current mute state on the toggle button. Only the Video.js
+	 * Applies the effective mute state to the player and syncs the button icon.
+	 * Kept separate from `player.muted()` so preview start (always muted for
+	 * autoplay) and the viewer's stored choice stay in one place.
+	 */
+	applyPreviewMute() {
+		const muted = this.getEffectiveMuted();
+		this.player.muted( muted );
+		this.updateMuteButton( muted );
+	}
+
+	/**
+	 * Reflects the given mute state on the toggle button. Only the Video.js
 	 * volume-state class is swapped (`vjs-vol-0` ↔ `vjs-vol-3`) so the skin's CSS
 	 * paints the matching glyph; the label/ARIA describe the action available.
+	 *
+	 * @param {boolean} [muted] - Mute state to reflect; defaults to the effective one.
 	 */
-	updateMuteButton() {
+	updateMuteButton( muted = this.getEffectiveMuted() ) {
 		if ( ! this.previewMuteButton ) {
 			return;
 		}
 
-		this.previewMuteButton.classList.toggle( VJS_VOL_MUTED, previewSessionMuted );
-		this.previewMuteButton.classList.toggle( VJS_VOL_ON, ! previewSessionMuted );
+		this.previewMuteButton.classList.toggle( VJS_VOL_MUTED, muted );
+		this.previewMuteButton.classList.toggle( VJS_VOL_ON, ! muted );
 
-		const label = previewSessionMuted ? 'Unmute' : 'Mute';
+		const label = muted ? __( 'Unmute', 'godam' ) : __( 'Mute', 'godam' );
 		this.previewMuteButton.setAttribute( 'aria-label', label );
 		this.previewMuteButton.setAttribute( 'title', label );
-		this.previewMuteButton.setAttribute( 'aria-pressed', String( ! previewSessionMuted ) );
+		this.previewMuteButton.setAttribute( 'aria-pressed', String( ! muted ) );
 		if ( this.previewMuteIcon ) {
 			this.previewMuteIcon.textContent = label;
 		}
@@ -262,7 +293,9 @@ class HoverManager {
 	 *
 	 * Stops the click from reaching the <video> (which would switch to normal
 	 * playback) and persists the choice for the rest of the page session so
-	 * later previews honour it.
+	 * later previews honour it. Toggles relative to the state the viewer can
+	 * actually see, so it does the opposite of the icon regardless of why the
+	 * preview was muted.
 	 *
 	 * @param {Event} event - The click event on the mute button.
 	 */
@@ -270,7 +303,9 @@ class HoverManager {
 		event.preventDefault();
 		event.stopPropagation();
 
-		previewSessionMuted = ! previewSessionMuted;
+		const currentlyMuted = this.getEffectiveMuted();
+		this.hasUserGesture = true;
+		previewSessionMuted = ! currentlyMuted;
 		this.applyPreviewMute();
 	}
 
@@ -308,23 +343,25 @@ class HoverManager {
 	 * Handles mouse leave events - stops preview if currently active.
 	 */
 	handleMouseLeave() {
-		if ( this.isVideoClicked ) {
+		// Always clear the hover flag first – otherwise, once playback is
+		// committed (`isVideoClicked`) the early return below would leave
+		// `isHovered` stuck true for the life of the page.
+		const wasHovered = this.isHovered;
+		this.isHovered = false;
+
+		if ( this.isVideoClicked || ! wasHovered ) {
 			return;
 		}
 
-		if ( this.isHovered ) {
-			this.isHovered = false;
+		// Cancel a preview that was still waiting out the hover delay.
+		this.clearPreviewTimer();
 
-			// Cancel a preview that was still waiting out the hover delay.
-			this.clearPreviewTimer();
-
-			// Only tear down the "started" visual state and playback if the
-			// preview actually began; otherwise nothing was ever changed.
-			if ( this.isPreviewPlaying ) {
-				this.player.removeClass( 'vjs-has-started' );
-				this.player.addClass( 'godam-hover-started' );
-				this.stopPreview();
-			}
+		// Only tear down the "started" visual state and playback if the
+		// preview actually began; otherwise nothing was ever changed.
+		if ( this.isPreviewPlaying ) {
+			this.player.removeClass( 'vjs-has-started' );
+			this.player.addClass( 'godam-hover-started' );
+			this.stopPreview();
 		}
 	}
 
@@ -349,21 +386,17 @@ class HoverManager {
 		if ( this.isHovered ) {
 			this.isVideoClicked = true;
 			this.isPreviewPlaying = false;
+			this.hasUserGesture = true;
 
 			// A click within the hover-delay window commits straight to real
 			// playback – drop the still-pending preview start.
 			this.clearPreviewTimer();
 
-			// Real playback: unmute and hand the chrome back to the control bar.
-			this.togglePreviewOverlays( false );
-			this.player.muted( false );
-			this.player.volume( 1 );
+			// Restore audio/controls/started state, then play. Done here rather
+			// than relying on the `play` handler because `play()` on an already
+			// playing preview fires no `play` event.
+			this.exitPreviewToPlayback();
 			this.player.play();
-
-			const controlBar = this.player.controlBar?.el();
-			if ( controlBar ) {
-				controlBar.classList.remove( 'hide' );
-			}
 		}
 	}
 
@@ -397,16 +430,43 @@ class HoverManager {
 		const played = this.player.play();
 		Promise.resolve( played )
 			.then( () => this.applyPreviewMute() )
-			.catch( () => {} );
+			.catch( () => {
+				// Autoplay was refused (e.g. iOS Low Power Mode), so no `play`
+				// event will fire to clear `isPreviewInitiatedPlay`. Roll both
+				// flags back, or the viewer's next real play would be mistaken
+				// for the preview's own and leave layers suppressed all session.
+				this.isPreviewInitiatedPlay = false;
+				this.isPreviewPlaying = false;
+				this.togglePreviewOverlays( false );
+			} );
 	}
 
 	/**
-	 * Stops preview, resets video to start, and shows controls.
+	 * Stops preview, resets video to start, and shows controls. The control bar
+	 * `hide` is lifted here too so a preview that ends on mouse-leave never
+	 * leaves a later real playback control-less.
 	 */
 	stopPreview() {
 		this.togglePreviewOverlays( false );
+		this.player.controlBar?.el()?.classList.remove( 'hide' );
 		this.player.pause();
 		this.player.currentTime( 0 );
+	}
+
+	/**
+	 * Restores everything `startPreview()` changed when the player commits to
+	 * real playback: shows the control bar, makes playback audible, lifts the
+	 * hover-poster state (Video.js keeps `hasStarted_` latched, so the poster
+	 * only clears once `godam-hover-started` is removed and `vjs-has-started`
+	 * restored), and hides the preview chrome. Idempotent.
+	 */
+	exitPreviewToPlayback() {
+		this.togglePreviewOverlays( false );
+		this.player.controlBar?.el()?.classList.remove( 'hide' );
+		this.player.muted( false );
+		this.player.volume( 1 );
+		this.player.addClass( 'vjs-has-started' );
+		this.player.removeClass( 'godam-hover-started' );
 	}
 
 	/**
@@ -423,6 +483,14 @@ class HoverManager {
 	isPreviewActive() {
 		return this.isPreviewPlaying;
 	}
+}
+
+/**
+ * Test-only helper: reset the shared, page-session mute preference so it does
+ * not leak between specs. Not referenced by production code.
+ */
+export function resetPreviewSessionMuted() {
+	previewSessionMuted = true;
 }
 
 export default HoverManager;

--- a/assets/src/js/godam-player/managers/hoverManager.js
+++ b/assets/src/js/godam-player/managers/hoverManager.js
@@ -140,9 +140,14 @@ class HoverManager {
 				this.isPreviewInitiatedPlay = false;
 				return;
 			}
-			// Real, committed playback (big play button, control bar, keyboard,
-			// programmatic). Mark the player committed so a later hover cannot
-			// restart a preview over it, then fully restore anything a preceding
+			// Already committed: this is an ordinary resume, not the transition
+			// out of preview. Leave the viewer's mute/volume alone.
+			if ( this.isVideoClicked ) {
+				return;
+			}
+			// First real, committed playback (big play button, control bar,
+			// keyboard, programmatic). Mark the player committed so a later hover
+			// cannot restart a preview over it, then restore anything a preceding
 			// `startPreview()` changed – otherwise this path can leave the player
 			// muted, control-less and stuck behind its own poster.
 			this.isPreviewPlaying = false;
@@ -359,8 +364,7 @@ class HoverManager {
 		// Only tear down the "started" visual state and playback if the
 		// preview actually began; otherwise nothing was ever changed.
 		if ( this.isPreviewPlaying ) {
-			this.player.removeClass( 'vjs-has-started' );
-			this.player.addClass( 'godam-hover-started' );
+			this.showPoster();
 			this.stopPreview();
 		}
 	}
@@ -410,9 +414,10 @@ class HoverManager {
 		this.isPreviewInitiatedPlay = true;
 
 		// Always begin muted so the hover-triggered autoplay is never blocked;
-		// the session preference is re-applied once playback has started.
+		// the session preference is re-applied once playback has started. Mute
+		// via `muted()` only – the volume level is left untouched so the site's
+		// or viewer's configured volume survives the preview.
 		this.player.muted( true );
-		this.player.volume( 1 );
 		this.player.currentTime( 0 );
 
 		const controlBar = this.player.controlBar?.el();
@@ -432,12 +437,14 @@ class HoverManager {
 			.then( () => this.applyPreviewMute() )
 			.catch( () => {
 				// Autoplay was refused (e.g. iOS Low Power Mode), so no `play`
-				// event will fire to clear `isPreviewInitiatedPlay`. Roll both
-				// flags back, or the viewer's next real play would be mistaken
-				// for the preview's own and leave layers suppressed all session.
+				// event will fire to clear `isPreviewInitiatedPlay`. Roll the
+				// flags back and fully tear the preview down – otherwise the
+				// video is left paused at frame 0 with the control bar hidden and
+				// no poster, and a following `mouseleave` skips its teardown.
 				this.isPreviewInitiatedPlay = false;
 				this.isPreviewPlaying = false;
-				this.togglePreviewOverlays( false );
+				this.showPoster();
+				this.stopPreview();
 			} );
 	}
 
@@ -454,17 +461,26 @@ class HoverManager {
 	}
 
 	/**
+	 * Returns the player to its poster/idle look. Video.js keeps `hasStarted_`
+	 * latched once a preview has played, so the poster only reappears when
+	 * `vjs-has-started` is removed and `godam-hover-started` restored.
+	 */
+	showPoster() {
+		this.player.removeClass( 'vjs-has-started' );
+		this.player.addClass( 'godam-hover-started' );
+	}
+
+	/**
 	 * Restores everything `startPreview()` changed when the player commits to
-	 * real playback: shows the control bar, makes playback audible, lifts the
-	 * hover-poster state (Video.js keeps `hasStarted_` latched, so the poster
-	 * only clears once `godam-hover-started` is removed and `vjs-has-started`
-	 * restored), and hides the preview chrome. Idempotent.
+	 * real playback: shows the control bar, unmutes (leaving the volume level
+	 * alone), lifts the hover-poster state (`vjs-has-started` back on,
+	 * `godam-hover-started` off), and hides the preview chrome. Runs once per
+	 * commit – the `play` handler guards against re-running it on later resumes.
 	 */
 	exitPreviewToPlayback() {
 		this.togglePreviewOverlays( false );
 		this.player.controlBar?.el()?.classList.remove( 'hide' );
 		this.player.muted( false );
-		this.player.volume( 1 );
 		this.player.addClass( 'vjs-has-started' );
 		this.player.removeClass( 'godam-hover-started' );
 	}

--- a/assets/src/js/godam-player/managers/hoverManager.js
+++ b/assets/src/js/godam-player/managers/hoverManager.js
@@ -5,7 +5,8 @@
  * It supports two primary behaviors:
  *
  * 1. **Preview Mode (`hover-select="start-preview"`)**
- * - Plays a muted preview on mouse hover.
+ * - Plays a muted preview after a short hover-intent delay (the pointer must
+ * linger on the video), so a pointer merely passing over it does nothing.
  * - Stops and resets the preview when the mouse leaves.
  * - On click during preview, switches to normal playback (unmuted, with controls).
  *
@@ -25,6 +26,26 @@
  * @example
  * const hoverManager = new HoverManager(playerInstance, videoElement);
  */
+// How long the pointer must linger over the video before a hover preview
+// actually starts. Prevents play/pause churn when the pointer merely passes
+// across the video on its way somewhere else.
+const PREVIEW_START_DELAY_MS = 700;
+
+// Shared across every hover preview on the page: once the viewer unmutes any
+// preview, later previews start unmuted too (reel-like), and vice-versa. Lives
+// for the page session only. Previews always begin muted at the browser level
+// so autoplay is never blocked; this preference is re-applied once playback
+// has actually started.
+let previewSessionMuted = true;
+
+// Video.js mute-toggle volume-state classes. Reusing them (plus the Video.js
+// button/icon-placeholder markup) means the preview toggle renders with the
+// exact same volume glyph as the player's own control bar for every skin: the
+// bundled Video.js icon font drives the default and bubble skins, and the
+// classic skin's SVG override is extended to this button in its own stylesheet.
+const VJS_VOL_MUTED = 'vjs-vol-0';
+const VJS_VOL_ON = 'vjs-vol-3';
+
 class HoverManager {
 	constructor( player, videoElement, options = {} ) {
 		this.player = player;
@@ -32,10 +53,20 @@ class HoverManager {
 		this.hoverSelect = videoElement.dataset.hoverSelect || 'none';
 		this.isVideoClicked = false;
 		this.isHovered = false;
+		// Delay (ms) before a lingering hover starts the preview, and the handle of
+		// the pending timer so `mouseleave`/click can cancel a start that has not
+		// fired yet.
+		this.previewDelay = options.previewDelay ?? PREVIEW_START_DELAY_MS;
+		this.previewTimer = null;
 		// True while an uncommitted hover preview is running. Interactive layers
 		// are suppressed for its duration – a preview is a playback teaser, not
 		// a place to show forms/CTAs/hotspots.
 		this.isPreviewPlaying = false;
+		// Set by `startPreview()` immediately before it calls `player.play()`, so
+		// the preview's own (asynchronous) `play` event can be told apart from a
+		// `play` event that signals real, committed playback. Consumed once in the
+		// `play` handler.
+		this.isPreviewInitiatedPlay = false;
 		this.options = options;
 
 		this.init();
@@ -65,18 +96,37 @@ class HoverManager {
 	 * Handles mouseenter, mouseleave, and click events for video previews.
 	 */
 	setupPreview() {
-		this.videoElement.addEventListener( 'mouseenter', this.handleMouseEnter.bind( this ) );
-		this.videoElement.addEventListener( 'mouseleave', this.handleMouseLeave.bind( this ) );
+		this.buildPreviewOverlays();
+
+		// Hover is tracked on the player root, not the <video>, so moving the
+		// pointer onto an overlay control (the mute button) does not fire a
+		// `mouseleave` on the video and tear the preview down mid-hover.
+		this.hoverTarget = this.player.el() || this.videoElement;
+		this.hoverTarget.addEventListener( 'mouseenter', this.handleMouseEnter.bind( this ) );
+		this.hoverTarget.addEventListener( 'mouseleave', this.handleMouseLeave.bind( this ) );
 		this.videoElement.addEventListener( 'click', this.handleVideoClick.bind( this ) );
 
-		// Playback that starts while the pointer is away from the video is real
-		// playback, not a preview – e.g. the big play button or the control bar,
-		// whose clicks never reach the <video> element and so never run
-		// `handleVideoClick`. Clear the preview flag so layers resume working.
+		// Advance the reel progress stripe as the preview plays.
+		this.player.on( 'timeupdate', this.updatePreviewProgress.bind( this ) );
+
+		// Any `play` event other than the preview's own means real, committed
+		// playback has begun – e.g. the big play button, the control bar, the
+		// spacebar/keyboard handler, or a programmatic `player.play()`, none of
+		// which reach the <video> element to run `handleVideoClick`. Clear the
+		// preview flag so layers resume working.
+		//
+		// The preview's OWN `play` (queued by `startPreview()`) must not clear the
+		// flag: on a fast hover-flick that `play` can land after `mouseleave` has
+		// already queued the preview's `pause`, and clearing here would let the
+		// `on_pause` CTA slip through over the preview the pointer just left.
+		// `isPreviewInitiatedPlay` distinguishes the two regardless of hover
+		// state, which also covers real playback committed while still hovering.
 		this.player.on( 'play', () => {
-			if ( ! this.isHovered ) {
-				this.isPreviewPlaying = false;
+			if ( this.isPreviewInitiatedPlay ) {
+				this.isPreviewInitiatedPlay = false;
+				return;
 			}
+			this.isPreviewPlaying = false;
 		} );
 	}
 
@@ -89,6 +139,136 @@ class HoverManager {
 	}
 
 	/**
+	 * Builds the preview-only overlay chrome: a reel-style progress stripe along
+	 * the bottom edge and a mute/unmute toggle in the top-right corner. Both are
+	 * created once, hidden, and appended to the player root; they are shown only
+	 * while a preview is actually playing.
+	 */
+	buildPreviewOverlays() {
+		const root = this.player.el();
+		if ( ! root ) {
+			return;
+		}
+
+		// The overlay share / transcript buttons live on this ancestor container
+		// (outside `.video-js`), so they are toggled from here while previewing.
+		this.previewContainer = root.closest( '.easydam-video-container' );
+
+		// Reel-style progress stripe (presentational – no scrubbing).
+		this.previewProgress = document.createElement( 'div' );
+		this.previewProgress.className = 'godam-preview-progress';
+		this.previewProgress.setAttribute( 'aria-hidden', 'true' );
+
+		this.previewProgressFill = document.createElement( 'div' );
+		this.previewProgressFill.className = 'godam-preview-progress__fill';
+		this.previewProgress.appendChild( this.previewProgressFill );
+
+		// Mute / unmute toggle. Built with the same markup and classes as
+		// Video.js's own MuteToggle (`vjs-mute-control` + a `vjs-icon-placeholder`
+		// span) so the active skin styles its glyph exactly like the control bar.
+		this.previewMuteButton = document.createElement( 'button' );
+		this.previewMuteButton.type = 'button';
+		this.previewMuteButton.className = 'godam-preview-mute vjs-mute-control vjs-control vjs-button';
+		this.previewMuteButton.innerHTML =
+			'<span class="vjs-icon-placeholder" aria-hidden="true"></span>' +
+			'<span class="vjs-control-text" aria-live="polite"></span>';
+		this.previewMuteIcon = this.previewMuteButton.querySelector( '.vjs-control-text' );
+		this.previewMuteButton.addEventListener( 'click', this.handleMuteToggle.bind( this ) );
+
+		root.appendChild( this.previewProgress );
+		root.appendChild( this.previewMuteButton );
+
+		this.updateMuteButton();
+		this.togglePreviewOverlays( false );
+	}
+
+	/**
+	 * Shows or hides the preview overlay chrome, and flags the video container so
+	 * the share / transcript overlay buttons are hidden for the preview's
+	 * duration (a preview is a teaser, not a place to share or read transcripts).
+	 *
+	 * @param {boolean} visible - Whether the preview chrome should be visible.
+	 */
+	togglePreviewOverlays( visible ) {
+		if ( this.previewProgress ) {
+			this.previewProgress.classList.toggle( 'is-visible', visible );
+		}
+		if ( this.previewMuteButton ) {
+			this.previewMuteButton.classList.toggle( 'is-visible', visible );
+		}
+		if ( this.previewContainer ) {
+			this.previewContainer.classList.toggle( 'godam-hover-preview-active', visible );
+		}
+	}
+
+	/**
+	 * Redraws the reel progress stripe from the current playback position.
+	 * No-ops unless a preview is actively playing.
+	 */
+	updatePreviewProgress() {
+		if ( ! this.isPreviewPlaying || ! this.previewProgressFill ) {
+			return;
+		}
+
+		const duration = this.player.duration();
+		if ( ! duration || ! isFinite( duration ) ) {
+			return;
+		}
+
+		const percent = Math.min( 100, ( this.player.currentTime() / duration ) * 100 );
+		this.previewProgressFill.style.width = `${ percent }%`;
+	}
+
+	/**
+	 * Applies the session mute preference to the player and syncs the button
+	 * icon. Kept separate from `player.muted()` so preview start (always muted
+	 * for autoplay) and the viewer's stored choice stay in one place.
+	 */
+	applyPreviewMute() {
+		this.player.muted( previewSessionMuted );
+		this.updateMuteButton();
+	}
+
+	/**
+	 * Reflects the current mute state on the toggle button. Only the Video.js
+	 * volume-state class is swapped (`vjs-vol-0` ↔ `vjs-vol-3`) so the skin's CSS
+	 * paints the matching glyph; the label/ARIA describe the action available.
+	 */
+	updateMuteButton() {
+		if ( ! this.previewMuteButton ) {
+			return;
+		}
+
+		this.previewMuteButton.classList.toggle( VJS_VOL_MUTED, previewSessionMuted );
+		this.previewMuteButton.classList.toggle( VJS_VOL_ON, ! previewSessionMuted );
+
+		const label = previewSessionMuted ? 'Unmute' : 'Mute';
+		this.previewMuteButton.setAttribute( 'aria-label', label );
+		this.previewMuteButton.setAttribute( 'title', label );
+		this.previewMuteButton.setAttribute( 'aria-pressed', String( ! previewSessionMuted ) );
+		if ( this.previewMuteIcon ) {
+			this.previewMuteIcon.textContent = label;
+		}
+	}
+
+	/**
+	 * Toggles preview sound without committing to full playback.
+	 *
+	 * Stops the click from reaching the <video> (which would switch to normal
+	 * playback) and persists the choice for the rest of the page session so
+	 * later previews honour it.
+	 *
+	 * @param {Event} event - The click event on the mute button.
+	 */
+	handleMuteToggle( event ) {
+		event.preventDefault();
+		event.stopPropagation();
+
+		previewSessionMuted = ! previewSessionMuted;
+		this.applyPreviewMute();
+	}
+
+	/**
 	 * Handles mouse enter events - starts preview if conditions are met.
 	 */
 	handleMouseEnter() {
@@ -97,10 +277,25 @@ class HoverManager {
 		}
 
 		this.isHovered = true;
-		this.player.addClass( 'vjs-has-started' );
-		this.player.removeClass( 'godam-hover-started' );
 
-		this.startPreview();
+		// Defer the actual preview so a pointer that only grazes the video never
+		// starts playback. The visual "started" state is flipped alongside the
+		// play in the timer callback so the poster/controls do not change until
+		// the preview truly begins.
+		this.clearPreviewTimer();
+		this.previewTimer = setTimeout( () => {
+			this.previewTimer = null;
+
+			// A leave or click may have landed during the delay window.
+			if ( ! this.isHovered || this.isVideoClicked ) {
+				return;
+			}
+
+			this.player.addClass( 'vjs-has-started' );
+			this.player.removeClass( 'godam-hover-started' );
+
+			this.startPreview();
+		}, this.previewDelay );
 	}
 
 	/**
@@ -112,10 +307,28 @@ class HoverManager {
 		}
 
 		if ( this.isHovered ) {
-			this.player.removeClass( 'vjs-has-started' );
-			this.player.addClass( 'godam-hover-started' );
-			this.stopPreview();
 			this.isHovered = false;
+
+			// Cancel a preview that was still waiting out the hover delay.
+			this.clearPreviewTimer();
+
+			// Only tear down the "started" visual state and playback if the
+			// preview actually began; otherwise nothing was ever changed.
+			if ( this.isPreviewPlaying ) {
+				this.player.removeClass( 'vjs-has-started' );
+				this.player.addClass( 'godam-hover-started' );
+				this.stopPreview();
+			}
+		}
+	}
+
+	/**
+	 * Cancels a pending (delayed) preview start, if any.
+	 */
+	clearPreviewTimer() {
+		if ( this.previewTimer ) {
+			clearTimeout( this.previewTimer );
+			this.previewTimer = null;
 		}
 	}
 
@@ -131,6 +344,13 @@ class HoverManager {
 			this.isVideoClicked = true;
 			this.isPreviewPlaying = false;
 
+			// A click within the hover-delay window commits straight to real
+			// playback – drop the still-pending preview start.
+			this.clearPreviewTimer();
+
+			// Real playback: unmute and hand the chrome back to the control bar.
+			this.togglePreviewOverlays( false );
+			this.player.muted( false );
 			this.player.volume( 1 );
 			this.player.play();
 
@@ -146,8 +366,14 @@ class HoverManager {
 	 */
 	startPreview() {
 		this.isPreviewPlaying = true;
+		// Mark the play() below as preview-initiated so the `play` handler ignores
+		// it and does not lift layer suppression for the preview itself.
+		this.isPreviewInitiatedPlay = true;
 
-		this.player.volume( 0 );
+		// Always begin muted so the hover-triggered autoplay is never blocked;
+		// the session preference is re-applied once playback has started.
+		this.player.muted( true );
+		this.player.volume( 1 );
 		this.player.currentTime( 0 );
 
 		const controlBar = this.player.controlBar?.el();
@@ -155,13 +381,24 @@ class HoverManager {
 			controlBar.classList.add( 'hide' );
 		}
 
-		this.player.play();
+		// Reset and reveal the reel chrome for this preview.
+		if ( this.previewProgressFill ) {
+			this.previewProgressFill.style.width = '0%';
+		}
+		this.updateMuteButton();
+		this.togglePreviewOverlays( true );
+
+		const played = this.player.play();
+		Promise.resolve( played )
+			.then( () => this.applyPreviewMute() )
+			.catch( () => {} );
 	}
 
 	/**
 	 * Stops preview, resets video to start, and shows controls.
 	 */
 	stopPreview() {
+		this.togglePreviewOverlays( false );
 		this.player.pause();
 		this.player.currentTime( 0 );
 	}

--- a/assets/src/js/godam-player/managers/hoverManager.test.js
+++ b/assets/src/js/godam-player/managers/hoverManager.test.js
@@ -298,6 +298,7 @@ const createStatefulPlayer = () => {
 	const root = document.createElement( 'div' );
 	const controlBarEl = document.createElement( 'div' );
 	let mutedState = false;
+	let vol = 1;
 	let paused = true;
 	let hasStarted = false;
 	const p = {
@@ -309,11 +310,12 @@ const createStatefulPlayer = () => {
 		addClass: ( c ) => root.classList.add( c ),
 		removeClass: ( c ) => root.classList.remove( c ),
 		muted: ( v ) => ( v === undefined ? mutedState : ( mutedState = v ) ),
-		volume: () => {},
+		volume: ( v ) => ( v === undefined ? vol : ( vol = v ) ),
 		duration: () => 10,
 		currentTime: () => 0,
 		pause: () => {
 			paused = true;
+			( handlers.pause || [] ).forEach( ( cb ) => cb() );
 		},
 		// Video.js fires `play` only when transitioning from paused, and
 		// hasStarted(true) is a no-op once already started.
@@ -351,6 +353,31 @@ describe( 'HoverManager exit-to-playback restore', () => {
 		expect( root.classList.contains( 'vjs-has-started' ) ).toBe( true );
 		expect( root.classList.contains( 'godam-hover-started' ) ).toBe( false );
 	} );
+
+	it( 'keeps the viewer mute and volume across a pause/resume after commit', () => {
+		const { p } = createStatefulPlayer();
+		createManager( p );
+
+		p.play(); // commit real playback
+		p.muted( true ); // viewer mutes
+		p.volume( 0.2 ); // viewer lowers volume
+		p.pause();
+		p.play(); // resume
+
+		expect( p.muted() ).toBe( true );
+		expect( p.volume() ).toBe( 0.2 );
+	} );
+
+	it( 'leaves the configured volume level untouched when committing', () => {
+		const { p } = createStatefulPlayer();
+		p.volume( 0.5 ); // site-configured volume
+		createManager( p );
+
+		p.play(); // commit real playback (unmutes, must not slam volume to 1)
+
+		expect( p.muted() ).toBe( false );
+		expect( p.volume() ).toBe( 0.5 );
+	} );
 } );
 
 describe( 'HoverManager robustness fixes', () => {
@@ -369,6 +396,22 @@ describe( 'HoverManager robustness fixes', () => {
 
 		// A later real play must not be swallowed as the preview's own.
 		player.emit( 'play' );
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+
+	it( 'restores the poster and control bar when autoplay is refused', async () => {
+		const { p, root, controlBarEl } = createStatefulPlayer();
+		p.play = () => Promise.reject( new Error( 'NotAllowedError' ) );
+		const manager = createManager( p );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers(); // startPreview → play() rejects
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect( controlBarEl.classList.contains( 'hide' ) ).toBe( false );
+		expect( root.classList.contains( 'vjs-has-started' ) ).toBe( false );
+		expect( root.classList.contains( 'godam-hover-started' ) ).toBe( true );
 		expect( manager.isPreviewActive() ).toBe( false );
 	} );
 

--- a/assets/src/js/godam-player/managers/hoverManager.test.js
+++ b/assets/src/js/godam-player/managers/hoverManager.test.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import HoverManager from './hoverManager';
+import HoverManager, { resetPreviewSessionMuted } from './hoverManager';
+
+// The mute preference is shared, page-session module state; reset it after
+// every spec so a failure mid-test cannot leak `false` into later specs.
+afterEach( () => resetPreviewSessionMuted() );
 
 /**
  * Minimal Video.js player stub.
@@ -279,5 +283,121 @@ describe( 'HoverManager preview reel chrome', () => {
 
 		// Restore the shared page-session mute preference for other tests.
 		manager.handleMuteToggle( { preventDefault() {}, stopPropagation() {} } );
+	} );
+} );
+
+/**
+ * Richer player stub that models the two things the minimal stub cannot: a
+ * stable control-bar element (so the `hide` class is observable) and Video.js's
+ * `hasStarted_` latch (so `vjs-has-started` cannot be re-added once set).
+ *
+ * @return {Object} `{ p, root, controlBarEl }`.
+ */
+const createStatefulPlayer = () => {
+	const handlers = {};
+	const root = document.createElement( 'div' );
+	const controlBarEl = document.createElement( 'div' );
+	let mutedState = false;
+	let paused = true;
+	let hasStarted = false;
+	const p = {
+		autoplay: () => false,
+		el: () => root,
+		controlBar: { el: () => controlBarEl },
+		on: ( e, cb ) => ( handlers[ e ] = handlers[ e ] || [] ).push( cb ),
+		emit: ( e ) => ( handlers[ e ] || [] ).forEach( ( cb ) => cb() ),
+		addClass: ( c ) => root.classList.add( c ),
+		removeClass: ( c ) => root.classList.remove( c ),
+		muted: ( v ) => ( v === undefined ? mutedState : ( mutedState = v ) ),
+		volume: () => {},
+		duration: () => 10,
+		currentTime: () => 0,
+		pause: () => {
+			paused = true;
+		},
+		// Video.js fires `play` only when transitioning from paused, and
+		// hasStarted(true) is a no-op once already started.
+		play: () => {
+			if ( ! paused ) {
+				return;
+			}
+			paused = false;
+			if ( ! hasStarted ) {
+				hasStarted = true;
+				root.classList.add( 'vjs-has-started' );
+			}
+			( handlers.play || [] ).forEach( ( cb ) => cb() );
+		},
+	};
+	return { p, root, controlBarEl };
+};
+
+describe( 'HoverManager exit-to-playback restore', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'restores sound, controls and started state when the big play button commits after a preview', () => {
+		const { p, root, controlBarEl } = createStatefulPlayer();
+		const manager = createManager( p );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers(); // preview runs (muted, control bar hidden)
+		manager.handleMouseLeave(); // pointer leaves; poster returns
+		manager.handleMouseEnter(); // re-enter, timer pending
+		p.play(); // big play button, before the timer fires
+
+		expect( p.muted() ).toBe( false );
+		expect( controlBarEl.classList.contains( 'hide' ) ).toBe( false );
+		expect( root.classList.contains( 'vjs-has-started' ) ).toBe( true );
+		expect( root.classList.contains( 'godam-hover-started' ) ).toBe( false );
+	} );
+} );
+
+describe( 'HoverManager robustness fixes', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'rolls the preview-initiated flag back when play() is rejected', async () => {
+		const player = createPlayer();
+		player.play = jest.fn( () => Promise.reject( new Error( 'NotAllowedError' ) ) );
+		const manager = createManager( player );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		await Promise.resolve(); // let the rejected play() settle
+		await Promise.resolve();
+
+		// A later real play must not be swallowed as the preview's own.
+		player.emit( 'play' );
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+
+	it( 'cancels a pending preview timer on player dispose', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		manager.handleMouseEnter(); // schedules the delayed preview
+		player.emit( 'dispose' );
+		jest.runOnlyPendingTimers();
+
+		expect( manager.isPreviewActive() ).toBe( false );
+		expect( player.play ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not carry a cross-preview unmute onto an un-gestured player', () => {
+		const gestured = createPlayer();
+		const gesturedManager = createManager( gestured );
+
+		// Viewer unmutes this preview (a user gesture on this player).
+		gesturedManager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		gesturedManager.handleMuteToggle( { preventDefault() {}, stopPropagation() {} } );
+		expect( gestured.muted ).toHaveBeenLastCalledWith( false );
+
+		// A different video's preview, with no gesture, must still start muted.
+		const other = createPlayer();
+		const otherManager = createManager( other );
+		otherManager.applyPreviewMute();
+		expect( other.muted ).toHaveBeenLastCalledWith( true );
 	} );
 } );

--- a/assets/src/js/godam-player/managers/hoverManager.test.js
+++ b/assets/src/js/godam-player/managers/hoverManager.test.js
@@ -1,0 +1,268 @@
+/**
+ * Internal dependencies
+ */
+import HoverManager from './hoverManager';
+
+/**
+ * Minimal Video.js player stub.
+ *
+ * Records the handlers registered via `player.on()` so tests can dispatch the
+ * asynchronous `play`/`pause` events by hand, and no-ops the rest of the API
+ * HoverManager touches.
+ *
+ * @param {Object}  [opts]          - Overrides.
+ * @param {boolean} [opts.autoplay] - Value returned by `player.autoplay()`.
+ * @return {Object} The stub player, plus an `emit( event )` test helper.
+ */
+const createPlayer = ( { autoplay = false } = {} ) => {
+	const handlers = {};
+	const root = document.createElement( 'div' );
+	return {
+		autoplay: () => autoplay,
+		on: ( event, cb ) => {
+			( handlers[ event ] = handlers[ event ] || [] ).push( cb );
+		},
+		emit: ( event ) => ( handlers[ event ] || [] ).forEach( ( cb ) => cb() ),
+		el: () => root,
+		addClass: jest.fn(),
+		removeClass: jest.fn(),
+		play: jest.fn(),
+		pause: jest.fn(),
+		muted: jest.fn(),
+		volume: jest.fn(),
+		duration: jest.fn( () => 10 ),
+		currentTime: jest.fn( () => 0 ),
+		controlBar: { el: () => document.createElement( 'div' ) },
+	};
+};
+
+/**
+ * Builds a HoverManager wired to a `start-preview` <video>.
+ *
+ * @param {Object} player    - Player stub from `createPlayer`.
+ * @param {Object} [options] - HoverManager options (e.g. `previewDelay`).
+ * @return {HoverManager} The manager under test.
+ */
+const createManager = ( player, options = {} ) => {
+	const video = document.createElement( 'video' );
+	video.dataset.hoverSelect = 'start-preview';
+	return new HoverManager( player, video, options );
+};
+
+describe( 'HoverManager preview suppression flag', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'is inactive before any preview starts', () => {
+		const manager = createManager( createPlayer() );
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+
+	it( 'becomes active when a preview starts', () => {
+		const manager = createManager( createPlayer() );
+		manager.startPreview();
+		expect( manager.isPreviewActive() ).toBe( true );
+	} );
+
+	it( 'reports strictly boolean state', () => {
+		const manager = createManager( createPlayer() );
+		expect( manager.isPreviewActive() ).toStrictEqual( false );
+		manager.startPreview();
+		expect( manager.isPreviewActive() ).toStrictEqual( true );
+	} );
+
+	it( "ignores the preview's own play event so a fast flick keeps suppression", () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		// Hover lingers past the delay, so the preview starts and queues its `play`.
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		expect( manager.isPreviewActive() ).toBe( true );
+
+		// Pointer leaves before the queued `play` fires; the flag must survive so
+		// the trailing `pause` cannot reveal an on_pause CTA.
+		manager.handleMouseLeave();
+		player.emit( 'play' );
+
+		expect( manager.isPreviewActive() ).toBe( true );
+	} );
+
+	it( 'is not cleared by stopPreview()', () => {
+		const manager = createManager( createPlayer() );
+		manager.startPreview();
+		manager.stopPreview();
+		expect( manager.isPreviewActive() ).toBe( true );
+	} );
+
+	it( 'clears on a real play event even while still hovering', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		player.emit( 'play' ); // consumes the preview-initiated play
+		expect( manager.isPreviewActive() ).toBe( true );
+
+		// A second, un-marked play (spacebar / programmatic) is real playback.
+		player.emit( 'play' );
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+
+	it( 'clears when the video is clicked to commit playback', () => {
+		const manager = createManager( createPlayer() );
+		manager.handleMouseEnter();
+		manager.handleVideoClick();
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+} );
+
+describe( 'HoverManager hover-intent delay', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'does not start the preview until the pointer lingers past the delay', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		manager.handleMouseEnter();
+		expect( player.play ).not.toHaveBeenCalled();
+		expect( manager.isPreviewActive() ).toBe( false );
+
+		jest.advanceTimersByTime( 1000 );
+		expect( player.play ).toHaveBeenCalled();
+		expect( manager.isPreviewActive() ).toBe( true );
+	} );
+
+	it( 'never starts the preview when the pointer leaves before the delay', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		manager.handleMouseEnter();
+		manager.handleMouseLeave();
+		jest.advanceTimersByTime( 1000 );
+
+		expect( player.play ).not.toHaveBeenCalled();
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+
+	it( 'commits straight to real playback when clicked during the delay', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		manager.handleMouseEnter();
+		manager.handleVideoClick();
+		jest.advanceTimersByTime( 1000 );
+
+		// Committing unmutes; the pending muted preview must never run (it would
+		// have called muted(true)).
+		expect( player.muted ).toHaveBeenCalledWith( false );
+		expect( player.muted ).not.toHaveBeenCalledWith( true );
+		expect( manager.isPreviewActive() ).toBe( false );
+	} );
+
+	it( 'honours a custom delay from options', () => {
+		const player = createPlayer();
+		const manager = createManager( player, { previewDelay: 250 } );
+
+		manager.handleMouseEnter();
+		jest.advanceTimersByTime( 249 );
+		expect( manager.isPreviewActive() ).toBe( false );
+
+		jest.advanceTimersByTime( 1 );
+		expect( manager.isPreviewActive() ).toBe( true );
+	} );
+} );
+
+describe( 'HoverManager preview reel chrome', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'builds a hidden progress stripe and mute button on the player root', () => {
+		const player = createPlayer();
+		createManager( player );
+
+		const progress = player.el().querySelector( '.godam-preview-progress' );
+		const fill = player.el().querySelector( '.godam-preview-progress__fill' );
+		const mute = player.el().querySelector( '.godam-preview-mute' );
+
+		expect( progress ).not.toBeNull();
+		expect( fill ).not.toBeNull();
+		expect( mute ).not.toBeNull();
+		expect( progress.classList.contains( 'is-visible' ) ).toBe( false );
+		expect( mute.classList.contains( 'is-visible' ) ).toBe( false );
+	} );
+
+	it( 'shows the chrome during a preview and advances the fill on timeupdate', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+		const progress = player.el().querySelector( '.godam-preview-progress' );
+		const fill = player.el().querySelector( '.godam-preview-progress__fill' );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		expect( progress.classList.contains( 'is-visible' ) ).toBe( true );
+
+		player.currentTime = () => 5; // duration is 10 → 50%
+		player.emit( 'timeupdate' );
+		expect( fill.style.width ).toBe( '50%' );
+
+		manager.handleMouseLeave();
+		expect( progress.classList.contains( 'is-visible' ) ).toBe( false );
+	} );
+
+	it( 'flags the container to hide share/transcript buttons while previewing', () => {
+		const player = createPlayer();
+		const container = document.createElement( 'div' );
+		container.className = 'easydam-video-container';
+		container.appendChild( player.el() );
+		const manager = createManager( player );
+
+		expect( container.classList.contains( 'godam-hover-preview-active' ) ).toBe( false );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		expect( container.classList.contains( 'godam-hover-preview-active' ) ).toBe( true );
+
+		manager.handleMouseLeave();
+		expect( container.classList.contains( 'godam-hover-preview-active' ) ).toBe( false );
+	} );
+
+	it( 'clears the container flag when playback is committed by a click', () => {
+		const player = createPlayer();
+		const container = document.createElement( 'div' );
+		container.className = 'easydam-video-container';
+		container.appendChild( player.el() );
+		const manager = createManager( player );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		expect( container.classList.contains( 'godam-hover-preview-active' ) ).toBe( true );
+
+		manager.handleVideoClick();
+		expect( container.classList.contains( 'godam-hover-preview-active' ) ).toBe( false );
+	} );
+
+	it( 'toggles preview sound without committing to real playback', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+		const mute = player.el().querySelector( '.godam-preview-mute' );
+
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+
+		const before = mute.getAttribute( 'aria-pressed' );
+		const event = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
+		manager.handleMuteToggle( event );
+
+		// The click is kept off the <video>, so it never commits to playback.
+		expect( event.stopPropagation ).toHaveBeenCalled();
+		expect( manager.isVideoClicked ).toBe( false );
+		expect( manager.isPreviewActive() ).toBe( true );
+		// The button state flipped.
+		expect( mute.getAttribute( 'aria-pressed' ) ).not.toBe( before );
+
+		// Restore the shared page-session mute preference for other tests.
+		manager.handleMuteToggle( { preventDefault() {}, stopPropagation() {} } );
+	} );
+} );

--- a/assets/src/js/godam-player/managers/hoverManager.test.js
+++ b/assets/src/js/godam-player/managers/hoverManager.test.js
@@ -109,6 +109,21 @@ describe( 'HoverManager preview suppression flag', () => {
 		expect( manager.isPreviewActive() ).toBe( false );
 	} );
 
+	it( 'marks real playback committed so a later hover cannot restart a preview', () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+
+		// Real playback from the big play button (no click on the <video>).
+		player.emit( 'play' );
+		expect( manager.isVideoClicked ).toBe( true );
+
+		// A subsequent hover must not schedule or start another preview.
+		manager.handleMouseEnter();
+		jest.runOnlyPendingTimers();
+		expect( manager.isPreviewActive() ).toBe( false );
+		expect( player.play ).not.toHaveBeenCalled();
+	} );
+
 	it( 'clears when the video is clicked to commit playback', () => {
 		const manager = createManager( createPlayer() );
 		manager.handleMouseEnter();

--- a/assets/src/js/godam-player/managers/layersManager.js
+++ b/assets/src/js/godam-player/managers/layersManager.js
@@ -21,6 +21,7 @@ export default class LayersManager {
 		this.isDisplayingLayers = isDisplayingLayers;
 		this.currentPlayerVideoInstanceId = currentPlayerVideoInstanceId;
 		this.customLayerManagers = {}; // Storage for custom manager instances
+		this.suppressionCheck = null; // Optional predicate that pauses all layer firing
 
 		// Initialize sub-managers
 		this.formLayerManager = new FormLayerManager( player, isDisplayingLayers, currentPlayerVideoInstanceId );
@@ -58,12 +59,42 @@ export default class LayersManager {
 			// Event-driven CTA triggers: `on_pause` shows a layer when the viewer
 			// pauses, `end_of_video` overlays one when playback ends. (The
 			// `timestamp` and `watch_depth` triggers run off `timeupdate`.)
-			this.player.on( 'pause', () => this.formLayerManager.handlePause() );
-			this.player.on( 'ended', () => this.formLayerManager.handleEnded() );
+			this.player.on( 'pause', () => {
+				if ( ! this.areLayersSuppressed() ) {
+					this.formLayerManager.handlePause();
+				}
+			} );
+			this.player.on( 'ended', () => {
+				if ( ! this.areLayersSuppressed() ) {
+					this.formLayerManager.handleEnded();
+				}
+			} );
 		}
 
 		this.formLayerManager.sortLayers();
 		this.isDisplayingLayers[ this.currentPlayerVideoInstanceId ] = false;
+	}
+
+	/**
+	 * Register a predicate that temporarily suppresses all layer firing.
+	 *
+	 * Used by the hover "Start Preview" behaviour: layers are still set up (and
+	 * stay `hidden`), but nothing is revealed while the muted preview runs, so
+	 * event-driven layers also keep their un-`triggered` state for real playback.
+	 *
+	 * @param {Function} check - Returns true while layers must stay suppressed.
+	 */
+	setSuppressionCheck( check ) {
+		this.suppressionCheck = typeof check === 'function' ? check : null;
+	}
+
+	/**
+	 * Whether layer firing is currently suppressed.
+	 *
+	 * @return {boolean} True when no layer should be revealed.
+	 */
+	areLayersSuppressed() {
+		return this.suppressionCheck?.() === true;
 	}
 
 	/**
@@ -133,6 +164,10 @@ export default class LayersManager {
 	 * @param {number} currentTime - Current video time in seconds
 	 */
 	handleFormLayersTimeUpdate( currentTime ) {
+		if ( this.areLayersSuppressed() ) {
+			return;
+		}
+
 		this.formLayerManager.handleFormLayersTimeUpdate( currentTime );
 	}
 
@@ -142,6 +177,10 @@ export default class LayersManager {
 	 * @param {number} currentTime - Current video time in seconds
 	 */
 	handleHotspotLayersTimeUpdate( currentTime ) {
+		if ( this.areLayersSuppressed() ) {
+			return;
+		}
+
 		this.hotspotLayerManager.handleHotspotLayersTimeUpdate( currentTime );
 	}
 
@@ -152,6 +191,10 @@ export default class LayersManager {
 	 * @param {number} currentTime - Current video time in seconds
 	 */
 	handleCustomLayersTimeUpdate( currentTime ) {
+		if ( this.areLayersSuppressed() ) {
+			return;
+		}
+
 		Object.values( this.customLayerManagers ).forEach( ( manager ) => {
 			if ( typeof manager.handleTimeUpdate === 'function' ) {
 				manager.handleTimeUpdate( currentTime );

--- a/assets/src/js/godam-player/managers/layersManager.js
+++ b/assets/src/js/godam-player/managers/layersManager.js
@@ -91,6 +91,13 @@ export default class LayersManager {
 	/**
 	 * Whether layer firing is currently suppressed.
 	 *
+	 * NOTE: this gate only covers layers processed through `LayersManager`.
+	 * Layers created through the public `GoDAMAPI` run their own `timeupdate`
+	 * listener (`api/player.js` → `handleCustomLayersTimeUpdate`) and do not
+	 * consult this check, so third-party add-on layers can still appear during a
+	 * hover preview. Wiring that path through this suppression state is tracked
+	 * as follow-up work.
+	 *
 	 * @return {boolean} True when no layer should be revealed.
 	 */
 	areLayersSuppressed() {

--- a/assets/src/js/godam-player/managers/layersManager.test.js
+++ b/assets/src/js/godam-player/managers/layersManager.test.js
@@ -1,0 +1,109 @@
+/**
+ * Internal dependencies
+ */
+import LayersManager from './layersManager';
+
+// The sub-managers do real DOM/player work; stub them so this spec is about the
+// suppression gate alone, and expose jest.fn() methods to assert delegation.
+jest.mock( './layers/formLayerManager.js', () => ( {
+	__esModule: true,
+	default: jest.fn().mockImplementation( () => ( {
+		handleFormLayersTimeUpdate: jest.fn(),
+		handlePause: jest.fn(),
+		handleEnded: jest.fn(),
+		sortLayers: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( './layers/hotspotLayerManager.js', () => ( {
+	__esModule: true,
+	default: jest.fn().mockImplementation( () => ( {
+		handleHotspotLayersTimeUpdate: jest.fn(),
+	} ) ),
+} ) );
+
+jest.mock( '../utils/pluginLoader.js', () => ( {
+	loadFontAwesome: jest.fn( () => Promise.resolve() ),
+	hasHotspotsWithIcons: jest.fn( () => false ),
+} ) );
+
+/**
+ * Minimal Video.js player stub that records event handlers for dispatch.
+ *
+ * @return {Object} Stub player with an `emit( event )` test helper.
+ */
+const createPlayer = () => {
+	const handlers = {};
+	return {
+		on: ( event, cb ) => ( handlers[ event ] = handlers[ event ] || [] ).push( cb ),
+		emit: ( event ) => ( handlers[ event ] || [] ).forEach( ( cb ) => cb() ),
+	};
+};
+
+/**
+ * Builds a LayersManager with stubbed sub-managers.
+ *
+ * @param {Object} player - Player stub.
+ * @return {LayersManager} The manager under test.
+ */
+const createManager = ( player ) => {
+	const video = document.createElement( 'video' );
+	video.dataset.instanceId = '1';
+	const config = { isPreviewEnabled: false, videoSetupOptions: { layers: [] } };
+	return new LayersManager( player, video, config, {}, 'player-1' );
+};
+
+describe( 'LayersManager suppression gate', () => {
+	it( 'defaults to not suppressed', () => {
+		const manager = createManager( createPlayer() );
+		expect( manager.areLayersSuppressed() ).toBe( false );
+	} );
+
+	it( 'is suppressed only when the predicate returns strictly true', () => {
+		const manager = createManager( createPlayer() );
+
+		manager.setSuppressionCheck( () => true );
+		expect( manager.areLayersSuppressed() ).toBe( true );
+
+		// A truthy-but-not-true value must not suppress (strict `=== true`).
+		manager.setSuppressionCheck( () => 'yes' );
+		expect( manager.areLayersSuppressed() ).toBe( false );
+
+		manager.setSuppressionCheck( () => false );
+		expect( manager.areLayersSuppressed() ).toBe( false );
+	} );
+
+	it( 'gates the form and hotspot timeupdate paths', () => {
+		const manager = createManager( createPlayer() );
+		manager.setSuppressionCheck( () => true );
+
+		manager.handleFormLayersTimeUpdate( 5 );
+		manager.handleHotspotLayersTimeUpdate( 5 );
+		expect( manager.formLayerManager.handleFormLayersTimeUpdate ).not.toHaveBeenCalled();
+		expect( manager.hotspotLayerManager.handleHotspotLayersTimeUpdate ).not.toHaveBeenCalled();
+
+		manager.setSuppressionCheck( () => false );
+		manager.handleFormLayersTimeUpdate( 5 );
+		manager.handleHotspotLayersTimeUpdate( 5 );
+		expect( manager.formLayerManager.handleFormLayersTimeUpdate ).toHaveBeenCalledWith( 5 );
+		expect( manager.hotspotLayerManager.handleHotspotLayersTimeUpdate ).toHaveBeenCalledWith( 5 );
+	} );
+
+	it( 'gates the pause and ended CTA triggers', async () => {
+		const player = createPlayer();
+		const manager = createManager( player );
+		await manager.setupLayers(); // registers the pause / ended handlers
+
+		manager.setSuppressionCheck( () => true );
+		player.emit( 'pause' );
+		player.emit( 'ended' );
+		expect( manager.formLayerManager.handlePause ).not.toHaveBeenCalled();
+		expect( manager.formLayerManager.handleEnded ).not.toHaveBeenCalled();
+
+		manager.setSuppressionCheck( () => false );
+		player.emit( 'pause' );
+		player.emit( 'ended' );
+		expect( manager.formLayerManager.handlePause ).toHaveBeenCalled();
+		expect( manager.formLayerManager.handleEnded ).toHaveBeenCalled();
+	} );
+} );

--- a/assets/src/js/godam-player/videoPlayer.js
+++ b/assets/src/js/godam-player/videoPlayer.js
@@ -392,6 +392,12 @@ export default class GodamVideoPlayer {
 			onControlsMove: () => this.controlsManager.moveVideoControls(),
 		} );
 
+		// Suppress layers while an uncommitted hover preview ("Start Preview")
+		// is playing – the preview is meant to show playback, not layers.
+		this.layersManager.setSuppressionCheck(
+			() => this.hoverManager?.isPreviewActive() === true,
+		);
+
 		// Set up preview state change callback
 		if ( this.previewManager.getPreviewWatcher() ) {
 			this.previewManager.setPreviewStateChangeCallback(


### PR DESCRIPTION
**Fixes:** https://github.com/rtCamp/godam/issues/1847

This pull request introduces a mechanism to suppress interactive video layers (such as forms, CTAs, and hotspots) during uncommitted hover previews, ensuring that previews act as pure playback teasers without distractions. The suppression is coordinated between the `HoverManager`, `LayersManager`, and `GodamVideoPlayer` classes. The most important changes are grouped below:

**Hover preview state tracking:**

* Added an `isPreviewPlaying` flag and an `isPreviewActive()` method to `HoverManager` to track when a hover preview is running and expose this state. [[1]](diffhunk://#diff-4035647df222e387856aca8ae9132de0ed0578beedc583f25e702e97b1f221f5R35-R38) [[2]](diffhunk://#diff-4035647df222e387856aca8ae9132de0ed0578beedc583f25e702e97b1f221f5R148-R149) [[3]](diffhunk://#diff-4035647df222e387856aca8ae9132de0ed0578beedc583f25e702e97b1f221f5R168-R182)
* Ensured `isPreviewPlaying` is set appropriately on preview start, on play events, and when the video is clicked to transition from preview to real playback. [[1]](diffhunk://#diff-4035647df222e387856aca8ae9132de0ed0578beedc583f25e702e97b1f221f5R71-R80) [[2]](diffhunk://#diff-4035647df222e387856aca8ae9132de0ed0578beedc583f25e702e97b1f221f5R132)

**Layer suppression logic:**

* Added a suppression mechanism to `LayersManager`, including a `suppressionCheck` predicate, `setSuppressionCheck()`, and `areLayersSuppressed()` methods. These prevent layer firing (including time-based and event-driven triggers) while suppression is active. [[1]](diffhunk://#diff-d27f00ebcb7bf4a8cb4b92e63a2e9a81dd56186cf68999809d48e1837421d501R24) [[2]](diffhunk://#diff-d27f00ebcb7bf4a8cb4b92e63a2e9a81dd56186cf68999809d48e1837421d501L61-R99) [[3]](diffhunk://#diff-d27f00ebcb7bf4a8cb4b92e63a2e9a81dd56186cf68999809d48e1837421d501R167-R170) [[4]](diffhunk://#diff-d27f00ebcb7bf4a8cb4b92e63a2e9a81dd56186cf68999809d48e1837421d501R180-R183) [[5]](diffhunk://#diff-d27f00ebcb7bf4a8cb4b92e63a2e9a81dd56186cf68999809d48e1837421d501R194-R197)

**Integration with player:**

* Registered the suppression check in `GodamVideoPlayer` so that all layers are suppressed while a hover preview is running.

## Demo

https://github.com/user-attachments/assets/a685a0c8-011d-4e3b-9aae-721ef745b8cd

**Improve the hover preview by with video progress clue, and mute/unmute toggle button (Inspired from YT)**

https://github.com/user-attachments/assets/34816651-7310-4715-8b3c-3d9c91f82749




---

## Added preview behaviour (QA notes)

Beyond the layer-suppression fix in #1847, this PR also adjusts hover-preview UX. Flagging so QA knows what to exercise on every `start-preview` embed:

- **Hover-intent delay (~700ms):** a preview now starts only if the pointer lingers; a pointer merely passing over the video no longer starts/stops playback. This changes timing for all existing `start-preview` embeds.
- **Reel-style progress stripe** along the bottom while previewing (presentational, not scrubbable).
- **Mute/unmute toggle** (top-right, player primary colour): toggles preview sound without committing to playback; the choice is remembered for the page session and re-applied only to players the viewer has interacted with (browser autoplay policy).
- **Share/transcript overlay buttons are hidden** while a preview is playing, and restored once it ends or the viewer commits to playback.

Happy to split the chrome into its own PR if preferred — kept together here as they were requested alongside the fix.
