### PR TITLE
feat(media-library): folder-id mapping foundation for two-way sync

### DIFF
--- a/inc/classes/media-library/class-folder-sync-map.php
+++ b/inc/classes/media-library/class-folder-sync-map.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Maps WordPress `media-folder` terms to GoDAM Central `GoDAM File Label` ids.
+ *
+ * The link between a WordPress media folder and its GoDAM Central folder is stored
+ * as the `_godam_folder_id` term meta (registered in Media_Folders). This helper is
+ * the single seam every sync operation goes through, so the meta key and its lookup
+ * logic live in one place instead of being scattered across the folder CRUD hooks,
+ * the upload payload, and the reconcile job.
+ *
+ * The mapping is server-managed. The term meta is out of REST and write-denied, so
+ * the only writers are the sync layer through set_central_id()/clear() below.
+ *
+ * @package GoDAM
+ */
+
+namespace RTGODAM\Inc\Media_Library;
+
+use RTGODAM\Inc\Traits\Singleton;
+use RTGODAM\Inc\Taxonomies\Media_Folders;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Folder_Sync_Map
+ */
+class Folder_Sync_Map {
+
+	use Singleton;
+
+	/**
+	 * Term meta key holding the GoDAM Central `GoDAM File Label` id.
+	 *
+	 * Kept in sync with the meta registered in Media_Folders::register_term_meta().
+	 *
+	 * @var string
+	 */
+	const META_KEY = '_godam_folder_id';
+
+	/**
+	 * Get the Central File Label id mapped to a WordPress term.
+	 *
+	 * @param int $term_id WordPress `media-folder` term id.
+	 *
+	 * @return string|null Central File Label id, or null when the term is unmapped.
+	 */
+	public function get_central_id( $term_id ) {
+		$value = get_term_meta( (int) $term_id, self::META_KEY, true );
+
+		return ( is_string( $value ) && '' !== $value ) ? $value : null;
+	}
+
+	/**
+	 * Store the WordPress term to Central mapping.
+	 *
+	 * Server-side only — the meta is not writable through REST.
+	 *
+	 * @param int    $term_id    WordPress `media-folder` term id.
+	 * @param string $central_id GoDAM Central `GoDAM File Label` id (docname).
+	 *
+	 * @return void
+	 */
+	public function set_central_id( $term_id, $central_id ) {
+		$central_id = sanitize_text_field( (string) $central_id );
+
+		if ( '' === $central_id ) {
+			return;
+		}
+
+		update_term_meta( (int) $term_id, self::META_KEY, $central_id );
+	}
+
+	/**
+	 * Reverse lookup: find the WordPress term mapped to a Central File Label id.
+	 *
+	 * @param string $central_id GoDAM Central `GoDAM File Label` id (docname).
+	 *
+	 * @return int|null WordPress `media-folder` term id, or null when none is mapped.
+	 */
+	public function get_term_id_by_central_id( $central_id ) {
+		$central_id = sanitize_text_field( (string) $central_id );
+
+		if ( '' === $central_id ) {
+			return null;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => Media_Folders::SLUG,
+				'hide_empty' => false,
+				'number'     => 1,
+				'fields'     => 'ids',
+				'meta_key'   => self::META_KEY,   // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $central_id,      // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return null;
+		}
+
+		return (int) $terms[0];
+	}
+
+	/**
+	 * Remove the mapping from a WordPress term.
+	 *
+	 * @param int $term_id WordPress `media-folder` term id.
+	 *
+	 * @return void
+	 */
+	public function clear( $term_id ) {
+		delete_term_meta( (int) $term_id, self::META_KEY );
+	}
+}

--- a/inc/classes/rest-api/class-site.php
+++ b/inc/classes/rest-api/class-site.php
@@ -85,6 +85,16 @@ class Site extends Base {
 			}
 
 			if ( ! empty( $site_data_response['message']['folder_id'] ) ) {
+				/*
+				 * Persist the site's GoDAM Central root folder id durably. The transient
+				 * below is only a 24h cache; this option is the stable anchor the media
+				 * -library sync layer diffs against — it is the parent for top-level
+				 * folder pushes and the reference that stops a Central-side rename of the
+				 * site folder from creating a duplicate. Mirror only: the authoritative
+				 * site-to-folder link is `site_folder` on the Active Site row in Central.
+				 */
+				update_option( 'rtgodam_site_folder_id', sanitize_text_field( $site_data_response['message']['folder_id'] ), false );
+
 				// Cache the response data for future requests.
 				rtgodam_cache_set( $cache_key, $site_data_response, 86400 );
 				$site_data = $site_data_response;

--- a/inc/classes/taxonomies/class-media-folders.php
+++ b/inc/classes/taxonomies/class-media-folders.php
@@ -146,5 +146,26 @@ class Media_Folders extends Base {
 				'auth_callback' => $manage_meta_auth_callback,
 			)
 		);
+
+		/*
+		 * Maps this WordPress `media-folder` term to its GoDAM Central `GoDAM File Label`
+		 * (a Frappe docname — a string, not an int). System-managed: written only by the
+		 * media-library sync layer via update_term_meta() (see Folder_Sync_Map). It is
+		 * deliberately kept out of REST (`show_in_rest => false`) and write-denied
+		 * (`auth_callback => __return_false`) so no user can repoint a folder at another
+		 * tenant's Central folder through the native term-meta route. If the React tree
+		 * needs the mapping (e.g. to show sync status) it is surfaced read-only via the
+		 * godam/v1/media-library/media-folders payload, never this meta directly.
+		 */
+		register_term_meta(
+			static::SLUG,
+			'_godam_folder_id',
+			array(
+				'type'          => 'string',
+				'single'        => true,
+				'show_in_rest'  => false,
+				'auth_callback' => '__return_false',
+			)
+		);
 	}
 }

--- a/inc/helpers/custom-functions.php
+++ b/inc/helpers/custom-functions.php
@@ -2376,3 +2376,18 @@ function rtgodam_format_html_attributes( $attributes ) {
 
 	return implode( ' ', $formatted );
 }
+
+/**
+ * Get this site's GoDAM Central root folder id.
+ *
+ * Durable local mirror of the site's `GoDAM File Label` root, persisted by
+ * RTGODAM\Inc\REST_API\Site::get_site_data() when Central resolves it. Used by the
+ * media-library sync layer as the parent for top-level folder pushes and as the
+ * anchor a Central-side rename is diffed against. Returns an empty string until the
+ * site has been resolved against Central at least once.
+ *
+ * @return string GoDAM Central root folder id, or empty string when unknown.
+ */
+function rtgodam_get_site_folder_id() {
+	return (string) get_option( 'rtgodam_site_folder_id', '' );
+}


### PR DESCRIPTION
## What

Groundwork for two-way Media Library sync between WordPress and GoDAM Central — **Track A, Phase 1** of rtCamp/godam-plugin-wp#42. This is the folder-id **mapping foundation only**: storage + accessors, with **no calls to Central** in this PR, so it can land independently of the Central folder-endpoint security PRs and the sync UI mockups.

Today the WP↔Central folder link is name-based and one-way (the site folder is a `GoDAM File Label` named after the hostname; WP `media-folder` terms carry no pointer to their Central folder). This PR establishes an explicit id link so later work isn't building on the hostname-string coupling.

## Changes

- **`_godam_folder_id` term meta** on the `media-folder` taxonomy — maps a WP term to its Central `GoDAM File Label` (a Frappe docname string). Registered with `show_in_rest => false` and `auth_callback => __return_false`: it is **system-managed**, written only by the sync layer, and deliberately not writable/readable through the native term-meta REST route so a user cannot repoint a folder at another tenant's Central folder (guards the IDOR surface the epic flags). If the React tree ever needs the mapping it should be surfaced read-only via the `godam/v1/media-library/media-folders` payload.
- **`Folder_Sync_Map`** (`inc/classes/media-library/class-folder-sync-map.php`) — a `Singleton` helper that is the single seam for the mapping: `get_central_id()`, `set_central_id()`, `get_term_id_by_central_id()` (reverse lookup), `clear()`. The upcoming folder-CRUD hooks and the reconcile job call this instead of scattering `get_term_meta()` calls.
- **Persist the site's Central root folder id** — `Site::get_site_data()` now writes the resolved id to the `rtgodam_site_folder_id` option (the existing 24h transient stays as the cache), with a `rtgodam_get_site_folder_id()` reader. This is a durable local anchor for top-level folder pushes and for diffing against a Central-side rename.

## Notes for reviewers

- **`Folder_Sync_Map` is defined but not yet referenced** — it's wired up in the follow-up PR (folder CRUD hooks + upload `file_label` + `assign_images_to_folder → bulk_update_files`). Not dead code.
- **`rtgodam_site_folder_id` is a mirror, not the source of truth.** The authoritative site→folder link is `site_folder` on the `Active Site` row in Central (open question on the epic, owned on the Central/frappe-stripe-subscription side).
- No behaviour change to the existing folder tree, lock/bookmark meta, or the `media-folders` payload — Change 1 adds nothing to `prepare_term_responses()`.

## Testing

- `php -l` and project PHPCS clean on all four files (pre-commit lint-staged + hook-integrity checks pass).
- Follow-up test PR will add a `Folder_Sync_Map` round-trip test and a REST-guard assertion that `POST wp/v2/media-folder/<id>` with `meta._godam_folder_id` is ignored.

## Related

- Epic: rtCamp/godam-plugin-wp#42
- Next: PR 2 (WP→Central push wiring), gated on the Central folder security PRs merging first.