### PR TITLE
 Resolve: the plugin deletion error issue on QM

### DIFF
--- a/godam.php
+++ b/godam.php
@@ -144,45 +144,49 @@ function rtgodam_plugin_deactivate() {
 
 register_deactivation_hook( __FILE__, 'rtgodam_plugin_deactivate' );
 
-/**
- * Runs when the plugin is deleted.
+/*
+ * Plugin-state cleanup on deletion lives in uninstall.php (run in isolation by WordPress),
+ * NOT in a register_uninstall_hook() callback. The register_uninstall_hook() path makes
+ * WordPress bootstrap this whole file (and load bundled Action Scheduler) during deletion,
+ * which then fatals on `shutdown` once the files are gone — see uninstall.php and issue #1146.
  */
-function rtgodam_plugin_delete() {
-	// Delete options related to plugin state (What's New, version).
-	// This is to ensure redirection on a fresh install.
-	if ( is_multisite() ) {
-		// Get all blogs in the network and delete options from each blog.
-		$blogs = get_sites( array( 'fields' => 'ids' ) );
 
-		foreach ( $blogs as $blog_id ) {
-			switch_to_blog( $blog_id ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+/**
+ * Prevent a `shutdown` fatal when GoDAM is deleted while active.
+ *
+ * GoDAM bundles WooCommerce Action Scheduler, whose queue runner registers a `shutdown`
+ * callback (`ActionScheduler_QueueRunner::maybe_dispatch_async_request`). Deleting the
+ * plugin removes its files mid-request, so on `shutdown` that callback tries to autoload a
+ * class from the now-deleted plugin (e.g. `ActionScheduler_Lock`) and throws a fatal. A
+ * fatal-catcher such as Query Monitor appends that error to the delete-plugin AJAX body,
+ * corrupting the JSON so the admin shows "Deletion failed" even though the plugin was
+ * actually removed. `delete_plugin` fires immediately before the files are deleted, so
+ * detaching Action Scheduler's shutdown dispatch here avoids the fatal entirely (and the
+ * async request it would dispatch is pointless when the plugin is going away). See #1146.
+ *
+ * @since 2.2.1
+ *
+ * @param string $plugin_file Plugin being deleted, relative to the plugins directory.
+ * @return void
+ */
+function rtgodam_detach_action_scheduler_on_delete( $plugin_file ) {
+	if ( plugin_basename( __FILE__ ) !== $plugin_file ) {
+		return;
+	}
 
-			delete_option( 'rtgodam_plugin_version' );
-			delete_option( 'rtgodam_show_whats_new' );
-			delete_transient( 'rtgodam_show_whats_new' ); // Stored as a transient in ≤1.7.2.
-			delete_option( 'rtgodam_user_data' );
-			delete_option( 'rtgodam-api-key' );
-			delete_option( 'rtgodam-api-key-stored' );
-			delete_option( 'rtgodam-account-token' );
-			delete_option( 'rtgodam-api-key-status' );
-			delete_option( 'rtgodam-api-key-error-since' );
-			delete_transient( 'rtgodam_release_data' );
+	if ( ! class_exists( 'ActionScheduler_QueueRunner' ) || ! method_exists( 'ActionScheduler_QueueRunner', 'instance' ) ) {
+		return;
+	}
 
-			restore_current_blog();
-		}
+	$runner = ActionScheduler_QueueRunner::instance();
+
+	// Prefer Action Scheduler's own API; fall back to removing the hook directly for older
+	// versions that predate unhook_dispatch_async_request().
+	if ( method_exists( $runner, 'unhook_dispatch_async_request' ) ) {
+		$runner->unhook_dispatch_async_request();
 	} else {
-		// For single site, delete options directly.
-		delete_option( 'rtgodam_plugin_version' );
-		delete_option( 'rtgodam_show_whats_new' );
-		delete_transient( 'rtgodam_show_whats_new' ); // Stored as a transient in ≤1.7.2.
-		delete_option( 'rtgodam_user_data' );
-		delete_option( 'rtgodam-api-key' );
-		delete_option( 'rtgodam-api-key-stored' );
-		delete_option( 'rtgodam-account-token' );
-		delete_option( 'rtgodam-api-key-status' );
-		delete_option( 'rtgodam-api-key-error-since' );
-		delete_transient( 'rtgodam_release_data' );
+		remove_action( 'shutdown', array( $runner, 'maybe_dispatch_async_request' ) );
 	}
 }
 
-register_uninstall_hook( __FILE__, 'rtgodam_plugin_delete' );
+add_action( 'delete_plugin', 'rtgodam_detach_action_scheduler_on_delete' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Uninstall handler for GoDAM.
+ *
+ * WordPress runs THIS file — in isolation, with WP_UNINSTALL_PLUGIN defined — when the plugin
+ * is deleted, instead of including the main plugin file. Doing cleanup here rather than via
+ * register_uninstall_hook() is deliberate and fixes issue #1146:
+ *
+ * register_uninstall_hook() makes WordPress `include` godam.php during deletion, which
+ * bootstraps the entire plugin AND loads the bundled WooCommerce Action Scheduler. WordPress
+ * then deletes the plugin's files, so on `shutdown` the now-dangling references (Action
+ * Scheduler's shutdown callback, the class autoloaders) fatally try to load classes that no
+ * longer exist. That surfaces as a "Deletion failed" error under Query Monitor, or as a
+ * "502 Bad Gateway" on servers that buffer the response until shutdown — even though the
+ * plugin is actually removed (a page refresh confirms it). Running cleanup from uninstall.php
+ * never bootstraps the plugin, so those references simply do not exist at shutdown.
+ *
+ * @package GoDAM
+ */
+
+// Exit if uninstall is not called from WordPress.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+$rtgodam_uninstall_options = array(
+	'rtgodam_plugin_version',
+	'rtgodam_show_whats_new',
+	'rtgodam_user_data',
+	'rtgodam-api-key',
+	'rtgodam-api-key-stored',
+	'rtgodam-account-token',
+	'rtgodam-api-key-status',
+	'rtgodam-api-key-error-since',
+);
+
+$rtgodam_uninstall_transients = array(
+	'rtgodam_show_whats_new', // Stored as a transient in ≤1.7.2.
+	'rtgodam_release_data',
+);
+
+/**
+ * Delete GoDAM's plugin-state options and transients for the current site.
+ *
+ * A closure (rather than a named function) keeps this self-contained and avoids any
+ * redeclaration concerns in the shared uninstall context.
+ *
+ * @var callable $rtgodam_cleanup
+ */
+$rtgodam_cleanup = static function () use ( $rtgodam_uninstall_options, $rtgodam_uninstall_transients ) {
+	foreach ( $rtgodam_uninstall_options as $rtgodam_option ) {
+		delete_option( $rtgodam_option );
+	}
+
+	foreach ( $rtgodam_uninstall_transients as $rtgodam_transient ) {
+		delete_transient( $rtgodam_transient );
+	}
+};
+
+if ( is_multisite() ) {
+	// Clean each site's options. Kept lightweight (option/transient deletes only) so it is
+	// safe to run across every site without the plugin being loaded.
+	$rtgodam_blog_ids = get_sites( array( 'fields' => 'ids' ) );
+
+	foreach ( $rtgodam_blog_ids as $rtgodam_blog_id ) {
+		switch_to_blog( $rtgodam_blog_id ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		$rtgodam_cleanup();
+		restore_current_blog();
+	}
+} else {
+	$rtgodam_cleanup();
+}


### PR DESCRIPTION
**Fix: Plugin deletion error (502 / "Deletion failed") when GoDAM is deleted**

Closes #1146

### Problem
Deleting the GoDAM plugin threw an error — a `502 Bad Gateway` (openresty), or under Query Monitor a "Deletion failed: … Class `ActionScheduler_Lock` not found" — even though the plugin was actually removed (a page refresh confirmed it). Other plugins deleted cleanly; only GoDAM failed.

### Root cause
GoDAM cleaned up on delete via `register_uninstall_hook()`, which makes WordPress **include and fully bootstrap `godam.php`** during deletion — loading the bundled WooCommerce Action Scheduler and registering its `shutdown` callback / autoloaders. WordPress then deletes the plugin's files, so on `shutdown` those now-dangling references fatally autoload classes that no longer exist. Query Monitor appends that fatal to the delete AJAX response (corrupting the JSON), and on buffered servers the FPM worker dies before the response flushes, returning a 502.

### Fix
- Added an **`uninstall.php`**. WordPress runs it in isolation (with `WP_UNINSTALL_PLUGIN` defined) and **does not bootstrap the plugin**, so Action Scheduler is never loaded during deletion and no dangling references exist at `shutdown`. Moved the option cleanup here and removed `register_uninstall_hook()`.
- Added a `delete_plugin` guard in `godam.php` that detaches Action Scheduler's `shutdown` dispatch as a safety net for the case where GoDAM is loaded during the delete request.

### Testing
- Deleting a fixed test copy on a local site (Query Monitor active) returns a clean `{success:true}` and removes immediately — no fatal, no 502, no refresh needed.
- Verified working on a separate environment.
- Non-GoDAM plugins unaffected.

### Changed files
- `godam.php`
- `uninstall.php` (new)

### Demo
<img width="1469" height="830" alt="Screenshot 2026-09-10 at 5 22 25 PM" src="https://github.com/user-attachments/assets/a745bc20-692c-4d92-a72b-38c8ac0eb002" />
