### PR TITLE
Fix: API Key Error handling

### DIFF
--- a/assets/src/css/media-library.scss
+++ b/assets/src/css/media-library.scss
@@ -738,3 +738,11 @@ $media-library-active-folder: #f5f5f5;
 		background-size: contain !important;
 	}
 }
+
+// Error notice shown inside the GoDAM media-modal tab (e.g. invalid/expired API key).
+// Colours, border and padding come from core's `.notice.notice-error`, so it follows the
+// active admin colour scheme (including dark mode); this only handles placement inside the
+// modal so the message sits above the attachments grid.
+.godam-tab-notice {
+	margin: 12px 16px;
+}

--- a/assets/src/js/media-library/models/attachments.js
+++ b/assets/src/js/media-library/models/attachments.js
@@ -8,6 +8,35 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Derive a clear, user-facing message from a failed GoDAM tab request.
+ *
+ * The GoDAM tab proxies to Central with the stored API key. When that key is missing,
+ * invalid, or was revoked, the request fails with a 401/403 (or the REST proxy returns
+ * `success:false` carrying the upstream status). Without this the tab either span forever
+ * or showed a misleading "No items found", so we translate the failure into an actionable
+ * message the UI can display.
+ *
+ * @param {Object} source The failed jqXHR, or the `{ success:false, message }` response body.
+ * @return {string} A human-readable error message.
+ */
+function deriveGodamTabError( source ) {
+	const status = source?.status ?? null;
+	const message = source?.responseJSON?.message || source?.message || '';
+
+	// Authentication/authorization failures → the API key is the problem.
+	if ( 401 === status || 403 === status || /\b40[13]\b/.test( message ) ) {
+		return __( 'Invalid or expired GoDAM API key. Please verify your API key on the GoDAM settings page.', 'godam' );
+	}
+
+	return message || __( 'Could not load your GoDAM media. Please try again.', 'godam' );
+}
+
+/**
  * Extended Attachments Collection to override the default `_requery` behavior.
  * It mirrors the query with a custom query model (`wp.media.godamQuery`).
  */
@@ -52,8 +81,19 @@ const Attachments = wp?.media?.model?.Attachments.extend( {
 			return deferred.resolveWith( this ).promise();
 		}
 
-		mirroring.more( options ).done( function() {
+		// Resolve on BOTH success and failure. Previously only `.done()` was handled, so a
+		// failed GoDAM request (e.g. an invalid/expired API key returning 401/403) left this
+		// deferred pending forever — which is exactly what kept the media modal's GoDAM tab
+		// stuck on an infinite loading spinner. `.always()` guarantees the browser view is
+		// always told the fetch finished, so the spinner clears either way.
+		mirroring.more( options ).always( function() {
+			// Surface any error the query captured so the tab can show a clear message
+			// rather than an endless spinner or a misleading "No items found".
+			attachments._godamError = mirroring._godamError || null;
+
 			deferred.resolveWith( attachments );
+
+			attachments.trigger( 'godam:fetched', attachments, attachments._godamError );
 			// Used for the search results.
 			attachments.trigger( 'attachments:received', attachments );
 		} );
@@ -166,6 +206,9 @@ const GODAMAttachmentCollection = wp?.media?.model?.Query?.extend(
 							hasMore = response.has_more;
 						}
 
+						// Successful response — clear any error from a previous failed fetch.
+						this._godamError = null;
+
 						// Update pagination state - stop loading if no more results or empty response.
 						this._hasMore = hasMore && items.length > 0;
 
@@ -194,12 +237,17 @@ const GODAMAttachmentCollection = wp?.media?.model?.Query?.extend(
 						return items;
 					}
 
+					// Reached on `success:false` (e.g. the REST proxy relaying an upstream
+					// 401/403 for an invalid key, or an unexpected response format).
 					this._hasMore = false;
 					this.total = 0;
+					this._godamError = deriveGodamTabError( response );
 					options.error?.( response );
 				},
 				error: ( xhr ) => {
+					// Reached on an HTTP-level failure (401/403, network error, etc.).
 					this._hasMore = false;
+					this._godamError = deriveGodamTabError( xhr );
 					options.error?.( xhr );
 				},
 			} );

--- a/assets/src/js/media-library/models/attachments.js
+++ b/assets/src/js/media-library/models/attachments.js
@@ -28,8 +28,12 @@ function deriveGodamTabError( source ) {
 	const status = source?.status ?? null;
 	const message = source?.responseJSON?.message || source?.message || '';
 
-	// Authentication/authorization failures → the API key is the problem.
-	if ( 401 === status || 403 === status || /\b40[13]\b/.test( message ) ) {
+	// Authentication/authorization failures → the API key is the problem. Trust the HTTP
+	// status when present; on the `success:false` path there is no status, so match only the
+	// REST proxy's own phrasing ("GoDAM API returned HTTP status: 401") rather than any bare
+	// 401/403 token, which could otherwise appear in an unrelated id/count and misclassify a
+	// valid key.
+	if ( 401 === status || 403 === status || /HTTP status:\s*40[13]\b/i.test( message ) ) {
 		return __( 'Invalid or expired GoDAM API key. Please verify your API key on the GoDAM settings page.', 'godam' );
 	}
 
@@ -88,12 +92,13 @@ const Attachments = wp?.media?.model?.Attachments.extend( {
 		// always told the fetch finished, so the spinner clears either way.
 		mirroring.more( options ).always( function() {
 			// Surface any error the query captured so the tab can show a clear message
-			// rather than an endless spinner or a misleading "No items found".
-			attachments._godamError = mirroring._godamError || null;
+			// rather than an endless spinner or a misleading "No items found". Read it from
+			// the query and pass it straight through — no need to stash it on the collection.
+			const godamError = mirroring._godamError || null;
 
 			deferred.resolveWith( attachments );
 
-			attachments.trigger( 'godam:fetched', attachments, attachments._godamError );
+			attachments.trigger( 'godam:fetched', attachments, godamError );
 			// Used for the search results.
 			attachments.trigger( 'attachments:received', attachments );
 		} );
@@ -153,6 +158,9 @@ const GODAMAttachmentCollection = wp?.media?.model?.Query?.extend(
 			}
 
 			if ( ! this.hasMore() ) {
+				// No fetch will run on this short-circuit, so drop any error from a previous
+				// page load — otherwise the caller's `.always()` would re-emit a stale message.
+				this._godamError = null;
 				return jQuery.Deferred().resolveWith( this ).promise();
 			}
 

--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -200,14 +200,23 @@ const GoDAMMediaFrameShared = {
 		}
 
 		// Browse our library of attachments.
+		const collection = getQuery( { controller: this, type: mimeTypes } );
+
 		const RenderedContent = new wp.media.view.AttachmentsBrowser( {
 			controller: this,
-			collection: getQuery( { controller: this, type: mimeTypes } ),
+			collection,
 			selection: state.get( 'selection' ),
 			model: state,
 		} );
 
 		this.content.set( RenderedContent );
+
+		// Surface GoDAM fetch failures (e.g. an invalid/expired API key) as a clear notice in
+		// the tab instead of leaving it on an infinite spinner or a misleading "No items found".
+		// The collection triggers 'godam:fetched' with the error message (or null) after every
+		// fetch; see models/attachments.js.
+		collection.off( 'godam:fetched', this.renderGoDAMTabNotice, this );
+		collection.on( 'godam:fetched', this.renderGoDAMTabNotice, this );
 
 		// Attaches callback to create attachment entry in WordPress for GoDAM Video.
 		state.off( 'select', this.onGoDAMSelect, this );
@@ -226,6 +235,62 @@ const GoDAMMediaFrameShared = {
 		// GalleryEdit fires frame-level 'update' (not 'select') when "Insert gallery" is clicked.
 		this.off( 'update', this.onGoDAMGalleryUpdate, this );
 		this.on( 'update', this.onGoDAMGalleryUpdate, this );
+	},
+
+	/**
+	 * Show or clear a clear error notice inside the GoDAM tab.
+	 *
+	 * Bound to the collection's 'godam:fetched' event. `errorMessage` is a human-readable
+	 * string when the fetch failed (e.g. invalid API key) or null on success. Rendering here
+	 * — rather than relying on the extended AttachmentsBrowser view — keeps it working in
+	 * additive mode, where the native browser view is used.
+	 *
+	 * @param {Object}      collection   The GoDAM attachments collection (unused).
+	 * @param {string|null} errorMessage The error to show, or null to clear.
+	 */
+	renderGoDAMTabNotice( collection, errorMessage ) {
+		// Only touch the DOM while the GoDAM tab is the active content mode.
+		if ( ! this.content || this.content.mode() !== 'godam' ) {
+			return;
+		}
+
+		const view = this.content.get();
+		const $el = view && view.$el;
+
+		if ( ! $el || ! $el.length ) {
+			return;
+		}
+
+		// Remove any previous notice so success clears it and errors don't stack.
+		$el.find( '.godam-tab-notice' ).remove();
+
+		if ( ! errorMessage ) {
+			return;
+		}
+
+		const $notice = window.jQuery(
+			'<div class="godam-tab-notice notice notice-error" role="alert" />',
+		)
+			.text( errorMessage )
+			// Inline styling so the notice is clearly visible inside the media modal without
+			// depending on a separate stylesheet build.
+			.css( {
+				margin: '12px 16px',
+				padding: '10px 14px',
+				background: '#fcf0f1',
+				borderLeft: '4px solid #d63638',
+				color: '#1d2327',
+				fontSize: '13px',
+				lineHeight: '1.5',
+			} );
+
+		// Place it above the attachments grid so it's the first thing the user sees.
+		const $attachments = $el.find( '.attachments-browser' ).first();
+		if ( $attachments.length ) {
+			$attachments.prepend( $notice );
+		} else {
+			$el.prepend( $notice );
+		}
 	},
 
 	async onGoDAMSelect() {

--- a/assets/src/js/media-library/views/godam-media-frame-shared.js
+++ b/assets/src/js/media-library/views/godam-media-frame-shared.js
@@ -245,7 +245,7 @@ const GoDAMMediaFrameShared = {
 	 * — rather than relying on the extended AttachmentsBrowser view — keeps it working in
 	 * additive mode, where the native browser view is used.
 	 *
-	 * @param {Object}      collection   The GoDAM attachments collection (unused).
+	 * @param {Object}      collection   The collection that emitted the event.
 	 * @param {string|null} errorMessage The error to show, or null to clear.
 	 */
 	renderGoDAMTabNotice( collection, errorMessage ) {
@@ -261,6 +261,13 @@ const GoDAMMediaFrameShared = {
 			return;
 		}
 
+		// Ignore a late event from a previous tab activation's collection. Re-opening the tab
+		// builds a fresh collection/view, but an in-flight request from the old one can resolve
+		// afterwards — without this guard its (stale) result could overwrite the current tab.
+		if ( view.collection && collection && view.collection !== collection ) {
+			return;
+		}
+
 		// Remove any previous notice so success clears it and errors don't stack.
 		$el.find( '.godam-tab-notice' ).remove();
 
@@ -268,21 +275,12 @@ const GoDAMMediaFrameShared = {
 			return;
 		}
 
+		// Styling lives in CSS (see media-library styles) so the notice inherits core's
+		// `notice notice-error` theming — including the dark admin colour scheme — instead of
+		// baking in light-mode colours here.
 		const $notice = window.jQuery(
 			'<div class="godam-tab-notice notice notice-error" role="alert" />',
-		)
-			.text( errorMessage )
-			// Inline styling so the notice is clearly visible inside the media modal without
-			// depending on a separate stylesheet build.
-			.css( {
-				margin: '12px 16px',
-				padding: '10px 14px',
-				background: '#fcf0f1',
-				borderLeft: '4px solid #d63638',
-				color: '#1d2327',
-				fontSize: '13px',
-				lineHeight: '1.5',
-			} );
+		).text( errorMessage );
 
 		// Place it above the attachments grid so it's the first thing the user sees.
 		const $attachments = $el.find( '.attachments-browser' ).first();


### PR DESCRIPTION
<h2>The issue (what was happening)</h2>

#1355 

<p>The GoDAM tab in the Video block's media picker fetches your video library from Central using the stored API key. When that key is missing, invalid, or was revoked (e.g. switching environments), the request fails — and the UI handled failure badly in two ways:</p>
<ul>
<li><strong>HTTP-level failure (401/403):</strong> the tab was stuck on an <strong>infinite loading spinner</strong> that never stopped.</li>
<li><strong>Proxy relaying an error (<code>success:false</code>):</strong> the tab silently showed <strong>"No items found"</strong>, as if you simply had no videos — no indication the key was the problem.</li>
</ul>
<p><strong>Root cause:</strong> In <code>models/attachments.js</code>, the <code>more()</code> override only handled the success case:</p>
<pre><code class="language-js">mirroring.more( options ).done( function() { deferred.resolveWith( attachments ); ... } );
</code></pre>
<p>On a failed fetch, <code>.done()</code> never fires, so the deferred <strong>never resolves</strong> → the media browser's spinner spins forever. And nothing ever surfaced the backend's error message.</p>
<h2>The fix</h2>
<ol>
<li><code>models/attachments.js</code>:
<ul>
<li><code>more()</code> now uses <code>.always()</code> so the deferred <strong>always resolves</strong> (spinner clears on success <em>or</em> failure).</li>
<li><code>sync()</code> records a friendly message (<code>deriveGodamTabError()</code> maps 401/403 → "Invalid or expired GoDAM API key…") on both the <code>success:false</code> and HTTP-error paths, and clears it on success.</li>
<li>After each fetch it fires <code>godam:fetched</code> with the error (or null).</li>
</ul>
</li>
<li><code>views/godam-media-frame-shared.js</code>: <code>GoDAMCreate</code> listens for <code>godam:fetched</code> and renders (or clears) a clear error notice in the tab (<code>renderGoDAMTabNotice</code>). Done at the frame level so it also works in additive mode.</li>
</ol>
<h2>Before / after</h2>

State | Before | After
-- | -- | --
Invalid/expired key (401/403) | ♾️ infinite spinner, Unexpected response in console | Spinner stops; red notice "Invalid or expired GoDAM API key. Please verify your API key on the GoDAM settings page."
Proxy error (success:false) | Misleading "No items found" | Same clear error notice
Valid key | Works | Works — 40 videos load, no notice (no regression, verified above)


<h2>How to test after the fix</h2>
<ol>
<li>Add a <strong>GoDAM Video block</strong> to a post → click <strong>Add Video</strong> → open the <strong>GoDAM</strong> tab.</li>
<li><strong>Valid key:</strong> your videos load normally (no spinner, no notice).</li>
<li><strong>Invalid key:</strong> temporarily change the API key on the GoDAM settings page to an invalid value (or switch to an environment where the key isn't valid), then reopen the GoDAM tab → you should see the <strong>red "Invalid or expired GoDAM API key" notice</strong> instead of an endless spinner or "No items found".</li>
<li>Restore a valid key and reopen → the notice is gone and videos load again.</li>
</ol>
<p>To simulate without touching your key, in DevTools you can force the endpoint to fail:</p>
<pre><code class="language-js">const o = jQuery.ajax;
jQuery.ajax = f =&gt; f?.url?.includes('get-godam-cmm-files')
  ? jQuery.Deferred(d =&gt; setTimeout(() =&gt; { f.error?.({status:401}); d.reject(); }, 300)).promise()
  : o(f);
</code></pre>
<p>then open the GoDAM tab.</p>

## Demo 

### Before

https://github.com/user-attachments/assets/83b42874-17a8-4a00-a280-ee6869b66126

### After
https://github.com/user-attachments/assets/c0a6d955-4337-4f60-8db2-e6b4b479527d